### PR TITLE
test: test if nonce is being reset after dust account clean up

### DIFF
--- a/tests/tests/test-nonce.ts
+++ b/tests/tests/test-nonce.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { step } from "mocha-steps";
 
 import { createAndFinalizeBlock, describeWithMoonbeam, customRequest } from "./util";
+import { Keyring } from "@polkadot/keyring";
 
 describeWithMoonbeam("Moonbeam RPC (Nonce)", `simple-specs.json`, (context) => {
   const GENESIS_ACCOUNT = "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b";
@@ -34,5 +35,41 @@ describeWithMoonbeam("Moonbeam RPC (Nonce)", `simple-specs.json`, (context) => {
     expect(await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, "latest")).to.eq(1);
     expect(await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, "pending")).to.eq(1);
     expect(await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT, "earliest")).to.eq(0);
+  });
+
+  it("nonce should not be reset to 0 when emptying dust accounts", async function () {
+    this.timeout(15000);
+
+    const testAccountPrivateKey1 = context.web3.utils.randomHex(32);
+    const testAccountPrivateKey2 = context.web3.utils.randomHex(32);
+    const keyring = new Keyring({ type: "ethereum" });
+    const testAccount1 = await keyring.addFromUri(testAccountPrivateKey1, null, "ethereum");
+    const testAccount2 = await keyring.addFromUri(testAccountPrivateKey2, null, "ethereum");
+    const genesisAccount = await keyring.addFromUri(GENESIS_ACCOUNT_PRIVATE_KEY, null, "ethereum");
+
+    const info = await context.polkadotApi.tx.balances
+      .transfer(testAccount1.address, 1)
+      .paymentInfo(genesisAccount);
+
+    // We should estimate the fee to ensure we are transferring enough funds
+    const fee = info.partialFee.toNumber();
+
+    await context.polkadotApi.tx.balances
+      .transfer(testAccount1.address, fee + 1)
+      .signAndSend(genesisAccount);
+    await createAndFinalizeBlock(context.polkadotApi);
+
+    await context.polkadotApi.tx.balances
+      .transfer(testAccount2.address, 1)
+      .signAndSend(testAccount1);
+
+    await createAndFinalizeBlock(context.polkadotApi);
+
+    const { nonce, data: balance } = await context.polkadotApi.query.system.account(
+      testAccount1.address
+    );
+
+    expect(nonce.toNumber()).to.equal(1);
+    expect(balance.free.toNumber()).to.equal(0);
   });
 });


### PR DESCRIPTION
### What does it do?
It adds a test ensuring an account's nonce is not being reset to 0 (after already having done transactions) when this account's balance goes below the minimumDeposit

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
