### PR TITLE
added 18 decimals to chain specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,6 +3670,7 @@ dependencies = [
  "sc-transaction-graph",
  "sc-transaction-pool",
  "serde",
+ "serde_json",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",

--- a/node/parachain/Cargo.toml
+++ b/node/parachain/Cargo.toml
@@ -23,6 +23,7 @@ codec = { package = 'parity-scale-codec', version = '1.0.0' }
 structopt = "0.3.3"
 ansi_term = "0.12.1"
 serde = { version = "1.0.101", features = ["derive"] }
+serde_json = "1.0"
 jsonrpc-core = "14.0.3"
 jsonrpc-pubsub = "14.0.3"
 

--- a/node/parachain/src/chain_spec.rs
+++ b/node/parachain/src/chain_spec.rs
@@ -93,7 +93,12 @@ pub fn get_chain_spec(id: ParaId) -> Result<ChainSpec, String> {
 		vec![],
 		None,
 		None,
-		None,
+		Some(
+			serde_json::from_str(
+				"{\"tokenDecimals\": 18}"
+			)
+			.expect("Provided valid json map")
+		),,
 		Extensions {
 			relay_chain: "local_testnet".into(),
 			para_id: id.into(),
@@ -118,7 +123,12 @@ pub fn staging_test_net(id: ParaId) -> Result<ChainSpec, String> {
 		Vec::new(),
 		None,
 		None,
-		None,
+		Some(
+			serde_json::from_str(
+				"{\"tokenDecimals\": 18}"
+			)
+			.expect("Provided valid json map")
+		),,
 		Extensions {
 			relay_chain: "rococo_local_testnet".into(),
 			para_id: id.into(),

--- a/node/parachain/src/chain_spec.rs
+++ b/node/parachain/src/chain_spec.rs
@@ -98,7 +98,7 @@ pub fn get_chain_spec(id: ParaId) -> Result<ChainSpec, String> {
 				"{\"tokenDecimals\": 18}"
 			)
 			.expect("Provided valid json map")
-		),,
+		),
 		Extensions {
 			relay_chain: "local_testnet".into(),
 			para_id: id.into(),
@@ -128,7 +128,7 @@ pub fn staging_test_net(id: ParaId) -> Result<ChainSpec, String> {
 				"{\"tokenDecimals\": 18}"
 			)
 			.expect("Provided valid json map")
-		),,
+		),
 		Extensions {
 			relay_chain: "rococo_local_testnet".into(),
 			para_id: id.into(),

--- a/node/standalone/Cargo.lock
+++ b/node/standalone/Cargo.lock
@@ -3492,6 +3492,7 @@ dependencies = [
  "sc-service",
  "sc-transaction-graph",
  "sc-transaction-pool",
+ "serde_json",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",

--- a/node/standalone/Cargo.toml
+++ b/node/standalone/Cargo.toml
@@ -26,6 +26,7 @@ log = "0.4.8"
 structopt = "0.3.8"
 jsonrpc-core = "14.0.3"
 jsonrpc-pubsub = "14.0.3"
+serde_json = "1.0"
 
 sp-api = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-branch" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-branch" }

--- a/node/standalone/src/chain_spec.rs
+++ b/node/standalone/src/chain_spec.rs
@@ -89,7 +89,12 @@ pub fn development_config() -> Result<ChainSpec, String> {
 		// Protocol ID
 		None,
 		// Properties
-		None,
+		Some(
+			serde_json::from_str(
+				"{\"tokenDecimals\": 18}"
+			)
+			.expect("Provided valid json map")
+		),
 		// Extensions
 		None,
 	))
@@ -137,7 +142,12 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 		// Protocol ID
 		None,
 		// Properties
-		None,
+		Some(
+			serde_json::from_str(
+				"{\"tokenDecimals\": 18}"
+			)
+			.expect("Provided valid json map")
+		),
 		// Extensions
 		None,
 	))

--- a/specs/moonbase-alphanet-dev-specs-template.json
+++ b/specs/moonbase-alphanet-dev-specs-template.json
@@ -5,7 +5,9 @@
   "bootNodes": [],
   "telemetryEndpoints": null,
   "protocolId": null,
-  "properties": null,
+  "properties": {
+    "tokenDecimals": 18
+  },
   "relay_chain": "local_testnet",
   "para_id": 1000,
   "consensusEngine": null,

--- a/specs/moonbase-alphanet-specs-template.json
+++ b/specs/moonbase-alphanet-specs-template.json
@@ -5,7 +5,9 @@
   "bootNodes": [],
   "telemetryEndpoints": null,
   "protocolId": null,
-  "properties": null,
+  "properties": {
+    "tokenDecimals": 18
+  },
   "relay_chain": "local_testnet",
   "para_id": 1000,
   "consensusEngine": null,

--- a/specs/rococo-alphanet-specs-template.json
+++ b/specs/rococo-alphanet-specs-template.json
@@ -5,7 +5,9 @@
   "bootNodes": [],
   "telemetryEndpoints": null,
   "protocolId": "dot",
-  "properties": null,
+  "properties": {
+    "tokenDecimals": 18
+  },
   "consensusEngine": null,
   "genesis": {
     "runtime": {

--- a/tests/moonbeam-test-specs/simple-specs.json
+++ b/tests/moonbeam-test-specs/simple-specs.json
@@ -5,7 +5,9 @@
   "bootNodes": [],
   "telemetryEndpoints": null,
   "protocolId": null,
-  "properties": null,
+  "properties": {
+    "tokenDecimals": 18
+  },
   "consensusEngine": null,
   "genesis": {
     "runtime": {

--- a/tests/moonbeam-test-specs/templates/simple-specs-template.json
+++ b/tests/moonbeam-test-specs/templates/simple-specs-template.json
@@ -5,7 +5,9 @@
   "bootNodes": [],
   "telemetryEndpoints": null,
   "protocolId": null,
-  "properties": null,
+  "properties": {
+    "tokenDecimals": 18
+  },
   "consensusEngine": null,
   "genesis": {
     "runtime": {


### PR DESCRIPTION
If not specified in chain specs, decimals will default to 15.

We should set it to 18, the standard decimal number for ethereum.

solves #98 