### PR TITLE
Alan polkadot compiled wasm v 0.4.0

### DIFF
--- a/docker/polkadot-relay.Dockerfile
+++ b/docker/polkadot-relay.Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
 RUN git clone https://github.com/paritytech/polkadot
 WORKDIR /polkadot
 RUN git checkout ${POLKADOT_COMMIT}
+RUN sed -i '/sc_executor::WasmExecutionMethod::Interpreted/c\\t\tsc_executor::WasmExecutionMethod::Compiled,' parachain/src/wasm_executor/mod.rs
 
 # Download rust dependencies and build the rust binary
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \

--- a/docker/polkadot-relay.Dockerfile
+++ b/docker/polkadot-relay.Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && \
 RUN git clone https://github.com/paritytech/polkadot
 WORKDIR /polkadot
 RUN git checkout ${POLKADOT_COMMIT}
+
+# Forces to use the compiled wasm engine for parachain validation
 RUN sed -i '/sc_executor::WasmExecutionMethod::Interpreted/c\\t\tsc_executor::WasmExecutionMethod::Compiled,' parachain/src/wasm_executor/mod.rs
 
 # Download rust dependencies and build the rust binary


### PR DESCRIPTION
### What does it do?
Forces the polkadot docker image to build polkadot using the compiled wasm engine for the Parachain Validation Function.

### What important points reviewers should know?
It will probably be fixed by paritytech on their side at some point.

