### PR TITLE
Request funds from bot faucet immediately if transaction fails

### DIFF
--- a/tools/bots/mission-control-bot.ts
+++ b/tools/bots/mission-control-bot.ts
@@ -224,8 +224,8 @@ const botActionFaucetSend = async (msg: Message, authorId: string, messageConten
         await web3Api.eth.accounts.signTransaction(
           {
             value: `${params.TOKEN_COUNT * 10n ** TOKEN_DECIMAL}`,
-            gasPrice: "0x01",
-            gas: "0x21000",
+            gasPrice: "0",
+            gas: "21000",
             to: `0x${address}`,
           },
           params.ACCOUNT_KEY

--- a/tools/bots/mission-control-bot.ts
+++ b/tools/bots/mission-control-bot.ts
@@ -200,7 +200,7 @@ const botActionFaucetSend = async (msg: Message, authorId: string, messageConten
         "Remaining time",
         `You still need to wait ${nextAvailableToken(receivers[authorId])} to receive more tokens`
       )
-      .setFooter("Funds transactions are limited to once per hour");
+      .setFooter(`Funds transactions are limited to once every ${params.FAUCET_SEND_INTERVAL} hour(s)`);
 
     msg.channel.send(errorEmbed);
     return;
@@ -271,7 +271,7 @@ const botActionFaucetSend = async (msg: Message, authorId: string, messageConten
     .addField("To account", `0x${address}`, true)
     .addField("Amount sent", `${params.TOKEN_COUNT} DEV`, true)
     .addField("Current account balance", `${accountBalance / 10n ** TOKEN_DECIMAL} DEV`)
-    .setFooter("Funds transactions are limited to once per hour");
+    .setFooter(`Funds transactions are limited to once every ${params.FAUCET_SEND_INTERVAL} hour(s)`);
 
   msg.channel.send(fundsTransactionEmbed);
 };

--- a/tools/bots/mission-control-bot.ts
+++ b/tools/bots/mission-control-bot.ts
@@ -236,6 +236,18 @@ const botActionFaucetSend = async (msg: Message, authorId: string, messageConten
     // rollback the update of user's last fund retrieval
     receivers[authorId] = previousRequestTime;
 
+    // alert in channel
+    const errorEmbed = new MessageEmbed()
+      .setColor(EMBED_COLOR_ERROR)
+      .setTitle("Could not submit the transaction")
+      .setFooter(
+        "The transaction of funds could not be submitted. " +
+        "Please, try requesting funds again."
+      );
+
+    // send message
+    msg.channel.send(errorEmbed);
+
     throw error;
   }
 


### PR DESCRIPTION
### What does it do?

- Inform users in case of error when sending the funds transaction
- If the tx resutls in an error, the stored _last time a user requested funds_ is rollback to the previous value (aka. users will be able to request funds again immediately if the tx doesn't succeed).
- Includes a fallback message for Slack notifications not supporting the formatting

### What important points reviewers should know?
Nothing new from the config standpoint, the code requires the same data input as before.

### Is there something left for follow-up PRs?
No

### What alternative implementations were considered?
None

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?
No

### What value does it bring to the blockchain users?
Able to request again funds if faucet transaction fails. Also able to check the Slack message directly from notifications thanks to the fallback.

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
