### PR TITLE
Support instant seal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3978,6 +3978,7 @@ version = "0.1.0"
 dependencies = [
  "ansi_term 0.12.1",
  "assert_cmd",
+ "async-io",
  "author-inherent",
  "cumulus-collator",
  "cumulus-consensus",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -13,6 +13,7 @@ name = 'moonbase-alphanet'
 path = 'src/main.rs'
 
 [dependencies]
+async-io = "1.3"
 derive_more = '0.15.0'
 exit-future = '0.1.4'
 futures = { version = "0.3.1", features = ["compat"] }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -96,6 +96,10 @@ pub struct RunCmd {
 	#[structopt(long)]
 	pub parachain_id: Option<u32>,
 
+	/// Whether to use manual seal when starting the dev service
+	#[structopt(long)]
+	pub manual_seal: bool,
+
 	/// Public identity for participating in staking and receiving rewards
 	#[structopt(long, parse(try_from_str = parse_h160))]
 	pub author_id: Option<H160>,

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -16,6 +16,7 @@
 
 use sp_core::H160;
 use std::path::PathBuf;
+use std::str::FromStr;
 use structopt::StructOpt;
 
 /// Sub-commands supported by the collator.
@@ -96,9 +97,11 @@ pub struct RunCmd {
 	#[structopt(long)]
 	pub parachain_id: Option<u32>,
 
-	/// Whether to use manual seal when starting the dev service
-	#[structopt(long)]
-	pub manual_seal: bool,
+	/// When blocks should be sealed in the dev service.
+	///
+	/// Options are "instant", "manual", or timer interval in milliseconds
+	#[structopt(long, default_value = "instant")]
+	pub sealing: Sealing,
 
 	/// Public identity for participating in staking and receiving rewards
 	#[structopt(long, parse(try_from_str = parse_h160))]
@@ -167,5 +170,32 @@ impl RelayChainCli {
 			chain_id,
 			base: polkadot_cli::RunCmd::from_iter(relay_chain_args),
 		}
+	}
+}
+
+/// Block authoring scheme to be used by the dev service.
+#[derive(Debug)]
+pub enum Sealing {
+	/// Author a block immediately upon receiving a transaction into the transaction pool
+	Instant,
+	/// Author a block upon receiving an RPC command
+	Manual,
+	/// Author blocks at a regular interval specified in milliseconds
+	Interval(u64),
+}
+
+impl FromStr for Sealing {
+	type Err = String;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(match s {
+			"instant" => Self::Instant,
+			"manual" => Self::Manual,
+			s => {
+				let millis =
+					u64::from_str_radix(s, 10).map_err(|_| "couldn't decode sealing param")?;
+				Self::Interval(millis)
+			}
+		})
 	}
 }

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -291,7 +291,7 @@ pub fn run() -> Result<()> {
 							.expect("Gerald is a valid account"),
 					));
 
-					return crate::dev_service::new_full(config, true, author_id);
+					return crate::dev_service::new_full(config, cli.run.manual_seal, author_id);
 				}
 
 				let key = sp_core::Pair::generate().0;

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -291,7 +291,7 @@ pub fn run() -> Result<()> {
 							.expect("Gerald is a valid account"),
 					));
 
-					return crate::dev_service::new_full(config, author_id);
+					return crate::dev_service::new_full(config, true, author_id);
 				}
 
 				let key = sp_core::Pair::generate().0;

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -291,7 +291,7 @@ pub fn run() -> Result<()> {
 							.expect("Gerald is a valid account"),
 					));
 
-					return crate::dev_service::new_full(config, cli.run.manual_seal, author_id);
+					return crate::dev_service::new_full(config, cli.run.sealing, author_id);
 				}
 
 				let key = sp_core::Pair::generate().0;

--- a/node/src/dev_service.rs
+++ b/node/src/dev_service.rs
@@ -17,15 +17,21 @@
 //! Service and ServiceFactory implementation. Specialized wrapper over Substrate service.
 //! This one is used specifically for the --dev service.
 
+use crate::cli::Sealing;
+use async_io::Timer;
 use fc_consensus::FrontierBlockImport;
 use fc_rpc_core::types::PendingTransactions;
+use futures::Stream;
+use futures::StreamExt;
 use moonbeam_runtime::{self, opaque::Block, RuntimeApi};
 use sc_client_api::BlockchainEvents;
-use sc_consensus_manual_seal::{self as manual_seal};
+use sc_consensus_manual_seal::{run_manual_seal, EngineCommand, ManualSealParams};
 use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
 use sc_service::{error::Error as ServiceError, Configuration, TaskManager};
 use sp_core::H160;
+use sp_core::H256;
+use std::time::Duration;
 use std::{
 	collections::HashMap,
 	sync::{Arc, Mutex},
@@ -44,7 +50,6 @@ type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
 
 pub fn new_partial(
 	config: &Configuration,
-	// manual_seal: bool, // For now only manual seal. Maybe bring this back to support instant later.
 	author: Option<H160>,
 ) -> Result<
 	sc_service::PartialComponents<
@@ -101,7 +106,7 @@ pub fn new_partial(
 /// Builds a new service for a full client.
 pub fn new_full(
 	config: Configuration,
-	manual_seal: bool,
+	sealing: Sealing,
 	author_id: Option<H160>,
 ) -> Result<TaskManager, ServiceError> {
 	let sc_service::PartialComponents {
@@ -153,38 +158,53 @@ pub fn new_full(
 			prometheus_registry.as_ref(),
 		);
 
-		if manual_seal {
-			// Channel for the rpc handler to communicate with the authorship task.
-			let (sink, commands_stream) = futures::channel::mpsc::channel(1000);
-			command_sink = Some(sink);
+		let commands_stream: Box<dyn Stream<Item = EngineCommand<H256>> + Send + Sync + Unpin> =
+			match sealing {
+				Sealing::Instant => {
+					Box::new(
+						// This bit cribbed from the implementation of instant seal.
+						transaction_pool
+							.pool()
+							.validated_pool()
+							.import_notification_stream()
+							.map(|_| EngineCommand::SealNewBlock {
+								create_empty: false,
+								finalize: false,
+								parent_hash: None,
+								sender: None,
+							}),
+					)
+				}
+				Sealing::Manual => {
+					let (sink, stream) = futures::channel::mpsc::channel(1000);
+					// Keep a reference to the other end of the channel. It goes to the RPC.
+					command_sink = Some(sink);
+					Box::new(stream)
+				}
+				Sealing::Interval(millis) => Box::new(StreamExt::map(
+					Timer::interval(Duration::from_millis(millis)),
+					|_| EngineCommand::SealNewBlock {
+						create_empty: true,
+						finalize: false,
+						parent_hash: None,
+						sender: None,
+					},
+				)),
+			};
 
-			task_manager.spawn_essential_handle().spawn_blocking(
-				"manual-seal",
-				manual_seal::run_manual_seal(manual_seal::ManualSealParams {
-					block_import,
-					env,
-					client: client.clone(),
-					pool: transaction_pool.pool().clone(),
-					commands_stream,
-					select_chain,
-					consensus_data_provider: None,
-					inherent_data_providers,
-				}),
-			);
-		} else {
-			task_manager.spawn_essential_handle().spawn_blocking(
-				"instant-seal",
-				manual_seal::run_instant_seal(manual_seal::InstantSealParams {
-					block_import,
-					env,
-					client: client.clone(),
-					pool: transaction_pool.pool().clone(),
-					select_chain,
-					consensus_data_provider: None,
-					inherent_data_providers,
-				}),
-			);
-		};
+		task_manager.spawn_essential_handle().spawn_blocking(
+			"authorship_task",
+			run_manual_seal(ManualSealParams {
+				block_import,
+				env,
+				client: client.clone(),
+				pool: transaction_pool.pool().clone(),
+				commands_stream,
+				select_chain,
+				consensus_data_provider: None,
+				inherent_data_providers,
+			}),
+		);
 	}
 
 	let rpc_extensions_builder = {
@@ -226,7 +246,6 @@ pub fn new_full(
 	// Spawn Frontier pending transactions maintenance task (as essential, otherwise we leak).
 	if pending_transactions.is_some() {
 		use fp_consensus::{ConsensusLog, FRONTIER_ENGINE_ID};
-		use futures::StreamExt;
 		use sp_runtime::generic::OpaqueDigestItemId;
 
 		const TRANSACTION_RETAIN_THRESHOLD: u64 = 5;

--- a/tests/tests/util/testWithMoonbeam.ts
+++ b/tests/tests/util/testWithMoonbeam.ts
@@ -47,6 +47,7 @@ export async function startMoonbeamNode(
     `--no-telemetry`,
     `--no-prometheus`,
     `--dev`,
+    `--manual-seal`,
     `-l${MOONBEAM_LOG}`,
     `--port=${PORT}`,
     `--rpc-port=${RPC_PORT}`,

--- a/tests/tests/util/testWithMoonbeam.ts
+++ b/tests/tests/util/testWithMoonbeam.ts
@@ -47,7 +47,7 @@ export async function startMoonbeamNode(
     `--no-telemetry`,
     `--no-prometheus`,
     `--dev`,
-    `--sealing manual`,
+    `--sealing=manual`,
     `-l${MOONBEAM_LOG}`,
     `--port=${PORT}`,
     `--rpc-port=${RPC_PORT}`,

--- a/tests/tests/util/testWithMoonbeam.ts
+++ b/tests/tests/util/testWithMoonbeam.ts
@@ -47,7 +47,7 @@ export async function startMoonbeamNode(
     `--no-telemetry`,
     `--no-prometheus`,
     `--dev`,
-    `--manual-seal`,
+    `--sealing manual`,
     `-l${MOONBEAM_LOG}`,
     `--port=${PORT}`,
     `--rpc-port=${RPC_PORT}`,


### PR DESCRIPTION
This PR adds instant seal and interval seal as authoring schemes in the `--dev` service. This will allow users to easily run an instant seal node for testing their local development against moonbeam, while also allowing testing of block-time based things like staking and democracy periods, and also supporting manual seal for integration tests.

```bash
# Manual seal like we use in the tests, and when reproducing complex forking behavior
moonbase-alphanet --dev --tmp --sealing manual

# Instant seal for testing your contracts, bots, dapp, etc really fast like ganache
moonbease-alphanet --dev --tmp --sealing instant

# Interval seal for when you want blocks to come at a fixed time interval
# The parameter is miliseconds. So this will author every 6 seconds
# Useful for testing stuff that happens in block time eg. democracy
moonbase-alphanet --dev --tmp --sealing 6000

# The default is instant seal
moonbase-alphanet --dev --tmp
```

## Checklist

- :x: Does it require a purge of the network?
- :x: You bumped the runtime version if there are breaking changes in the **runtime** ?
- :heavy_check_mark:  Does it require changes in documentation/tutorials ?
