### PR TITLE
Remove redundant author requirement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,7 +387,9 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "sp-authorship",
+ "sp-core",
  "sp-inherents",
+ "sp-io",
  "sp-runtime",
  "sp-std",
 ]

--- a/pallets/author-inherent/Cargo.toml
+++ b/pallets/author-inherent/Cargo.toml
@@ -15,6 +15,10 @@ sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "mast
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 
+[dev-dependencies]
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+
 [features]
 default = ["std"]
 std = [

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -269,8 +269,6 @@ mod tests {
 	pub struct Test;
 	parameter_types! {
 		pub const BlockHashCount: u64 = 250;
-		pub BlockWeights: frame_system::limits::BlockWeights =
-			frame_system::limits::BlockWeights::simple_max(1024);
 	}
 	impl System for Test {
 		type BaseCallFilter = ();

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -229,7 +229,7 @@ mod tests {
 	use super::*;
 
 	use frame_support::{
-		assert_err, assert_ok, impl_outer_event, impl_outer_origin, parameter_types,
+		assert_noop, assert_ok, impl_outer_event, impl_outer_origin, parameter_types,
 		traits::{OnFinalize, OnInitialize},
 	};
 	use sp_core::H256;
@@ -325,7 +325,7 @@ mod tests {
 	fn double_author_fails() {
 		new_test_ext().execute_with(|| {
 			assert_ok!(AuthorInherent::set_author(Origin::none(), 1));
-			assert_err!(
+			assert_noop!(
 				AuthorInherent::set_author(Origin::none(), 1),
 				Error::<Test>::AuthorAlreadySet
 			);

--- a/runtime/src/parachain.rs
+++ b/runtime/src/parachain.rs
@@ -22,7 +22,7 @@ macro_rules! runtime_parachain {
 			spec_name: create_runtime_str!("moonbase-alphanet"),
 			impl_name: create_runtime_str!("moonbase-alphanet"),
 			authoring_version: 3,
-			spec_version: 12,
+			spec_version: 13,
 			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,

--- a/runtime/src/standalone.rs
+++ b/runtime/src/standalone.rs
@@ -31,7 +31,7 @@ macro_rules! runtime_standalone {
 			spec_name: create_runtime_str!("moonbeam-standalone"),
 			impl_name: create_runtime_str!("moonbeam-standalone"),
 			authoring_version: 3,
-			spec_version: 12,
+			spec_version: 13,
 			impl_version: 1,
 			apis: RUNTIME_API_VERSIONS,
 			transaction_version: 2,


### PR DESCRIPTION
### What does it do?

Removes panic in `on_finalize` if Author storage item isn't set. The requirement should still be enforced by the fact that the inherent which sets this storage item is required to be included in every block afaik https://github.com/paritytech/substrate/pull/8002

I moved `Author::kill()` to `on_initialize` so that every block is finalized with the author set (assuming the inherent requirement enforces setting it correctly). I think this is better than clearing the author storage item before the block is finalized.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- Does it require a purge of the network? No
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- Does it require changes in documentation/tutorials ? No
