### PR TITLE
Adds Gas to Weight mapping

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -248,7 +248,7 @@ pub const GAS_PER_SECOND: u64 = 4_000_000;
 // u64 works for approximations because Weight is a very small unit compared to gas.
 pub const WEIGHT_PER_GAS: u64 = WEIGHT_PER_SECOND as u64 / GAS_PER_SECOND;
 
-pub struct MoonbeamGasWeightMapping {}
+pub struct MoonbeamGasWeightMapping;
 
 impl pallet_evm::GasWeightMapping for MoonbeamGasWeightMapping {
 	fn gas_to_weight(gas: usize) -> Weight {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -240,9 +240,11 @@ impl pallet_sudo::Config for Runtime {
 
 impl pallet_ethereum_chain_id::Config for Runtime {}
 
-/// Current (safe) approximation of the gas/s consumption considering
-/// EVM execution over compiled WASM.
-pub const GAS_PER_SECOND: u64 = 4_000_000;
+/// Current approximation of the gas/s consumption considering
+/// EVM execution over compiled WASM (on 4.4Ghz CPU).
+/// Given the 500ms Weight, from which 75% only are used for transactions,
+/// the total EVM execution gas limit is: GAS_PER_SECOND * 0.500 * 0.75 => 3_000_000.
+pub const GAS_PER_SECOND: u64 = 8_000_000;
 
 /// Approximate ratio of the amount of Weight per Gas.
 /// u64 works for approximations because Weight is a very small unit compared to gas.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -244,9 +244,9 @@ impl pallet_ethereum_chain_id::Config for Runtime {}
 /// EVM execution over compiled WASM.
 pub const GAS_PER_SECOND: u64 = 4_000_000;
 
-// Approximate ratio of the amount of Weight per Gas.
-// u64 works for approximations because Weight is a very small unit compared to gas.
-pub const WEIGHT_PER_GAS: u64 = WEIGHT_PER_SECOND as u64 / GAS_PER_SECOND;
+/// Approximate ratio of the amount of Weight per Gas.
+/// u64 works for approximations because Weight is a very small unit compared to gas.
+pub const WEIGHT_PER_GAS: u64 = WEIGHT_PER_SECOND / GAS_PER_SECOND;
 
 pub struct MoonbeamGasWeightMapping;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -240,8 +240,8 @@ impl pallet_sudo::Config for Runtime {
 
 impl pallet_ethereum_chain_id::Config for Runtime {}
 
-// Current (safe) approximation of the gas/s consumption considering
-// EVM execution over compiled WASM.
+/// Current (safe) approximation of the gas/s consumption considering
+/// EVM execution over compiled WASM.
 pub const GAS_PER_SECOND: u64 = 4_000_000;
 
 // Approximate ratio of the amount of Weight per Gas.

--- a/tests/tests/constants/constants.ts
+++ b/tests/tests/constants/constants.ts
@@ -1,0 +1,17 @@
+export const PORT = 19931;
+export const RPC_PORT = 19932;
+export const WS_PORT = 19933;
+export const SPECS_PATH = `./moonbeam-test-specs`;
+
+export const DISPLAY_LOG = process.env.MOONBEAM_LOG || false;
+export const MOONBEAM_LOG = process.env.MOONBEAM_LOG || "info";
+
+export const BINARY_PATH =
+  process.env.BINARY_PATH || `../node/standalone/target/release/moonbase-standalone`;
+export const SPAWNING_TIME = 30000;
+
+// Test variables
+export const GENESIS_ACCOUNT = "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b";
+export const GENESIS_ACCOUNT_PRIVATE_KEY =
+  "0x99B3C12287537E38C90A9219D4CB074A89A16E9CDB20BF85728EBD97C343E342";
+export const TEST_ACCOUNT = "0x1111111111111111111111111111111111111111";

--- a/tests/tests/constants/index.ts
+++ b/tests/tests/constants/index.ts
@@ -12,25 +12,21 @@ export {
   FINITE_LOOP_CONTRACT_ABI,
 } from "./testContracts";
 
-export { basicTransfertx, contractCreation } from "./transactionConfigs";
+export {
+  PORT,
+  RPC_PORT,
+  WS_PORT,
+  SPECS_PATH,
+  DISPLAY_LOG,
+  MOONBEAM_LOG,
+  BINARY_PATH,
+  SPAWNING_TIME,
+  GENESIS_ACCOUNT,
+  GENESIS_ACCOUNT_PRIVATE_KEY,
+  TEST_ACCOUNT,
+} from "./constants";
 
-export const PORT = 19931;
-export const RPC_PORT = 19932;
-export const WS_PORT = 19933;
-export const SPECS_PATH = `./moonbeam-test-specs`;
-
-export const DISPLAY_LOG = process.env.MOONBEAM_LOG || false;
-export const MOONBEAM_LOG = process.env.MOONBEAM_LOG || "info";
-
-export const BINARY_PATH =
-  process.env.BINARY_PATH || `../node/standalone/target/release/moonbase-standalone`;
-export const SPAWNING_TIME = 30000;
-
-// Test variables
-export const GENESIS_ACCOUNT = "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b";
-export const GENESIS_ACCOUNT_PRIVATE_KEY =
-  "0x99B3C12287537E38C90A9219D4CB074A89A16E9CDB20BF85728EBD97C343E342";
-export const TEST_ACCOUNT = "0x1111111111111111111111111111111111111111";
+export { basicTransfertx, contractCreation, CompleteTransactionConfig } from "./transactionConfigs";
 
 // TESTING NOTES
 //

--- a/tests/tests/constants/transactionConfigs.ts
+++ b/tests/tests/constants/transactionConfigs.ts
@@ -1,21 +1,31 @@
 // +++ TransactionConfig +++
 
-import { GENESIS_ACCOUNT, TEST_ACCOUNT, TEST_CONTRACT_BYTECODE } from ".";
+import { GENESIS_ACCOUNT, TEST_ACCOUNT } from "./constants";
+import { TEST_CONTRACT_BYTECODE } from "./testContracts";
 
 import { TransactionConfig } from "web3-core";
 
-export const basicTransfertx: TransactionConfig = {
+export type CompleteTransactionConfig =
+  | TransactionConfig
+  | {
+      chainId?: string;
+    };
+
+console.log(GENESIS_ACCOUNT, TEST_ACCOUNT);
+export const basicTransfertx: CompleteTransactionConfig = {
   from: GENESIS_ACCOUNT,
   to: TEST_ACCOUNT,
   value: "0x200", // =512 Must me higher than ExistentialDeposit (500)
   gasPrice: "0x01",
-  gas: "0x100000",
+  gas: 21000,
+  chainId: "0x501", // Prevents web3 from requesting the chainId
 };
 
-export const contractCreation: TransactionConfig = {
+export const contractCreation: CompleteTransactionConfig = {
   from: GENESIS_ACCOUNT,
   data: TEST_CONTRACT_BYTECODE,
   value: "0x00",
   gasPrice: "0x01",
-  gas: "0x100000",
+  gas: 91019,
+  chainId: "0x501", // Prevents web3 from requesting the chainId
 };

--- a/tests/tests/test-block.ts
+++ b/tests/tests/test-block.ts
@@ -122,21 +122,32 @@ describeWithMoonbeam("Moonbeam RPC (Block)", `simple-specs.json`, (context) => {
   // the maximum number of tx/ blocks is not constant but is always around 1500
 
   it("should be able to fill a block with a 1 tx", async function () {
-    this.timeout(0);
+    this.timeout(15000);
     let { txPassedFirstBlock } = await fillBlockWithTx(context, 1);
     expect(txPassedFirstBlock).to.eq(1);
   });
 
-  it("should be able to fill a block with a 1000 tx", async function () {
-    this.timeout(0);
-    let { txPassedFirstBlock } = await fillBlockWithTx(context, 1000);
-    expect(txPassedFirstBlock).to.eq(1000);
+  it("should be able to fill a block with 136 tx", async function () {
+    this.timeout(15000);
+    // We have 3_000_000 Gas available for transactions per block.
+    // Each transaction needs 1_000 (extrinsic cost) + 21_000 (eth cost)
+    // 3_000_000 / 22_000 = ~136.36
+
+    // The test will send 137 tx and verify the first block contains only 136.
+    let { txPassed, txPassedFirstBlock } = await fillBlockWithTx(context, 137);
+    expect(txPassedFirstBlock).to.eq(136);
+    expect(txPassed).to.eq(137); // including all blocks
   });
 
-  it("should be able to fill a block with 1000 contract creations tx", async function () {
-    this.timeout(0);
-    let { txPassedFirstBlock } = await fillBlockWithTx(context, 1000, contractCreation);
-    expect(txPassedFirstBlock).to.eq(1000);
+  it("should be able to fill a block with 32 contract creations tx", async function () {
+    this.timeout(15000);
+    // We have 3_000_000 Gas available for transactions per block.
+    // Each transaction needs 1_000 (extrinsic cost) + 91019 (contract cost)
+    // 3_000_000 / 92_019 = ~32.96
+
+    // The test will send 33 contract tx and verify the first block contains only 32.
+    let { txPassedFirstBlock } = await fillBlockWithTx(context, 33, contractCreation);
+    expect(txPassedFirstBlock).to.eq(32);
   });
 
   // 8192 is the number of tx that can be sent to the Pool
@@ -144,26 +155,26 @@ describeWithMoonbeam("Moonbeam RPC (Block)", `simple-specs.json`, (context) => {
 
   it("should be able to send 8192 tx to the pool and have them all published\
   within the following blocks", async function () {
-    this.timeout(0);
+    this.timeout(120000);
     let { txPassed } = await fillBlockWithTx(context, 8192);
     expect(txPassed).to.eq(8192);
   });
 
   it("but shouldn't work for 8193", async function () {
-    this.timeout(0);
+    this.timeout(120000);
     let { txPassed } = await fillBlockWithTx(context, 8193);
     expect(txPassed).to.eq(0);
   });
 
   it("should be able to send 8192 tx to the pool and have them all published\
   within the following blocks - bigger tx", async function () {
-    this.timeout(0);
+    this.timeout(120000);
     let { txPassed } = await fillBlockWithTx(context, 8192, contractCreation);
     expect(txPassed).to.eq(8192);
   });
 
   it("but shouldn't work for 8193 - bigger tx", async function () {
-    this.timeout(0);
+    this.timeout(120000);
     let { txPassed } = await fillBlockWithTx(context, 8193, contractCreation);
     expect(txPassed).to.eq(0);
   });

--- a/tests/tests/test-gas.ts
+++ b/tests/tests/test-gas.ts
@@ -82,7 +82,7 @@ describeWithMoonbeam("Moonbeam RPC (Gas)", `simple-specs.json`, (context) => {
   });
 
   it("gas limit should be fine under the weight limit", async function () {
-    const maxBlockGas = 2000000 * 0.65; // 2M per block limited to 65% for transactions
+    const maxBlockTxGas = 2000000 * 0.65; // 2M per block limited to 65% for transactions
 
     const nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
     const goodTx = await context.web3.eth.accounts.signTransaction(
@@ -91,7 +91,7 @@ describeWithMoonbeam("Moonbeam RPC (Gas)", `simple-specs.json`, (context) => {
         data: TEST_CONTRACT_BYTECODE,
         value: "0x00",
         gasPrice: "0x01",
-        gas: Math.floor(maxBlockGas * 0.9),
+        gas: Math.floor(maxBlockTxGas * 0.9),
         nonce,
       },
       GENESIS_ACCOUNT_PRIVATE_KEY
@@ -102,7 +102,7 @@ describeWithMoonbeam("Moonbeam RPC (Gas)", `simple-specs.json`, (context) => {
   });
 
   it("gas limit should be limited by weight", async function () {
-    const maxBlockGas = 2000000 * 0.65; // 2M per block limited to 65% for transactions
+    const maxBlockTxGas = 2000000 * 0.65; // 2M per block limited to 65% for transactions
     const nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
     const badTx = await context.web3.eth.accounts.signTransaction(
       {
@@ -110,7 +110,7 @@ describeWithMoonbeam("Moonbeam RPC (Gas)", `simple-specs.json`, (context) => {
         data: TEST_CONTRACT_BYTECODE,
         value: "0x00",
         gasPrice: "0x01",
-        gas: Math.floor(maxBlockGas * 1.1),
+        gas: Math.floor(maxBlockTxGas * 1.1),
         nonce: nonce,
       },
       GENESIS_ACCOUNT_PRIVATE_KEY

--- a/tests/tests/test-gas.ts
+++ b/tests/tests/test-gas.ts
@@ -81,10 +81,10 @@ describeWithMoonbeam("Moonbeam RPC (Gas)", `simple-specs.json`, (context) => {
     expect(await contract.methods.multiply(3).estimateGas()).to.equal(21204);
   });
 
-  // Current gas per second is at 4M and our weight limit is 500ms.
-  // This computes to 2M gas per block.
+  // Current gas per second is at 8M and our weight limit is 500ms.
+  // This computes to 4M gas per block.
   // Current implementation is limiting block operation to ~0.65% of the block gas limit
-  const MAX_BLOCK_TX_GAS = 2000000 * 0.65;
+  const MAX_BLOCK_TX_GAS = 4000000 * 0.65;
 
   it("gas limit should be fine under the weight limit", async function () {
     const nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);

--- a/tests/tests/test-gas.ts
+++ b/tests/tests/test-gas.ts
@@ -81,9 +81,12 @@ describeWithMoonbeam("Moonbeam RPC (Gas)", `simple-specs.json`, (context) => {
     expect(await contract.methods.multiply(3).estimateGas()).to.equal(21204);
   });
 
-  it("gas limit should be fine under the weight limit", async function () {
-    const maxBlockTxGas = 2000000 * 0.65; // 2M per block limited to 65% for transactions
+  // Current gas per second is at 4M and our weight limit is 500ms.
+  // This computes to 2M gas per block.
+  // Current implementation is limiting block operation to ~0.65% of the block gas limit
+  const MAX_BLOCK_TX_GAS = 2000000 * 0.65;
 
+  it("gas limit should be fine under the weight limit", async function () {
     const nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
     const goodTx = await context.web3.eth.accounts.signTransaction(
       {
@@ -91,7 +94,7 @@ describeWithMoonbeam("Moonbeam RPC (Gas)", `simple-specs.json`, (context) => {
         data: TEST_CONTRACT_BYTECODE,
         value: "0x00",
         gasPrice: "0x01",
-        gas: Math.floor(maxBlockTxGas * 0.9),
+        gas: Math.floor(MAX_BLOCK_TX_GAS * 0.9),
         nonce,
       },
       GENESIS_ACCOUNT_PRIVATE_KEY
@@ -102,7 +105,6 @@ describeWithMoonbeam("Moonbeam RPC (Gas)", `simple-specs.json`, (context) => {
   });
 
   it("gas limit should be limited by weight", async function () {
-    const maxBlockTxGas = 2000000 * 0.65; // 2M per block limited to 65% for transactions
     const nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
     const badTx = await context.web3.eth.accounts.signTransaction(
       {
@@ -110,7 +112,7 @@ describeWithMoonbeam("Moonbeam RPC (Gas)", `simple-specs.json`, (context) => {
         data: TEST_CONTRACT_BYTECODE,
         value: "0x00",
         gasPrice: "0x01",
-        gas: Math.floor(maxBlockTxGas * 1.1),
+        gas: Math.floor(MAX_BLOCK_TX_GAS * 1.1),
         nonce: nonce,
       },
       GENESIS_ACCOUNT_PRIVATE_KEY

--- a/tests/tests/test-gas.ts
+++ b/tests/tests/test-gas.ts
@@ -119,7 +119,8 @@ describeWithMoonbeam("Moonbeam RPC (Gas)", `simple-specs.json`, (context) => {
       ((await customRequest(context.web3, "eth_sendRawTransaction", [badTx.rawTransaction]))
         .error as any).message
     ).to.equal(
-      "submit transaction to pool failed: Pool(InvalidTransaction(InvalidTransaction::ExhaustsResources))"
+      "submit transaction to pool failed: " +
+        "Pool(InvalidTransaction(InvalidTransaction::ExhaustsResources))"
     );
   });
 });

--- a/tests/tests/util/fillBlockWithTx.ts
+++ b/tests/tests/util/fillBlockWithTx.ts
@@ -2,7 +2,12 @@ import Web3 from "web3";
 
 import { JsonRpcResponse } from "web3-core-helpers";
 import { SignedTransaction, TransactionConfig } from "web3-core";
-import { basicTransfertx, GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY } from "../constants";
+import {
+  basicTransfertx,
+  CompleteTransactionConfig,
+  GENESIS_ACCOUNT,
+  GENESIS_ACCOUNT_PRIVATE_KEY,
+} from "../constants";
 import { wrappedCustomRequest } from "./web3Requests";
 import { createAndFinalizeBlock } from ".";
 import { Context, log } from "./testWithMoonbeam";
@@ -84,13 +89,13 @@ export interface ErrorReport {
 }
 
 // This functiom sends a batch of signed transactions to the pool and records both
-// how many tx were included in the first block and the total numbe rof tx that were
+// how many tx were included in the first block and the total number of tx that were
 // included in a block
 // By default, the tx is a simple transfer, but a TransactionConfig can be specified as an option
 export async function fillBlockWithTx(
   context: Context,
   numberOfTx: number,
-  customTxConfig: TransactionConfig = basicTransfertx
+  customTxConfig: CompleteTransactionConfig = basicTransfertx
 ): Promise<FillBlockReport> {
   let nonce: number = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
 
@@ -118,7 +123,7 @@ export async function fillBlockWithTx(
     context.web3,
     numberOfTx,
     nonce,
-    customTxConfig
+    customTxConfig as any // needed as the web3 types don't support chainId but the code does.
   );
 
   const signingTime: number = Date.now() - startSigningTime;


### PR DESCRIPTION
### What does it do?
It adds a better GasWeightMapper than the default one (1-1 mapping).
The new GasWeightMapper compute the gas/weight based on a given ratio.

From our benchmarking, the EVM computation can consume up to 10M Gas/second (on a 4.4ghz) with some optimizations (no trace log, using compiled WASM).

To stay on a very safe path and considering that our current targets are under the required specs, we are targeting a consumption of 4M Gas/second. The GasToWeight conversation is doing: `gas * WEIGHT_PER_SECOND / GAS_PER_SECOND`

Considering that our current block limit is 500ms Weight (requirement to be a parachain), it means we will have **4M Gas limit per block**. 
However, the current computation of block weight consider that 25% for operations (including 10% for block initialization) and 75% for the transactions (so 3M gas here)

This diagram gives an overview of the gas consumption:
![Moonbeam Gas_Weight Consumption - Alphanet v5](https://user-images.githubusercontent.com/329248/104410784-0a577c80-5537-11eb-9b4f-6df5e7cc3b3e.jpg)

This gives us a approximate **effective gas per block** of **3M/block** (so 0.5M effective gas/s, ~50% of Ethereum mainnet)

Also, additional note for now, current extrinsics are consuming 125_000_000 weight extra (which is 1000 gas). We might want to merge that into the 21_000 already consumed by the EVM

Another addition is the fact that the maximum extrinsic weight is equal to the maximum normal class weight (75%) minux the data block initialization (10%, not sure why it is included as it doesn't belong to the normal class), minus the extrinsic base weight (125_000), (which is roughly around 64.9% of the block weight). In term of gas it means a Tx is limited to `2_599_000` gas

### Is there something left for follow-up PRs?
There will be some tweaking PR to increase those numbers once our benchmark are more accurate and once we have defined our final specs.

Another PR to adapt the Ethereum Gas Limit to reflect the actual gas limit is needed. That will be possible after https://github.com/paritytech/frontier/pull/265 lands.

### What value does it bring to the blockchain users?
It gives an accurate limit of the possibilities of the current parachain.
It prevents the network to stall when a TX saturates the EVM and is too long
