### PR TITLE
Allow full node to verify author inherent

### DIFF
--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -196,7 +196,7 @@ impl<T: Config> ProvideInherent for Module<T> {
 	}
 
 	fn check_inherent(call: &Self::Call, _data: &InherentData) -> Result<(), Self::Error> {
-		// This if let should always be true. This is the only call that the inehrent could make.
+		// This if let should always be true. This is the only call that the inherent could make.
 		if let Self::Call::set_author(claimed_author) = call {
 			ensure!(
 				T::CanAuthor::can_author(&claimed_author),

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -195,7 +195,7 @@ impl<T: Config> ProvideInherent for Module<T> {
 		Some(Call::set_author(author))
 	}
 
-	fn check_inherent(call: &Self::Call, data: &InherentData) -> Result<(), Self::Error> {
+	fn check_inherent(call: &Self::Call, _data: &InherentData) -> Result<(), Self::Error> {
 		// This if let should always be true. This is the only call that the inehrent could make.
 		if let Self::Call::set_author(claimed_author) = call {
 			ensure!(

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -196,39 +196,14 @@ impl<T: Config> ProvideInherent for Module<T> {
 	}
 
 	fn check_inherent(call: &Self::Call, data: &InherentData) -> Result<(), Self::Error> {
-		use sp_std::if_std;
-		if_std!{
-			println!("{:?}", call);
-		}
 		// This if let should always be true. This is the only call that the inehrent could make.
 		if let Self::Call::set_author(claimed_author) = call {
-			if_std!{
-				println!("Made it into the if let");
-			}
 			ensure!(
 				T::CanAuthor::can_author(&claimed_author),
 				InherentError::Other(sp_runtime::RuntimeString::Borrowed("Cannot Be Author"))
 			);
 		}
 
-
-		// This is the old logic. It is incorrect because it is based on what the inherent would
-		// have contained if the verifying node created it, rather than the actual inherent
-		// that the actual author created.
-		// let author_raw = data
-		// 	.get_data::<InherentType>(&INHERENT_IDENTIFIER)
-		// 	.expect("Gets and decodes authorship inherent data")
-		// 	.ok_or_else(|| {
-		// 		InherentError::Other(sp_runtime::RuntimeString::Borrowed(
-		// 			"Decode authorship inherent data failed",
-		// 		))
-		// 	})?;
-		// let author =
-		// 	T::AccountId::decode(&mut &author_raw[..]).expect("Decodes author raw inherent data");
-		// ensure!(
-		// 	T::CanAuthor::can_author(&author),
-		// 	InherentError::Other(sp_runtime::RuntimeString::Borrowed("Cannot Be Author"))
-		// );
 		Ok(())
 	}
 }


### PR DESCRIPTION
### What does it do?

Changes the inherent checking logic for the author inherent. It was previously "checking" the inherent as if the verifying node had made the inherent. It now checks the actual inherent that the actual author included.

### What important points reviewers should know?

Docs for the `ProvideInherent` trait: https://crates.parity.io/sp_inherents/trait.ProvideInherent.html These docs are not great, and I've made an attempt to improve them in https://github.com/paritytech/substrate/pull/7941

### What alternative implementations were considered?

We considered not checking the inherent at all, but this would remove most of the usefulness of the stake pallet.

### What value does it bring to the blockchain users?

It is possible to run full nodes.

## Checklist

- [x] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
