### PR TITLE
Enable binary search in gas estimation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3986,7 +3986,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "moonbase-alphanet"
+name = "moonbeam"
 version = "0.1.0"
 dependencies = [
  "ansi_term 0.12.1",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -74,7 +74,7 @@ ethereum = { package = "pallet-ethereum", git = "https://github.com/purestake/fr
 fc-consensus = { git = "https://github.com/purestake/frontier", branch = "v0.6-moonbeam" }
 fp-consensus = { git = "https://github.com/purestake/frontier", branch = "v0.6-moonbeam" }
 fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "v0.6-moonbeam" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "v0.6-moonbeam" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "v0.6-moonbeam", features = ["rpc_binary_search_estimate"] }
 fp-rpc = { git = "https://github.com/purestake/frontier", branch = "v0.6-moonbeam" }
 
 # Cumulus dependencies


### PR DESCRIPTION
### What does it do?

This PR enables the binary search mechanism for estimating gas that was introduced to Frontier in https://github.com/paritytech/frontier/pull/269

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

https://github.com/paritytech/frontier/pull/269

### What value does it bring to the blockchain users?

Better gas estimation. Can you check this @albertov19 

## Checklist

- :x: Does it require a purge of the network?
- :x: You bumped the runtime version if there are breaking changes in the **runtime** ?
- :x: Does it require changes in documentation/tutorials ?
