### PR TITLE
Disable log trace at compile-time

### DIFF
--- a/node/parachain/Cargo.toml
+++ b/node/parachain/Cargo.toml
@@ -16,7 +16,7 @@ path = 'src/main.rs'
 derive_more = '0.15.0'
 exit-future = '0.1.4'
 futures = { version = "0.3.1", features = ["compat"] }
-log = '0.4.8'
+log = { version = "0.4.8", features = ["release_max_level_debug" ] }
 parking_lot = '0.9.0'
 trie-root = '0.15.2'
 codec = { package = 'parity-scale-codec', version = '1.0.0' }

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -42,4 +42,4 @@ sp-storage = { git = "https://github.com/paritytech/substrate.git", branch = "ma
 frontier-rpc-core = { package = "fc-rpc-core", git = "https://github.com/purestake/frontier", branch = "v0.4-hotfixes" }
 rlp = "0.4"
 frontier-consensus = { package = "fc-consensus", git = "https://github.com/purestake/frontier", branch = "v0.4-hotfixes" }
-log = "0.4.8"
+log = { version = "0.4.8", features = ["release_max_level_debug" ] }

--- a/node/standalone/Cargo.toml
+++ b/node/standalone/Cargo.toml
@@ -22,7 +22,7 @@ exclude = [
 
 [dependencies]
 futures = "0.3.4"
-log = "0.4.8"
+log = { version = "0.4.8", features = ["release_max_level_debug" ] }
 structopt = "0.3"
 jsonrpc-core = "15.0.0"
 jsonrpc-pubsub = "15.0.0"


### PR DESCRIPTION
This prevents a log trace statement which appears deep inside the evm from having a significant (50%+) overhead at runtime (even when trace statements are disabled at runtime).

### What does it do?

Specifically, every opcode that is visited in the evm comes with a call to `pre_validate()` which contains a log trace. My profiling and benchmarks indicate that this has significant overhead, especially when we're running in `wasm-compiled (wasmtime)` mode.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

This should eventually be addressed upstream.

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

This issue against substrate *might* be related:

https://github.com/paritytech/substrate/issues/7800

### What value does it bring to the blockchain users?

EVM throughput doubles or better

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
