### PR TITLE
Added toolchain file to WASM

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -4,8 +4,10 @@ set -e
 
 echo "*** Initializing WASM build environment"
 
+RUST_NIGHTLY_VERSION=$(cat rust-toolchain)
+
 if [ -z ${WASM_BUILD_TOOLCHAIN+x} ]; then
-	WASM_BUILD_TOOLCHAIN=nightly
+	WASM_BUILD_TOOLCHAIN=$RUST_NIGHTLY_VERSION
 fi
 
 if [ -z $CI_PROJECT_NAME ] ; then


### PR DESCRIPTION
This goes with the same PR from @JoshOrndorff about adding the rust-toolchain file. 

This way we can use the _init.sh_ script in the tutorial to make sure people are using a nightly version compatible with our build and they add the wasm32 to that nightly build.