### PR TITLE
Clean .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# md book build directory
-book
-
 # MacOS thing
 **/.DS_Store
 
@@ -14,3 +11,5 @@ book
 
 # Generated test specs
 /tests/moonbeam-test-specs/*.json
+
+artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,3 @@
 
 # Generated test specs
 /tests/moonbeam-test-specs/*.json
-
-artifacts


### PR DESCRIPTION
This PR removes an unrelated line from the .gitignore file. This line was most likely copied from the Substrate Recipes at some point.
