### PR TITLE
Crystalin fix standalone docker

### DIFF
--- a/docker/moonbase-alphanet.Dockerfile
+++ b/docker/moonbase-alphanet.Dockerfile
@@ -20,7 +20,7 @@ RUN mv /usr/share/ca* /tmp && \
 
 USER moonbeam
 
-COPY build/alphanet /moonbase-alphanet
+COPY --chown=moonbeam build/alphanet /moonbase-alphanet
 RUN chmod uog+x /moonbase-alphanet/moonbase-alphanet
 
 # 30333 for p2p traffic

--- a/docker/moonbase-alphanet.Dockerfile
+++ b/docker/moonbase-alphanet.Dockerfile
@@ -13,7 +13,7 @@ RUN mv /usr/share/ca* /tmp && \
 	rm -rf /usr/lib/python* && \
 	useradd -m -u 1000 -U -s /bin/sh -d /moonbase-alphanet moonbeam && \
 	mkdir -p /moonbase-alphanet/.local/share/moonbase-alphanet && \
-	chown -R moonbeam:moonbeam /moonbase-alphanet/.local && \
+	chown -R moonbeam:moonbeam /moonbase-alphanet && \
 	ln -s /moonbase-alphanet/.local/share/moonbase-alphanet /data && \
 	rm -rf /usr/bin /usr/sbin
 
@@ -21,6 +21,7 @@ RUN mv /usr/share/ca* /tmp && \
 USER moonbeam
 
 COPY build/alphanet /moonbase-alphanet
+RUN chmod uog+x /moonbase-alphanet/moonbase-alphanet
 
 # 30333 for p2p traffic
 # 9933 for RPC call

--- a/docker/moonbase-standalone.Dockerfile
+++ b/docker/moonbase-standalone.Dockerfile
@@ -13,7 +13,7 @@ RUN mv /usr/share/ca* /tmp && \
 	rm -rf /usr/lib/python* && \
 	useradd -m -u 1000 -U -s /bin/sh -d /moonbase moonbeam && \
 	mkdir -p /moonbase/.local/share/moonbase && \
-	chown -R moonbeam:moonbeam /moonbase/.local && \
+	chown -R moonbeam:moonbeam /moonbase && \
 	ln -s /moonbase/.local/share/moonbase /data && \
 	rm -rf /usr/bin /usr/sbin
 
@@ -28,7 +28,7 @@ COPY build/standalone /moonbase
 # 9615 for Prometheus (metrics)
 EXPOSE 30333 9933 9944 9615
 
-CMD ["/moonbase/moonbase", \
+CMD ["/moonbase/moonbase-standalone", \
 	"--dev" \
 	"--tmp" \
 	"--charlie" \

--- a/docker/moonbase-standalone.Dockerfile
+++ b/docker/moonbase-standalone.Dockerfile
@@ -21,6 +21,7 @@ RUN mv /usr/share/ca* /tmp && \
 USER moonbeam
 
 COPY --chown=moonbeam build/standalone /moonbase
+RUN chmod uog+x /moonbase/moonbase-standalone
 
 # 30333 for p2p traffic
 # 9933 for RPC call

--- a/docker/moonbase-standalone.Dockerfile
+++ b/docker/moonbase-standalone.Dockerfile
@@ -20,7 +20,7 @@ RUN mv /usr/share/ca* /tmp && \
 
 USER moonbeam
 
-COPY build/standalone /moonbase
+COPY --chown=moonbeam build/standalone /moonbase
 
 # 30333 for p2p traffic
 # 9933 for RPC call


### PR DESCRIPTION
This PR fixes the `permission denied` issue when executing the docker images directly, for our automatically built docker image (parachain + standalone)