### PR TITLE
Only require author id on CLI when node is authoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,15 +744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ci_info"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f638c70e8c5753795cc9a8c07c44da91554a09e4cf11a7326e8161b0a3c45e"
-dependencies = [
- "envmnt",
-]
-
-[[package]]
 name = "cipher"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,16 +1475,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6576a1755ddffd988788025e75bce9e74b018f7cc226198fe931d077911c6d7e"
 
 [[package]]
-name = "envmnt"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d328fc287c61314c4a61af7cfdcbd7e678e39778488c7cb13ec133ce0f4059"
-dependencies = [
- "fsio",
- "indexmap",
-]
-
-[[package]]
 name = "erased-serde"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,12 +2044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fsio"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
-
-[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,15 +2265,6 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -4293,12 +4259,6 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "nias"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
 
 [[package]]
 name = "nix"

--- a/node/parachain/src/cli.rs
+++ b/node/parachain/src/cli.rs
@@ -98,7 +98,7 @@ pub struct RunCmd {
 
 	/// Public identity for participating in staking and receiving rewards
 	#[structopt(long, parse(try_from_str = parse_h160))]
-	pub account_id: Option<H160>,
+	pub author_id: Option<H160>,
 }
 
 fn parse_h160(input: &str) -> Result<H160, String> {

--- a/node/parachain/src/command.rs
+++ b/node/parachain/src/command.rs
@@ -268,7 +268,7 @@ pub fn run() -> Result<()> {
 		None => {
 			let runner = cli.create_runner(&*cli.run)?;
 			let collator = cli.run.base.validator || cli.collator;
-			let author_id: Option<H160> = cli.run.account_id;
+			let author_id: Option<H160> = cli.run.author_id;
 			if collator {
 				if author_id.is_none() {
 					return Err("Collator nodes must specify an author account id".into());

--- a/node/parachain/src/service.rs
+++ b/node/parachain/src/service.rs
@@ -135,7 +135,7 @@ pub fn new_partial(
 async fn start_node_impl<RB>(
 	parachain_config: Configuration,
 	collator_key: CollatorPair,
-	account_id: H160,
+	author_id: Option<H160>,
 	polkadot_config: Configuration,
 	id: polkadot_primitives::v0::Id,
 	validator: bool,
@@ -162,7 +162,7 @@ where
 			},
 		)?;
 
-	let params = new_partial(&parachain_config, Some(account_id))?;
+	let params = new_partial(&parachain_config, author_id)?;
 
 	let client = params.client.clone();
 	let backend = params.backend.clone();
@@ -331,7 +331,7 @@ where
 pub async fn start_node(
 	parachain_config: Configuration,
 	collator_key: CollatorPair,
-	account_id: H160,
+	author_id: Option<H160>,
 	polkadot_config: Configuration,
 	id: polkadot_primitives::v0::Id,
 	validator: bool,
@@ -339,7 +339,7 @@ pub async fn start_node(
 	start_node_impl(
 		parachain_config,
 		collator_key,
-		account_id,
+		author_id,
 		polkadot_config,
 		id,
 		validator,

--- a/node/standalone/src/cli.rs
+++ b/node/standalone/src/cli.rs
@@ -30,7 +30,7 @@ pub struct RunCmd {
 
 	/// Public identity for participating in staking and receiving rewards
 	#[structopt(long, parse(try_from_str = parse_h160))]
-	pub account_id: Option<H160>,
+	pub author_id: Option<H160>,
 }
 
 fn parse_h160(input: &str) -> Result<H160, String> {

--- a/node/standalone/src/command.rs
+++ b/node/standalone/src/command.rs
@@ -133,13 +133,10 @@ pub fn run() -> sc_cli::Result<()> {
 		}
 		None => {
 			let runner = cli.create_runner(&cli.run.base)?;
-			let account = cli.run.account_id.ok_or(sc_cli::Error::Input(
-				"Account ID required but not set".to_string(),
-			))?;
 			runner.run_node_until_exit(|config| async move {
 				match config.role {
 					Role::Light => service::new_light(config),
-					_ => service::new_full(config, cli.run.manual_seal, account),
+					_ => service::new_full(config, cli.run.manual_seal, cli.run.author_id),
 				}
 			})
 		}

--- a/node/standalone/src/service.rs
+++ b/node/standalone/src/service.rs
@@ -16,13 +16,12 @@
 
 //! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
 
-use std::{sync::{Arc, Mutex}, time::Duration, collections::HashMap};
-use fc_rpc_core::types::PendingTransactions;
 use crate::mock_timestamp::MockTimestampInherentDataProvider;
 use fc_consensus::FrontierBlockImport;
+use fc_rpc_core::types::PendingTransactions;
 use moonbeam_runtime::{self, opaque::Block, RuntimeApi};
-use sc_client_api::{ExecutorProvider, RemoteBackend, BlockchainEvents};
 use parity_scale_codec::Encode;
+use sc_client_api::{BlockchainEvents, ExecutorProvider, RemoteBackend};
 use sc_consensus_manual_seal::{self as manual_seal};
 use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
@@ -31,6 +30,11 @@ use sc_service::{error::Error as ServiceError, Configuration, TaskManager};
 use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
 use sp_core::H160;
 use sp_inherents::InherentDataProviders;
+use std::{
+	collections::HashMap,
+	sync::{Arc, Mutex},
+	time::Duration,
+};
 
 // Our native executor instance.
 native_executor_instance!(
@@ -117,8 +121,7 @@ pub fn new_partial(
 		client.clone(),
 	);
 
-	let pending_transactions: PendingTransactions
-		= Some(Arc::new(Mutex::new(HashMap::new())));
+	let pending_transactions: PendingTransactions = Some(Arc::new(Mutex::new(HashMap::new())));
 
 	if manual_seal {
 		let frontier_block_import = FrontierBlockImport::new(client.clone(), client.clone(), true);
@@ -138,7 +141,10 @@ pub fn new_partial(
 			select_chain,
 			transaction_pool,
 			inherent_data_providers,
-			other: (ConsensusResult::ManualSeal(frontier_block_import), pending_transactions),
+			other: (
+				ConsensusResult::ManualSeal(frontier_block_import),
+				pending_transactions,
+			),
 		});
 	}
 
@@ -176,7 +182,10 @@ pub fn new_partial(
 		select_chain,
 		transaction_pool,
 		inherent_data_providers,
-		other: (ConsensusResult::Aura(aura_block_import, grandpa_link), pending_transactions),
+		other: (
+			ConsensusResult::Aura(aura_block_import, grandpa_link),
+			pending_transactions,
+		),
 	})
 }
 
@@ -184,7 +193,7 @@ pub fn new_partial(
 pub fn new_full(
 	config: Configuration,
 	manual_seal: bool,
-	author: H160,
+	author_id: Option<H160>,
 ) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
 		client,
@@ -196,7 +205,7 @@ pub fn new_full(
 		transaction_pool,
 		inherent_data_providers,
 		other: (consensus_result, pending_transactions),
-	} = new_partial(&config, manual_seal, Some(author))?;
+	} = new_partial(&config, manual_seal, author_id)?;
 
 	let (network, network_status_sinks, system_rpc_tx, network_starter) = match consensus_result {
 		ConsensusResult::ManualSeal(_) => {
@@ -284,43 +293,48 @@ pub fn new_full(
 
 	// Spawn Frontier pending transactions maintenance task (as essential, otherwise we leak).
 	if pending_transactions.is_some() {
+		use fp_consensus::{ConsensusLog, FRONTIER_ENGINE_ID};
 		use futures::StreamExt;
-		use fp_consensus::{FRONTIER_ENGINE_ID, ConsensusLog};
 		use sp_runtime::generic::OpaqueDigestItemId;
 
 		const TRANSACTION_RETAIN_THRESHOLD: u64 = 5;
 		task_manager.spawn_essential_handle().spawn(
 			"frontier-pending-transactions",
-			client.import_notification_stream().for_each(move |notification| {
-
-				if let Ok(locked) = &mut pending_transactions.clone().unwrap().lock() {
-					// As pending transactions have a finite lifespan anyway
-					// we can ignore MultiplePostRuntimeLogs error checks.
-					let mut frontier_log: Option<_> = None;
-					for log in notification.header.digest.logs {
-						let log = log.try_to::<ConsensusLog>(OpaqueDigestItemId::Consensus(&FRONTIER_ENGINE_ID));
-						if let Some(log) = log {
-							frontier_log = Some(log);
+			client
+				.import_notification_stream()
+				.for_each(move |notification| {
+					if let Ok(locked) = &mut pending_transactions.clone().unwrap().lock() {
+						// As pending transactions have a finite lifespan anyway
+						// we can ignore MultiplePostRuntimeLogs error checks.
+						let mut frontier_log: Option<_> = None;
+						for log in notification.header.digest.logs {
+							let log = log.try_to::<ConsensusLog>(OpaqueDigestItemId::Consensus(
+								&FRONTIER_ENGINE_ID,
+							));
+							if let Some(log) = log {
+								frontier_log = Some(log);
+							}
 						}
-					}
 
-					let imported_number: u64 = notification.header.number as u64;
+						let imported_number: u64 = notification.header.number as u64;
 
-					if let Some(ConsensusLog::EndBlock {
-						block_hash: _, transaction_hashes,
-					}) = frontier_log {
-						// Retain all pending transactions that were not
-						// processed in the current block.
-						locked.retain(|&k, _| !transaction_hashes.contains(&k));
+						if let Some(ConsensusLog::EndBlock {
+							block_hash: _,
+							transaction_hashes,
+						}) = frontier_log
+						{
+							// Retain all pending transactions that were not
+							// processed in the current block.
+							locked.retain(|&k, _| !transaction_hashes.contains(&k));
+						}
+						locked.retain(|_, v| {
+							// Drop all the transactions that exceeded the given lifespan.
+							let lifespan_limit = v.at_block + TRANSACTION_RETAIN_THRESHOLD;
+							lifespan_limit > imported_number
+						});
 					}
-					locked.retain(|_, v| {
-						// Drop all the transactions that exceeded the given lifespan.
-						let lifespan_limit = v.at_block + TRANSACTION_RETAIN_THRESHOLD;
-						lifespan_limit > imported_number
-					});
-				}
-				futures::future::ready(())
-			})
+					futures::future::ready(())
+				}),
 		);
 	}
 

--- a/scripts/run-alphanet-parachain.sh
+++ b/scripts/run-alphanet-parachain.sh
@@ -84,7 +84,7 @@ $PARACHAIN_BINARY \
   --name parachain_$PARACHAIN_INDEX \
   $PARACHAIN_BASE_PATH \
   '-linfo,evm=debug,ethereum=trace,rpc=trace,cumulus_collator=debug,txpool=debug' \
-  --account-id 6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b \
+  --author-id 6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b \
   $PARACHAIN_BOOTNODES_ARGS \
   -- \
     --node-key ${PARACHAIN_KEYS[$PARACHAIN_INDEX]} \

--- a/scripts/run-moonbase-standalone.sh
+++ b/scripts/run-moonbase-standalone.sh
@@ -58,7 +58,7 @@ $EXECUTABLE \
   --rpc-port $((STANDALONE_PORT + 1)) \
   --ws-port $((STANDALONE_PORT + 2)) \
   --validator \
-  --account-id 6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b \
+  --author-id 6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b \
   --rpc-cors all \
   --rpc-methods=unsafe \
   --execution wasm \

--- a/tests/tests/util/testWithMoonbeam.ts
+++ b/tests/tests/util/testWithMoonbeam.ts
@@ -49,7 +49,7 @@ export async function startMoonbeamNode(
     `--no-telemetry`,
     `--no-prometheus`,
     `--manual-seal`,
-    `--account-id=${GENESIS_ACCOUNT.substring(2)}`, // Required by author inherent
+    `--author-id=${GENESIS_ACCOUNT.substring(2)}`, // Required by author inherent
     `--no-grandpa`,
     `--force-authoring`,
     `-l${MOONBEAM_LOG}`,


### PR DESCRIPTION
### What does it do?

This PR makes the `--accoutn-id` flag only required whenthe node is authoring (eg, when they specify `--collator` or `--validator`).

### What value does it bring to the blockchain users?

Non-authoring nodes no longer need to provide a bogus account id to satisfy the CLI parser.
## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
