### PR TITLE
update ripemd160 precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6206,7 +6206,6 @@ version = "0.1.0"
 dependencies = [
  "log",
  "pallet-evm",
- "ripemd160",
  "rustc-hex",
  "sp-core",
  "sp-std",

--- a/node/standalone/Cargo.lock
+++ b/node/standalone/Cargo.lock
@@ -4492,7 +4492,6 @@ version = "0.1.0"
 dependencies = [
  "log",
  "pallet-evm",
- "ripemd160",
  "rustc-hex",
  "sp-core",
  "sp-std",

--- a/runtime/precompiles/Cargo.toml
+++ b/runtime/precompiles/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 log = "0.4.8"
 rustc-hex = { version = "2.0.1", default-features = false }
-ripemd160 = { version = "0.9", default-features = false }
 
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
@@ -18,5 +17,4 @@ default = [ "std" ]
 std = [
 	"sp-std/std",
 	"sp-core/std",
-	"ripemd160/std",
 ]

--- a/runtime/precompiles/src/lib.rs
+++ b/runtime/precompiles/src/lib.rs
@@ -18,7 +18,7 @@
 
 use sp_std::prelude::*;
 use sp_core::H160;
-use pallet_evm::{ExitError, ExitSucceed, Precompile};
+use pallet_evm::{Precompile, Precompiles};
 
 pub struct ExperimentalMoonbeamPrecompiles;
 
@@ -43,7 +43,7 @@ fn ensure_linear_cost(
 // prepends "deadbeef" to any data provided
 struct DeadbeefPrecompiled;
 
-impl pallet_evm::Precompile for DeadbeefPrecompiled {
+impl Precompile for DeadbeefPrecompiled {
 	fn execute(
 		input: &[u8],
 		target_gas: Option<usize>
@@ -79,7 +79,7 @@ fn get_precompiled_func_from_address(address: &H160) -> Option<PrecompiledCallab
 	None
 }
 
-impl pallet_evm::Precompiles for ExperimentalMoonbeamPrecompiles {
+impl Precompiles for ExperimentalMoonbeamPrecompiles {
 	fn execute(
 		address: H160,
 		input: &[u8],
@@ -99,33 +99,11 @@ impl pallet_evm::Precompiles for ExperimentalMoonbeamPrecompiles {
 	}
 }
 
-
-
-use ripemd160::Digest;
-/// The ripemd precompile.
-pub struct Ripemd160;
-
-impl Precompile for Ripemd160 {
-	fn execute(
-		input: &[u8],
-		target_gas: Option<usize>,
-	) -> core::result::Result<(ExitSucceed, Vec<u8>, usize), ExitError> {
-		let cost = ensure_linear_cost(target_gas, input.len(), 600, 120)?;
-
-		let mut v32 = [0u8; 32];
-		v32[12..32].copy_from_slice(&ripemd160::Ripemd160::digest(input));
-		Ok((ExitSucceed::Returned, v32.to_vec(), cost))
-	}
-}
-
-
 pub type MoonbeamPrecompiles =
 (
 	pallet_evm::precompiles::ECRecover,
 	pallet_evm::precompiles::Sha256,
-	// Reset to pallet_evm ripemd160 once
-	// https://github.com/paritytech/substrate/pull/7296 is included
-	Ripemd160,
+	pallet_evm::precompiles::Ripemd160,
 	pallet_evm::precompiles::Identity,
 );
 

--- a/runtime/src/parachain.rs
+++ b/runtime/src/parachain.rs
@@ -24,7 +24,7 @@ macro_rules! runtime_parachain {
 			impl_name: create_runtime_str!("moonbase-alphanet"),
 			authoring_version: 3,
 			spec_version: 5,
-			impl_version: 0,
+			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 1,
 		};

--- a/runtime/src/standalone.rs
+++ b/runtime/src/standalone.rs
@@ -34,7 +34,7 @@ macro_rules! runtime_standalone {
 			impl_name: create_runtime_str!("moonbeam-standalone"),
 			authoring_version: 3,
 			spec_version: 5,
-			impl_version: 0,
+			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 1,
 		};


### PR DESCRIPTION
### What does it do?
- [x] replace direct ripemd160 impl with `pallet_evm::Ripemd160` from https://github.com/paritytech/substrate/pull/7296 CC @crystalin 

### Is there something left for follow-up PRs?
Use individual precompile crates introduced in https://github.com/paritytech/frontier/pull/242/

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?
https://github.com/paritytech/substrate/pull/7296

## Checklist

- Does it require a purge of the network? No
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- Does it require changes in documentation/tutorials ? No