### PR TITLE
Add current_block_gas_limit to EthereumRuntimeRPCApi

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -355,7 +355,7 @@ pub struct EthereumFindAuthor<F>(PhantomData<F>);
 
 parameter_types! {
 	pub BlockGasLimit: U256
-        = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT / WEIGHT_PER_GAS);
+		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT / WEIGHT_PER_GAS);
 }
 
 impl pallet_ethereum::Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -354,7 +354,8 @@ impl fp_rpc::ConvertTransaction<opaque::UncheckedExtrinsic> for TransactionConve
 pub struct EthereumFindAuthor<F>(PhantomData<F>);
 
 parameter_types! {
-	pub BlockGasLimit: u64 = NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT / WEIGHT_PER_GAS;
+	pub BlockGasLimit: U256
+        = U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT / WEIGHT_PER_GAS);
 }
 
 impl pallet_ethereum::Config for Runtime {
@@ -679,6 +680,10 @@ impl_runtime_apis! {
 				Ethereum::current_receipts(),
 				Ethereum::current_transaction_statuses()
 			)
+		}
+
+		fn current_block_gas_limit() -> U256 {
+			<Runtime as pallet_ethereum::Config>::BlockGasLimit::get()
 		}
 	}
 


### PR DESCRIPTION
### What does it do?

This adds `current_block_gas_limit` to the `EthereumRuntimeRPCApi` which allows the latter to use the limit in `estimate_gas`.

Also note that this changes the type of `BlockGasLimit` to be consistent with `frontier`.

### What important points reviewers should know?

This is required for breaking changes introduced on the frontier `v0.6-moonbeam` branch and either needs to be included in our v0.6 release or 8ea861444979f213b5965bdf3e6626d7def032f9 (https://github.com/PureStake/frontier/commit/8ea861444979f213b5965bdf3e6626d7def032f9) will need to be reverted.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
