### PR TITLE
Added tests for extrinsic events

### DIFF
--- a/tests/tests/test-balance.ts
+++ b/tests/tests/test-balance.ts
@@ -4,6 +4,7 @@ import { step } from "mocha-steps";
 
 import { createAndFinalizeBlock, describeWithMoonbeam, customRequest } from "./util";
 import { GENESIS_ACCOUNT_BALANCE } from "./constants";
+import { AnyTuple, IEvent } from "@polkadot/types/types";
 
 describeWithMoonbeam("Moonbeam RPC (Balance)", `simple-specs.json`, (context) => {
   const GENESIS_ACCOUNT = "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b";
@@ -40,6 +41,47 @@ describeWithMoonbeam("Moonbeam RPC (Balance)", `simple-specs.json`, (context) =>
       "1108925819614629174684664"
     );
     expect(await context.web3.eth.getBalance(TEST_ACCOUNT)).to.equal("512");
+  });
+
+  step("read ethereum.transact extrinsic events", async function () {
+    const signedBlock = await context.polkadotApi.rpc.chain.getBlock();
+    const allRecords = await context.polkadotApi.query.system.events.at(
+      signedBlock.block.header.hash
+    );
+
+    // map between the extrinsics and events
+    signedBlock.block.extrinsics.forEach(({ method: { method, section } }, index) => {
+      // filter the specific events based on the phase and then the
+      // index of our extrinsic in the block
+      const events: IEvent<AnyTuple>[] = allRecords
+        .filter(({ phase }) => phase.isApplyExtrinsic && phase.asApplyExtrinsic.eq(index))
+        .map(({ event }) => event);
+
+      switch (index) {
+        // First 3 events:
+        // timestamp.set:: system.ExtrinsicSuccess
+        // parachainUpgrade.setValidationData:: system.ExtrinsicSuccess
+        // authorInherent.setAuthor:: system.ExtrinsicSuccess
+        case 0:
+        case 1:
+        case 2:
+          expect(
+            events.length === 1 && context.polkadotApi.events.system.ExtrinsicSuccess.is(events[0])
+          ).to.be.true;
+          break;
+        // Fourth event: ethereum.transact:: system.NewAccount, balances.Endowed, ethereum.Executed, system.ExtrinsicSuccess
+        case 3:
+          expect(section === "ethereum" && method === "transact").to.be.true;
+          expect(events.length === 4);
+          expect(context.polkadotApi.events.system.NewAccount.is(events[0])).to.be.true;
+          expect(context.polkadotApi.events.balances.Endowed.is(events[1])).to.be.true;
+          expect(context.polkadotApi.events.ethereum.Executed.is(events[2])).to.be.true;
+          expect(context.polkadotApi.events.system.ExtrinsicSuccess.is(events[3])).to.be.true;
+          break;
+        default:
+          throw new Error(`Unexpected extrinsic`);
+      }
+    });
   });
 
   step("balance should be the same on polkadot/web3", async function () {

--- a/tests/tests/test-balance.ts
+++ b/tests/tests/test-balance.ts
@@ -69,7 +69,8 @@ describeWithMoonbeam("Moonbeam RPC (Balance)", `simple-specs.json`, (context) =>
             events.length === 1 && context.polkadotApi.events.system.ExtrinsicSuccess.is(events[0])
           ).to.be.true;
           break;
-        // Fourth event: ethereum.transact:: system.NewAccount, balances.Endowed, ethereum.Executed, system.ExtrinsicSuccess
+        // Fourth event: ethereum.transact:: system.NewAccount, balances.Endowed, ethereum.Executed,
+        // system.ExtrinsicSuccess
         case 3:
           expect(section === "ethereum" && method === "transact").to.be.true;
           expect(events.length === 4);

--- a/tests/tests/test-polkadot-api.ts
+++ b/tests/tests/test-polkadot-api.ts
@@ -3,6 +3,7 @@ import { Keyring } from "@polkadot/keyring";
 import { step } from "mocha-steps";
 
 import { createAndFinalizeBlock, describeWithMoonbeam } from "./util";
+import { AnyTuple, IEvent } from "@polkadot/types/types";
 
 describeWithMoonbeam("Moonbeam Polkadot API", `simple-specs.json`, (context) => {
   const GENESIS_ACCOUNT = "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b";
@@ -72,6 +73,46 @@ describeWithMoonbeam("Moonbeam Polkadot API", `simple-specs.json`, (context) => 
           break;
         default:
           throw new Error(`Unexpected extrinsic: ${message}`);
+      }
+    });
+  });
+
+  step("read extrinsic events", async function () {
+    const signedBlock = await context.polkadotApi.rpc.chain.getBlock();
+    const allRecords = await context.polkadotApi.query.system.events.at(
+      signedBlock.block.header.hash
+    );
+
+    // map between the extrinsics and events
+    signedBlock.block.extrinsics.forEach(({ method: { method, section } }, index) => {
+      // filter the specific events based on the phase and then the
+      // index of our extrinsic in the block
+      const events: IEvent<AnyTuple>[] = allRecords
+        .filter(({ phase }) => phase.isApplyExtrinsic && phase.asApplyExtrinsic.eq(index))
+        .map(({ event }) => event);
+
+      switch (index) {
+        // First 3 events:
+        // timestamp.set:: system.ExtrinsicSuccess
+        // parachainUpgrade.setValidationData:: system.ExtrinsicSuccess
+        // authorInherent.setAuthor:: system.ExtrinsicSuccess
+        case 0:
+        case 1:
+        case 2:
+          expect(
+            events.length === 1 && context.polkadotApi.events.system.ExtrinsicSuccess.is(events[0])
+          ).to.be.true;
+          break;
+        // Fourth event: balances.transfer:: system.NewAccount, balances.Endowed, balances.Transfer, system.ExtrinsicSuccess
+        case 3:
+          expect(events.length === 4);
+          expect(context.polkadotApi.events.system.NewAccount.is(events[0])).to.be.true;
+          expect(context.polkadotApi.events.balances.Endowed.is(events[1])).to.be.true;
+          expect(context.polkadotApi.events.balances.Transfer.is(events[2])).to.be.true;
+          expect(context.polkadotApi.events.system.ExtrinsicSuccess.is(events[3])).to.be.true;
+          break;
+        default:
+          throw new Error(`Unexpected extrinsic`);
       }
     });
   });

--- a/tests/tests/test-polkadot-api.ts
+++ b/tests/tests/test-polkadot-api.ts
@@ -103,7 +103,8 @@ describeWithMoonbeam("Moonbeam Polkadot API", `simple-specs.json`, (context) => 
             events.length === 1 && context.polkadotApi.events.system.ExtrinsicSuccess.is(events[0])
           ).to.be.true;
           break;
-        // Fourth event: balances.transfer:: system.NewAccount, balances.Endowed, balances.Transfer, system.ExtrinsicSuccess
+        // Fourth event: balances.transfer:: system.NewAccount, balances.Endowed, balances.Transfer,
+        // system.ExtrinsicSuccess
         case 3:
           expect(events.length === 4);
           expect(context.polkadotApi.events.system.NewAccount.is(events[0])).to.be.true;


### PR DESCRIPTION
### What does it do?

Added tests for extrinsic events for balance.transfer and ethereum.transact

closes https://github.com/PureStake/moonbeam/issues/157

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
