### PR TITLE
Add transaction graph pool pre-checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4102,6 +4102,7 @@ dependencies = [
  "sc-network",
  "sc-rpc",
  "sc-rpc-api",
+ "sc-transaction-graph",
  "serde",
  "serde_json",
  "sha3 0.8.2",

--- a/node/parachain/src/service.rs
+++ b/node/parachain/src/service.rs
@@ -172,6 +172,7 @@ where
 			let deps = moonbeam_rpc::FullDeps {
 				client: client.clone(),
 				pool: pool.clone(),
+				graph: pool.pool().clone(),
 				deny_unsafe,
 				is_authority,
 				network: network.clone(),

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -21,6 +21,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", default-features
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-transaction-graph = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/rpc/src/server_hotfixes.rs
+++ b/node/rpc/src/server_hotfixes.rs
@@ -682,11 +682,7 @@ where
 		match check_is_known {
 			Ok(_) => Box::new(
 				self.pool
-					.submit_one(
-						&BlockId::hash(hash),
-						TransactionSource::Local,
-						self.convert_transaction.convert_transaction(transaction),
-					)
+					.submit_one(&BlockId::hash(hash), TransactionSource::Local, uxt)
 					.compat()
 					.map(move |_| transaction_hash)
 					.map_err(|err| {
@@ -719,11 +715,7 @@ where
 		match check_is_known {
 			Ok(_) => Box::new(
 				self.pool
-					.submit_one(
-						&BlockId::hash(hash),
-						TransactionSource::Local,
-						self.convert_transaction.convert_transaction(transaction),
-					)
+					.submit_one(&BlockId::hash(hash), TransactionSource::Local, uxt)
 					.compat()
 					.map(move |_| transaction_hash)
 					.map_err(|err| {

--- a/node/standalone/Cargo.lock
+++ b/node/standalone/Cargo.lock
@@ -3677,6 +3677,7 @@ dependencies = [
  "sc-network",
  "sc-rpc",
  "sc-rpc-api",
+ "sc-transaction-graph",
  "serde",
  "serde_json",
  "sha3 0.8.2",

--- a/node/standalone/src/service.rs
+++ b/node/standalone/src/service.rs
@@ -222,6 +222,7 @@ pub fn new_full(config: Configuration, manual_seal: bool) -> Result<TaskManager,
 			let deps = moonbeam_rpc::FullDeps {
 				client: client.clone(),
 				pool: pool.clone(),
+				graph: pool.pool().clone(),
 				deny_unsafe,
 				is_authority,
 				network: network.clone(),

--- a/tests/tests/test-transaction-prechecks.ts
+++ b/tests/tests/test-transaction-prechecks.ts
@@ -1,0 +1,59 @@
+import { expect } from "chai";
+
+import { createAndFinalizeBlock, customRequest, describeWithMoonbeam } from "./util";
+import {
+    FIRST_CONTRACT_ADDRESS,
+    GENESIS_ACCOUNT,
+    GENESIS_ACCOUNT_PRIVATE_KEY,
+    TEST_CONTRACT_ABI,
+    TEST_CONTRACT_BYTECODE,
+} from "./constants";
+
+let tx;
+
+describeWithMoonbeam("Moonbeam RPC (Transaction validity pre-checks)", `simple-specs.json`, (context) => {
+    it("should not return error on the same block", async function () {
+        tx = await context.web3.eth.accounts.signTransaction(
+            {
+                from: GENESIS_ACCOUNT,
+                data: TEST_CONTRACT_BYTECODE,
+                value: "0x00",
+                gasPrice: "0x01",
+                gas: "0x100000",
+            },
+            GENESIS_ACCOUNT_PRIVATE_KEY
+        );
+        // `a` is a new submitted transaction.
+        let a = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+        // `b` is already known at Rpc-level, and is not submitted to the pool.
+        let b = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+
+        expect(a.result).to.be.equal("0xe87ed993e4d186748404a52a2d13612eef8356331f30fa6b3fb9bc2c16be2e9c");
+        // Before adding the checks, bellow assertion would fail with `submit transaction to pool failed: Pool(AlreadyImported(Any))`.
+        expect(b.result).to.be.equal("0xe87ed993e4d186748404a52a2d13612eef8356331f30fa6b3fb9bc2c16be2e9c");
+    });
+
+    it("should be Stale next block", async function () {
+        await createAndFinalizeBlock(context.polkadotApi);
+        // In a new block, `a` is not known at Rpc-level because is not in the transaction pool anymore.
+        // 
+        // `a` will be submitted to the pool and identified as Stale in pallet-ethereum::validate_unsigned(), because 
+        // the transaction nonce (0) is lesser than the account nonce (1).
+        //
+        // `a` therefore is added to the banned list when invalid::Stale.
+        let a = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+        // `b` is now banned, and already known at Rpc-level, so is not submitted to the pool.
+        let b = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+        expect(a).to.deep.equal({
+            jsonrpc: '2.0',
+            error: {
+                code: -32603,
+                message: 'submit transaction to pool failed: Pool(InvalidTransaction(InvalidTransaction::Stale))'
+            },
+            id: 1
+        });
+        // Before adding the checks, bellow assertion would fail with `submit transaction to pool failed: Pool(TemporarilyBanned)`.
+        // `b` will now return the known (banned) transaction hash instead.
+        expect(b.result).to.be.equal("0xe87ed993e4d186748404a52a2d13612eef8356331f30fa6b3fb9bc2c16be2e9c");
+    });
+});

--- a/tests/tests/test-transaction-prechecks.ts
+++ b/tests/tests/test-transaction-prechecks.ts
@@ -2,58 +2,74 @@ import { expect } from "chai";
 
 import { createAndFinalizeBlock, customRequest, describeWithMoonbeam } from "./util";
 import {
-    FIRST_CONTRACT_ADDRESS,
-    GENESIS_ACCOUNT,
-    GENESIS_ACCOUNT_PRIVATE_KEY,
-    TEST_CONTRACT_ABI,
-    TEST_CONTRACT_BYTECODE,
+  FIRST_CONTRACT_ADDRESS,
+  GENESIS_ACCOUNT,
+  GENESIS_ACCOUNT_PRIVATE_KEY,
+  TEST_CONTRACT_ABI,
+  TEST_CONTRACT_BYTECODE,
 } from "./constants";
 
 let tx;
 
-describeWithMoonbeam("Moonbeam RPC (Transaction validity pre-checks)", `simple-specs.json`, (context) => {
+describeWithMoonbeam(
+  "Moonbeam RPC (Transaction validity pre-checks)",
+  `simple-specs.json`,
+  (context) => {
     it("should not return error on the same block", async function () {
-        tx = await context.web3.eth.accounts.signTransaction(
-            {
-                from: GENESIS_ACCOUNT,
-                data: TEST_CONTRACT_BYTECODE,
-                value: "0x00",
-                gasPrice: "0x01",
-                gas: "0x100000",
-            },
-            GENESIS_ACCOUNT_PRIVATE_KEY
-        );
-        // `a` is a new submitted transaction.
-        let a = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
-        // `b` is already known at Rpc-level, and is not submitted to the pool.
-        let b = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+      tx = await context.web3.eth.accounts.signTransaction(
+        {
+          from: GENESIS_ACCOUNT,
+          data: TEST_CONTRACT_BYTECODE,
+          value: "0x00",
+          gasPrice: "0x01",
+          gas: "0x100000",
+        },
+        GENESIS_ACCOUNT_PRIVATE_KEY
+      );
+      // `a` is a new submitted transaction.
+      let a = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+      // `b` is already known at Rpc-level, and is not submitted to the pool.
+      let b = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
 
-        expect(a.result).to.be.equal("0xe87ed993e4d186748404a52a2d13612eef8356331f30fa6b3fb9bc2c16be2e9c");
-        // Before adding the checks, bellow assertion would fail with `submit transaction to pool failed: Pool(AlreadyImported(Any))`.
-        expect(b.result).to.be.equal("0xe87ed993e4d186748404a52a2d13612eef8356331f30fa6b3fb9bc2c16be2e9c");
+      expect(a.result).to.be.equal(
+        "0xe87ed993e4d186748404a52a2d13612eef8356331f30fa6b3fb9bc2c16be2e9c"
+      );
+      // Before adding the checks, bellow assertion would fail with `submit transaction to
+      // pool failed: Pool(AlreadyImported(Any))`.
+      expect(b.result).to.be.equal(
+        "0xe87ed993e4d186748404a52a2d13612eef8356331f30fa6b3fb9bc2c16be2e9c"
+      );
     });
 
     it("should be Stale next block", async function () {
-        await createAndFinalizeBlock(context.polkadotApi);
-        // In a new block, `a` is not known at Rpc-level because is not in the transaction pool anymore.
-        // 
-        // `a` will be submitted to the pool and identified as Stale in pallet-ethereum::validate_unsigned(), because 
-        // the transaction nonce (0) is lesser than the account nonce (1).
-        //
-        // `a` therefore is added to the banned list when invalid::Stale.
-        let a = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
-        // `b` is now banned, and already known at Rpc-level, so is not submitted to the pool.
-        let b = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
-        expect(a).to.deep.equal({
-            jsonrpc: '2.0',
-            error: {
-                code: -32603,
-                message: 'submit transaction to pool failed: Pool(InvalidTransaction(InvalidTransaction::Stale))'
-            },
-            id: 1
-        });
-        // Before adding the checks, bellow assertion would fail with `submit transaction to pool failed: Pool(TemporarilyBanned)`.
-        // `b` will now return the known (banned) transaction hash instead.
-        expect(b.result).to.be.equal("0xe87ed993e4d186748404a52a2d13612eef8356331f30fa6b3fb9bc2c16be2e9c");
+      await createAndFinalizeBlock(context.polkadotApi);
+      // In a new block, `a` is not known at Rpc-level because is not in the transaction pool
+      // anymore.
+      //
+      // `a` will be submitted to the pool and identified as Stale in
+      // pallet-ethereum::validate_unsigned(), because the transaction nonce (0) is lesser
+      // than the account nonce (1).
+      //
+      // `a` therefore is added to the banned list when invalid::Stale.
+      let a = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+      // `b` is now banned, and already known at Rpc-level, so is not submitted to the pool.
+      let b = await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+      expect(a).to.deep.equal({
+        jsonrpc: "2.0",
+        error: {
+          code: -32603,
+          message:
+            "submit transaction to pool failed: " +
+            "Pool(InvalidTransaction(InvalidTransaction::Stale))",
+        },
+        id: 1,
+      });
+      // Before adding the checks, bellow assertion would fail with `submit transaction to
+      // pool failed: Pool(TemporarilyBanned)`.
+      // `b` will now return the known (banned) transaction hash instead.
+      expect(b.result).to.be.equal(
+        "0xe87ed993e4d186748404a52a2d13612eef8356331f30fa6b3fb9bc2c16be2e9c"
+      );
     });
-});
+  }
+);


### PR DESCRIPTION
### What does it do?

Prevents transactions sent via RPC to hit the transaction pool if the hash is known (either in the pool `AlreadyImported`, or banned `TemporarilyBanned`..). 

If the transaction hash is known, just return the calculated ethereum transaction hash directly.

https://github.com/paritytech/substrate/blob/9b08105b8c7106d723c4f470304ad9e2868569d9/client/transaction-pool/graph/src/validated_pool.rs#L146

**Test behaviour**

- In this patch, a transaction is known at Rpc-level when is either in the transaction pool or in the banned list.
- If multiple instances of the same transaction are trying to co-exist in the pool, Substrate identifies them as [AlreadyImported](https://crates.parity.io/sp_transaction_pool/error/enum.Error.html#variant.AlreadyImported).
- If an old transaction is submitted to the pool (`transaction nonce < account nonce`), Substrate adds it to the [banned list ](https://github.com/paritytech/substrate/blob/9b08105b8c7106d723c4f470304ad9e2868569d9/client/transaction-pool/graph/src/rotator.rs#L60) for a default 30 minutes.

The new behaviour added in this patch is to not submit a known transaction (already in pool or banned) and return its hash instead.  

### What alternative implementations were considered?

I guess known transactions can be replaced with a higher priority, instead 

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
