### PR TITLE
Adds script to test gas from a loop contract

### DIFF
--- a/tools/load-testing/load-gas-loop.ts
+++ b/tools/load-testing/load-gas-loop.ts
@@ -4,10 +4,9 @@ import yargs from "yargs";
 import * as rlp from "rlp";
 
 const argv = yargs(process.argv.slice(2))
-  .usage("Usage: $0  [--net stagenet] [--step 10]")
+  .usage("Usage: $0  [--net stagenet]")
   .version("1.0.0")
   .options({
-    step: { type: "number", default: 10 },
     net: { type: "string", default: "stagenet" },
   }).argv;
 
@@ -101,7 +100,7 @@ const callContract = async (loopCount: number) => {
       to: contractAddress,
       data: encoded,
       gasPrice: 0,
-      gas: 12000000,
+      gas: "9627370496",
       nonce: 0,
     },
     freshAccount.privateKey
@@ -130,9 +129,10 @@ const callContract = async (loopCount: number) => {
 
 const main = async () => {
   await deployContract();
-  let loopCount = 1;
-  while (true) {
-    await callContract(loopCount++ * argv.step);
+  let loopCount = 2;
+  while (loopCount > 0) {
+    await callContract(loopCount);
+    loopCount *= 2;
   }
 };
 

--- a/tools/load-testing/load-gas-loop.ts
+++ b/tools/load-testing/load-gas-loop.ts
@@ -1,0 +1,141 @@
+import { importAccount, compileSolidity, web3, customRequest, init } from "../init-web3";
+import { TransactionReceipt } from "web3-core";
+import yargs from "yargs";
+import * as rlp from "rlp";
+
+const argv = yargs(process.argv.slice(2))
+  .usage("Usage: $0  [--net stagenet] [--step 10]")
+  .version("1.0.0")
+  .options({
+    step: { type: "number", default: 10 },
+    net: { type: "string", default: "stagenet" },
+  }).argv;
+
+const contractSource = `
+pragma solidity >=0.4.22;
+
+contract Loop {
+  function big_loop(uint256 target) pure public returns (uint256) {
+    uint256 number = 0;
+    for (uint i = 0; i < target; i++) {
+      number += 1;
+    }
+    return number;
+  }
+}`;
+
+init(
+  argv["net"] == "stagenet"
+    ? "https://rpc.stagenet.moonbeam.gcp.purestake.run"
+    : argv["net"] == "localhost"
+    ? "http://127.0.0.1:9933"
+    : argv["net"] == "alan"
+    ? "http://127.0.0.1:56053"
+    : argv["net"] == "alan-standalone"
+    ? "http://127.0.0.1:55543"
+    : undefined
+);
+
+const contractCompiled = compileSolidity(contractSource, "Loop");
+const contractBytecode = contractCompiled.bytecode;
+const contractAbi = contractCompiled.contract.abi;
+const deployer = importAccount("79b78465e13f3bf8472492c0b6068bfab0a24de8ddd76346f7b09d779f435b9b");
+const contractAddress = "0x" + web3.utils.sha3(rlp.encode([deployer.address, 0]) as any).substr(26);
+
+const printAddressInfo = async (address: string) => {
+  const nonce = await web3.eth.getTransactionCount(address);
+  const balance = await web3.eth.getBalance(address);
+  console.log(`Account: ${address} (nonce: ${nonce}) => ${balance}`);
+};
+
+const deployContract = async () => {
+  // 1M gas contract call (big_loop)
+
+  const code = await customRequest("eth_getCode", [contractAddress]);
+  if (code.result != "0x") {
+    console.log("Contract already deployed");
+    return;
+  }
+
+  const tx = await web3.eth.accounts.signTransaction(
+    {
+      from: deployer.address,
+      data: contractBytecode,
+      value: "0x00",
+      gasPrice: "0x00",
+      gas: "0x1000000",
+      nonce: 0,
+    },
+    deployer.privateKey
+  );
+  const result = await customRequest("eth_sendRawTransaction", [tx.rawTransaction]);
+  if (result.error) {
+    console.error(`Error deploying contract!`);
+    console.error(result.error);
+    return;
+  }
+  console.log(`Transaction sent: ${tx.transactionHash}`);
+  const startTime = Date.now();
+  while (Date.now() - startTime < 40000) {
+    let rcpt: TransactionReceipt = await web3.eth.getTransactionReceipt(tx.transactionHash);
+    if (rcpt) {
+      console.log(`Transaction done - block #${rcpt.blockNumber} (${rcpt.blockHash})`);
+      return;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2000);
+    });
+  }
+  throw new Error("Failed to verify contract deployment (timeout)");
+};
+
+const callContract = async (loopCount: number) => {
+  const contract = new web3.eth.Contract(contractAbi, contractAddress);
+
+  const encoded = await contract.methods.big_loop(loopCount).encodeABI();
+
+  const freshAccount = web3.eth.accounts.create();
+  const tx = await web3.eth.accounts.signTransaction(
+    {
+      from: freshAccount.address,
+      to: contractAddress,
+      data: encoded,
+      gasPrice: 0,
+      gas: 12000000,
+      nonce: 0,
+    },
+    freshAccount.privateKey
+  );
+
+  const result = await customRequest("eth_sendRawTransaction", [tx.rawTransaction]);
+  if (result.error) {
+    console.error(result.error);
+    throw new Error(`Error calling contract!`);
+  }
+
+  console.log(`Transaction for Loop count ${loopCount} sent: ${tx.transactionHash}`);
+  const startTime = Date.now();
+  while (Date.now() - startTime < 60000) {
+    let rcpt: TransactionReceipt = await web3.eth.getTransactionReceipt(tx.transactionHash);
+    if (rcpt) {
+      console.log(`Loop count ${loopCount} - block #${rcpt.blockNumber} (${rcpt.blockHash})`);
+      return;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2000);
+    });
+  }
+  throw new Error("Failed to verify contract call (timeout)");
+};
+
+const main = async () => {
+  await deployContract();
+  let loopCount = 1;
+  while (true) {
+    await callContract(loopCount++ * argv.step);
+  }
+};
+
+main().catch((err) => {
+  console.log("Error", err);
+});

--- a/tools/package.json
+++ b/tools/package.json
@@ -10,6 +10,8 @@
     "ethjs-provider-http": "^0.1.6",
     "minimist": ">=0.2.1",
     "pkg": "^4.4.9",
+    "rlp": "^2.2.6",
+    "solc": "^0.8.0",
     "substrate-evm-contracts": "file:truffle",
     "truffle-privatekey-provider": "^1.5.0",
     "ts-node": "^8.10.1",
@@ -19,7 +21,7 @@
     "yargs": "^13.3.2"
   },
   "devDependencies": {
-    "@types/yargs": "^15.0.11"
+    "@types/yargs": "^15.0.12"
   },
   "scripts": {
     "package-moon-key": "node_modules/.bin/tsc moon-key.ts; node_modules/.bin/pkg -t node14 moon-key.js; rm moon-key.js"


### PR DESCRIPTION
### What does it do?
Adds a script to test the gas limit by using a Looping smart contract.
This is currently revealing a bug in the parachain implementation as we are reaching a limit of 110 addition before it fails to include in a block

Script is executed like this:
```
ts-node .\load-testing\load-gas-loop.ts -net alan-standalone
```
(there are few predefined --net but you can add yours)

You need to have a parachain or standalone running.
It will try to run a [smart contract ](https://github.com/PureStake/moonbeam/pull/155/files#diff-998fcd46ef5198c4a32dd2082a9a8bb5ffbc3a00ca489207bbc188c12cf15650R16) with a parameterized loop with an increased number each time (multiply by 2).

Current limits are 110 on parachain and 262144 for standalone.
The `110` seems to be wrong.

### Is there something left for follow-up PRs?
Next step will be to add this in a proper testing suite

### What value does it bring to the blockchain users?
To know what will be the gas limit

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
