### PR TITLE
Remove relay block from author filter

### DIFF
--- a/pallets/author-filter/src/lib.rs
+++ b/pallets/author-filter/src/lib.rs
@@ -49,7 +49,7 @@ pub mod pallet {
 	/// Configuration trait of this pallet.
 	#[pallet::config]
 	pub trait Config:
-		frame_system::Config + stake::Config + cumulus_parachain_system::Config
+		frame_system::Config + stake::Config
 	{
 		/// The overarching event type
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
@@ -60,10 +60,6 @@ pub mod pallet {
 	// This code will be called by the author-inherent pallet to check whether the reported author
 	// of this block is eligible at this height. We calculate that result on demand and do not
 	// record it instorage (although we do emit a debugging event for now).
-	// This implementation relies on the relay parent's block number from the validation data
-	// inherent. Therefore the validation data inherent **must** be included before this check is
-	// performed. Concretely the validation data inherent must be included before the author
-	// inherent.
 	impl<T: Config> author_inherent::CanAuthor<T::AccountId> for Pallet<T> {
 		fn can_author(account: &T::AccountId) -> bool {
 			let mut staked: Vec<T::AccountId> = stake::Module::<T>::validators();
@@ -71,18 +67,13 @@ pub mod pallet {
 			let num_eligible = EligibleRatio::<T>::get().mul_ceil(staked.len());
 			let mut eligible = Vec::with_capacity(num_eligible);
 
-			// Grab the relay parent height as a temporary source of relay-based entropy
-			let validation_data = cumulus_parachain_system::Module::<T>::validation_data()
-				.expect("validation data was set in parachain system inherent");
-			let relay_height = validation_data.block_number;
-
 			for i in 0..num_eligible {
-				// A context identifier for grabbing the randomness. Consists of three parts
+				// A context identifier for grabbing the randomness. Consists of two parts
 				// - The constant string *b"filter" - to identify this pallet
 				// - The index `i` when we're selecting the ith eligible author
-				// - The relay parent block number so that the eligible authors at the next height
-				//   change. Avoids liveness attacks from colluding minorities of active authors.
-				// Third one will not be necessary once we dleverage the relay chain's randomness.
+				// Currently this has the weakness that the authors are based only on para-block
+				// height. This will be aleviated in the future by adding entropy from the relay
+				// chain inherent.
 				let subject: [u8; 8] = [
 					b'f',
 					b'i',
@@ -91,7 +82,6 @@ pub mod pallet {
 					b'e',
 					b'r',
 					i as u8,
-					relay_height as u8,
 				];
 				let index = T::RandomnessSource::random(&subject).to_low_u64_be() as usize;
 
@@ -105,7 +95,7 @@ pub mod pallet {
 
 			// Emit an event for debugging purposes
 			// let our_height = frame_system::Module::<T>::block_number();
-			// <Pallet<T>>::deposit_event(Event::Filtered(our_height, relay_height, eligible.clone()));
+			// <Pallet<T>>::deposit_event(Event::Filtered(our_height, eligible.clone()));
 
 			eligible.contains(account)
 		}
@@ -145,7 +135,7 @@ pub mod pallet {
 		EligibleUpdated(Percent),
 		/// The staked authors have been filtered to these eligible authors in this block.
 		/// This is a debugging and development event and should be removed eventually.
-		/// Fields are: para block height, relay block height, eligible authors
-		Filtered(T::BlockNumber, u32, Vec<T::AccountId>),
+		/// Fields are: para block height, eligible authors
+		Filtered(T::BlockNumber, Vec<T::AccountId>),
 	}
 }

--- a/pallets/author-filter/src/lib.rs
+++ b/pallets/author-filter/src/lib.rs
@@ -74,7 +74,7 @@ pub mod pallet {
 				// Currently this has the weakness that the authors are based only on para-block
 				// height. This will be aleviated in the future by adding entropy from the relay
 				// chain inherent.
-				let subject: [u8; 8] = [
+				let subject: [u8; 7] = [
 					b'f',
 					b'i',
 					b'l',

--- a/pallets/author-filter/src/lib.rs
+++ b/pallets/author-filter/src/lib.rs
@@ -48,9 +48,7 @@ pub mod pallet {
 
 	/// Configuration trait of this pallet.
 	#[pallet::config]
-	pub trait Config:
-		frame_system::Config + stake::Config
-	{
+	pub trait Config: frame_system::Config + stake::Config {
 		/// The overarching event type
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// Deterministic on-chain pseudo-randomness used to do the filtering
@@ -74,15 +72,7 @@ pub mod pallet {
 				// Currently this has the weakness that the authors are based only on para-block
 				// height. This will be aleviated in the future by adding entropy from the relay
 				// chain inherent.
-				let subject: [u8; 7] = [
-					b'f',
-					b'i',
-					b'l',
-					b't',
-					b'e',
-					b'r',
-					i as u8,
-				];
+				let subject: [u8; 7] = [b'f', b'i', b'l', b't', b'e', b'r', i as u8];
 				let index = T::RandomnessSource::random(&subject).to_low_u64_be() as usize;
 
 				// Move the selected author from the original vector into the eligible vector

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 19,
+	spec_version: 20,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -439,8 +439,6 @@ construct_runtime! {
 		Stake: stake::{Module, Call, Storage, Event<T>, Config<T>},
 		Scheduler: pallet_scheduler::{Module, Storage, Config, Event<T>, Call},
 		Democracy: pallet_democracy::{Module, Storage, Config, Event<T>, Call},
-		// The order matters here. Inherents will be included in the order specified here.
-		// Concretely wee need the author inherent to come after the parachain_upgrade inherent.
 		AuthorInherent: author_inherent::{Module, Call, Storage, Inherent},
 		AuthorFilter: pallet_author_filter::{Module, Storage, Event<T>,}
 	}


### PR DESCRIPTION
The author filter now depends only on information from the parachain parent block (not the relay parent block). This is to work around a panic when parachain nodes were not able to import apparently-valid blocks authored by their peers.

I'll do more follow up work on diagnosing this, and report back with an issue in cumulus.

- :x: Does it require a purge of the network?
- :heavy_check_mark:  You bumped the runtime version if there are breaking changes in the **runtime** ?
- :x: Does it require changes in documentation/tutorials ?
