### PR TITLE
Revert most of #70 (ef43de6)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,6 @@
 name: Release
 
-on:
-  pull_request:
-    branches:
-    - master
-  push:
-    branches:
-    - master
+on: ['push']
 
 jobs:
   get-variables:


### PR DESCRIPTION
This PR reverts the primary change introduced in #70. The desired behavior is that the CI runs on pushes to any branch in this repo, but not on PRs from external branches.