### PR TITLE
Add command line arguments for logs limit

### DIFF
--- a/node/parachain/src/cli.rs
+++ b/node/parachain/src/cli.rs
@@ -58,6 +58,19 @@ pub struct RunCmd {
 	pub parachain_id: Option<u32>,
 }
 
+#[allow(missing_docs)]
+#[derive(Debug, StructOpt)]
+pub struct EthCmd {
+	/// Number of past blocks allowed for querying ethereum events.
+	#[structopt(long = "eth-block-limit")]
+	pub block_limit: Option<u32>,
+
+	/// Number of logs allowed for querying ethereum events.
+	#[structopt(long = "eth-log-limit")]
+	pub log_limit: Option<u32>,
+}
+
+
 impl std::ops::Deref for RunCmd {
 	type Target = sc_cli::RunCmd;
 
@@ -82,6 +95,9 @@ pub struct Cli {
 	/// Relaychain arguments
 	#[structopt(raw = true)]
 	pub relaychain_args: Vec<String>,
+
+	#[structopt(flatten)]
+	pub eth: EthCmd,
 }
 
 #[derive(Debug)]

--- a/node/parachain/src/cli.rs
+++ b/node/parachain/src/cli.rs
@@ -58,7 +58,6 @@ pub struct RunCmd {
 	pub parachain_id: Option<u32>,
 }
 
-#[allow(missing_docs)]
 #[derive(Debug, StructOpt)]
 pub struct EthCmd {
 	/// Number of past blocks allowed for querying ethereum events.

--- a/node/parachain/src/command.rs
+++ b/node/parachain/src/command.rs
@@ -239,6 +239,8 @@ pub fn run() -> Result<()> {
 					polkadot_config,
 					id,
 					cli.run.base.validator,
+					cli.eth.block_limit,
+					cli.eth.log_limit,
 				)
 				.map(|(x, _)| x)
 			})

--- a/node/parachain/src/rpc.rs
+++ b/node/parachain/src/rpc.rs
@@ -48,6 +48,10 @@ pub struct FullDeps<C, P, A: ChainApi> {
 	pub deny_unsafe: DenyUnsafe,
 	/// The Node authority flag
 	pub is_authority: bool,
+	/// Number of past blocks allowed for querying ethereum events.
+	pub eth_block_limit: Option<u32>,
+	/// Number of logs allowed for querying ethereum events.
+	pub eth_log_limit: Option<u32>,
 	/// Network service
 	pub network: Arc<NetworkService<Block, Hash>>,
 	/// Manual seal command sink
@@ -84,6 +88,8 @@ pub fn create_full<C, P, BE, A>(
 		graph_pool,
 		deny_unsafe,
 		is_authority,
+		eth_block_limit,
+		eth_log_limit,
 		network,
 		command_sink
 	} = deps;
@@ -101,6 +107,8 @@ pub fn create_full<C, P, BE, A>(
 			pool.clone(),
 			moonbase_runtime::TransactionConverter,
 			is_authority,
+			eth_block_limit,
+			eth_log_limit,
 		))
 	);
 	io.extend_with(

--- a/node/parachain/src/service.rs
+++ b/node/parachain/src/service.rs
@@ -114,6 +114,8 @@ pub fn run_node(
 	mut polkadot_config: polkadot_collator::Configuration,
 	id: polkadot_primitives::v0::Id,
 	validator: bool,
+	eth_block_limit: Option<u32>,
+	eth_log_limit: Option<u32>
 ) -> sc_service::error::Result<(
 	TaskManager,
 	Arc<
@@ -189,6 +191,8 @@ pub fn run_node(
 				graph_pool: pool.pool().clone(),
 				deny_unsafe,
 				is_authority,
+				eth_block_limit,
+				eth_log_limit,
 				network: network.clone(),
 				command_sink: Some(command_sink.clone())
 			};

--- a/node/standalone/src/cli.rs
+++ b/node/standalone/src/cli.rs
@@ -28,6 +28,18 @@ pub struct RunCmd {
 	pub manual_seal: bool,
 }
 
+#[allow(missing_docs)]
+#[derive(Debug, StructOpt)]
+pub struct EthCmd {
+	/// Number of past blocks allowed for querying ethereum events.
+	#[structopt(long = "eth-block-limit")]
+	pub block_limit: Option<u32>,
+
+	/// Number of logs allowed for querying ethereum events.
+	#[structopt(long = "eth-log-limit")]
+	pub log_limit: Option<u32>,
+}
+
 #[derive(Debug, StructOpt)]
 pub struct Cli {
 	#[structopt(subcommand)]
@@ -35,6 +47,9 @@ pub struct Cli {
 
 	#[structopt(flatten)]
 	pub run: RunCmd,
+
+	#[structopt(flatten)]
+	pub eth: EthCmd,
 }
 
 #[derive(Debug, StructOpt)]

--- a/node/standalone/src/command.rs
+++ b/node/standalone/src/command.rs
@@ -118,7 +118,12 @@ pub fn run() -> sc_cli::Result<()> {
 			let runner = cli.create_runner(&cli.run.base)?;
 			runner.run_node_until_exit(|config| match config.role {
 				Role::Light => service::new_light(config),
-				_ => service::new_full(config, cli.run.manual_seal),
+				_ => service::new_full(
+					config,
+					cli.run.manual_seal,
+					cli.eth.block_limit,
+					cli.eth.log_limit,
+				),
 			})
 		}
 	}

--- a/node/standalone/src/rpc.rs
+++ b/node/standalone/src/rpc.rs
@@ -59,6 +59,10 @@ pub struct FullDeps<C, P, A: ChainApi> {
 	pub deny_unsafe: DenyUnsafe,
 	/// The Node authority flag
 	pub is_authority: bool,
+	/// Number of past blocks allowed for querying ethereum events.
+	pub eth_block_limit: Option<u32>,
+	/// Number of logs allowed for querying ethereum events.
+	pub eth_log_limit: Option<u32>,
 	/// Network service
 	pub network: Arc<NetworkService<Block, Hash>>,
 	/// Manual seal command sink
@@ -95,6 +99,8 @@ pub fn create_full<C, P, BE, A>(
 		graph_pool,
 		deny_unsafe,
 		is_authority,
+		eth_block_limit,
+		eth_log_limit,
 		network,
 		command_sink
 	} = deps;
@@ -112,6 +118,8 @@ pub fn create_full<C, P, BE, A>(
 			pool.clone(),
 			moonbeam_runtime::TransactionConverter,
 			is_authority,
+			eth_block_limit,
+			eth_log_limit,
 		))
 	);
 	io.extend_with(

--- a/node/standalone/src/service.rs
+++ b/node/standalone/src/service.rs
@@ -133,7 +133,9 @@ pub fn new_partial(config: &Configuration, manual_seal: bool) -> Result<
 }
 
 /// Builds a new service for a full client.
-pub fn new_full(config: Configuration, manual_seal: bool) -> Result<TaskManager, ServiceError> {
+pub fn new_full(
+	config: Configuration, manual_seal: bool, eth_block_limit: Option<u32>, eth_log_limit: Option<u32>
+) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
 		client, backend, mut task_manager, import_queue, keystore, select_chain, transaction_pool,
 		inherent_data_providers,
@@ -199,6 +201,8 @@ pub fn new_full(config: Configuration, manual_seal: bool) -> Result<TaskManager,
 				graph_pool: pool.pool().clone(),
 				deny_unsafe,
 				is_authority,
+				eth_block_limit,
+				eth_log_limit,
 				network: network.clone(),
 				command_sink: Some(command_sink.clone())
 			};


### PR DESCRIPTION
Adds optional command line arguments to limit the past events access:

- `eth-block-limit`: Number of past blocks allowed for querying ethereum events. (Defaults to 50)
- `eth-log-limit`: Number of logs allowed for querying ethereum events. (Defaults to 500)

