### PR TITLE
set frontier_log to last log that decodes and break

### DIFF
--- a/node/src/dev_service.rs
+++ b/node/src/dev_service.rs
@@ -199,12 +199,13 @@ pub fn new_full(
 						// As pending transactions have a finite lifespan anyway
 						// we can ignore MultiplePostRuntimeLogs error checks.
 						let mut frontier_log: Option<_> = None;
-						for log in notification.header.digest.logs {
+						for log in notification.header.digest.logs.iter().rev() {
 							let log = log.try_to::<ConsensusLog>(OpaqueDigestItemId::Consensus(
 								&FRONTIER_ENGINE_ID,
 							));
-							if let Some(log) = log {
-								frontier_log = Some(log);
+							if log.is_some() {
+								frontier_log = log;
+								break;
 							}
 						}
 

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -224,12 +224,13 @@ where
 						// As pending transactions have a finite lifespan anyway
 						// we can ignore MultiplePostRuntimeLogs error checks.
 						let mut frontier_log: Option<_> = None;
-						for log in notification.header.digest.logs {
+						for log in notification.header.digest.logs.iter().rev() {
 							let log = log.try_to::<ConsensusLog>(OpaqueDigestItemId::Consensus(
 								&FRONTIER_ENGINE_ID,
 							));
-							if let Some(log) = log {
-								frontier_log = Some(log);
+							if log.is_some() {
+								frontier_log = log;
+								break;
 							}
 						}
 


### PR DESCRIPTION
closes https://github.com/PureStake/moonbeam/issues/217

### What important points reviewers should know?

*[initial suggestion](https://github.com/PureStake/moonbeam/pull/204#discussion_r567328224)*

The previous loop set `frontier_log` to the last log that `is_some` (after a `try_to` decode attempt)  in `notification.header.digest.logs`. If there are no logs that are `is_some`, then it is None. 

The new loop starts from the end and goes backwards; it sets `frontier_log` to the last `log` that `is_some` and then breaks from the loop instead of going over all the logs every time. Worst case is still the same, but, if not worst case, this is better because it breaks early.

### Checklist
This is a small change to how the logic is expressed, but doesn't change the underlying logic.
* No purge of network required
* No version bumps required
* No changes to docs
