### PR TITLE
Crystalin ci hosted

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,11 +1,5 @@
 root = true
 
-[*]
-end_of_line=lf
-charset=utf-8
-trim_trailing_whitespace=true
-insert_final_newline=true
-
 [*.rs]
 indent_style=tab
 indent_size=tab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,8 @@ jobs:
 
   build:
     runs-on: self-hosted
+    env:
+      CARGO_SCCACHE_VERSION: 0.2.14-alpha.0-parity
     outputs:
       RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
     steps:
@@ -146,6 +148,23 @@ jobs:
       - name: Checkout
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
+        # Install sccache
+      - uses: actions/cache@v2
+        with:
+          path: ${{ runner.tool_cache }}/cargo-sccache
+          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}-v1
+      - name: Install sccache
+        run: |
+          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+            cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+          fi
+        shell: bash
+      - name: Start sccache
+        run: |
+          chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
+          ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
+          ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
+          echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
       # - name: Cache Rust dependencies
       #   uses: actions/cache@v2
       #   id: cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,11 +76,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup editorconfig checker
         run: |
-          wget https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.1.0/ec-linux-amd64.tar.gz
-          tar xvf ec-linux-amd64.tar.gz
-          chmod +x /tmp/ec-linux-amd64
+          ls /tmp/bin/ec-linux-amd64 || \
+          cd /tmp && \
+          wget https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.1.0/ec-linux-amd64.tar.gz && \
+          tar xvf ec-linux-amd64.tar.gz && \
+          chmod +x bin/ec-linux-amd64
       - name: Check files
-        run: /tmp/ec-linux-amd64
+        run: /tmp/bin/ec-linux-amd64
 
   check-prettier:
     name: "Check with Prettier"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   ####### Check files and formatting #######
 
   check-copyright:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request_target'
@@ -46,7 +46,7 @@ jobs:
           fi
 
   check-links:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request_target'
@@ -63,7 +63,7 @@ jobs:
 
   check-editorconfig:
     name: "Check editorconfig"
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request_target'
@@ -84,7 +84,7 @@ jobs:
 
   check-prettier:
     name: "Check with Prettier"
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request_target'
@@ -100,7 +100,7 @@ jobs:
 
   check-clippy:
     name: "Code checks"
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request_target'
@@ -131,7 +131,7 @@ jobs:
   ####### Building and Testing binaries #######
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
     steps:
@@ -215,7 +215,7 @@ jobs:
   ####### Prepare and Deploy Docker images #######
 
   docker-parachain:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: ["build"]
     if: github.event_name == 'push'
     steps:
@@ -286,7 +286,7 @@ jobs:
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
 
   docker-standalone:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: ["build"]
     if: github.event_name == 'push'
     steps:
@@ -359,7 +359,7 @@ jobs:
   ####### Prepare the release draft #######
 
   publish-draft-release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: ["build"]
     if: |
       github.event_name == 'push' &&
@@ -396,7 +396,7 @@ jobs:
           draft: true
 
   publish-runtimes:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: ["publish-draft-release"]
     # We want to store the binaries also when it is not a version release. This is used
     # in case such as providing binaries when creating a new tutorial version.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,9 @@ jobs:
         run: |
           wget https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.1.0/ec-linux-amd64.tar.gz
           tar xvf ec-linux-amd64.tar.gz
-          chmod +x bin/ec-linux-amd64
+          chmod +x /tmp/ec-linux-amd64
       - name: Check files
-        run: bin/ec-linux-amd64
+        run: /tmp/ec-linux-amd64
 
   check-prettier:
     name: "Check with Prettier"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,18 +144,18 @@ jobs:
       - name: Checkout
         if: github.event_name != 'pull_request_target'
         uses: actions/checkout@v2
-      - name: Cache Rust dependencies
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-            node/standalone/target
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-build
+      # - name: Cache Rust dependencies
+      #   uses: actions/cache@v2
+      #   id: cache
+      #   with:
+      #     path: |
+      #       ~/.cargo/registry
+      #       ~/.cargo/git
+      #       target
+      #       node/standalone/target
+      #     key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
+      #     restore-keys: |
+      #       ${{ runner.OS }}-build
       - uses: actions-rs/toolchain@v1
         with:
           target: wasm32-unknown-unknown


### PR DESCRIPTION
### What does it do?
Moves the CI to self-hosted.
The benefit is that we can use our servers to run the CI. The security is still a concern.
Current CI is designed so that only people allowed to push on the repository will trigger the CI, it makes it kind of safe.
Also the server currently running the CI is considered non-critical.

The editorconfig config removes check for binary files (was an issue on the self-hosted machine, not sure why)

