### PR TITLE
Adds workflow for docker push

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 **/target/
-build
+**/node_modules/
 Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,23 +1,49 @@
 name: Release
 
-on:
-  push:
-    tags:
-      - v**.**.**
+on: ['push']
 
 env:
   WASM_BUILD_TOOLCHAIN: nightly-2020-07-20
 
 jobs:
+  get-variables:
+    runs-on: ubuntu-latest
+    outputs:
+      tag-version: ${{ steps.variables.outputs.version }}
+      tag-exists: ${{ steps.variables.outputs.tag-exists }}
+      tag-count: ${{ steps.variables.outputs.count }}
+      sha-8: ${{ steps.variables.outputs.sha-8 }}
+    steps:
+    - 
+      uses: actions/checkout@v2
+    - 
+      id: variables
+      run: |
+        echo ::set-output name=version::$(git tag -l | tail -n1 | cut -c2- )
+        echo ::set-output name=count::$(git tag -l | wc -l )
+        echo ${{ github.ref }}
+        echo ::set-output name=tag-exists::$(git describe --exact-match HEAD 2>/dev/null && echo 1 || echo 0)
+        echo ::set-output name=sha-8::$(git rev-parse HEAD | cut -c1-8)
+    - 
+      id: show-variables
+      run: |
+        echo tag-version: ${{ steps.variables.outputs.version }}
+        echo tag-exists: ${{ steps.variables.outputs.tag-exists }}
+        echo tag-count: ${{ steps.variables.outputs.count }}
+        echo sha-8: ${{ steps.variables.outputs.sha-8 }}
+
   build:
     runs-on: ubuntu-latest
     outputs:
       RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Submodules
+    - 
+      uses: actions/checkout@v2
+    - 
+      name: Submodules
       run: git submodule update --init --recursive
-    - name: Cache Rust dependencies
+    - 
+      name: Cache Rust dependencies
       uses: actions/cache@v2
       id: cache
       with:
@@ -29,75 +55,159 @@ jobs:
         key: ${{ runner.OS }}-build-${{ env.WASM_BUILD_TOOLCHAIN }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.OS }}-build--${{ env.WASM_BUILD_TOOLCHAIN }}
-    - uses: actions-rs/toolchain@v1
+    - 
+      uses: actions-rs/toolchain@v1
       with:
         target: wasm32-unknown-unknown
         toolchain: ${{ env.WASM_BUILD_TOOLCHAIN }}
         default: true
-    - id: get-rust-versions
+    - 
+      id: get-rust-versions
       run: |
         echo "::set-output name=rustc::$(rustc --version)"
-    - name: Build
+    - 
+      name: Build
       run: cargo build --release --verbose --all
-    - name: Save parachain binary
+    - 
+      name: Save parachain binary
       run: |
         mkdir -p build/alphanet
         cp target/release/moonbase-alphanet build/alphanet/moonbase-alphanet;
-    - name: Upload moonbase-alphanet node
+    - 
+      name: Upload moonbase-alphanet node
       uses: actions/upload-artifact@v2
       with:
         name: moonbase-alphanet
         path: build/alphanet
-
 
   generate-specs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@v2
-
-    - uses: actions/download-artifact@v2
+    - 
+      uses: actions/checkout@v2
+    - 
+      uses: actions/download-artifact@v2
       with:
         name: moonbase-alphanet
         path: build/alphanet
-
-    - name: Generate specs
+    - 
+      name: Generate specs
       run: |
         chmod uog+x build/alphanet/moonbase-alphanet
         PARACHAIN_BINARY=build/alphanet/moonbase-alphanet scripts/generate-parachain-specs.sh
-
-    - name: Upload parachain spec plain
+    - 
+      name: Upload parachain spec plain
       uses: actions/upload-artifact@v2
       with:
         name: moonbase-alphanet
         path: build/alphanet
 
+  docker:
+    runs-on: ubuntu-latest
+    needs: ['get-variables', 'build', 'generate-specs']
+    if: needs.get-variables.outputs.tag-exists == 0 && github.event_name != 'pull_request'
+    steps:
+      - 
+        uses: actions/checkout@v2
+      - 
+        uses: actions/download-artifact@v2
+        with:
+          name: moonbase-alphanet
+          path: build/alphanet
+      -
+        name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=purestake/moonbase-parachain-testnet
+          VERSION=noop
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            VERSION=nightly
+          elif [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+              VERSION=edge
+            fi
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            MINOR=${VERSION%.*}
+            MAJOR=${MINOR%.*}
+            TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          driver-opts: |
+            image=moby/buildkit:master
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/moonbase-alphanet.Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+
   publish-draft-release:
     runs-on: ubuntu-latest
     needs: ['build', 'generate-specs']
+    if: needs.get-tag-version.outputs.tag-exists == 1 
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
-    - uses: actions/checkout@v2
+    - 
+      uses: actions/checkout@v2
       with:
         fetch-depth: 0
         path: moonbeam
-
-    - name: Set up Ruby 2.7
+    - 
+      name: Set up Ruby 2.7
       uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.7
-        
-    - name: Generate release text
+    - 
+      name: Generate release text
       env:
         RUSTC: ${{ needs.build.outputs.rustc }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gem install changelogerator git toml
         ruby $GITHUB_WORKSPACE/moonbeam/scripts/github/generate_release_text.rb | tee release_text.md
-
-    - name: Create draft release
+    - 
+      name: Create draft release
       id: create-release
       uses: actions/create-release@v1
       env:
@@ -112,29 +222,31 @@ jobs:
   publish-runtimes:
     runs-on: ubuntu-latest
     needs: ['publish-draft-release']
+    if: needs.get-tag-version.outputs.tag-exists == 1 
     strategy:
       matrix:
         runtime: ['moonbase-alphanet']
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/download-artifact@v2
+      - 
+        uses: actions/checkout@v2
+      - 
+        uses: actions/download-artifact@v2
         with:
           name: moonbase-alphanet
           path: build/alphanet
-
-      - name: Set up Ruby 2.7
+      - 
+        name: Set up Ruby 2.7
         uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.7
-
-      - name: Get runtime version
+      - 
+        name: Get runtime version
         id: get-runtime-ver
         run: |
           runtime_ver="$(ruby -e 'require "./scripts/github/lib.rb"; puts get_runtime("${{ matrix.runtime }}")')"
           echo "::set-output name=runtime_ver::$runtime_ver"
-
-      - name: Upload ${{ matrix.runtime }} wasm
+      -
+        name: Upload ${{ matrix.runtime }} wasm
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -143,8 +255,8 @@ jobs:
           asset_path: build/alphanet/${{ matrix.runtime }}-runtime.wasm
           asset_name: ${{ matrix.runtime }}-runtime-v${{ steps.get-runtime-ver.outputs.runtime_ver }}.wasm
           asset_content_type: application/wasm
-
-      - name: Upload ${{ matrix.runtime }} node
+      - 
+        name: Upload ${{ matrix.runtime }} node
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -153,8 +265,8 @@ jobs:
           asset_path: build/alphanet/${{ matrix.runtime }}
           asset_name: ${{ matrix.runtime }}
           asset_content_type: application/octet-stream 
-
-      - name: Upload ${{ matrix.runtime }} specs plain
+      - 
+        name: Upload ${{ matrix.runtime }} specs plain
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -163,8 +275,8 @@ jobs:
           asset_path: build/alphanet/${{ matrix.runtime }}-specs-plain.json
           asset_name: ${{ matrix.runtime }}-specs-plain.json
           asset_content_type: application/json 
-
-      - name: Upload ${{ matrix.runtime }} specs raw
+      - 
+        name: Upload ${{ matrix.runtime }} specs raw
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -173,8 +285,8 @@ jobs:
           asset_path: build/alphanet/${{ matrix.runtime }}-specs-raw.json
           asset_name: ${{ matrix.runtime }}-specs-raw.json
           asset_content_type: application/json 
-
-      - name: Upload ${{ matrix.runtime }} genesis
+      - 
+        name: Upload ${{ matrix.runtime }} genesis
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/moonbase-alphanet.Dockerfile
+++ b/docker/moonbase-alphanet.Dockerfile
@@ -1,0 +1,41 @@
+# Node for Moonbase Alphanet. 
+# 
+# Requires to run from repository root and to copy the binary in the build folder (part of the release workflow)
+
+FROM phusion/baseimage:0.11
+LABEL maintainer "alan@purestake.com"
+LABEL description="this is the parachain node running Moonbase Alphanet"
+ARG PROFILE=release
+
+RUN mv /usr/share/ca* /tmp && \
+	rm -rf /usr/share/*  && \
+	mv /tmp/ca-certificates /usr/share/ && \
+	rm -rf /usr/lib/python* && \
+	useradd -m -u 1000 -U -s /bin/sh -d /moonbase-alphanet moonbeam && \
+	mkdir -p /moonbase-alphanet/.local/share/moonbase-alphanet && \
+	chown -R moonbeam:moonbeam /moonbase-alphanet/.local && \
+	ln -s /moonbase-alphanet/.local/share/moonbase-alphanet /data && \
+	rm -rf /usr/bin /usr/sbin
+
+
+USER moonbeam
+
+COPY build/alphanet /moonbase-alphanet
+
+# 30333 for p2p traffic
+# 9933 for RPC call
+# 9944 for Websocket
+# 9615 for Prometheus (metrics)
+EXPOSE 30333 9933 9944 9615
+
+VOLUME ["/data"]
+
+CMD ["/moonbase-alphanet/moonbase-alphanet", \
+    "--port","30333", \
+    "--rpc-port","9933", \
+    "--ws-port","9944", \
+    "--validator", \
+    "--chain", "/moonbase-alphanet/moonbase-alphanet-specs-plain.json", \
+    "--", \
+      "--chain", "/moonbase-alphanet/rococo-alphanet-specs-raw.json" \
+]


### PR DESCRIPTION
This PR adds a script to autobuild the alphanet parachain node and push to docker.
It automatically takes the semantic versioning as tag if present and the branch-name and sha