### PR TITLE
stake: move BlocksPerRound to storage and make updatable by root

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -164,6 +164,7 @@ fn testnet_genesis(
 		stake: Some(StakeConfig {
 			stakers,
 			inflation_config,
+			blocks_per_round: 20u32,
 		}),
 	}
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -24,7 +24,7 @@ use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
 use sp_runtime::Perbill;
-use stake::{InflationInfo, Range};
+use stake::{InflationInfo, Range, RoundDuration};
 use std::{collections::BTreeMap, str::FromStr};
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
@@ -164,7 +164,10 @@ fn testnet_genesis(
 		stake: Some(StakeConfig {
 			stakers,
 			inflation_config,
-			blocks_per_round: 20u32,
+			blocks_per_round: RoundDuration {
+				old: None,
+				new: 20u32,
+			},
 		}),
 	}
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -164,10 +164,7 @@ fn testnet_genesis(
 		stake: Some(StakeConfig {
 			stakers,
 			inflation_config,
-			blocks_per_round: RoundDuration {
-				old: None,
-				new: 20u32,
-			},
+			blocks_per_round: RoundDuration::new(20u32),
 		}),
 	}
 }

--- a/pallets/stake/src/inflation.rs
+++ b/pallets/stake/src/inflation.rs
@@ -31,15 +31,24 @@ const BLOCKS_PER_YEAR: u32 = SECONDS_PER_YEAR / SECONDS_PER_BLOCK;
 pub struct RoundDuration {
 	pub old: Option<u32>,
 	pub new: u32,
+	pub changed: bool,
 }
 
 impl RoundDuration {
+	pub fn new(new: u32) -> Self {
+		Self {
+			old: None,
+			new,
+			changed: false,
+		}
+	}
 	pub fn set(&mut self, new: u32) {
 		self.old = Some(self.new);
 		self.new = new;
 	}
 	pub fn reset(&mut self) {
 		self.old = None;
+		self.changed = true;
 	}
 }
 

--- a/pallets/stake/src/inflation.rs
+++ b/pallets/stake/src/inflation.rs
@@ -15,8 +15,8 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Helper methods for computing issuance based on inflation
-use crate::{BalanceOf, Config};
-use frame_support::traits::{Currency, Get};
+use crate::{BalanceOf, Config, Module};
+use frame_support::traits::Currency;
 use parity_scale_codec::{Decode, Encode};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,7 @@ const SECONDS_PER_BLOCK: u32 = 6;
 const BLOCKS_PER_YEAR: u32 = SECONDS_PER_YEAR / SECONDS_PER_BLOCK;
 
 fn rounds_per_year<T: Config>() -> u32 {
-	BLOCKS_PER_YEAR / T::BlocksPerRound::get()
+	BLOCKS_PER_YEAR / <Module<T>>::blocks_per_round()
 }
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]

--- a/pallets/stake/src/inflation.rs
+++ b/pallets/stake/src/inflation.rs
@@ -31,7 +31,6 @@ const BLOCKS_PER_YEAR: u32 = SECONDS_PER_YEAR / SECONDS_PER_BLOCK;
 pub struct RoundDuration {
 	pub old: Option<u32>,
 	pub new: u32,
-	pub changed: bool,
 }
 
 impl RoundDuration {
@@ -39,7 +38,6 @@ impl RoundDuration {
 		Self {
 			old: None,
 			new,
-			changed: false,
 		}
 	}
 	pub fn set(&mut self, new: u32) {
@@ -48,7 +46,6 @@ impl RoundDuration {
 	}
 	pub fn reset(&mut self) {
 		self.old = None;
-		self.changed = true;
 	}
 }
 

--- a/pallets/stake/src/inflation.rs
+++ b/pallets/stake/src/inflation.rs
@@ -35,10 +35,7 @@ pub struct RoundDuration {
 
 impl RoundDuration {
 	pub fn new(new: u32) -> Self {
-		Self {
-			old: None,
-			new,
-		}
+		Self { old: None, new }
 	}
 	pub fn set(&mut self, new: u32) {
 		self.old = Some(self.new);

--- a/pallets/stake/src/inflation.rs
+++ b/pallets/stake/src/inflation.rs
@@ -26,8 +26,25 @@ const SECONDS_PER_YEAR: u32 = 31557600;
 const SECONDS_PER_BLOCK: u32 = 6;
 const BLOCKS_PER_YEAR: u32 = SECONDS_PER_YEAR / SECONDS_PER_BLOCK;
 
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Encode, Decode, Default)]
+pub struct RoundDuration {
+	pub old: Option<u32>,
+	pub new: u32,
+}
+
+impl RoundDuration {
+	pub fn set(&mut self, new: u32) {
+		self.old = Some(self.new);
+		self.new = new;
+	}
+	pub fn reset(&mut self) {
+		self.old = None;
+	}
+}
+
 fn rounds_per_year<T: Config>() -> u32 {
-	BLOCKS_PER_YEAR / <Module<T>>::blocks_per_round()
+	BLOCKS_PER_YEAR / <Module<T>>::blocks_per_round().new
 }
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]

--- a/pallets/stake/src/lib.rs
+++ b/pallets/stake/src/lib.rs
@@ -966,16 +966,11 @@ decl_module! {
 				duration.new
 			};
 			if (n % interval.into()).is_zero() {
-				// skip 1st round transition after interval change to prevent really short rounds
-				if duration.changed {
-					duration.changed = false;
-					<BlocksPerRound>::put(duration);
-					return;
-				}
-				// if interval just changed, finish old round before setting changed to true
+				// if interval just changed, skip round transition until now % new duration == 0
 				if duration.old.is_some() {
 					duration.reset();
 					<BlocksPerRound>::put(duration);
+					return;
 				}
 				// update round number
 				let next = <Round>::get() + 1;

--- a/pallets/stake/src/lib.rs
+++ b/pallets/stake/src/lib.rs
@@ -966,11 +966,18 @@ decl_module! {
 				duration.new
 			};
 			if (n % interval.into()).is_zero() {
-				// handle round changes
+				// skip 1st round transition after interval change to prevent really short rounds
+				if duration.changed {
+					duration.changed = false;
+					<BlocksPerRound>::put(duration);
+					return;
+				}
+				// if interval just changed, finish old round before setting changed to true
 				if duration.old.is_some() {
 					duration.reset();
 					<BlocksPerRound>::put(duration);
 				}
+				// update round number
 				let next = <Round>::get() + 1;
 				// pay all stakers for T::BondDuration rounds ago
 				Self::pay_stakers(next);

--- a/pallets/stake/src/mock.rs
+++ b/pallets/stake/src/mock.rs
@@ -147,7 +147,7 @@ fn genesis(
 	GenesisConfig::<Test> {
 		stakers,
 		inflation_config,
-		blocks_per_round: 5,
+		blocks_per_round: RoundDuration { old: None, new: 5 },
 	}
 	.assimilate_storage(&mut storage)
 	.unwrap();

--- a/pallets/stake/src/mock.rs
+++ b/pallets/stake/src/mock.rs
@@ -147,7 +147,7 @@ fn genesis(
 	GenesisConfig::<Test> {
 		stakers,
 		inflation_config,
-		blocks_per_round: RoundDuration { old: None, new: 5 },
+		blocks_per_round: RoundDuration::new(5),
 	}
 	.assimilate_storage(&mut storage)
 	.unwrap();

--- a/pallets/stake/src/mock.rs
+++ b/pallets/stake/src/mock.rs
@@ -95,7 +95,7 @@ impl pallet_balances::Config for Test {
 	type WeightInfo = ();
 }
 parameter_types! {
-	pub const BlocksPerRound: u32 = 5;
+	pub const MinBlocksPerRound: u32 = 5;
 	pub const BondDuration: u32 = 2;
 	pub const MaxValidators: u32 = 5;
 	pub const MaxNominatorsPerValidator: u32 = 4;
@@ -109,7 +109,7 @@ impl Config for Test {
 	type Event = MetaEvent;
 	type Currency = Balances;
 	type SetMonetaryPolicyOrigin = frame_system::EnsureRoot<Self::AccountId>;
-	type BlocksPerRound = BlocksPerRound;
+	type MinBlocksPerRound = MinBlocksPerRound;
 	type BondDuration = BondDuration;
 	type MaxValidators = MaxValidators;
 	type MaxNominatorsPerValidator = MaxNominatorsPerValidator;

--- a/pallets/stake/src/mock.rs
+++ b/pallets/stake/src/mock.rs
@@ -95,7 +95,7 @@ impl pallet_balances::Config for Test {
 	type WeightInfo = ();
 }
 parameter_types! {
-	pub const MinBlocksPerRound: u32 = 5;
+	pub const MinBlocksPerRound: u32 = 3;
 	pub const BondDuration: u32 = 2;
 	pub const MaxValidators: u32 = 5;
 	pub const MaxNominatorsPerValidator: u32 = 4;
@@ -147,6 +147,7 @@ fn genesis(
 	GenesisConfig::<Test> {
 		stakers,
 		inflation_config,
+		blocks_per_round: 5,
 	}
 	.assimilate_storage(&mut storage)
 	.unwrap();

--- a/pallets/stake/src/tests.rs
+++ b/pallets/stake/src/tests.rs
@@ -910,11 +910,11 @@ fn payouts_follow_nomination_changes() {
 		);
 		assert_ok!(Stake::leave_nominators(Origin::signed(6)));
 		roll_to(21);
-		// keep paying 6 (note: inflation is in terms of total issuance so that's why 1 is 21)
+		// keep paying 6
 		let mut new2 = vec![
 			RawEvent::NominatorLeftValidator(6, 1, 10, 40),
 			RawEvent::NominatorLeft(6, 10),
-			RawEvent::Rewarded(1, 21),
+			RawEvent::Rewarded(1, 20),
 			RawEvent::Rewarded(6, 10),
 			RawEvent::Rewarded(7, 10),
 			RawEvent::Rewarded(10, 10),
@@ -932,10 +932,10 @@ fn payouts_follow_nomination_changes() {
 		roll_to(26);
 		// keep paying 6
 		let mut new3 = vec![
-			RawEvent::Rewarded(1, 22),
-			RawEvent::Rewarded(6, 11),
-			RawEvent::Rewarded(7, 11),
-			RawEvent::Rewarded(10, 11),
+			RawEvent::Rewarded(1, 21),
+			RawEvent::Rewarded(6, 10),
+			RawEvent::Rewarded(7, 10),
+			RawEvent::Rewarded(10, 10),
 			RawEvent::ValidatorChosen(6, 2, 40),
 			RawEvent::ValidatorChosen(6, 1, 40),
 			RawEvent::ValidatorChosen(6, 4, 20),
@@ -949,7 +949,7 @@ fn payouts_follow_nomination_changes() {
 		roll_to(31);
 		// no more paying 6
 		let mut new4 = vec![
-			RawEvent::Rewarded(1, 29),
+			RawEvent::Rewarded(1, 27),
 			RawEvent::Rewarded(7, 14),
 			RawEvent::Rewarded(10, 14),
 			RawEvent::ValidatorChosen(7, 2, 40),
@@ -972,9 +972,9 @@ fn payouts_follow_nomination_changes() {
 		// new nomination is not rewarded yet
 		let mut new5 = vec![
 			RawEvent::ValidatorNominated(8, 10, 1, 50),
-			RawEvent::Rewarded(1, 30),
-			RawEvent::Rewarded(7, 15),
-			RawEvent::Rewarded(10, 15),
+			RawEvent::Rewarded(1, 29),
+			RawEvent::Rewarded(7, 14),
+			RawEvent::Rewarded(10, 14),
 			RawEvent::ValidatorChosen(8, 1, 50),
 			RawEvent::ValidatorChosen(8, 2, 40),
 			RawEvent::ValidatorChosen(8, 4, 20),
@@ -988,9 +988,9 @@ fn payouts_follow_nomination_changes() {
 		roll_to(41);
 		// new nomination is still not rewarded yet
 		let mut new6 = vec![
-			RawEvent::Rewarded(1, 32),
-			RawEvent::Rewarded(7, 16),
-			RawEvent::Rewarded(10, 16),
+			RawEvent::Rewarded(1, 30),
+			RawEvent::Rewarded(7, 15),
+			RawEvent::Rewarded(10, 15),
 			RawEvent::ValidatorChosen(9, 1, 50),
 			RawEvent::ValidatorChosen(9, 2, 40),
 			RawEvent::ValidatorChosen(9, 4, 20),
@@ -1003,7 +1003,7 @@ fn payouts_follow_nomination_changes() {
 		roll_to(46);
 		// new nomination is rewarded for first time, 2 rounds after joining (`BondDuration` = 2)
 		let mut new7 = vec![
-			RawEvent::Rewarded(1, 27),
+			RawEvent::Rewarded(1, 25),
 			RawEvent::Rewarded(7, 13),
 			RawEvent::Rewarded(8, 13),
 			RawEvent::Rewarded(10, 13),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -379,8 +379,8 @@ impl parachain_info::Config for Runtime {}
 pub const GLMR: Balance = 1_000_000_000_000_000_000;
 
 parameter_types! {
-	/// Moonbeam starts a new round every hour (600 * block_time)
-	pub const BlocksPerRound: u32 = 600;
+	/// The minimum round duration is ~1 minute
+	pub const MinBlocksPerRound: u32 = 10;
 	/// Reward payments and validator exit requests are delayed by 2 hours (2 * 600 * block_time)
 	pub const BondDuration: u32 = 2;
 	/// Maximum 8 valid block authors at any given time
@@ -400,7 +400,7 @@ impl stake::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
 	type SetMonetaryPolicyOrigin = frame_system::EnsureRoot<AccountId>;
-	type BlocksPerRound = BlocksPerRound;
+	type MinBlocksPerRound = MinBlocksPerRound;
 	type BondDuration = BondDuration;
 	type MaxValidators = MaxValidators;
 	type MaxNominatorsPerValidator = MaxNominatorsPerValidator;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 21,
+	spec_version: 22,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
### What does it do?

makes BlocksPerRound more configurable by root https://github.com/PureStake/moonbeam/pull/246#discussion_r576951985

Before issuance was computed at the time of payout. Now issuance is computed at the start of the round. There was no good reason why this wasn't done before, but only realized this is how it should be done while accomadating for the updatable `BlocksPerRound` storage item.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- Does it require changes in documentation/tutorials ?
