### PR TITLE
Use zero instead of intermediate state root

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -304,13 +304,17 @@ impl fp_rpc::ConvertTransaction<opaque::UncheckedExtrinsic> for TransactionConve
 
 pub struct EthereumFindAuthor<F>(PhantomData<F>);
 
+parameter_types! {
+	pub const DefaultStateRoot: H256 = H256::zero();
+}
+
 impl pallet_ethereum::Config for Runtime {
 	type Event = Event;
 	#[cfg(not(feature = "standalone"))]
 	type FindAuthor = EthereumFindAuthor<PhantomAura>;
 	#[cfg(feature = "standalone")]
 	type FindAuthor = EthereumFindAuthor<Aura>;
-	type StateRoot = pallet_ethereum::IntermediateStateRoot;
+	type StateRoot = DefaultStateRoot;
 }
 
 // 18 decimals

--- a/runtime/src/parachain.rs
+++ b/runtime/src/parachain.rs
@@ -22,8 +22,8 @@ macro_rules! runtime_parachain {
 			spec_name: create_runtime_str!("moonbase-alphanet"),
 			impl_name: create_runtime_str!("moonbase-alphanet"),
 			authoring_version: 3,
-			spec_version: 9,
-			impl_version: 2,
+			spec_version: 10,
+			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,
 		};

--- a/runtime/src/standalone.rs
+++ b/runtime/src/standalone.rs
@@ -31,8 +31,8 @@ macro_rules! runtime_standalone {
 			spec_name: create_runtime_str!("moonbeam-standalone"),
 			impl_name: create_runtime_str!("moonbeam-standalone"),
 			authoring_version: 3,
-			spec_version: 9,
-			impl_version: 2,
+			spec_version: 10,
+			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,
 		};


### PR DESCRIPTION
This PR switches changes the moonbeam runtime so that the intermediate substrate state root is not injected. Telmo's hypothesis is that this will solve the digest item must match that calculated error. If it does, then we know the underlying cause is how Frontier uses sp-io.

If this does not solve the issue (or, more precisely, replaces it with an error about state root must match) then we know Frontier's use of sp-io is not the problem. In that case we should turn our attention toward cumulus and the relay parent.

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
