### PR TITLE
Disable intermediate state root in Pallet Ethereum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "derive_more 0.99.11",
  "fp-consensus",
@@ -1701,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1738,7 +1738,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core 15.1.0",
@@ -1842,7 +1842,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "0.8.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "evm",
  "impl-trait-for-tuples 0.1.3",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4662,7 +4662,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4699,7 +4699,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "evm",
  "fp-evm",
@@ -4737,7 +4737,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "evm",
  "fp-evm",
@@ -4749,7 +4749,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "evm",
  "fp-evm",

--- a/client/rpc-core/txpool/Cargo.toml
+++ b/client/rpc-core/txpool/Cargo.toml
@@ -16,4 +16,4 @@ jsonrpc-derive = "14.0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }

--- a/node/parachain/Cargo.toml
+++ b/node/parachain/Cargo.toml
@@ -62,13 +62,13 @@ pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrat
 sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
-evm = { package = "pallet-evm", git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
-ethereum = { package = "pallet-ethereum", git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
+evm = { package = "pallet-evm", git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
+ethereum = { package = "pallet-ethereum", git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
 
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
-fp-consensus = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
+fc-consensus = { git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
+fp-consensus = { git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
 
 author-inherent = { path = "../../pallets/author-inherent"}
 

--- a/node/rpc/Cargo.toml
+++ b/node/rpc/Cargo.toml
@@ -31,9 +31,9 @@ sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "
 sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-transaction-graph = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
 moonbeam-rpc-txpool = { path = "../../client/rpc/txpool" }
 moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool" }
 

--- a/node/standalone/Cargo.lock
+++ b/node/standalone/Cargo.lock
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "derive_more",
  "fp-consensus",
@@ -1486,7 +1486,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1523,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core 15.1.0",
@@ -1617,7 +1617,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -1628,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "0.8.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "evm",
  "impl-trait-for-tuples 0.1.3",
@@ -1641,7 +1641,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4173,7 +4173,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "evm",
  "fp-evm",
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "evm",
  "fp-evm",
@@ -4260,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.5-hotfixes#1f38522d2c9126bf30372345d0c9282ac90da010"
+source = "git+https://github.com/purestake/frontier?branch=disable-intermediate-state-root#05791611d0c1c110b7a127b93988c06b9cd39b9d"
 dependencies = [
  "evm",
  "fp-evm",

--- a/node/standalone/Cargo.toml
+++ b/node/standalone/Cargo.toml
@@ -58,9 +58,9 @@ sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "
 
 moonbeam-runtime = {path = "../../runtime", default-features = false, features = ["std", "standalone"] }
 moonbeam-rpc = { path = "../rpc" }
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
-fp-consensus = { git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
+fc-consensus = { git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
+fp-consensus = { git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
 
 author-inherent = { path = "../../pallets/author-inherent"}
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -43,13 +43,13 @@ pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", 
 
 frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "v0.5-hotfixes" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "disable-intermediate-state-root" }
 
 sp-consensus-aura = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master", optional = true }
 pallet-grandpa = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master", optional = true }
 
-pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
-fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "v0.5-hotfixes" }
+pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
+fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "disable-intermediate-state-root" }
 
 moonbeam-rpc-primitives-txpool = { path = "../primitives/rpc/txpool", default-features = false }
 

--- a/runtime/account/Cargo.toml
+++ b/runtime/account/Cargo.toml
@@ -24,7 +24,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "v0.5-hotfixes" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "disable-intermediate-state-root" }
 
 
 [features]

--- a/runtime/precompiles/Cargo.toml
+++ b/runtime/precompiles/Cargo.toml
@@ -10,11 +10,11 @@ rustc-hex = { version = "2.0.1", default-features = false }
 
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "v0.5-hotfixes" }
-# pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", default-features = false, branch = "v0.5-hotfixes" }
-pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", default-features = false, branch = "v0.5-hotfixes" }
-pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", default-features = false, branch = "v0.5-hotfixes" }
-pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", default-features = false, branch = "v0.5-hotfixes" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "disable-intermediate-state-root" }
+# pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", default-features = false, branch = "disable-intermediate-state-root" }
+pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", default-features = false, branch = "disable-intermediate-state-root" }
+pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", default-features = false, branch = "disable-intermediate-state-root" }
+pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", default-features = false, branch = "disable-intermediate-state-root" }
 
 [features]
 default = [ "std" ]


### PR DESCRIPTION
This PR switches to a patched version of pallet ethereum in which the intermediate substrate state root is not injected. Telmo's hypothesis is that this will solve the `digest item must match that calculated` error. If it does, then we know the underlying cause is how Frontier uses sp-io.

If this does not solve the issue (or, more precisely, replaces it with an error about `state root must match`) then we know Frontier's use of sp-io is not the problem. In that case we should turn our attention toward cumulus and the relay parent.