### PR TITLE
Restore Alice and Bob accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3962,6 +3962,7 @@ dependencies = [
 name = "moonbase-alphanet"
 version = "0.1.0"
 dependencies = [
+ "account",
  "ansi_term 0.12.1",
  "assert_cmd",
  "author-inherent",

--- a/node/parachain/Cargo.toml
+++ b/node/parachain/Cargo.toml
@@ -71,6 +71,7 @@ fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "v0.5-ho
 fc-rpc = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
 
 author-inherent = { path = "../../pallets/author-inherent"}
+account = { path = "../../runtime/account"}
 
 # Cumulus dependencies
 cumulus-consensus = { git = "https://github.com/paritytech/cumulus", branch = "master" }

--- a/node/parachain/src/chain_spec.rs
+++ b/node/parachain/src/chain_spec.rs
@@ -89,7 +89,7 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		None,
 		Some(serde_json::from_str("{\"tokenDecimals\": 18}").expect("Provided valid json map")),
 		Extensions {
-			relay_chain: "local_testnet".into(),
+			relay_chain: "rococo-local".into(),
 			para_id: para_id.into(),
 		},
 	)

--- a/node/parachain/src/command.rs
+++ b/node/parachain/src/command.rs
@@ -270,43 +270,43 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(&*cli.run)?;
 			let collator = cli.run.base.validator || cli.collator;
 
+			if cli.run.base.shared_params.dev {
+				// Dev node does not make sense in a parachain-only context.
+				// This is being adressed in a big way in github.com/PureStake/moonbeam/pull/204
+				return Err("--dev does not make sense in a parachain context".into());
+			}
+
 			// Supply the correct author id for wellknown validators.
 			// This isn't super elegant, but the alternative is modifying Substrate
 			// and this will go away when we start signing blocks
-			let author_id = if cli.run.base.shared_params.dev {
-				//TODO what do we actually expect `--dev` to do in the parachain context
-				let alice_public = ecdsa::Pair::from_string("//Alice", None)
-					.expect("Alice is a valid phrase")
-					.public();
-				Some(EthereumSigner::from(alice_public).into_account())
-			} else if cli.run.base.alice {
+			let author_id = if cli.run.base.alice {
 				let alice_public = ecdsa::Pair::from_string("//Alice", None)
 					.expect("Alice is a valid phrase")
 					.public();
 				Some(EthereumSigner::from(alice_public).into_account())
 			} else if cli.run.base.bob {
 				let alice_public = ecdsa::Pair::from_string("//Bob", None)
-					.expect("Alice is a valid phrase")
+					.expect("Bob is a valid phrase")
 					.public();
 				Some(EthereumSigner::from(alice_public).into_account())
 			} else if cli.run.base.charlie {
 				let alice_public = ecdsa::Pair::from_string("//Charlie", None)
-					.expect("Alice is a valid phrase")
+					.expect("Charlie is a valid phrase")
 					.public();
 				Some(EthereumSigner::from(alice_public).into_account())
 			} else if cli.run.base.dave {
 				let alice_public = ecdsa::Pair::from_string("//Dave", None)
-					.expect("Alice is a valid phrase")
+					.expect("Dave is a valid phrase")
 					.public();
 				Some(EthereumSigner::from(alice_public).into_account())
 			} else if cli.run.base.eve {
 				let alice_public = ecdsa::Pair::from_string("//Eve", None)
-					.expect("Alice is a valid phrase")
+					.expect("Eve is a valid phrase")
 					.public();
 				Some(EthereumSigner::from(alice_public).into_account())
 			} else if cli.run.base.ferdie {
 				let alice_public = ecdsa::Pair::from_string("//Ferdie", None)
-					.expect("Alice is a valid phrase")
+					.expect("Ferdie is a valid phrase")
 					.public();
 				Some(EthereumSigner::from(alice_public).into_account())
 			} else {

--- a/node/standalone/Cargo.lock
+++ b/node/standalone/Cargo.lock
@@ -3631,6 +3631,7 @@ dependencies = [
 name = "moonbase-standalone"
 version = "0.1.1"
 dependencies = [
+ "account",
  "author-inherent",
  "fc-consensus",
  "fc-rpc-core",

--- a/node/standalone/Cargo.toml
+++ b/node/standalone/Cargo.toml
@@ -63,6 +63,7 @@ fc-consensus = { git = "https://github.com/purestake/frontier", branch = "v0.5-h
 fp-consensus = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
 
 author-inherent = { path = "../../pallets/author-inherent"}
+account = { path = "../../runtime/account"}
 
 [build-dependencies]
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/node/standalone/src/chain_spec.rs
+++ b/node/standalone/src/chain_spec.rs
@@ -16,13 +16,14 @@
 
 use moonbeam_runtime::{
 	AccountId, AuraConfig, BalancesConfig, EVMConfig, EthereumChainIdConfig, EthereumConfig,
-	GenesisConfig, GrandpaConfig, Signature, StakeConfig, SudoConfig, SystemConfig, GLMR, WASM_BINARY,
+	GenesisConfig, GrandpaConfig, Signature, StakeConfig, SudoConfig, SystemConfig, GLMR,
+	WASM_BINARY,
 };
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{ecdsa, Pair, Public};
-use sp_runtime::traits::{IdentifyAccount, Verify};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
+use sp_runtime::traits::{IdentifyAccount, Verify};
 use std::collections::BTreeMap;
 use std::str::FromStr;
 

--- a/node/standalone/src/chain_spec.rs
+++ b/node/standalone/src/chain_spec.rs
@@ -55,7 +55,7 @@ pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
 	(get_from_seed::<AuraId>(s), get_from_seed::<GrandpaId>(s))
 }
 
-// The development chain spec is useful for starting a single-node local network to test your runtime.
+// The development chain spec is useful for starting a single-node local test network.
 // This is not useful for testing ntworking or consensus.
 // It is used in the typescript integration tests found in `/tests`.
 pub fn development_chain_spec() -> Result<ChainSpec, String> {

--- a/node/standalone/src/chain_spec.rs
+++ b/node/standalone/src/chain_spec.rs
@@ -16,11 +16,12 @@
 
 use moonbeam_runtime::{
 	AccountId, AuraConfig, BalancesConfig, EVMConfig, EthereumChainIdConfig, EthereumConfig,
-	GenesisConfig, GrandpaConfig, StakeConfig, SudoConfig, SystemConfig, GLMR, WASM_BINARY,
+	GenesisConfig, GrandpaConfig, Signature, StakeConfig, SudoConfig, SystemConfig, GLMR, WASM_BINARY,
 };
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_core::{Pair, Public};
+use sp_core::{ecdsa, Pair, Public};
+use sp_runtime::traits::{IdentifyAccount, Verify};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
 use std::collections::BTreeMap;
 use std::str::FromStr;
@@ -36,6 +37,16 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 	TPublic::Pair::from_string(&format!("//{}", seed), None)
 		.expect("static values are valid; qed")
 		.public()
+}
+
+type AccountPublic = <Signature as Verify>::Signer;
+
+/// Generate an account ID from seed.
+pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
+where
+	AccountPublic: From<<TPublic::Pair as Pair>::Public>,
+{
+	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
 
 /// Generate an Aura authority key.
@@ -61,9 +72,13 @@ pub fn development_config() -> Result<ChainSpec, String> {
 				// Initial PoA authorities
 				vec![authority_keys_from_seed("Alice")],
 				// Sudo account
-				AccountId::from_str("6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b").unwrap(),
+				get_account_id_from_seed::<ecdsa::Public>("Alice"),
 				// Pre-funded accounts
-				vec![AccountId::from_str("6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b").unwrap()],
+				vec![
+					get_account_id_from_seed::<ecdsa::Public>("Alice"),
+					get_account_id_from_seed::<ecdsa::Public>("Bob"),
+					AccountId::from_str("6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b").unwrap(),
+				],
 				true,
 				1281, // ChainId
 			)

--- a/node/standalone/src/chain_spec.rs
+++ b/node/standalone/src/chain_spec.rs
@@ -54,10 +54,10 @@ pub fn authority_keys_from_seed(s: &str) -> (AuraId, GrandpaId) {
 	(get_from_seed::<AuraId>(s), get_from_seed::<GrandpaId>(s))
 }
 
-// The development config is useful for starting a single-node local network to test your runtime.
+// The development chain spec is useful for starting a single-node local network to test your runtime.
 // This is not useful for testing ntworking or consensus.
 // It is used in the typescript integration tests found in `/tests`.
-pub fn development_config() -> Result<ChainSpec, String> {
+pub fn development_chain_spec() -> Result<ChainSpec, String> {
 	let wasm_binary = WASM_BINARY.ok_or("Development wasm binary not available".to_string())?;
 
 	Ok(ChainSpec::from_genesis(
@@ -97,7 +97,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
 }
 
 // The local testnet is useful for spinning up a two-node network.
-pub fn local_testnet_config() -> Result<ChainSpec, String> {
+pub fn local_testnet_chain_spec() -> Result<ChainSpec, String> {
 	let wasm_binary = WASM_BINARY.ok_or("Development wasm binary not available".to_string())?;
 
 	Ok(ChainSpec::from_genesis(

--- a/node/standalone/src/command.rs
+++ b/node/standalone/src/command.rs
@@ -18,9 +18,9 @@ use crate::chain_spec;
 use crate::cli::{Cli, Subcommand};
 use crate::service;
 use crate::service::new_partial;
+use account::EthereumSigner;
 use sc_cli::{ChainSpec, Role, RuntimeVersion, SubstrateCli};
 use sc_service::PartialComponents;
-use account::EthereumSigner;
 use sp_core::{ecdsa, Pair};
 use sp_runtime::traits::IdentifyAccount;
 

--- a/node/standalone/src/command.rs
+++ b/node/standalone/src/command.rs
@@ -140,39 +140,34 @@ pub fn run() -> sc_cli::Result<()> {
 			// Supply the correct author id for wellknown validators.
 			// This isn't super elegant, but the alternative is modifying Substrate
 			// and this will go away when we start signing blocks
-			let author_id = if cli.run.base.shared_params.dev {
-				let alice_public = ecdsa::Pair::from_string("//Alice", None)
-					.expect("Alice is a valid phrase")
-					.public();
-				Some(EthereumSigner::from(alice_public).into_account())
-			} else if cli.run.base.alice {
+			let author_id = if cli.run.base.alice || cli.run.base.shared_params.dev {
 				let alice_public = ecdsa::Pair::from_string("//Alice", None)
 					.expect("Alice is a valid phrase")
 					.public();
 				Some(EthereumSigner::from(alice_public).into_account())
 			} else if cli.run.base.bob {
 				let alice_public = ecdsa::Pair::from_string("//Bob", None)
-					.expect("Alice is a valid phrase")
+					.expect("Bob is a valid phrase")
 					.public();
 				Some(EthereumSigner::from(alice_public).into_account())
 			} else if cli.run.base.charlie {
 				let alice_public = ecdsa::Pair::from_string("//Charlie", None)
-					.expect("Alice is a valid phrase")
+					.expect("Charlie is a valid phrase")
 					.public();
 				Some(EthereumSigner::from(alice_public).into_account())
 			} else if cli.run.base.dave {
 				let alice_public = ecdsa::Pair::from_string("//Dave", None)
-					.expect("Alice is a valid phrase")
+					.expect("Dave is a valid phrase")
 					.public();
 				Some(EthereumSigner::from(alice_public).into_account())
 			} else if cli.run.base.eve {
 				let alice_public = ecdsa::Pair::from_string("//Eve", None)
-					.expect("Alice is a valid phrase")
+					.expect("Eve is a valid phrase")
 					.public();
 				Some(EthereumSigner::from(alice_public).into_account())
 			} else if cli.run.base.ferdie {
 				let alice_public = ecdsa::Pair::from_string("//Ferdie", None)
-					.expect("Alice is a valid phrase")
+					.expect("Ferdie is a valid phrase")
 					.public();
 				Some(EthereumSigner::from(alice_public).into_account())
 			} else {

--- a/node/standalone/src/command.rs
+++ b/node/standalone/src/command.rs
@@ -48,8 +48,8 @@ impl SubstrateCli for Cli {
 
 	fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
 		Ok(match id {
-			"dev" | "development" => Box::new(chain_spec::development_config()?),
-			"" | "local" => Box::new(chain_spec::local_testnet_config()?),
+			"dev" | "development" => Box::new(chain_spec::development_chain_spec()?),
+			"" | "local" => Box::new(chain_spec::local_testnet_chain_spec()?),
 			path => Box::new(chain_spec::ChainSpec::from_json_file(
 				std::path::PathBuf::from(path),
 			)?),


### PR DESCRIPTION
### What does it do?

This PR changes the Rust-based genesis configurations to use the standard Alice and Bob accounts for sudo and prefunded accounts. This make Moonbeam more similar to other Substrate based chains. This does not remove the old "Gerald" (`0x6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b`) account from being prefunded in order to keep intergations that depend on it working.

It also fixes the `--dev`, `--alice`, `--bob`, etc flags to work with the author inherent.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

The part about making the `--alice` flags work could be accomplished more elegantly code-wise by patching substrate. But because maintaining a Substrate fork brings a significant overhead and because the author inherent will change when we start signing blocks, I decided to do a slightly less elegant fix here in Moonbeam.

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

Apps does not currently derive the Alice Bob, etc accounts correctly. https://github.com/polkadot-js/apps/issues/4467 This may make it _appear_ that this PR is incorrect, but really the problem is with Apps.

For example the default chainspec now pre-funds the Alice account. If you go to Apps and add the Alice account by mnemonic, it will appear that Alice was not prefunded. In reality Apps is not deriving the correct account, and the incorrect account that Apps derived is not prefunded. To work around this, import accounts into Apps by private key as described in that issue.

### What value does it bring to the blockchain users?

Ability to quickly spin up testnets using standard accounts.

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
