### PR TITLE
Add missing --raw flag in the raw spec baking command

### DIFF
--- a/launch-notes.md
+++ b/launch-notes.md
@@ -138,7 +138,7 @@ Insert the custom session keys like so in the chain spec. (TODO as I mentioned a
 Finally, bake a raw spec
 
 ```bash
-./polkadot-d7257026-real-overseer build-spec --chain rococo-local-d7257026-real-overseer.json --disable-default-bootnode > rococo-local-d7257026-real-overseer-raw.json
+./polkadot-d7257026-real-overseer build-spec --chain rococo-local-d7257026-real-overseer.json --disable-default-bootnode --raw > rococo-local-d7257026-real-overseer-raw.json
 ```
 
 ## Validator Commands


### PR DESCRIPTION
### What does it do?

It adds a missing `--raw` flag to the raw chain spec baking command.
The `--raw` flag is already used to generate the raw chain spec, but is simply missing in this documentation.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
