### PR TITLE
declare stake constants for polkadot-js

### DIFF
--- a/pallets/stake/src/lib.rs
+++ b/pallets/stake/src/lib.rs
@@ -429,9 +429,9 @@ pub trait Config: System {
 	/// Maximum validators per round
 	type MaxValidators: Get<u32>;
 	/// Maximum nominators per validator
-	type MaxNominatorsPerValidator: Get<usize>;
+	type MaxNominatorsPerValidator: Get<u32>;
 	/// Maximum validators per nominator
-	type MaxValidatorsPerNominator: Get<usize>;
+	type MaxValidatorsPerNominator: Get<u32>;
 	/// Balance issued as rewards per round (constant issuance)
 	type IssuancePerRound: Get<BalanceOf<Self>>;
 	/// Maximum fee for any validator
@@ -583,9 +583,9 @@ decl_module! {
 		/// Maximum validators per round.
 		const MaxValidators: u32 = T::MaxValidators::get();
 		/// Maximum nominators per validator
-		const MaxNominatorsPerValidator: usize = T::MaxNominatorsPerValidator::get();
+		const MaxNominatorsPerValidator: u32 = T::MaxNominatorsPerValidator::get();
 		/// Maximum validators per nominator
-		const MaxValidatorsPerNominator: usize = T::MaxValidatorsPerNominator::get();
+		const MaxValidatorsPerNominator: u32 = T::MaxValidatorsPerNominator::get();
 		/// Balance issued as rewards per round (constant issuance)
 		const IssuancePerRound: BalanceOf<T> = T::IssuancePerRound::get();
 		/// Maximum fee for any validator
@@ -743,7 +743,7 @@ decl_module! {
 			ensure!(amount >= T::MinNomination::get(), Error::<T>::NominationBelowMin);
 			let mut nominator = <Nominators<T>>::get(&acc).ok_or(Error::<T>::NominatorDNE)?;
 			ensure!(
-				nominator.nominations.0.len() < T::MaxValidatorsPerNominator::get(),
+				(nominator.nominations.0.len() as u32) < T::MaxValidatorsPerNominator::get(),
 				Error::<T>::ExceedMaxValidatorsPerNom
 			);
 			let mut state = <Candidates<T>>::get(&validator).ok_or(Error::<T>::CandidateDNE)?;
@@ -756,7 +756,7 @@ decl_module! {
 				amount,
 			};
 			ensure!(
-				state.nominators.0.len() < T::MaxNominatorsPerValidator::get(),
+				(state.nominators.0.len() as u32) < T::MaxNominatorsPerValidator::get(),
 				Error::<T>::TooManyNominators
 			);
 			ensure!(
@@ -912,7 +912,7 @@ impl<T: Config> Module<T> {
 			Error::<T>::NominatorExists
 		);
 		ensure!(
-			state.nominators.0.len() <= T::MaxNominatorsPerValidator::get(),
+			(state.nominators.0.len() as u32) <= T::MaxNominatorsPerValidator::get(),
 			Error::<T>::TooManyNominators
 		);
 		T::Currency::reserve(&nominator, amount)?;

--- a/pallets/stake/src/lib.rs
+++ b/pallets/stake/src/lib.rs
@@ -576,6 +576,27 @@ decl_module! {
 		type Error = Error<T>;
 		fn deposit_event() = default;
 
+		/// A new round chooses a new validator set. Runtime config (RC) is 20 so every 2 minutes.
+		const BlocksPerRound: T::BlockNumber = T::BlocksPerRound::get();
+		/// Number of rounds that validators remain bonded before exit request is executed
+		const BondDuration: RoundIndex = T::BondDuration::get();
+		/// Maximum validators per round.
+		const MaxValidators: u32 = T::MaxValidators::get();
+		/// Maximum nominators per validator
+		const MaxNominatorsPerValidator: usize = T::MaxNominatorsPerValidator::get();
+		/// Maximum validators per nominator
+		const MaxValidatorsPerNominator: usize = T::MaxValidatorsPerNominator::get();
+		/// Balance issued as rewards per round (constant issuance)
+		const IssuancePerRound: BalanceOf<T> = T::IssuancePerRound::get();
+		/// Maximum fee for any validator
+		const MaxFee: Perbill = T::MaxFee::get();
+		/// Minimum stake for any registered on-chain account to become a validator
+		const MinValidatorStk: BalanceOf<T> = T::MinNominatorStk::get();
+		/// Minimum stake for any registered on-chain account to nominate
+		const MinNomination: BalanceOf<T> = T::MinNomination::get();
+		/// Minimum stake for any registered on-chain account to become a nominator
+		const MinNominatorStk: BalanceOf<T> = T::MinNominatorStk::get();
+
 		#[weight = 0]
 		fn join_candidates(
 			origin,

--- a/pallets/stake/src/lib.rs
+++ b/pallets/stake/src/lib.rs
@@ -576,7 +576,7 @@ decl_module! {
 		type Error = Error<T>;
 		fn deposit_event() = default;
 
-		/// A new round chooses a new validator set. Runtime config (RC) is 20 so every 2 minutes.
+		/// A new round chooses a new validator set. Runtime config is 20 so every 2 minutes.
 		const BlocksPerRound: T::BlockNumber = T::BlocksPerRound::get();
 		/// Number of rounds that validators remain bonded before exit request is executed
 		const BondDuration: RoundIndex = T::BondDuration::get();

--- a/pallets/stake/src/mock.rs
+++ b/pallets/stake/src/mock.rs
@@ -98,8 +98,8 @@ parameter_types! {
 	pub const BlocksPerRound: u32 = 5;
 	pub const BondDuration: u32 = 2;
 	pub const MaxValidators: u32 = 5;
-	pub const MaxNominatorsPerValidator: usize = 4;
-	pub const MaxValidatorsPerNominator: usize = 4;
+	pub const MaxNominatorsPerValidator: u32 = 4;
+	pub const MaxValidatorsPerNominator: u32 = 4;
 	pub const IssuancePerRound: u128 = 10;
 	pub const MaxFee: Perbill = Perbill::from_percent(50);
 	pub const MinValidatorStk: u128 = 10;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -109,7 +109,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase-alphanet"),
 	impl_name: create_runtime_str!("moonbase-alphanet"),
 	authoring_version: 3,
-	spec_version: 16,
+	spec_version: 17,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -309,9 +309,9 @@ parameter_types! {
 	/// Maximum 8 valid block authors at any given time
 	pub const MaxValidators: u32 = 8;
 	/// Maximum 10 nominators per validator
-	pub const MaxNominatorsPerValidator: usize = 10;
+	pub const MaxNominatorsPerValidator: u32 = 10;
 	/// Maximum 8 validators per nominator (same as MaxValidators)
-	pub const MaxValidatorsPerNominator: usize = 8;
+	pub const MaxValidatorsPerNominator: u32 = 8;
 	/// Issue 49 new tokens as rewards to validators every 2 minutes (round)
 	pub const IssuancePerRound: u128 = 49 * GLMR;
 	/// The maximum percent a validator can take off the top of its rewards is 50%


### PR DESCRIPTION
closes #228 

This PR only changes the `usize` runtime constants to `u32` and declares the constants in `decl_module`. Is this a breaking change (do I have to increment the version)?