### PR TITLE
patch stake nominations bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3986,7 +3986,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "moonbase-alphanet"
+name = "moonbeam"
 version = "0.1.0"
 dependencies = [
  "ansi_term 0.12.1",
@@ -9508,7 +9508,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
- "pallet-staking",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/pallets/stake/Cargo.toml
+++ b/pallets/stake/Cargo.toml
@@ -10,7 +10,6 @@ author-inherent = { path = "../author-inherent", default-features = false }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
-pallet-staking = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
 parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "master", default-features = false }
@@ -27,7 +26,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"pallet-balances/std",
-	"pallet-staking/std",
 	"parity-scale-codec/std",
 	"serde",
 	"sp-std/std",

--- a/pallets/stake/src/lib.rs
+++ b/pallets/stake/src/lib.rs
@@ -72,7 +72,6 @@ use sp_std::{cmp::Ordering, prelude::*};
 #[derive(Default, Clone, Encode, Decode, RuntimeDebug)]
 pub struct Bond<AccountId, Balance> {
 	pub owner: AccountId,
-	#[codec(compact)]
 	pub amount: Balance,
 }
 
@@ -126,10 +125,8 @@ impl Default for ValidatorStatus {
 /// Snapshot of validator state at the start of the round for which they are selected
 pub struct ValidatorSnapshot<AccountId, Balance> {
 	pub fee: Perbill,
-	#[codec(compact)]
 	pub bond: Balance,
 	pub nominators: Vec<Bond<AccountId, Balance>>,
-	#[codec(compact)]
 	pub total: Balance,
 }
 
@@ -138,10 +135,8 @@ pub struct ValidatorSnapshot<AccountId, Balance> {
 pub struct Validator<AccountId, Balance> {
 	pub id: AccountId,
 	pub fee: Perbill,
-	#[codec(compact)]
 	pub bond: Balance,
 	pub nominators: OrderedSet<Bond<AccountId, Balance>>,
-	#[codec(compact)]
 	pub total: Balance,
 	pub state: ValidatorStatus,
 }
@@ -275,7 +270,6 @@ impl<A: Clone, B: Copy> From<Validator<A, B>> for ValidatorSnapshot<A, B> {
 #[derive(Encode, Decode, RuntimeDebug)]
 pub struct Nominator<AccountId, Balance> {
 	pub nominations: OrderedSet<Bond<AccountId, Balance>>,
-	#[codec(compact)]
 	pub total: Balance,
 }
 
@@ -668,7 +662,7 @@ decl_module! {
 		fn join_candidates(
 			origin,
 			fee: Perbill,
-			#[compact] bond: BalanceOf<T>,
+			bond: BalanceOf<T>,
 		) -> DispatchResult {
 			let acc = ensure_signed(origin)?;
 			ensure!(!Self::is_candidate(&acc),Error::<T>::CandidateExists);
@@ -750,7 +744,7 @@ decl_module! {
 		}
 		/// Bond more for validator candidates
 		#[weight = 0]
-		fn candidate_bond_more(origin, #[compact] more: BalanceOf<T>) -> DispatchResult {
+		fn candidate_bond_more(origin, more: BalanceOf<T>) -> DispatchResult {
 			let validator = ensure_signed(origin)?;
 			let mut state = <Candidates<T>>::get(&validator).ok_or(Error::<T>::CandidateDNE)?;
 			ensure!(!state.is_leaving(),Error::<T>::CannotActivateIfLeaving);
@@ -767,7 +761,7 @@ decl_module! {
 		}
 		/// Bond less for validator candidates
 		#[weight = 0]
-		fn candidate_bond_less(origin, #[compact] less: BalanceOf<T>) -> DispatchResult {
+		fn candidate_bond_less(origin, less: BalanceOf<T>) -> DispatchResult {
 			let validator = ensure_signed(origin)?;
 			let mut state = <Candidates<T>>::get(&validator).ok_or(Error::<T>::CandidateDNE)?;
 			ensure!(!state.is_leaving(),Error::<T>::CannotActivateIfLeaving);
@@ -787,7 +781,7 @@ decl_module! {
 		fn join_nominators(
 			origin,
 			validator: T::AccountId,
-			#[compact] amount: BalanceOf<T>,
+			amount: BalanceOf<T>,
 		) -> DispatchResult {
 			let acc = ensure_signed(origin)?;
 			ensure!(amount >= T::MinNominatorStk::get(), Error::<T>::NomBondBelowMin);
@@ -815,7 +809,7 @@ decl_module! {
 		fn nominate_new(
 			origin,
 			validator: T::AccountId,
-			#[compact] amount: BalanceOf<T>,
+			amount: BalanceOf<T>,
 		) -> DispatchResult {
 			let acc = ensure_signed(origin)?;
 			ensure!(amount >= T::MinNomination::get(), Error::<T>::NominationBelowMin);
@@ -895,7 +889,7 @@ decl_module! {
 		fn nominator_bond_more(
 			origin,
 			candidate: T::AccountId,
-			#[compact] more: BalanceOf<T>
+			more: BalanceOf<T>
 		) -> DispatchResult {
 			let nominator = ensure_signed(origin)?;
 			let mut nominations = <Nominators<T>>::get(&nominator).ok_or(Error::<T>::NominatorDNE)?;
@@ -920,7 +914,7 @@ decl_module! {
 		fn nominator_bond_less(
 			origin,
 			candidate: T::AccountId,
-			#[compact] less: BalanceOf<T>
+			less: BalanceOf<T>
 		) -> DispatchResult {
 			let nominator = ensure_signed(origin)?;
 			let mut nominations = <Nominators<T>>::get(&nominator).ok_or(Error::<T>::NominatorDNE)?;

--- a/pallets/stake/src/lib.rs
+++ b/pallets/stake/src/lib.rs
@@ -72,6 +72,7 @@ use sp_std::{cmp::Ordering, prelude::*};
 #[derive(Default, Clone, Encode, Decode, RuntimeDebug)]
 pub struct Bond<AccountId, Balance> {
 	pub owner: AccountId,
+	#[codec(compact)]
 	pub amount: Balance,
 }
 
@@ -124,10 +125,11 @@ impl Default for ValidatorStatus {
 #[derive(Default, Encode, Decode, RuntimeDebug)]
 /// Snapshot of validator state at the start of the round for which they are selected
 pub struct ValidatorSnapshot<AccountId, Balance> {
-	pub id: AccountId,
 	pub fee: Perbill,
+	#[codec(compact)]
 	pub bond: Balance,
 	pub nominators: Vec<Bond<AccountId, Balance>>,
+	#[codec(compact)]
 	pub total: Balance,
 }
 
@@ -136,8 +138,10 @@ pub struct ValidatorSnapshot<AccountId, Balance> {
 pub struct Validator<AccountId, Balance> {
 	pub id: AccountId,
 	pub fee: Perbill,
+	#[codec(compact)]
 	pub bond: Balance,
 	pub nominators: OrderedSet<Bond<AccountId, Balance>>,
+	#[codec(compact)]
 	pub total: Balance,
 	pub state: ValidatorStatus,
 }
@@ -260,7 +264,6 @@ impl<
 impl<A: Clone, B: Copy> From<Validator<A, B>> for ValidatorSnapshot<A, B> {
 	fn from(other: Validator<A, B>) -> ValidatorSnapshot<A, B> {
 		ValidatorSnapshot {
-			id: other.id,
 			fee: other.fee,
 			bond: other.bond,
 			nominators: other.nominators.0,
@@ -272,6 +275,7 @@ impl<A: Clone, B: Copy> From<Validator<A, B>> for ValidatorSnapshot<A, B> {
 #[derive(Encode, Decode, RuntimeDebug)]
 pub struct Nominator<AccountId, Balance> {
 	pub nominations: OrderedSet<Bond<AccountId, Balance>>,
+	#[codec(compact)]
 	pub total: Balance,
 }
 
@@ -664,7 +668,7 @@ decl_module! {
 		fn join_candidates(
 			origin,
 			fee: Perbill,
-			bond: BalanceOf<T>,
+			#[compact] bond: BalanceOf<T>,
 		) -> DispatchResult {
 			let acc = ensure_signed(origin)?;
 			ensure!(!Self::is_candidate(&acc),Error::<T>::CandidateExists);
@@ -746,7 +750,7 @@ decl_module! {
 		}
 		/// Bond more for validator candidates
 		#[weight = 0]
-		fn candidate_bond_more(origin, more: BalanceOf<T>) -> DispatchResult {
+		fn candidate_bond_more(origin, #[compact] more: BalanceOf<T>) -> DispatchResult {
 			let validator = ensure_signed(origin)?;
 			let mut state = <Candidates<T>>::get(&validator).ok_or(Error::<T>::CandidateDNE)?;
 			ensure!(!state.is_leaving(),Error::<T>::CannotActivateIfLeaving);
@@ -763,7 +767,7 @@ decl_module! {
 		}
 		/// Bond less for validator candidates
 		#[weight = 0]
-		fn candidate_bond_less(origin, less: BalanceOf<T>) -> DispatchResult {
+		fn candidate_bond_less(origin, #[compact] less: BalanceOf<T>) -> DispatchResult {
 			let validator = ensure_signed(origin)?;
 			let mut state = <Candidates<T>>::get(&validator).ok_or(Error::<T>::CandidateDNE)?;
 			ensure!(!state.is_leaving(),Error::<T>::CannotActivateIfLeaving);
@@ -783,7 +787,7 @@ decl_module! {
 		fn join_nominators(
 			origin,
 			validator: T::AccountId,
-			amount: BalanceOf<T>,
+			#[compact] amount: BalanceOf<T>,
 		) -> DispatchResult {
 			let acc = ensure_signed(origin)?;
 			ensure!(amount >= T::MinNominatorStk::get(), Error::<T>::NomBondBelowMin);
@@ -811,7 +815,7 @@ decl_module! {
 		fn nominate_new(
 			origin,
 			validator: T::AccountId,
-			amount: BalanceOf<T>,
+			#[compact] amount: BalanceOf<T>,
 		) -> DispatchResult {
 			let acc = ensure_signed(origin)?;
 			ensure!(amount >= T::MinNomination::get(), Error::<T>::NominationBelowMin);
@@ -891,7 +895,7 @@ decl_module! {
 		fn nominator_bond_more(
 			origin,
 			candidate: T::AccountId,
-			more: BalanceOf<T>
+			#[compact] more: BalanceOf<T>
 		) -> DispatchResult {
 			let nominator = ensure_signed(origin)?;
 			let mut nominations = <Nominators<T>>::get(&nominator).ok_or(Error::<T>::NominatorDNE)?;
@@ -916,7 +920,7 @@ decl_module! {
 		fn nominator_bond_less(
 			origin,
 			candidate: T::AccountId,
-			less: BalanceOf<T>
+			#[compact] less: BalanceOf<T>
 		) -> DispatchResult {
 			let nominator = ensure_signed(origin)?;
 			let mut nominations = <Nominators<T>>::get(&nominator).ok_or(Error::<T>::NominatorDNE)?;

--- a/pallets/stake/src/lib.rs
+++ b/pallets/stake/src/lib.rs
@@ -61,8 +61,7 @@ use frame_support::{
 	traits::{Currency, EnsureOrigin, Get, Imbalance, ReservableCurrency},
 };
 use frame_system::{ensure_signed, Config as System};
-use pallet_staking::{Exposure, IndividualExposure};
-use parity_scale_codec::{Decode, Encode, HasCompact};
+use parity_scale_codec::{Decode, Encode};
 use set::OrderedSet;
 use sp_runtime::{
 	traits::{AtLeast32BitUnsigned, Zero},
@@ -105,15 +104,6 @@ impl<AccountId: Ord, Balance> PartialEq for Bond<AccountId, Balance> {
 	}
 }
 
-impl<A, B: HasCompact> Into<IndividualExposure<A, B>> for Bond<A, B> {
-	fn into(self) -> IndividualExposure<A, B> {
-		IndividualExposure {
-			who: self.owner,
-			value: self.amount,
-		}
-	}
-}
-
 #[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
 /// The activity status of the validator
 pub enum ValidatorStatus {
@@ -131,7 +121,18 @@ impl Default for ValidatorStatus {
 	}
 }
 
+#[derive(Default, Encode, Decode, RuntimeDebug)]
+/// Snapshot of validator state at the start of the round for which they are selected
+pub struct ValidatorSnapshot<AccountId, Balance> {
+	pub id: AccountId,
+	pub fee: Perbill,
+	pub bond: Balance,
+	pub nominators: Vec<Bond<AccountId, Balance>>,
+	pub total: Balance,
+}
+
 #[derive(Encode, Decode, RuntimeDebug)]
+/// Global validator state with commission fee, bonded stake, and nominations
 pub struct Validator<AccountId, Balance> {
 	pub id: AccountId,
 	pub fee: Perbill,
@@ -256,12 +257,14 @@ impl<
 	}
 }
 
-impl<A: PartialEq, B: HasCompact + Zero> Into<Exposure<A, B>> for Validator<A, B> {
-	fn into(self) -> Exposure<A, B> {
-		Exposure {
-			total: self.total,
-			own: self.bond,
-			others: self.nominators.0.into_iter().map(|x| x.into()).collect(),
+impl<A: Clone, B: Copy> From<Validator<A, B>> for ValidatorSnapshot<A, B> {
+	fn from(other: Validator<A, B>) -> ValidatorSnapshot<A, B> {
+		ValidatorSnapshot {
+			id: other.id,
+			fee: other.fee,
+			bond: other.bond,
+			nominators: other.nominators.0,
+			total: other.total,
 		}
 	}
 }
@@ -540,7 +543,7 @@ decl_storage! {
 		/// Exposure at stake per round, per validator
 		AtStake: double_map
 			hasher(blake2_128_concat) RoundIndex,
-			hasher(blake2_128_concat) T::AccountId => Exposure<T::AccountId,BalanceOf<T>>;
+			hasher(blake2_128_concat) T::AccountId => ValidatorSnapshot<T::AccountId, BalanceOf<T>>;
 		/// Snapshot of total staked in this round; used to determine round issuance
 		Staked: map
 			hasher(blake2_128_concat) RoundIndex => BalanceOf<T>;
@@ -1095,28 +1098,28 @@ impl<T: Config> Module<T> {
 				if amt_due <= T::Currency::minimum_balance() {
 					continue;
 				}
-				if let Some(state) = <Candidates<T>>::get(&val) {
-					if state.nominators.0.is_empty() {
-						// solo validator with no nominators
-						mint(amt_due, val.clone());
+				// Take the snapshot of block author and nominations
+				let state = <AtStake<T>>::take(round_to_payout, &val);
+				if state.nominators.is_empty() {
+					// solo validator with no nominators
+					mint(amt_due, val.clone());
+				} else {
+					// pay validator first; commission + due_portion
+					let val_pct = Perbill::from_rational_approximation(state.bond, state.total);
+					let commission = state.fee * amt_due;
+					let val_due = if commission > T::Currency::minimum_balance() {
+						amt_due -= commission;
+						(val_pct * amt_due) + commission
 					} else {
-						// pay validator first; commission + due_portion
-						let val_pct = Perbill::from_rational_approximation(state.bond, state.total);
-						let commission = state.fee * amt_due;
-						let val_due = if commission > T::Currency::minimum_balance() {
-							amt_due -= commission;
-							(val_pct * amt_due) + commission
-						} else {
-							// commission is negligible so not applied
-							val_pct * amt_due
-						};
-						mint(val_due, val.clone());
-						// pay nominators due portion
-						for Bond { owner, amount } in state.nominators.0 {
-							let percent = Perbill::from_rational_approximation(amount, state.total);
-							let due = percent * amt_due;
-							mint(due, owner);
-						}
+						// commission is negligible so not applied
+						val_pct * amt_due
+					};
+					mint(val_due, val.clone());
+					// pay nominators due portion
+					for Bond { owner, amount } in state.nominators {
+						let percent = Perbill::from_rational_approximation(amount, state.total);
+						let due = percent * amt_due;
+						mint(due, owner);
 					}
 				}
 			}
@@ -1176,12 +1179,12 @@ impl<T: Config> Module<T> {
 			.take(max_validators)
 			.map(|x| x.owner)
 			.collect::<Vec<T::AccountId>>();
-		// snapshot exposure for round
+		// snapshot exposure for round for weighting reward distribution
 		for account in validators.iter() {
 			let state = <Candidates<T>>::get(&account)
-				.expect("all members of CandidateQ must be viable candidates by construction; qed");
+				.expect("all members of CandidateQ must be candidates");
 			let amount = state.total;
-			let exposure: Exposure<T::AccountId, BalanceOf<T>> = state.into();
+			let exposure: ValidatorSnapshot<T::AccountId, BalanceOf<T>> = state.into();
 			<AtStake<T>>::insert(next, account, exposure);
 			all_validators += 1u32;
 			total += amount;

--- a/pallets/stake/src/tests.rs
+++ b/pallets/stake/src/tests.rs
@@ -21,7 +21,7 @@ use mock::*;
 use sp_runtime::DispatchError;
 
 #[test]
-fn genesis_works() {
+fn geneses() {
 	two_validators_four_nominators().execute_with(|| {
 		assert!(Sys::events().is_empty());
 		// validators
@@ -69,7 +69,7 @@ fn genesis_works() {
 }
 
 #[test]
-fn online_offline_behaves() {
+fn online_offline_works() {
 	two_validators_four_nominators().execute_with(|| {
 		roll_to(4);
 		assert_noop!(
@@ -124,7 +124,7 @@ fn online_offline_behaves() {
 }
 
 #[test]
-fn join_validator_candidates_works() {
+fn join_validator_candidates() {
 	two_validators_four_nominators().execute_with(|| {
 		assert_noop!(
 			Stake::join_candidates(Origin::signed(1), Perbill::from_percent(2), 11u128,),
@@ -204,7 +204,6 @@ fn validator_exit_executes_after_delay() {
 #[test]
 fn validator_selection_chooses_top_candidates() {
 	five_validators_no_nominators().execute_with(|| {
-		roll_to(4);
 		roll_to(8);
 		// should choose top MaxValidators (5), in order
 		let expected = vec![
@@ -273,9 +272,8 @@ fn validator_selection_chooses_top_candidates() {
 }
 
 #[test]
-fn exit_queue_works() {
+fn exit_queue() {
 	five_validators_no_nominators().execute_with(|| {
-		roll_to(4);
 		roll_to(8);
 		// should choose top MaxValidators (5), in order
 		let mut expected = vec![
@@ -339,7 +337,6 @@ fn exit_queue_works() {
 #[test]
 fn payout_distribution_to_solo_validators() {
 	five_validators_no_nominators().execute_with(|| {
-		roll_to(4);
 		roll_to(8);
 		// should choose top MaxValidators (5), in order
 		let mut expected = vec![
@@ -354,7 +351,7 @@ fn payout_distribution_to_solo_validators() {
 		// ~ set block author as 1 for all blocks this round
 		set_author(2, 1, 100);
 		roll_to(16);
-		// pay total issuance (=10) to 1
+		// pay total issuance to 1
 		let mut new = vec![
 			RawEvent::ValidatorChosen(3, 1, 100),
 			RawEvent::ValidatorChosen(3, 2, 90),
@@ -438,53 +435,8 @@ fn payout_distribution_to_solo_validators() {
 }
 
 #[test]
-fn payout_distribution_to_nominators() {
-	five_validators_five_nominators().execute_with(|| {
-		roll_to(4);
-		roll_to(8);
-		// chooses top MaxValidators (5), in order
-		let mut expected = vec![
-			RawEvent::ValidatorChosen(2, 1, 50),
-			RawEvent::ValidatorChosen(2, 2, 40),
-			RawEvent::ValidatorChosen(2, 4, 20),
-			RawEvent::ValidatorChosen(2, 3, 20),
-			RawEvent::ValidatorChosen(2, 5, 10),
-			RawEvent::NewRound(5, 2, 5, 140),
-		];
-		assert_eq!(events(), expected);
-		// ~ set block author as 1 for all blocks this round
-		set_author(2, 1, 100);
-		roll_to(16);
-		// distribute total issuance (=10) to validator 1 and its nominators 6, 7, 19
-		// -> NOTE that no fee is taken because validators at genesis set default 2% fee
-		// and 2% of 10 is ~0 by the Perbill arithmetic
-		let mut new = vec![
-			RawEvent::ValidatorChosen(3, 1, 50),
-			RawEvent::ValidatorChosen(3, 2, 40),
-			RawEvent::ValidatorChosen(3, 4, 20),
-			RawEvent::ValidatorChosen(3, 3, 20),
-			RawEvent::ValidatorChosen(3, 5, 10),
-			RawEvent::NewRound(10, 3, 5, 140),
-			RawEvent::Rewarded(1, 20),
-			RawEvent::Rewarded(6, 10),
-			RawEvent::Rewarded(7, 10),
-			RawEvent::Rewarded(10, 10),
-			RawEvent::ValidatorChosen(4, 1, 50),
-			RawEvent::ValidatorChosen(4, 2, 40),
-			RawEvent::ValidatorChosen(4, 4, 20),
-			RawEvent::ValidatorChosen(4, 3, 20),
-			RawEvent::ValidatorChosen(4, 5, 10),
-			RawEvent::NewRound(15, 4, 5, 140),
-		];
-		expected.append(&mut new);
-		assert_eq!(events(), expected);
-	});
-}
-
-#[test]
-fn pays_validator_commission() {
+fn validator_commission() {
 	one_validator_two_nominators().execute_with(|| {
-		roll_to(4);
 		roll_to(8);
 		// chooses top MaxValidators (5), in order
 		let mut expected = vec![
@@ -541,7 +493,6 @@ fn pays_validator_commission() {
 #[test]
 fn multiple_nominations() {
 	five_validators_five_nominators().execute_with(|| {
-		roll_to(4);
 		roll_to(8);
 		// chooses top MaxValidators (5), in order
 		let mut expected = vec![
@@ -694,7 +645,7 @@ fn multiple_nominations() {
 }
 
 #[test]
-fn validators_bond_more_less() {
+fn validators_bond() {
 	five_validators_five_nominators().execute_with(|| {
 		roll_to(4);
 		assert_noop!(
@@ -744,7 +695,7 @@ fn validators_bond_more_less() {
 }
 
 #[test]
-fn nominators_bond_more_less() {
+fn nominators_bond() {
 	five_validators_five_nominators().execute_with(|| {
 		roll_to(4);
 		assert_noop!(
@@ -795,9 +746,8 @@ fn nominators_bond_more_less() {
 }
 
 #[test]
-fn switch_nomination_works() {
+fn switch_nomination() {
 	five_validators_five_nominators().execute_with(|| {
-		roll_to(4);
 		roll_to(8);
 		let mut expected = vec![
 			RawEvent::ValidatorChosen(2, 1, 50),
@@ -877,6 +827,168 @@ fn switch_nomination_works() {
 			RawEvent::NewRound(15, 4, 5, 140),
 		];
 		expected.append(&mut new);
+		assert_eq!(events(), expected);
+	});
+}
+
+#[test]
+fn revoke_nomination_or_leave_nominators() {
+	assert!(true);
+}
+
+#[test]
+fn payouts_follow_nomination_changes() {
+	five_validators_five_nominators().execute_with(|| {
+		roll_to(8);
+		// chooses top MaxValidators (5), in order
+		let mut expected = vec![
+			RawEvent::ValidatorChosen(2, 1, 50),
+			RawEvent::ValidatorChosen(2, 2, 40),
+			RawEvent::ValidatorChosen(2, 4, 20),
+			RawEvent::ValidatorChosen(2, 3, 20),
+			RawEvent::ValidatorChosen(2, 5, 10),
+			RawEvent::NewRound(5, 2, 5, 140),
+		];
+		assert_eq!(events(), expected);
+		// ~ set block author as 1 for all blocks this round
+		set_author(2, 1, 100);
+		roll_to(16);
+		// distribute total issuance to validator 1 and its nominators 6, 7, 19
+		let mut new = vec![
+			RawEvent::ValidatorChosen(3, 1, 50),
+			RawEvent::ValidatorChosen(3, 2, 40),
+			RawEvent::ValidatorChosen(3, 4, 20),
+			RawEvent::ValidatorChosen(3, 3, 20),
+			RawEvent::ValidatorChosen(3, 5, 10),
+			RawEvent::NewRound(10, 3, 5, 140),
+			RawEvent::Rewarded(1, 20),
+			RawEvent::Rewarded(6, 10),
+			RawEvent::Rewarded(7, 10),
+			RawEvent::Rewarded(10, 10),
+			RawEvent::ValidatorChosen(4, 1, 50),
+			RawEvent::ValidatorChosen(4, 2, 40),
+			RawEvent::ValidatorChosen(4, 4, 20),
+			RawEvent::ValidatorChosen(4, 3, 20),
+			RawEvent::ValidatorChosen(4, 5, 10),
+			RawEvent::NewRound(15, 4, 5, 140),
+		];
+		expected.append(&mut new);
+		assert_eq!(events(), expected);
+		// ~ set block author as 1 for all blocks this round
+		set_author(3, 1, 100);
+		set_author(4, 1, 100);
+		// 1. ensure nominators are paid for 2 rounds after they leave
+		assert_noop!(
+			Stake::leave_nominators(Origin::signed(66)),
+			Error::<Test>::NominatorDNE
+		);
+		assert_ok!(Stake::leave_nominators(Origin::signed(6)));
+		roll_to(21);
+		// keep paying 6 (note: inflation is in terms of total issuance so that's why 1 is 21)
+		let mut new2 = vec![
+			RawEvent::NominatorLeftValidator(6, 1, 10, 40),
+			RawEvent::NominatorLeft(6, 10),
+			RawEvent::Rewarded(1, 21),
+			RawEvent::Rewarded(6, 10),
+			RawEvent::Rewarded(7, 10),
+			RawEvent::Rewarded(10, 10),
+			RawEvent::ValidatorChosen(5, 2, 40),
+			RawEvent::ValidatorChosen(5, 1, 40),
+			RawEvent::ValidatorChosen(5, 4, 20),
+			RawEvent::ValidatorChosen(5, 3, 20),
+			RawEvent::ValidatorChosen(5, 5, 10),
+			RawEvent::NewRound(20, 5, 5, 130),
+		];
+		expected.append(&mut new2);
+		assert_eq!(events(), expected);
+		// 6 won't be paid for this round because they left already
+		set_author(5, 1, 100);
+		roll_to(26);
+		// keep paying 6
+		let mut new3 = vec![
+			RawEvent::Rewarded(1, 22),
+			RawEvent::Rewarded(6, 11),
+			RawEvent::Rewarded(7, 11),
+			RawEvent::Rewarded(10, 11),
+			RawEvent::ValidatorChosen(6, 2, 40),
+			RawEvent::ValidatorChosen(6, 1, 40),
+			RawEvent::ValidatorChosen(6, 4, 20),
+			RawEvent::ValidatorChosen(6, 3, 20),
+			RawEvent::ValidatorChosen(6, 5, 10),
+			RawEvent::NewRound(25, 6, 5, 130),
+		];
+		expected.append(&mut new3);
+		assert_eq!(events(), expected);
+		set_author(6, 1, 100);
+		roll_to(31);
+		// no more paying 6
+		let mut new4 = vec![
+			RawEvent::Rewarded(1, 29),
+			RawEvent::Rewarded(7, 14),
+			RawEvent::Rewarded(10, 14),
+			RawEvent::ValidatorChosen(7, 2, 40),
+			RawEvent::ValidatorChosen(7, 1, 40),
+			RawEvent::ValidatorChosen(7, 4, 20),
+			RawEvent::ValidatorChosen(7, 3, 20),
+			RawEvent::ValidatorChosen(7, 5, 10),
+			RawEvent::NewRound(30, 7, 5, 130),
+		];
+		expected.append(&mut new4);
+		assert_eq!(events(), expected);
+		set_author(7, 1, 100);
+		// 2. ensure new nominations do not dilute old ones for last 2 rounds
+		assert_noop!(
+			Stake::nominate_new(Origin::signed(6), 2, 10),
+			Error::<Test>::NominatorDNE
+		);
+		assert_ok!(Stake::nominate_new(Origin::signed(8), 1, 10));
+		roll_to(36);
+		// new nomination is not rewarded yet
+		let mut new5 = vec![
+			RawEvent::ValidatorNominated(8, 10, 1, 50),
+			RawEvent::Rewarded(1, 30),
+			RawEvent::Rewarded(7, 15),
+			RawEvent::Rewarded(10, 15),
+			RawEvent::ValidatorChosen(8, 1, 50),
+			RawEvent::ValidatorChosen(8, 2, 40),
+			RawEvent::ValidatorChosen(8, 4, 20),
+			RawEvent::ValidatorChosen(8, 3, 20),
+			RawEvent::ValidatorChosen(8, 5, 10),
+			RawEvent::NewRound(35, 8, 5, 140),
+		];
+		expected.append(&mut new5);
+		assert_eq!(events(), expected);
+		set_author(8, 1, 100);
+		roll_to(41);
+		// new nomination is still not rewarded yet
+		let mut new6 = vec![
+			RawEvent::Rewarded(1, 32),
+			RawEvent::Rewarded(7, 16),
+			RawEvent::Rewarded(10, 16),
+			RawEvent::ValidatorChosen(9, 1, 50),
+			RawEvent::ValidatorChosen(9, 2, 40),
+			RawEvent::ValidatorChosen(9, 4, 20),
+			RawEvent::ValidatorChosen(9, 3, 20),
+			RawEvent::ValidatorChosen(9, 5, 10),
+			RawEvent::NewRound(40, 9, 5, 140),
+		];
+		expected.append(&mut new6);
+		assert_eq!(events(), expected);
+		roll_to(46);
+		// new nomination is rewarded for first time, 2 rounds after joining (`BondDuration` = 2)
+		let mut new7 = vec![
+			RawEvent::Rewarded(1, 27),
+			RawEvent::Rewarded(7, 13),
+			RawEvent::Rewarded(8, 13),
+			RawEvent::Rewarded(10, 13),
+			RawEvent::ValidatorChosen(10, 1, 50),
+			RawEvent::ValidatorChosen(10, 2, 40),
+			RawEvent::ValidatorChosen(10, 4, 20),
+			RawEvent::ValidatorChosen(10, 3, 20),
+			RawEvent::ValidatorChosen(10, 5, 10),
+			RawEvent::NewRound(45, 10, 5, 140),
+		];
+		expected.append(&mut new7);
 		assert_eq!(events(), expected);
 	});
 }

--- a/pallets/stake/src/tests.rs
+++ b/pallets/stake/src/tests.rs
@@ -833,7 +833,33 @@ fn switch_nomination() {
 
 #[test]
 fn revoke_nomination_or_leave_nominators() {
-	assert!(true);
+	five_validators_five_nominators().execute_with(|| {
+		roll_to(4);
+		assert_noop!(
+			Stake::revoke_nomination(Origin::signed(1), 2),
+			Error::<Test>::NominatorDNE
+		);
+		assert_noop!(
+			Stake::revoke_nomination(Origin::signed(6), 2),
+			Error::<Test>::NominationDNE
+		);
+		// must leave set of nominators if total bonds below MinNominatorStk
+		assert_noop!(
+			Stake::revoke_nomination(Origin::signed(6), 1),
+			Error::<Test>::NomBondBelowMin
+		);
+		assert_noop!(
+			Stake::leave_nominators(Origin::signed(1)),
+			Error::<Test>::NominatorDNE
+		);
+		assert_ok!(Stake::leave_nominators(Origin::signed(6)));
+		assert_noop!(
+			Stake::revoke_nomination(Origin::signed(8), 2),
+			Error::<Test>::NomBondBelowMin
+		);
+		assert_ok!(Stake::nominate_new(Origin::signed(8), 1, 10));
+		assert_ok!(Stake::revoke_nomination(Origin::signed(8), 2));
+	});
 }
 
 #[test]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 20,
+	spec_version: 21,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 19,
+	spec_version: 20,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
### What does it do?
CC @artkaseman Before, we were NOT using the snapshot of validator state at the time of validator selection for payout distribution. Instead, we were using the `CandidateState` at the time of the delayed payment to determine payout distribution. This means nominators that left before the payout distribution were not paid and, more dangerously, new nominators that joined during the delay were paid instead even though they weren't nominators at the time of the validator's block author reward.

Note that this PR also removes `pallet-staking` as a dependency. We may add this back if we choose to use the `Exposure` type when we implement slashing, but we don't need it now. I replaced it with `ValidatorSnapshot` which provides a snapshot of the state of the validator at the time they are selected for the round.

### What important points reviewers should know?

Context
* validators are rewarded by a point system according to how many blocks they author in a round
* the issuance for the round is distributed among the validators based on relative point scores
* within each validator, the due issuance is distributed to validators first (commission + due_proportion) and then to nominators second (due_proportion)
  * `due_proportion` is actors_stake/total_validator_stake * total_due_issuance_for_the_validator

The bug used the current `CandidateState` to calculate distribution of rewards earned 2 rounds prior. This means nominators that left before the payout distribution were not paid and, more dangerously, new nominators that joined during the delay were paid instead even though they weren't nominators at the time of the validator's block author reward.

The fix snapshots `CandidateState` at the time the account is chosen for the round so it can weight the earnings distribution based on this snapshot instead of on the current `CandidateState` (which could easily have changed between the time the block author was recognized and the payout was executed).

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- Does it require a purge of the network? No
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- Does it require changes in documentation/tutorials ? No
