### PR TITLE
Ensure net_peerCount is in hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1689,7 +1689,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#677548ce782afd28174548dc4badbedf064e8bae"
 dependencies = [
  "derive_more 0.99.11",
  "fp-consensus",
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#677548ce782afd28174548dc4badbedf064e8bae"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -1749,7 +1749,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#677548ce782afd28174548dc4badbedf064e8bae"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core 15.1.0",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#677548ce782afd28174548dc4badbedf064e8bae"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "0.8.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#677548ce782afd28174548dc4badbedf064e8bae"
 dependencies = [
  "evm",
  "impl-trait-for-tuples 0.1.3",
@@ -1877,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#677548ce782afd28174548dc4badbedf064e8bae"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4681,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "0.1.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#677548ce782afd28174548dc4badbedf064e8bae"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4718,7 +4718,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#677548ce782afd28174548dc4badbedf064e8bae"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -4742,7 +4742,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#677548ce782afd28174548dc4badbedf064e8bae"
 dependencies = [
  "evm",
  "fp-evm",
@@ -4756,7 +4756,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#677548ce782afd28174548dc4badbedf064e8bae"
 dependencies = [
  "evm",
  "fp-evm",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#8ea861444979f213b5965bdf3e6626d7def032f9"
+source = "git+https://github.com/purestake/frontier?branch=v0.6-moonbeam#677548ce782afd28174548dc4badbedf064e8bae"
 dependencies = [
  "evm",
  "fp-evm",

--- a/tests/tests/test-web3api.ts
+++ b/tests/tests/test-web3api.ts
@@ -21,7 +21,7 @@ describeWithMoonbeam("Moonbeam RPC (Web3Api)", `simple-specs.json`, (context) =>
   it("should report peer count in hex", async function () {
     // this tests that the "net_peerCount" response comes back in hex and not decimal.
     // this seems a bit inconsistent amongst Ethereum APIs, but hex seems to be most common.
-    
+
     // related: frontier commits 677548c and 78fb3bc
 
     const result = await customRequest(context.web3, "net_peerCount", []);

--- a/tests/tests/test-web3api.ts
+++ b/tests/tests/test-web3api.ts
@@ -17,4 +17,18 @@ describeWithMoonbeam("Moonbeam RPC (Web3Api)", `simple-specs.json`, (context) =>
     const local_hash = context.web3.utils.sha3("hello");
     expect(hash.result).to.be.equal(local_hash);
   });
+
+  it("should report peer count in hex", async function () {
+    // this tests that the "net_peerCount" response comes back in hex and not decimal.
+    // this seems a bit inconsistent amongst Ethereum APIs, but hex seems to be most common.
+    
+    // related: frontier commits 677548c and 78fb3bc
+
+    const result = await customRequest(context.web3, "net_peerCount", []);
+
+    // TODO: this is really just testing that the result comes back as a string, not that it's
+    //       expressed in hex (as opposed to decimal)
+    expect(result.result).to.be.equal("0");
+    expect(typeof result.result).to.be.equal("string");
+  });
 });


### PR DESCRIPTION
### What does it do?

This adds a test to ensure that `net_peerCount` returns a value hex instead of decimal, which seems to be the most common behavior among Ethereum RPC clients.

The first commit adds a test, and we should see that CI fails. Then bumping `frontier` to  677548c should cause the test to pass.

See also frontier commit https://github.com/PureStake/frontier/commit/677548ce782afd28174548dc4badbedf064e8bae