### PR TITLE
CI enforces editorconfig compliance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         cd tests
         npm install
         BINARY_PATH='../target/release/moonbase-standalone' npm run test;
-    - 
+    -
       name: Save parachain binary
       run: |
         mkdir -p build/alphanet
@@ -413,3 +413,7 @@ jobs:
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
+
+  check-editorconfig:
+    runs-on: ubuntu-latest
+    uses: zbeekman/EditorConfig-Action@v1.1.0


### PR DESCRIPTION
This PR adds a CI job that checks whether the code conforms to our editorconfig file.

The Frontier repo also does this without an action. So if the action doesn't work out, we can try it this way https://github.com/paritytech/frontier/blob/master/.github/workflows/editorconfig.yml