### PR TITLE
Runtime requires <= 1/2 second block execution.

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -100,6 +100,9 @@ pub type Hash = sp_core::H256;
 /// Digest item type.
 pub type DigestItem = generic::DigestItem<Hash>;
 
+/// Minimum time between blocks. Slot duration is double this.
+pub const MINIMUM_PERIOD: u64 = 3000;
+
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
 /// of data like extrinsics, allowing for them to continue syncing the network through upgrades
@@ -187,10 +190,11 @@ impl frame_system::Config for Runtime {
 
 parameter_types! {
 	// When running in standalone mode, this controls the block time.
-	// Block time is double the minimum period.
+	// Slot duration is double the minimum period.
 	// https://github.com/paritytech/substrate/blob/e4803bd/frame/aura/src/lib.rs#L197-L199
 	// We maintain a six second block time in standalone to imitate parachain-like performance
-	pub const MinimumPeriod: u64 = 3000;
+	// This value is stored in a seperate constant because it is used in our mock timestamp provider
+	pub const MinimumPeriod: u64 = MINIMUM_PERIOD;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -49,7 +49,7 @@ use sp_api::impl_runtime_apis;
 use sp_core::{OpaqueMetadata, H160, H256, U256};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, Saturating, Verify},
+	traits::{BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, Verify},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult,
 };
@@ -100,9 +100,6 @@ pub type Hash = sp_core::H256;
 /// Digest item type.
 pub type DigestItem = generic::DigestItem<Hash>;
 
-/// Minimum time between blocks.
-pub const MINIMUM_PERIOD: u64 = 3000;
-
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
 /// of data like extrinsics, allowing for them to continue syncing the network through upgrades
@@ -140,17 +137,12 @@ const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
-	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
-	/// Assume 10% of weight for average on_initialize calls.
-	pub MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
-		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
-	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const Version: RuntimeVersion = VERSION;
-	pub const ExtrinsicBaseWeight: Weight = 10_000_000;
-
-
+	/// We allow for one half second of compute with a 6 second average block time.
+	/// These values are dictated by Polkadot for the parachain.
 	pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights
-		::with_sensible_defaults(2 * WEIGHT_PER_SECOND, NORMAL_DISPATCH_RATIO);
+		::with_sensible_defaults(WEIGHT_PER_SECOND / 2, NORMAL_DISPATCH_RATIO);
+	/// We allow for 5 MB blocks.
 	pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength
 		::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
 }
@@ -197,7 +189,8 @@ parameter_types! {
 	// When running in standalone mode, this controls the block time.
 	// Block time is double the minimum period.
 	// https://github.com/paritytech/substrate/blob/e4803bd/frame/aura/src/lib.rs#L197-L199
-	pub const MinimumPeriod: u64 = MINIMUM_PERIOD;
+	// We maintain a six second block time in standalone to imitate parachain-like performance
+	pub const MinimumPeriod: u64 = 3000;
 }
 
 impl pallet_timestamp::Config for Runtime {


### PR DESCRIPTION
### What does it do?

Changes the maximum block weight to enforce no more than 1/2 second worth of weight.

Secondarily, it prunes some related but no-longer-used constants.

### What important points reviewers should know?

Substrate uses weight to quantify block execution time. Moonbeam will be limited by Polkadot to some upper limit of compute time. Currently it is expected to be 1/2 second. This PR adjusts the weight to reflect that.

This is only a small portion of getting our gas / weight / execution time story straight. See the next section for detail.

### Is there something left for follow-up PRs?

We still need to understand how much actual gas we can process per second with some reasonable assumptions.
Then we need to update our gas to weight mapping accordingly.
Ultimately we need to either address (or at least work around) the fact that gas and weight measure fundamentally things.

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

https://github.com/rust-blockchain/evm/issues/6 - brainstorm about generalizing the gasometer to count compute and storage independently for better gas -> weight mapping. This is a long way off.

## Checklist

- [x] Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
