### PR TITLE
Increase Genesis Account Balance

### DIFF
--- a/node/standalone/src/chain_spec.rs
+++ b/node/standalone/src/chain_spec.rs
@@ -147,8 +147,8 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		}),
 		pallet_balances: Some(BalancesConfig {
-			// Configure endowed accounts with initial balance of 1000000 << 64.
-			balances: endowed_accounts.iter().cloned().map(|k|(k, 1000000 << 64)).collect(),
+			// Configure endowed accounts with initial balance of 1 << 70.
+			balances: endowed_accounts.iter().cloned().map(|k|(k, 1 << 70)).collect(),
 		}),
 		pallet_aura: Some(AuraConfig {
 			authorities: initial_authorities.iter().map(|x| (x.0.clone())).collect(),

--- a/node/standalone/src/chain_spec.rs
+++ b/node/standalone/src/chain_spec.rs
@@ -147,8 +147,8 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		}),
 		pallet_balances: Some(BalancesConfig {
-			// Configure endowed accounts with initial balance of 1 << 60.
-			balances: endowed_accounts.iter().cloned().map(|k|(k, 1 << 60)).collect(),
+			// Configure endowed accounts with initial balance of 1000000 << 64.
+			balances: endowed_accounts.iter().cloned().map(|k|(k, 1000000 << 64)).collect(),
 		}),
 		pallet_aura: Some(AuraConfig {
 			authorities: initial_authorities.iter().map(|x| (x.0.clone())).collect(),

--- a/node/standalone/src/chain_spec.rs
+++ b/node/standalone/src/chain_spec.rs
@@ -147,8 +147,8 @@ fn testnet_genesis(
 			changes_trie_config: Default::default(),
 		}),
 		pallet_balances: Some(BalancesConfig {
-			// Configure endowed accounts with initial balance of 1 << 70.
-			balances: endowed_accounts.iter().cloned().map(|k|(k, 1 << 70)).collect(),
+			// Configure endowed accounts with initial balance of 1 << 80.
+			balances: endowed_accounts.iter().cloned().map(|k|(k, 1 << 80)).collect(),
 		}),
 		pallet_aura: Some(AuraConfig {
 			authorities: initial_authorities.iter().map(|x| (x.0.clone())).collect(),


### PR DESCRIPTION
This increases the genesis account balance from 1.1529... to 18446744.0737....

We testing with @tgmichel we realized that the Genesis account did not account for the decimal format. So I've modified the number on the bit-shift operation to increase the initial balance.