### PR TITLE
Reduce Hotfixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "frontier-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#2c7139c768d675c8a6f360014a472297b74169f7"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
 dependencies = [
  "derive_more 0.99.11",
  "ethereum",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "frontier-consensus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#2c7139c768d675c8a6f360014a472297b74169f7"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "frontier-rpc"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#2c7139c768d675c8a6f360014a472297b74169f7"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1989,7 +1989,7 @@ dependencies = [
 [[package]]
 name = "frontier-rpc-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#2c7139c768d675c8a6f360014a472297b74169f7"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "frontier-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#2c7139c768d675c8a6f360014a472297b74169f7"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4298,7 +4298,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#2c7139c768d675c8a6f360014a472297b74169f7"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
 dependencies = [
  "ethereum",
  "ethereum-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "frontier-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#e4796f383475731942092fc08f21866590d2c198"
 dependencies = [
  "derive_more 0.99.11",
  "ethereum",
@@ -1944,7 +1944,7 @@ dependencies = [
 [[package]]
 name = "frontier-consensus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#e4796f383475731942092fc08f21866590d2c198"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -1955,7 +1955,7 @@ dependencies = [
 [[package]]
 name = "frontier-rpc"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#e4796f383475731942092fc08f21866590d2c198"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1989,7 +1989,7 @@ dependencies = [
 [[package]]
 name = "frontier-rpc-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#e4796f383475731942092fc08f21866590d2c198"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "frontier-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#e4796f383475731942092fc08f21866590d2c198"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4298,7 +4298,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#e4796f383475731942092fc08f21866590d2c198"
 dependencies = [
  "ethereum",
  "ethereum-types",

--- a/node/standalone/Cargo.lock
+++ b/node/standalone/Cargo.lock
@@ -1741,7 +1741,7 @@ dependencies = [
 [[package]]
 name = "frontier-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#e4796f383475731942092fc08f21866590d2c198"
 dependencies = [
  "derive_more",
  "ethereum",
@@ -1764,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "frontier-consensus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#e4796f383475731942092fc08f21866590d2c198"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "frontier-rpc"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#e4796f383475731942092fc08f21866590d2c198"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "frontier-rpc-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#e4796f383475731942092fc08f21866590d2c198"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "frontier-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#e4796f383475731942092fc08f21866590d2c198"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#e4796f383475731942092fc08f21866590d2c198"
 dependencies = [
  "ethereum",
  "ethereum-types",

--- a/node/standalone/Cargo.lock
+++ b/node/standalone/Cargo.lock
@@ -1741,7 +1741,7 @@ dependencies = [
 [[package]]
 name = "frontier-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#2c7139c768d675c8a6f360014a472297b74169f7"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
 dependencies = [
  "derive_more",
  "ethereum",
@@ -1764,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "frontier-consensus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#2c7139c768d675c8a6f360014a472297b74169f7"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -1775,7 +1775,7 @@ dependencies = [
 [[package]]
 name = "frontier-rpc"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#2c7139c768d675c8a6f360014a472297b74169f7"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "frontier-rpc-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#2c7139c768d675c8a6f360014a472297b74169f7"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "frontier-rpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#2c7139c768d675c8a6f360014a472297b74169f7"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#2c7139c768d675c8a6f360014a472297b74169f7"
+source = "git+https://github.com/purestake/frontier?branch=v0.3-hotfixes#06ffc598983d8ac51133eb0b516769ea42855010"
 dependencies = [
  "ethereum",
  "ethereum-types",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -45,7 +45,7 @@ use parachain::*;
 
 use codec::{Decode, Encode};
 use sp_api::impl_runtime_apis;
-use sp_core::{OpaqueMetadata, H160, U256};
+use sp_core::{OpaqueMetadata, H160, H256, U256};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{BlakeTwo256, Block as BlockT, IdentityLookup, Saturating, IdentifyAccount, Verify},
@@ -70,6 +70,7 @@ use pallet_evm::{
 	Account as EVMAccount, IdentityAddressMapping, EnsureAddressSame,
 	EnsureAddressNever, FeeCalculator, Runner
 };
+use pallet_ethereum::TransactionStatus;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
@@ -424,6 +425,20 @@ impl_runtime_apis! {
 			<Runtime as pallet_evm::Trait>::FeeCalculator::min_gas_price()
 		}
 
+		fn account_code_at(address: H160) -> Vec<u8> {
+			EVM::account_codes(address)
+		}
+
+		fn author() -> H160 {
+			<pallet_ethereum::Module<Runtime>>::find_author()
+		}
+
+		fn storage_at(address: H160, index: U256) -> H256 {
+			let mut tmp = [0u8; 32];
+			index.to_big_endian(&mut tmp);
+			EVM::account_storages(address, H256::from_slice(&tmp[..]))
+		}
+
 		fn call(
 			from: H160,
 			to: H160,
@@ -460,6 +475,30 @@ impl_runtime_apis! {
 				gas_price,
 				nonce,
 			).map_err(|err| err.into())
+		}
+
+		fn current_transaction_statuses() -> Option<Vec<TransactionStatus>> {
+			Ethereum::current_transaction_statuses()
+		}
+
+		fn current_block() -> Option<pallet_ethereum::Block> {
+			Ethereum::current_block()
+		}
+
+		fn current_receipts() -> Option<Vec<pallet_ethereum::Receipt>> {
+			Ethereum::current_receipts()
+		}
+
+		fn current_all() -> (
+			Option<pallet_ethereum::Block>,
+			Option<Vec<pallet_ethereum::Receipt>>,
+			Option<Vec<TransactionStatus>>
+		) {
+			(
+				Ethereum::current_block(),
+				Ethereum::current_receipts(),
+				Ethereum::current_transaction_statuses()
+			)
 		}
 	}
 

--- a/runtime/src/parachain.rs
+++ b/runtime/src/parachain.rs
@@ -25,7 +25,7 @@ macro_rules! runtime_parachain {
 			spec_name: create_runtime_str!("moonbase-alphanet"),
 			impl_name: create_runtime_str!("moonbase-alphanet"),
 			authoring_version: 3,
-			spec_version: 4,
+			spec_version: 5,
 			impl_version: 0,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 1,

--- a/runtime/src/standalone.rs
+++ b/runtime/src/standalone.rs
@@ -33,7 +33,7 @@ macro_rules! runtime_standalone {
 			spec_name: create_runtime_str!("moonbeam-standalone"),
 			impl_name: create_runtime_str!("moonbeam-standalone"),
 			authoring_version: 3,
-			spec_version: 4,
+			spec_version: 5,
 			impl_version: 0,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 1,


### PR DESCRIPTION
This PR removes a few hotfixes from our frontier fork and makes the corresponding changes in Moonbeam. This is prep work for the v0.4 release and the merging of #102 . Specifically, it removes these two hotfixes:

* The "header patch" that initially adressed cumulus's unique best block.
* The stripping of the runtime API

@tgmichel and I believe that these 

### What important points reviewers should know?

### Is there something left for follow-up PRs?

* Remove the Longest Chain Rule from the parachain node - addressed in #134 
* Bump the `rust-toolchain` version

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

* #102 - The big Parachains V1  branch that we are prepping for
* https://github.com/paritytech/frontier/pull/199 - The direction we're heading for RPC optimization - justifies restoring the runtime API.

### What value does it bring to the blockchain users?

This PR does not add or change any user-facing functionality. It is techdebt cleanup and prep work for the v0.4 release which will bring user-facing changes.

## Checklist

- [NO] Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [NO] Does it require changes in documentation/tutorials ?
