### PR TITLE
fix runtime build

### DIFF
--- a/runtime/parachain/src/lib.rs
+++ b/runtime/parachain/src/lib.rs
@@ -459,7 +459,7 @@ impl_runtime_apis! {
 		}
 
 		fn gas_price() -> U256 {
-			FixedGasPrice::min_gas_price()
+			<Runtime as pallet_evm::Trait>::FeeCalculator::min_gas_price()
 		}
 
 		fn account_code_at(address: H160) -> Vec<u8> {

--- a/runtime/standalone/src/lib.rs
+++ b/runtime/standalone/src/lib.rs
@@ -469,7 +469,7 @@ impl_runtime_apis! {
 		}
 
 		fn gas_price() -> U256 {
-			FixedGasPrice::min_gas_price()
+			<Runtime as frame_evm::Trait>::FeeCalculator::min_gas_price()
 		}
 
 		fn account_code_at(address: H160) -> Vec<u8> {


### PR DESCRIPTION
This PR is a followup to #65 which I merged before it was ready. This fixes the build by removing all references to the removed `FixedGasPrice` struct.