### PR TITLE
Wire author inherent to pallet ethereum

### DIFF
--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -21,7 +21,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::{
-	decl_error, decl_event, decl_module, decl_storage, ensure, traits::FindAuthor, weights::DispatchClass,
+	decl_error, decl_event, decl_module, decl_storage, ensure, traits::FindAuthor,
+	weights::DispatchClass,
 };
 use frame_system::{ensure_none, Config as System};
 use parity_scale_codec::{Decode, Encode};

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -131,11 +131,7 @@ impl<T: Config> FindAuthor<T::AccountId> for Module<T> {
 		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
 	{
 		// We don't use the digests at all.
-		// That assumes an implementation, and should be removed from the trait IMO
-
-		// This will only return the correct author _after_ the authorship inherent is processed. Is
-		// it valid to assume that inherents are the first extrinsics in a block? How does timestamp
-		// handle this?
+		// This will only return the correct author _after_ the authorship inherent is processed.
 		<Author<T>>::get()
 	}
 }

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -20,7 +20,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use frame_support::{decl_error, decl_event, decl_module, decl_storage, ensure};
+use frame_support::{
+	decl_error, decl_event, decl_module, decl_storage, ensure, traits::FindAuthor,
+};
 use frame_system::{ensure_none, Config as System};
 use parity_scale_codec::{Decode, Encode};
 #[cfg(feature = "std")]
@@ -114,6 +116,21 @@ decl_module! {
 		fn on_finalize() {
 			assert!(<Author<T>>::take().is_some(), "Author inherent must be in the block");
 		}
+	}
+}
+
+impl<T: Config> FindAuthor<T::AccountId> for Module<T> {
+	fn find_author<'a, I>(_digests: I) -> Option<T::AccountId>
+	where
+		I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
+	{
+		// We don't use the digests at all.
+		// That assumes an implementation, and should be removed from the trait IMO
+
+		// This will only return the correct author _after_ the authorship inherent is processed. Is
+		// it valid to assume that inherents are the first extrinsics in a block? How does timestamp
+		// handle this?
+		<Author<T>>::get()
 	}
 }
 

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -21,7 +21,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::{
-	decl_error, decl_event, decl_module, decl_storage, ensure, traits::FindAuthor,
+	decl_error, decl_event, decl_module, decl_storage, ensure,
+	traits::FindAuthor,
 	weights::{DispatchClass, Weight},
 };
 use frame_system::{ensure_none, Config as System};

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -306,10 +306,7 @@ pub struct EthereumFindAuthor<F>(PhantomData<F>);
 
 impl pallet_ethereum::Config for Runtime {
 	type Event = Event;
-	#[cfg(not(feature = "standalone"))]
-	type FindAuthor = EthereumFindAuthor<PhantomAura>;
-	#[cfg(feature = "standalone")]
-	type FindAuthor = EthereumFindAuthor<Aura>;
+	type FindAuthor = AuthorInherent;
 	type StateRoot = pallet_ethereum::IntermediateStateRoot;
 }
 

--- a/runtime/src/parachain.rs
+++ b/runtime/src/parachain.rs
@@ -22,7 +22,7 @@ macro_rules! runtime_parachain {
 			spec_name: create_runtime_str!("moonbase-alphanet"),
 			impl_name: create_runtime_str!("moonbase-alphanet"),
 			authoring_version: 3,
-			spec_version: 11,
+			spec_version: 12,
 			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,
@@ -35,26 +35,6 @@ macro_rules! runtime_parachain {
 		}
 
 		impl parachain_info::Config for Runtime {}
-
-		// TODO Consensus not supported in parachain
-		impl<F: FindAuthor<u32>> FindAuthor<H160> for EthereumFindAuthor<F> {
-			fn find_author<'a, I>(_digests: I) -> Option<H160>
-			where
-				I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
-			{
-				None
-			}
-		}
-
-		pub struct PhantomAura;
-		impl FindAuthor<u32> for PhantomAura {
-			fn find_author<'a, I>(_digests: I) -> Option<u32>
-			where
-				I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
-			{
-				Some(0 as u32)
-			}
-		}
 
 		construct_runtime! {
 			pub enum Runtime where

--- a/runtime/src/parachain.rs
+++ b/runtime/src/parachain.rs
@@ -22,7 +22,7 @@ macro_rules! runtime_parachain {
 			spec_name: create_runtime_str!("moonbase-alphanet"),
 			impl_name: create_runtime_str!("moonbase-alphanet"),
 			authoring_version: 3,
-			spec_version: 13,
+			spec_version: 14,
 			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,

--- a/runtime/src/parachain.rs
+++ b/runtime/src/parachain.rs
@@ -22,7 +22,7 @@ macro_rules! runtime_parachain {
 			spec_name: create_runtime_str!("moonbase-alphanet"),
 			impl_name: create_runtime_str!("moonbase-alphanet"),
 			authoring_version: 3,
-			spec_version: 12,
+			spec_version: 13,
 			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,

--- a/runtime/src/standalone.rs
+++ b/runtime/src/standalone.rs
@@ -31,7 +31,7 @@ macro_rules! runtime_standalone {
 			spec_name: create_runtime_str!("moonbeam-standalone"),
 			impl_name: create_runtime_str!("moonbeam-standalone"),
 			authoring_version: 3,
-			spec_version: 13,
+			spec_version: 14,
 			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,

--- a/runtime/src/standalone.rs
+++ b/runtime/src/standalone.rs
@@ -31,7 +31,7 @@ macro_rules! runtime_standalone {
 			spec_name: create_runtime_str!("moonbeam-standalone"),
 			impl_name: create_runtime_str!("moonbeam-standalone"),
 			authoring_version: 3,
-			spec_version: 11,
+			spec_version: 12,
 			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,

--- a/runtime/src/standalone.rs
+++ b/runtime/src/standalone.rs
@@ -31,7 +31,7 @@ macro_rules! runtime_standalone {
 			spec_name: create_runtime_str!("moonbeam-standalone"),
 			impl_name: create_runtime_str!("moonbeam-standalone"),
 			authoring_version: 3,
-			spec_version: 12,
+			spec_version: 13,
 			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,

--- a/tests/tests/test-block.ts
+++ b/tests/tests/test-block.ts
@@ -64,14 +64,14 @@ describeWithMoonbeam("Moonbeam RPC (Block)", `simple-specs.json`, (context) => {
 
     const block = await context.web3.eth.getBlock("latest");
     expect(block).to.include({
-      author: "0x0000000000000000000000000000000000000000",
+      author: "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b",
       difficulty: "0",
       extraData: "0x",
       gasLimit: 4294967295,
       gasUsed: 0,
       //hash: "0x14fe6f7c93597f79b901f8b5d7a84277a90915b8d355959b587e18de34f1dc17",
       logsBloom: `0x${"0".repeat(512)}`,
-      miner: "0x0000000000000000000000000000000000000000",
+      miner: "0x6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b",
       number: 1,
       //parentHash: "0x04540257811b46d103d9896e7807040e7de5080e285841c5430d1a81588a0ce4",
       receiptsRoot: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",

--- a/tests/tests/test-subscription.ts
+++ b/tests/tests/test-subscription.ts
@@ -166,11 +166,11 @@ describeWithMoonbeam(
       subscription.unsubscribe();
 
       expect(data).to.include({
-        author: "0x0000000000000000000000000000000000000000",
+        author: "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b",
         difficulty: "0",
         extraData: "0x",
         logsBloom: `0x${"0".repeat(512)}`,
-        miner: "0x0000000000000000000000000000000000000000",
+        miner: "0x6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b",
         receiptsRoot: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
         sha3Uncles: "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
         transactionsRoot: "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",


### PR DESCRIPTION
### What does it do?

Takes the author information provided by the author inherent, and feeds it into pallet Ethereum where it can be put into the ethereum-style block's `beneficiary` field. Previously this information came from aura in the standalone node and was stubbed to `0x00...00` in the parachain node.

### What value does it bring to the blockchain users?

Users who interact with the chain using only (or primarily) Ethereum RPC endpoints will still get to know the block author.

## Checklist

- [ ] Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
