### PR TITLE
Backend block_timestamp implementation return seconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4256,7 +4256,7 @@ checksum = "bd4556fb64842e71bb6e2f98b7541c0d310069eb607d432c6ac9bdaecbfd3118"
 [[package]]
 name = "pallet-evm"
 version = "2.0.0-rc6"
-source = "git+https://github.com/purestake/substrate?branch=tgmichel-rococo-branch#c73712eb7cc51a68de915baf8eb1312ebd6a84ab"
+source = "git+https://github.com/purestake/substrate?branch=tgmichel-rococo-branch#9c3a6b1d198cee2b542579752b096ef1968ef0c8"
 dependencies = [
  "evm",
  "frame-support",


### PR DESCRIPTION
The `pallet-evm` implementation of [evm::Backend](https://github.com/rust-blockchain/evm/blob/master/src/backend/mod.rs#L57) uses `pallet-timestamp` to return `block.timestamp` value in milliseconds as opposed to the expected value in seconds.