### PR TITLE
Tiny indentation fix

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -75,7 +75,7 @@ standalone = [
 	"pallet-aura",
 	"sp-consensus-aura",
 	"pallet-grandpa",
-	]
+]
 std = [
 	"codec/std",
 	"serde",


### PR DESCRIPTION
This PR fixes a tiny indentation problem in the runtime `Cargo.toml`. I noticed it during seminar this morning.