### PR TITLE
Better support for GasWeightMapping u32

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -258,7 +258,7 @@ pub struct MoonbeamGasWeightMapping;
 
 impl pallet_evm::GasWeightMapping for MoonbeamGasWeightMapping {
 	fn gas_to_weight(gas: usize) -> Weight {
-		Weight::try_from((gas as u64).saturating_mul(WEIGHT_PER_GAS)).unwrap_or(Weight::MAX);
+		Weight::try_from((gas as u64).saturating_mul(WEIGHT_PER_GAS)).unwrap_or(Weight::MAX)
 	}
 	fn weight_to_gas(weight: Weight) -> usize {
 		usize::try_from(weight.wrapping_div(WEIGHT_PER_GAS)).unwrap_or(usize::MAX)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -258,7 +258,7 @@ pub struct MoonbeamGasWeightMapping;
 
 impl pallet_evm::GasWeightMapping for MoonbeamGasWeightMapping {
 	fn gas_to_weight(gas: usize) -> Weight {
-		Weight::try_from(gas.saturating_mul(WEIGHT_PER_GAS as usize)).unwrap_or(Weight::MAX)
+		Weight::try_from((gas as u64).saturating_mul(WEIGHT_PER_GAS)).unwrap_or(Weight::MAX);
 	}
 	fn weight_to_gas(weight: Weight) -> usize {
 		usize::try_from(weight.wrapping_div(WEIGHT_PER_GAS)).unwrap_or(usize::MAX)

--- a/tools/load-testing/load-gas-loop.ts
+++ b/tools/load-testing/load-gas-loop.ts
@@ -62,7 +62,7 @@ const deployContract = async () => {
       data: contractBytecode,
       value: "0x00",
       gasPrice: "0x00",
-      gas: "0x1000000",
+      gas: 172663,
       nonce: 0,
     },
     deployer.privateKey
@@ -100,7 +100,7 @@ const callContract = async (loopCount: number) => {
       to: contractAddress,
       data: encoded,
       gasPrice: 0,
-      gas: "9627370496",
+      gas: 21829 + 381 * loopCount,
       nonce: 0,
     },
     freshAccount.privateKey


### PR DESCRIPTION
### What does it do?
It allows a better GasWeight conversation when usize is set to u32 type.

### What important points reviewers should know?
Wei will change the gas type from usize to u64 in future and this mapping will be improved at some point.
