### PR TITLE
Attempt stake migrations

### DIFF
--- a/pallets/stake/Cargo.toml
+++ b/pallets/stake/Cargo.toml
@@ -15,6 +15,7 @@ parity-scale-codec = { version = "1.0.0", default-features = false, features = [
 serde = { version = "1.0.101", optional = true }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 
 [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
@@ -32,4 +33,5 @@ std = [
 	"serde",
 	"sp-std/std",
 	"sp-runtime/std",
+	"sp-core/std",
 ]


### PR DESCRIPTION
This PR is my attempts to do some kind of state migration from for the stake pallet. Currently this is not working. I think the PR shows my attempts and the places I got stuck well. We can work on this more if it is desired.

Here are some notes I took while trying this:

```
I can see three paths regarding the storage migrations.
1. Purge. Ultimately this is probably my recommendation.
2. Hack migration that doesn't actually migrate data, just installs new data. Maybe even leaves old
3. behind assuming that alphanet won't live long enough for that to matter.
3. Genuine migrations. Tough part is what schema are we even migrating from?

Where are we migrating from? `adecdec5`
We're trying to migrate from whatever is on Alphanet right now. I believe alphanet was launched fresh
from commit adecdec5 after the stall incident. This is consistent with the runtime version 11 reported
by Apps on alphanet.
https://github.com/PureStake/moonbeam/blob/adecdec5e5889d87ed0e0d98b543e04609e8ffd9/runtime/src/parachain.rs#L25

There were two big PRs that touched pallet stake since then. Basically our migrations need to cover their changes:
* https://github.com/PureStake/moonbeam/pull/189 - multiple nominations
* https://github.com/PureStake/moonbeam/pull/232 - staking inflation
* (There was also #230 which just exposed constants in metadata; no migrations necessary)

Substrate pallets to follow: Scheduler, Balances
```