### PR TITLE
Specify frontier commit hash in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,7 +1689,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
 dependencies = [
  "derive_more 0.99.11",
  "fp-consensus",
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1749,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core 15.1.0",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "0.8.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
 dependencies = [
  "evm",
  "impl-trait-for-tuples 0.1.3",
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4718,7 +4718,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
 dependencies = [
  "evm",
  "fp-evm",
@@ -4756,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
 dependencies = [
  "evm",
  "fp-evm",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
 dependencies = [
  "evm",
  "fp-evm",


### PR DESCRIPTION
### What does it do?

Reestablishes a specific commit hash for `frontier`. This was causing us trouble recently, but seems to be working as expected now... :thinking: 