### PR TITLE
Make author inherent both required and mandatory

### DIFF
--- a/runtime/src/parachain.rs
+++ b/runtime/src/parachain.rs
@@ -22,7 +22,7 @@ macro_rules! runtime_parachain {
 			spec_name: create_runtime_str!("moonbase-alphanet"),
 			impl_name: create_runtime_str!("moonbase-alphanet"),
 			authoring_version: 3,
-			spec_version: 11,
+			spec_version: 12,
 			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,

--- a/runtime/src/standalone.rs
+++ b/runtime/src/standalone.rs
@@ -31,7 +31,7 @@ macro_rules! runtime_standalone {
 			spec_name: create_runtime_str!("moonbeam-standalone"),
 			impl_name: create_runtime_str!("moonbeam-standalone"),
 			authoring_version: 3,
-			spec_version: 11,
+			spec_version: 12,
 			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,


### PR DESCRIPTION
### What does it do?

Modifies the author inherent in two ways.

1. The inherent is now required. This should allow blocks that don't ahve it to be rejected during the quick prechecks rather than waiting until after they are executed.
2. The inherent is now Mandatory dispatch class https://crates.parity.io/frame_support/weights/enum.DispatchClass.html#variant.Mandatory This is consistent with how the timestamp inherent is handled.

### What important points reviewers should know?

We discovered the need for this change when we tried to install the democracy pallet. Democracy intentionally fills the entire block weight every `LaunchPeriod` blocks. This was leaving no room for the inherent which was dropped. That made our blocks invalid.

### What alternative implementations were considered?

As always, we may ditch the author inherent for a PReRuntime digest when cumulus supports slots (or we may not). But regardless of whether we use this inherent long-term, this is the correct design for it.

### What value does it bring to the blockchain users?

The chain doesn't stall after the first launch period.

## Checklist

- [ ] Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
