### PR TITLE
Antoine clean tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,12 @@ npm install
 npm run test
 ```
 
+and to print more information:
+
+```
+npm run test-with-logs
+```
+
 This command will generate the simple-specs.json file from the template and execute the tests.  
 To only generate the specs use `npm run generate-specs`.  
 To only run the tests use `npm run test-only`.

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,8 +5,10 @@
   "main": "index.js",
   "scripts": {
     "generate-specs": "cd .. && scripts/generate-test-specs.sh",
+    "test-only-with-logs": "mocha  --printlogs -r ts-node/register 'tests/**/*.ts'",
     "test-only": "mocha -r ts-node/register 'tests/**/*.ts'",
-    "test": "npm run generate-specs && npm run test-only"
+    "test": "npm run generate-specs && npm run test-only",
+    "test-with-logs": "npm run generate-specs && npm run test-only-with-logs"
   },
   "author": "",
   "license": "ISC",

--- a/tests/tests/util/fillBlockWithTx.ts
+++ b/tests/tests/util/fillBlockWithTx.ts
@@ -77,6 +77,12 @@ interface FillBlockReport {
   sendingTime: number;
 }
 
+export interface ErrorReport {
+  [key: string]: {
+    [key: string]: number;
+  };
+}
+
 // This functiom sends a batch of signed transactions to the pool and records both
 // how many tx were included in the first block and the total numbe rof tx that were
 // included in a block
@@ -89,12 +95,6 @@ export async function fillBlockWithTx(
   let nonce: number = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
 
   const numberArray = new Array(numberOfTx).fill(1);
-
-  interface ErrorReport {
-    [key: string]: {
-      [key: string]: number;
-    };
-  }
 
   let errorReport: ErrorReport = {
     signing: {},
@@ -143,7 +143,7 @@ export async function fillBlockWithTx(
 
   log("Time it took to send " + respList.length + " tx is " + sendingTime / 1000 + " seconds");
 
-  log("Error Report : ", errorReport.toString());
+  log("Error Report : ", errorReport);
 
   log("created block in ", (await createAndFinalizeBlock(context.polkadotApi)) / 1000, " seconds");
 

--- a/tests/tests/util/fillBlockWithTx.ts
+++ b/tests/tests/util/fillBlockWithTx.ts
@@ -5,7 +5,7 @@ import { SignedTransaction, TransactionConfig } from "web3-core";
 import { basicTransfertx, GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY } from "../constants";
 import { wrappedCustomRequest } from "./web3Requests";
 import { createAndFinalizeBlock } from ".";
-import { Context } from "./testWithMoonbeam";
+import { Context, log } from "./testWithMoonbeam";
 
 function isSignedTransaction(tx: Error | SignedTransaction): tx is SignedTransaction {
   return (tx as SignedTransaction).rawTransaction !== undefined;
@@ -123,9 +123,7 @@ export async function fillBlockWithTx(
 
   const signingTime: number = Date.now() - startSigningTime;
 
-  console.log(
-    "Time it took to sign " + txList.length + " tx is " + signingTime / 1000 + " seconds"
-  );
+  log("Time it took to sign " + txList.length + " tx is " + signingTime / 1000 + " seconds");
 
   const startSendingTime: number = Date.now();
 
@@ -143,23 +141,17 @@ export async function fillBlockWithTx(
 
   const sendingTime: number = Date.now() - startSendingTime;
 
-  console.log(
-    "Time it took to send " + respList.length + " tx is " + sendingTime / 1000 + " seconds"
-  );
+  log("Time it took to send " + respList.length + " tx is " + sendingTime / 1000 + " seconds");
 
-  console.log("Error Report : ", errorReport);
+  log("Error Report : ", errorReport.toString());
 
-  console.log(
-    "created block in ",
-    (await createAndFinalizeBlock(context.polkadotApi)) / 1000,
-    " seconds"
-  );
+  log("created block in ", (await createAndFinalizeBlock(context.polkadotApi)) / 1000, " seconds");
 
   let numberOfBlocks = 0;
   let block = await context.web3.eth.getBlock("latest");
   let txPassed: number = block.transactions.length;
   const txPassedFirstBlock: number = txPassed;
-  console.log(
+  log(
     "block.gasUsed",
     block.gasUsed,
     "block.number",
@@ -174,7 +166,7 @@ export async function fillBlockWithTx(
     await createAndFinalizeBlock(context.polkadotApi);
 
     block = await context.web3.eth.getBlock("latest");
-    console.log(
+    log(
       "following block, block" + i + ".gasUsed",
       block.gasUsed,
       "block" + i + ".number",

--- a/tests/tests/util/testWithMoonbeam.ts
+++ b/tests/tests/util/testWithMoonbeam.ts
@@ -12,10 +12,11 @@ import {
   SPECS_PATH,
   WS_PORT,
 } from "../constants";
+import { ErrorReport } from "./fillBlockWithTx";
 
-export function log(...msg: (string | number)[]) {
-  if (process.argv0 && process.argv0 === "printlogs") {
-    console.log(msg);
+export function log(...msg: (string | number | ErrorReport)[]) {
+  if (process.argv && process.argv[2] && process.argv[2] === "--printlogs") {
+    console.log(...msg);
   }
 }
 

--- a/tests/tests/util/testWithMoonbeam.ts
+++ b/tests/tests/util/testWithMoonbeam.ts
@@ -13,6 +13,12 @@ import {
   WS_PORT,
 } from "../constants";
 
+export function log(...msg: (string | number)[]) {
+  if (process.argv0 && process.argv0 === "printlogs") {
+    console.log(msg);
+  }
+}
+
 export interface Context {
   web3: Web3;
 


### PR DESCRIPTION
### What does it do?

Only print miscellaneous logs when using the `npm run test-with-logs` command.
These logs are only interesting if one wants to learn about tx/block perf

### What alternative implementations were considered?
I could have used a package like yargs but I felt like it was a little overkill for this.

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [x] Does it require changes in documentation/tutorials ?
Yes, as updated in the readme (only important for devs)
