### PR TITLE
Adds standalone run script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,12 +9,22 @@ For running nodes, you need to have **docker** running.
 It is used to run the polkadot relay node (also needed to generate the relay specs for the parachain)
 
 
-All the commands are to be executed from the repository root folder.
+!!All the commands are to be executed from the repository root folder.!!
 
 
 The node scripts are based on the USER_PORT env variable to set their
 ports, following this strategy:  
 (for USER_PORT=33000)  
+
+```
+Standalone Nodes: 33[5-8]XX (supports 3 standalone nodes)  
+P2P: 34[5-8]42  
+RPC: 34[5-8]43  
+WS: 34[5-8]44  
+```
+(so your first standalone node will have RPC at 33443)
+
+
 ```
 Relay Nodes: 33[0-2]XX (supports 3 relay nodes)
 P2P: 33[0-9]42  
@@ -50,7 +60,23 @@ export USER_PORT=<XX000>
 cargo build --release
 ```
 
-### Generating the relay specs
+# Standalone nodes
+The standalone nodes are made to be executed without any specs.  
+They also don't require any runtime wasm file or genesis state.
+
+```bash
+scripts/run-moonbase-standalone.sh
+```
+
+
+
+# Alphanet nodes
+The alphanet nodes require having relay nodes (at least 2) and parachain nodes (at least 1).
+Those require sharing many files (specs, runtime wasm, genesis state).
+
+The following steps will guide you through the generation of those files.
+
+## Generating the relay specs
 
 ```bash
 scripts/generate-relay-specs.sh
@@ -60,22 +86,31 @@ The script downloads `purestake/moonbase-relay-testnet:$POLKADOT_VERSION` docker
 It also relies on the `/specs/rococo-alphanet-specs-template.json` for the specs template.
 The files generated are (by default) stored in `build/rococo-alphanet-specs-[plain,raw].json`
 
-### Generating the parachain specs
+## Generating the parachain specs
 
 ```bash
 scripts/generate-parachain-specs.sh
 ```
 
 The script executes (by default) `target/release/moonbase-alphanet` `build-spec`
-It also relies on the `/specs/rococo-alphanet-specs-template.json` for the specs template.
-The files generated are (by default) stored in `build/rococo-alphanet-specs-[plain,raw].json`
+It also relies on the `/specs/moonbase-alphanet-specs-template.json` for the specs template.
+The files generated are (by default) stored in `build/moonbase-alphanet-specs-[plain,raw].json`
 
 It also generates the `build/parachain.wasm` and `build/parachain.genesis`
+
+### Alternate parachain specs
+If you want to use an alternative spec template (like [../moonbase-alphanet-dev-specs-template.json](moonbase-alphanet-dev-specs-template.json which contains gerald funds)),
+you can provide the template like this:
+
+```bash
+PARACHAIN_SPEC_TEMPLATE=specs/moonbase-alphanet-dev-specs-template.json scripts/generate-parachain-specs.sh
+```
 
 ## Running Relay nodes
 
 You can run up to 3 relay chain validators with this script. We use the `purestake/moonbase-relay-testnet` docker image for validators. Currently this image is manually published from commit (TODO), but this will change in the future.
-Each node will get its key inserted 5 seconds after starting.
+Each node will get its key inserted 5 seconds after starting, using curl command.
+(*The grandpa consensus is not yet supported as it requires to restart the node.*)
 
 ```bash
 scripts/run-alphanet-relay.sh
@@ -83,7 +118,7 @@ scripts/run-alphanet-relay.sh
 
 ## Running Parachain nodes
 
-You can run up to 9 relay nodes with this script
+You can run up to 3 relay nodes with this script
 
 ```bash
 scripts/run-alphanet-parachain.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -110,7 +110,7 @@ PARACHAIN_SPEC_TEMPLATE=specs/moonbase-alphanet-dev-specs-template.json scripts/
 
 You can run up to 3 relay chain validators with this script. We use the `purestake/moonbase-relay-testnet` docker image for validators. Currently this image is manually published from commit (TODO), but this will change in the future.
 Each node will get its key inserted 5 seconds after starting, using curl command.
-(*The grandpa consensus is not yet supported as it requires to restart the node.*)
+(*The grandpa finality gadget is not yet supported as it requires to restart the node.*)
 
 ```bash
 scripts/run-alphanet-relay.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -61,7 +61,7 @@ cargo build --release
 ```
 
 # Standalone nodes
-The standalone nodes are made to be executed without any specs.  
+The standalone nodes are made to be executed without explicitly supplied specs.  
 They also don't require any runtime wasm file or genesis state.
 
 ```bash

--- a/scripts/_init_var.sh
+++ b/scripts/_init_var.sh
@@ -6,13 +6,13 @@ fi
 
 mkdir -p $PARACHAIN_BUILD_FOLDER
 
-if [ -z "$PARACHAIN_BINARY" ]; then
-    PARACHAIN_BINARY="target/release/moonbase-alphanet"
+
+if [ -z "$STANDALONE_BINARY" ]; then
+    STANDALONE_BINARY="target/release/moonbase-standalone"
 fi
 
-if [ ! -f "$PARACHAIN_BINARY" ]; then
-    echo "Parachain binary $PARACHAIN_BINARY is missing"
-    echo "Please run: cargo build --release -p moonbase-alphanet"
+if [ -z "$PARACHAIN_BINARY" ]; then
+    PARACHAIN_BINARY="target/release/moonbase-alphanet"
 fi
 
 if [ -z "$PARACHAIN_SPEC_TEMPLATE" ]; then
@@ -76,7 +76,7 @@ if [ -z "$SUDO_SEED" ]; then
     SUDO_SEED="0x078782a1f82fd4f9ab59131646f92caa3104dfb6b6975d025647760f693991b3"
 fi
 
-RELAY_NODE_KEYS=(
+NODE_KEYS=(
     0000000000000000000000000000000000000000000000000000000000000000
     1111111111111111111111111111111111111111111111111111111111111111
     2222222222222222222222222222222222222222222222222222222222222222

--- a/scripts/generate-relay-specs.sh
+++ b/scripts/generate-relay-specs.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 source scripts/_init_var.sh
 
-POLKADOT_VERSION=`egrep -o 'paritytech/polkadot.*#([^\"]*)' Cargo.lock | head -1 | sed 's/.*#//' |  cut -c1-8`
+if [ -z "$POLKADOT_VERSION" ]; then
+  POLKADOT_VERSION="sha-`egrep -o 'paritytech/polkadot.*#([^\"]*)' Cargo.lock | head -1 | sed 's/.*#//' |  cut -c1-8`"
+fi
 
-# TODO remove this once docker images are tagger with revision
-POLKADOT_VERSION="latest"
 
 echo "Using Polkadot revision #${POLKADOT_VERSION}"
 

--- a/scripts/run-alphanet-parachain.sh
+++ b/scripts/run-alphanet-parachain.sh
@@ -18,6 +18,12 @@
 # Loading binary/specs variables
 source scripts/_init_var.sh
 
+if [ ! -f "$PARACHAIN_BINARY" ]; then
+    echo "Parachain binary $PARACHAIN_BINARY is missing"
+    echo "Please run: cargo build --release -p moonbase-alphanet"
+    exit 1
+fi
+
 # We retrieve the list of relay node for 
 RELAY_PORT=$((USER_PORT + 42))
 RELAY_INDEX=0
@@ -54,6 +60,13 @@ do
     fi
 done
 
+if [ -z "$PARACHAIN_BASE_PREFIX" ]; then
+    PARACHAIN_BASE_PATH="--tmp"
+    RELAY_BASE_PATH="--tmp"
+else
+    PARACHAIN_BASE_PATH="$PARACHAIN_BASE_PREFIX-parachain-$PARACHAIN_INDEX"
+    RELAY_BASE_PATH="$PARACHAIN_BASE_PREFIX-relay-$PARACHAIN_INDEX"
+fi
 
 echo "parachain $PARACHAIN_INDEX ($PARACHAIN_ID) - p2p-port: $((PARACHAIN_PORT + 10)), http-port: $((PARACHAIN_PORT + 10 + 1)) , ws-port: $((PARACHAIN_PORT + 10 + 2))"
 
@@ -64,13 +77,13 @@ $PARACHAIN_BINARY \
     --ws-port $((PARACHAIN_PORT + 10 + 2)) \
     --validator \
     --name parachain_$PARACHAIN_INDEX \
-    --tmp \
+    $PARACHAIN_BASE_PATH \
     '-linfo,evm=trace,ethereum=trace,rpc=trace' \
     --chain $PARACHAIN_SPEC_PLAIN  \
     $PARACHAIN_BOOTNODES_ARGS \
     -- \
       --node-key ${PARACHAIN_KEYS[$PARACHAIN_INDEX]} \
-      --tmp \
+      $RELAY_BASE_PATH \
       --port $((PARACHAIN_PORT)) \
       --rpc-port $((PARACHAIN_PORT + 1)) \
       --ws-port $((PARACHAIN_PORT + 2)) \

--- a/scripts/run-alphanet-parachain.sh
+++ b/scripts/run-alphanet-parachain.sh
@@ -62,10 +62,8 @@ done
 
 if [ -z "$PARACHAIN_BASE_PREFIX" ]; then
     PARACHAIN_BASE_PATH="--tmp"
-    RELAY_BASE_PATH="--tmp"
 else
     PARACHAIN_BASE_PATH="$PARACHAIN_BASE_PREFIX-parachain-$PARACHAIN_INDEX"
-    RELAY_BASE_PATH="$PARACHAIN_BASE_PREFIX-relay-$PARACHAIN_INDEX"
 fi
 
 echo "parachain $PARACHAIN_INDEX ($PARACHAIN_ID) - p2p-port: $((PARACHAIN_PORT + 10)), http-port: $((PARACHAIN_PORT + 10 + 1)) , ws-port: $((PARACHAIN_PORT + 10 + 2))"
@@ -83,7 +81,7 @@ $PARACHAIN_BINARY \
     $PARACHAIN_BOOTNODES_ARGS \
     -- \
       --node-key ${PARACHAIN_KEYS[$PARACHAIN_INDEX]} \
-      $RELAY_BASE_PATH \
+      $PARACHAIN_BASE_PATH \
       --port $((PARACHAIN_PORT)) \
       --rpc-port $((PARACHAIN_PORT + 1)) \
       --ws-port $((PARACHAIN_PORT + 2)) \

--- a/scripts/run-alphanet-relay.sh
+++ b/scripts/run-alphanet-relay.sh
@@ -43,17 +43,17 @@ echo "relay ${RELAY_INDEX} - p2p-port: $((RELAY_PORT)), http-port: $((RELAY_PORT
 # This part will insert the keys in the node
 bash -c "sleep 5; \
 insertKey() { \
-	curl http://localhost:$((RELAY_PORT + 2)) -H \"Content-Type:application/json;charset=utf-8\" -d '
+	curl http://localhost:$((RELAY_PORT + 1)) -H 'Content-Type:application/json;charset=utf-8' -d \"
 	{
-		\"jsonrpc\":\"2.0\",
-		\"id\":1,
-		\"method\":\"author_insertKey\",
-		\"params\": [
-			\"$1\",
-			\"$2\",
-			\"$3\"
+		\\\"jsonrpc\\\":\\\"2.0\\\",
+		\\\"id\\\":1,
+		\\\"method\\\":\\\"author_insertKey\\\",
+		\\\"params\\\": [
+			\\\"\$1\\\",
+			\\\"\$2\\\",
+			\\\"\$3\\\"
 		]
-	}'; \
+	}\"; \
 }; \
 \
 insertKey acco '${RELAY_SEEDS[$RELAY_INDEX]}' '${RELAY_SR25519_PUB[$RELAY_INDEX]}'; \
@@ -65,6 +65,11 @@ insertKey audi '${RELAY_SEEDS[$RELAY_INDEX]}' '${RELAY_SR25519_PUB[$RELAY_INDEX]
 insertKey para '${RELAY_SEEDS[$RELAY_INDEX]}' '${RELAY_SR25519_PUB[$RELAY_INDEX]}'; \
  " &
 
+if [ -z "$RELAY_BASE_PREFIX" ]; then
+    RELAY_BASE_PATH="--tmp"
+else
+    RELAY_BASE_PATH="$RELAY_BASE_PREFIX-relay-$RELAY_INDEX"
+fi
 
 # The -v build:/build allows to pass the spec files from the build folder to the docker container
 docker run \
@@ -75,8 +80,8 @@ docker run \
     -it purestake/moonbase-relay-testnet:latest \
     /usr/local/bin/polkadot \
         --chain /$POLKADOT_SPEC_RAW \
-        --node-key ${RELAY_NODE_KEYS[$RELAY_INDEX]} \
-        --tmp \
+        --node-key ${NODE_KEYS[$RELAY_INDEX]} \
+        $RELAY_BASE_PATH \
         --validator \
         --force-authoring \
         --name relay_$RELAY_INDEX \

--- a/scripts/run-moonbase-standalone.sh
+++ b/scripts/run-moonbase-standalone.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# User port XX000
+# Standalone port (XX+5)000
+# 42 for p2p
+# 43 for http
+# 44 for ws
+#
+# Ex: USER_PORT=20000 scripts/run-moonbase-standalone.sh
+# will open port 21542, 21543, 21544
+
+# Loading binary/specs variables
+source scripts/_init_var.sh
+
+if [ ! -f "$STANDALONE_BINARY" ]; then
+    echo "Standalone binary $STANDALONE_BINARY is missing"
+    echo "Please run: cargo build --release -p moonbase-standalone"
+    exit 1
+fi
+
+STANDALONE_PORT=$((USER_PORT + 500 + 42))
+STANDALONE_INDEX=0
+STANDALONE_BOOTNODES_ARGS=""
+while nc -z -v -w5 ${RELAY_IP} ${STANDALONE_PORT} 2> /dev/null
+do 
+    echo "Found existing relay on ${STANDALONE_PORT}."
+    BOOTNODES_ARGS="$BOOTNODES_ARGS --bootnodes /ip4/$RELAY_IP/tcp/${STANDALONE_PORT}/p2p/${RELAY_LOCAL_IDS[$STANDALONE_INDEX]}"
+    STANDALONE_INDEX=$((STANDALONE_INDEX + 1))
+    STANDALONE_PORT=$((STANDALONE_PORT + 100))
+    
+    if [ $STANDALONE_PORT -ge $((USER_PORT + 800)) ]
+    then
+        echo "No more standalone port available! (limited to 3 standalone nodes)"
+        exit 1
+    fi
+done
+
+echo "Node $STANDALONE_INDEX - p2p-port: $((STANDALONE_PORT)), http-port: $((STANDALONE_PORT + 1)) , ws-port: $((STANDALONE_PORT + 2))"
+
+if [ -z "$BASE_PREFIX" ]; then
+    BASE_PATH="--tmp"
+else
+    BASE_PATH="$BASE_PREFIX-relay-$STANDALONE_INDEX"
+fi
+
+$STANDALONE_BINARY \
+    --node-key ${NODE_KEYS[$STANDALONE_INDEX]} \
+    --dev \
+    --port $((STANDALONE_PORT)) \
+    --rpc-port $((STANDALONE_PORT + 1)) \
+    --ws-port $((STANDALONE_PORT + 2)) \
+    --validator \
+    --name STANDALONE_$STANDALONE_INDEX \
+    $STANDALONE_BASE_PATH \
+    '-linfo,evm=trace,ethereum=trace,rpc=trace' \
+    $STANDALONE_BOOTNODES_ARGS

--- a/scripts/run-moonbase-standalone.sh
+++ b/scripts/run-moonbase-standalone.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # User port XX000
-# Standalone port (XX+5)000
+# Standalone port XX500
 # 42 for p2p
 # 43 for http
 # 44 for ws

--- a/scripts/run-moonbase-standalone.sh
+++ b/scripts/run-moonbase-standalone.sh
@@ -43,7 +43,12 @@ else
     BASE_PATH="$BASE_PREFIX-relay-$STANDALONE_INDEX"
 fi
 
-$STANDALONE_BINARY \
+EXECUTABLE=$STANDALONE_BINARY
+if [ ! -z "$PERF" ]; then
+    EXECUTABLE="$PERF $STANDALONE_BINARY"
+fi
+
+$EXECUTABLE \
     --node-key ${NODE_KEYS[$STANDALONE_INDEX]} \
     --dev \
     --port $((STANDALONE_PORT)) \

--- a/specs/moonbase-alphanet-dev-specs-template.json
+++ b/specs/moonbase-alphanet-dev-specs-template.json
@@ -1,0 +1,40 @@
+{
+  "name": "Moonbase Alpha Dev",
+  "id": "local_testnet",
+  "chainType": "Local",
+  "bootNodes": [],
+  "telemetryEndpoints": null,
+  "protocolId": null,
+  "properties": null,
+  "relay_chain": "local_testnet",
+  "para_id": 1000,
+  "consensusEngine": null,
+  "genesis": {
+    "runtime": {
+      "frameSystem": {
+        "changesTrieConfig": null,
+        "code": "<runtime_code>"
+      },
+      "palletBalances": {
+        "balances": [
+        ]
+      },
+      "palletSudo": {
+        "key": "13jU2C8jiAMkMv5iXiJ8Ue2xLTmJo4byfKm5gBehqPAvkGC4"
+      },
+      "parachainInfo": {
+        "parachainId": 1000
+      },
+      "palletEvm": {
+        "accounts": {
+          "0x6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b": {
+            "balance": "0x11529215046068469760001",
+            "nonce": "0x0",
+            "storage": {},
+            "code": []
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the standalone script.
Change the run-alphanet-relay.sh script to be based on the polkadot commit number from the cargo.toml (previously was using "latest")