### PR TITLE
Insert keys using curl

### DIFF
--- a/scripts/run-alphanet-relay.sh
+++ b/scripts/run-alphanet-relay.sh
@@ -43,14 +43,17 @@ echo "relay ${RELAY_INDEX} - p2p-port: $((RELAY_PORT)), http-port: $((RELAY_PORT
 # This part will insert the keys in the node
 bash -c "sleep 5; \
 insertKey() { \
-    polkadot-js-api \
-        --ws 'ws://localhost:$((RELAY_PORT + 2))' \
-        --sudo \
-        --seed "$SUDO_SEED" \
-        rpc.author.insertKey \
-            \"\$1\" \
-            \"\$2\" \
-            \"\$3\" > /dev/null; \
+	curl http://localhost:$((RELAY_PORT + 2)) -H \"Content-Type:application/json;charset=utf-8\" -d '
+	{
+		\"jsonrpc\":\"2.0\",
+		\"id\":1,
+		\"method\":\"author_insertKey\",
+		\"params\": [
+			\"$1\",
+			\"$2\",
+			\"$3\"
+		]
+	}'; \
 }; \
 \
 insertKey acco '${RELAY_SEEDS[$RELAY_INDEX]}' '${RELAY_SR25519_PUB[$RELAY_INDEX]}'; \


### PR DESCRIPTION
Followup to #45. This PR adjusts the relay chains starting script to insert keys using curl rather than polkadot js. This eliminates the need to have `@polkadot/api-cli` installed globally.

I initially thought this also worked around the problem that the key-insertion was run as a background task that couldn't be killed with ctrl+c, but I was wrong, that issue still exists.