### PR TITLE
CI: Publish Docker images on PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,6 @@ jobs:
   docker-parachain:
     runs-on: ubuntu-latest
     needs: ['get-variables', 'build', 'generate-parachain-specs']
-    if: needs.get-variables.outputs.tag-exists == 0 && github.event_name != 'pull_request'
     steps:
       -
         uses: actions/checkout@v2
@@ -224,7 +223,6 @@ jobs:
   docker-standalone:
     runs-on: ubuntu-latest
     needs: ['get-variables', 'build']
-    if: needs.get-variables.outputs.tag-exists == 0 && github.event_name != 'pull_request'
     steps:
       -
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR removes some conditions on the docker image publishing jobs so that they run every time the CI itself runs. This will allow us to have docker images for PR branches.