### PR TITLE
Add default parachain telemetry endpoint.

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -22,6 +22,7 @@ use moonbeam_runtime::{
 };
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
+use sc_telemetry::TelemetryEndpoints;
 use serde::{Deserialize, Serialize};
 use sp_runtime::Perbill;
 use stake::{InflationInfo, Range};
@@ -69,7 +70,10 @@ pub fn development_chain_spec() -> ChainSpec {
 			)
 		},
 		vec![],
-		None,
+		Some(
+			TelemetryEndpoints::new(vec![("wss://telemetry.polkadot.io/submit/".to_string(), 0)])
+				.expect("Polkadot Staging telemetry url is valid; qed"),
+		),
 		None,
 		Some(serde_json::from_str("{\"tokenDecimals\": 18}").expect("Provided valid json map")),
 		Extensions {

--- a/specs/alphanet/parachain-embedded-specs-v6.json
+++ b/specs/alphanet/parachain-embedded-specs-v6.json
@@ -6,7 +6,12 @@
     "/dns4/bootnode1.testnet.moonbeam.network/tcp/30334/p2p/12D3KooWJD9yhtvBoaNviqt6yj9R1AXDqxMvbUaU3fkv73bThKNh",
     "/dns4/bootnode2.testnet.moonbeam.network/tcp/30334/p2p/12D3KooWPS1EzUXqLx4EdkqPJZ8jciCWmciSTou8DrPGAnPps1Lm"
   ],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [
+    [
+      "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
+      0
+    ]
+  ],
   "protocolId": null,
   "properties": {
     "tokenDecimals": 18

--- a/specs/alphanet/parachain-embedded-specs-v6.json
+++ b/specs/alphanet/parachain-embedded-specs-v6.json
@@ -7,10 +7,7 @@
     "/dns4/bootnode2.testnet.moonbeam.network/tcp/30334/p2p/12D3KooWPS1EzUXqLx4EdkqPJZ8jciCWmciSTou8DrPGAnPps1Lm"
   ],
   "telemetryEndpoints": [
-    [
-      "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
-      0
-    ]
+    ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]
   ],
   "protocolId": null,
   "properties": {

--- a/specs/alphanet/parachain-specs-template.json
+++ b/specs/alphanet/parachain-specs-template.json
@@ -3,7 +3,12 @@
   "id": "moonbase_alpha",
   "chainType": "Local",
   "bootNodes": [],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [
+    [
+      "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
+      0
+    ]
+  ],
   "protocolId": null,
   "properties": {
     "tokenDecimals": 18

--- a/specs/alphanet/parachain-specs-template.json
+++ b/specs/alphanet/parachain-specs-template.json
@@ -4,10 +4,7 @@
   "chainType": "Local",
   "bootNodes": [],
   "telemetryEndpoints": [
-    [
-      "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
-      0
-    ]
+    ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]
   ],
   "protocolId": null,
   "properties": {

--- a/specs/stagenet/parachain-embedded-specs-v6.json
+++ b/specs/stagenet/parachain-embedded-specs-v6.json
@@ -6,7 +6,12 @@
     "/dns4/bootnode1.stagenet.moonbeam.gcp.purestake.run/tcp/30334/p2p/12D3KooWH8ocqod6UqhiecikyoYuNWyjcewYjQG9FyhYbo1e4sKV",
     "/dns4/bootnode2.stagenet.moonbeam.gcp.purestake.run/tcp/30334/p2p/12D3KooWFmfo5EnBM1Y5w1ynLx4tvaBSLnbBz3cNfN36nU1mF6rA"
   ],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [
+    [
+      "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
+      0
+    ]
+  ],
   "protocolId": null,
   "properties": {
     "tokenDecimals": 18

--- a/specs/stagenet/parachain-embedded-specs-v6.json
+++ b/specs/stagenet/parachain-embedded-specs-v6.json
@@ -7,10 +7,7 @@
     "/dns4/bootnode2.stagenet.moonbeam.gcp.purestake.run/tcp/30334/p2p/12D3KooWFmfo5EnBM1Y5w1ynLx4tvaBSLnbBz3cNfN36nU1mF6rA"
   ],
   "telemetryEndpoints": [
-    [
-      "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
-      0
-    ]
+    ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]
   ],
   "protocolId": null,
   "properties": {

--- a/specs/stagenet/parachain-specs-template.json
+++ b/specs/stagenet/parachain-specs-template.json
@@ -4,10 +4,7 @@
   "chainType": "Local",
   "bootNodes": [],
   "telemetryEndpoints": [
-    [
-      "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
-      0
-    ]
+    ["/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F", 0]
   ],
   "protocolId": null,
   "properties": {

--- a/specs/stagenet/parachain-specs-template.json
+++ b/specs/stagenet/parachain-specs-template.json
@@ -3,7 +3,12 @@
   "id": "moonbase_stage",
   "chainType": "Local",
   "bootNodes": [],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [
+    [
+      "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
+      0
+    ]
+  ],
   "protocolId": null,
   "properties": {
     "tokenDecimals": 18


### PR DESCRIPTION
This PR adds a default telemetry endpoint to the Moonbeam Parachain (but not the relay chain; that will come later). The default endpoint is the one hosted by parity. For example, you can see stagenet here https://telemetry.polkadot.io/#list/Moonbase%20Stage
