### PR TITLE
Restore intermediate state root

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -304,17 +304,13 @@ impl fp_rpc::ConvertTransaction<opaque::UncheckedExtrinsic> for TransactionConve
 
 pub struct EthereumFindAuthor<F>(PhantomData<F>);
 
-parameter_types! {
-	pub const DefaultStateRoot: H256 = H256::zero();
-}
-
 impl pallet_ethereum::Config for Runtime {
 	type Event = Event;
 	#[cfg(not(feature = "standalone"))]
 	type FindAuthor = EthereumFindAuthor<PhantomAura>;
 	#[cfg(feature = "standalone")]
 	type FindAuthor = EthereumFindAuthor<Aura>;
-	type StateRoot = DefaultStateRoot;
+	type StateRoot = pallet_ethereum::IntermediateStateRoot;
 }
 
 // 18 decimals

--- a/runtime/src/parachain.rs
+++ b/runtime/src/parachain.rs
@@ -22,8 +22,8 @@ macro_rules! runtime_parachain {
 			spec_name: create_runtime_str!("moonbase-alphanet"),
 			impl_name: create_runtime_str!("moonbase-alphanet"),
 			authoring_version: 3,
-			spec_version: 9,
-			impl_version: 2,
+			spec_version: 11,
+			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,
 		};

--- a/runtime/src/parachain.rs
+++ b/runtime/src/parachain.rs
@@ -22,8 +22,8 @@ macro_rules! runtime_parachain {
 			spec_name: create_runtime_str!("moonbase-alphanet"),
 			impl_name: create_runtime_str!("moonbase-alphanet"),
 			authoring_version: 3,
-			spec_version: 10,
-			impl_version: 1,
+			spec_version: 9,
+			impl_version: 2,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,
 		};

--- a/runtime/src/standalone.rs
+++ b/runtime/src/standalone.rs
@@ -31,8 +31,8 @@ macro_rules! runtime_standalone {
 			spec_name: create_runtime_str!("moonbeam-standalone"),
 			impl_name: create_runtime_str!("moonbeam-standalone"),
 			authoring_version: 3,
-			spec_version: 9,
-			impl_version: 2,
+			spec_version: 11,
+			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,
 		};

--- a/runtime/src/standalone.rs
+++ b/runtime/src/standalone.rs
@@ -31,8 +31,8 @@ macro_rules! runtime_standalone {
 			spec_name: create_runtime_str!("moonbeam-standalone"),
 			impl_name: create_runtime_str!("moonbeam-standalone"),
 			authoring_version: 3,
-			spec_version: 10,
-			impl_version: 1,
+			spec_version: 9,
+			impl_version: 2,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,
 		};


### PR DESCRIPTION
### What does it do?

Reverts #198, and bumps the runtime upgrade to allow for onchain deployment.

### What important points reviewers should know?

#198 was added in hopes of fixing "digest item must match errors" with the hypothesis that they were caused by pallet ethereum's intermediate state root. That PR did not fix the errors. We later discovered that the issue is likely related to a dirty state cache. Running with state cache essentially disabled has solved the problem so far. We will now re-introduce the intermediate state root to confirm that the digest mismatch does not return.

## Checklist

- [ ] Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
