### PR TITLE
Publish rustdocs to github pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
       # This is how Frontier got the toolchain installed
+      # TODO This can probably be removed in favor of action-rs/toolchain below
+      # But I'm keeping it for now just in case I need to go back to it.
       # - name: Rust Setup
       #   run: |
       #     scripts/init.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Publish Rust Docs
+
+on:
+    #TODO we really only want to publish on pushes to master.
+    # But for now I'm testing the ci
+    pull_request:
+        branches:
+            - master
+
+jobs:
+    deploy-docs:
+      name: Deploy docs
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v1
+        # This is how Frontier got the toolchain installed
+        # - name: Rust Setup
+        #   run: |
+        #     scripts/init.sh
+        #     cargo --version
+        #     rustc --version
+        #     cargo +$WASM_BUILD_TOOLCHAIN --version
+        #     rustc +$WASM_BUILD_TOOLCHAIN --version
+        #   env:
+        #     WASM_BUILD_TOOLCHAIN: nightly-2020-08-29
+        - uses: actions-rs/toolchain@v1
+          with:
+            target: wasm32-unknown-unknown
+            # Toolchain is autodetected from `rust-toolchain` file
+            # https://github.com/actions-rs/toolchain#the-toolchain-file
+            #toolchain: ${{ env.WASM_BUILD_TOOLCHAIN }}
+            default: true
+
+        - name: Build rustdocs
+          uses: actions-rs/cargo@v1
+          with:
+            command: doc
+            args: --all --no-deps=
+
+        #TODO Do we need to make an index.html?
+        - name: Make index.html
+          run: echo "indexfile" > ./target/docs/index.html
+
+        - name: Deploy documentation
+          uses: peaceiris/actions-gh-pages@v3
+          with:
+            # TODO we'll need at add this key in github
+            deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+            publish_branch: gh-pages
+            publish_dir: ./target/doc
+            keep_files: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,9 +32,10 @@ jobs:
           command: doc
           args: --all --no-deps
 
-      #TODO Do we need to make an index.html?
+      # Make an index.html file so we start at the moonbeam_runtime page
+      # Copied from https://github.com/substrate-developer-hub/rustdocs/blob/master/index.html
       - name: Make index.html
-        run: echo "indexfile" > ./target/doc/index.html
+        run: echo "<meta http-equiv=refresh content=0;url=moonbeam_runtime/index.html>" > ./target/doc/index.html
 
       - name: Deploy documentation
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,10 +45,10 @@ jobs:
 
       #TODO Do we need to make an index.html?
       # See if this works when I explicitly create the file first.
-      - name: Make index.html
-        run: |
-          touch ./target/docs/index.html
-          echo "indexfile" > ./target/docs/index.html
+      # - name: Make index.html
+      #   run: |
+      #     touch ./target/docs/index.html
+      #     echo "indexfile" > ./target/docs/index.html
 
       - name: Deploy documentation
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
           uses: actions-rs/cargo@v1
           with:
             command: doc
-            args: --all --no-deps=
+            args: --all --no-deps
 
         #TODO Do we need to make an index.html?
         - name: Make index.html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,18 +15,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1
-      # This is how Frontier got the toolchain installed
-      # TODO This can probably be removed in favor of action-rs/toolchain below
-      # But I'm keeping it for now just in case I need to go back to it.
-      # - name: Rust Setup
-      #   run: |
-      #     scripts/init.sh
-      #     cargo --version
-      #     rustc --version
-      #     cargo +$WASM_BUILD_TOOLCHAIN --version
-      #     rustc +$WASM_BUILD_TOOLCHAIN --version
-      #   env:
-      #     WASM_BUILD_TOOLCHAIN: nightly-2020-08-29
+
       - uses: actions-rs/toolchain@v1
         with:
           target: wasm32-unknown-unknown

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,13 @@ jobs:
           #toolchain: ${{ env.WASM_BUILD_TOOLCHAIN }}
           default: true
 
-      #TODO caching?
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-doc-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build rustdocs
         uses: actions-rs/cargo@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,8 +44,11 @@ jobs:
           args: --all --no-deps
 
       #TODO Do we need to make an index.html?
+      # See if this works when I explicitly create the file first.
       - name: Make index.html
-        run: echo "indexfile" > ./target/docs/index.html
+        run: |
+          touch ./target/docs/index.html
+          echo "indexfile" > ./target/docs/index.html
 
       - name: Deploy documentation
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,8 @@ jobs:
           #toolchain: ${{ env.WASM_BUILD_TOOLCHAIN }}
           default: true
 
+      #TODO caching?
+
       - name: Build rustdocs
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,53 +1,53 @@
 name: Publish Rust Docs
 
 on:
-    #TODO we really only want to publish on pushes to master.
-    # But for now I'm testing the ci
-    pull_request:
-        branches:
-            - master
+  #TODO we really only want to publish on pushes to master.
+  # But for now I'm testing the ci
+  pull_request:
+    branches:
+      - master
 
 jobs:
-    deploy-docs:
-      name: Deploy docs
-      runs-on: ubuntu-latest
+  deploy-docs:
+    name: Deploy docs
+    runs-on: ubuntu-latest
 
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v1
-        # This is how Frontier got the toolchain installed
-        # - name: Rust Setup
-        #   run: |
-        #     scripts/init.sh
-        #     cargo --version
-        #     rustc --version
-        #     cargo +$WASM_BUILD_TOOLCHAIN --version
-        #     rustc +$WASM_BUILD_TOOLCHAIN --version
-        #   env:
-        #     WASM_BUILD_TOOLCHAIN: nightly-2020-08-29
-        - uses: actions-rs/toolchain@v1
-          with:
-            target: wasm32-unknown-unknown
-            # Toolchain is autodetected from `rust-toolchain` file
-            # https://github.com/actions-rs/toolchain#the-toolchain-file
-            #toolchain: ${{ env.WASM_BUILD_TOOLCHAIN }}
-            default: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      # This is how Frontier got the toolchain installed
+      # - name: Rust Setup
+      #   run: |
+      #     scripts/init.sh
+      #     cargo --version
+      #     rustc --version
+      #     cargo +$WASM_BUILD_TOOLCHAIN --version
+      #     rustc +$WASM_BUILD_TOOLCHAIN --version
+      #   env:
+      #     WASM_BUILD_TOOLCHAIN: nightly-2020-08-29
+      - uses: actions-rs/toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+          # Toolchain is autodetected from `rust-toolchain` file
+          # https://github.com/actions-rs/toolchain#the-toolchain-file
+          #toolchain: ${{ env.WASM_BUILD_TOOLCHAIN }}
+          default: true
 
-        - name: Build rustdocs
-          uses: actions-rs/cargo@v1
-          with:
-            command: doc
-            args: --all --no-deps
+      - name: Build rustdocs
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --all --no-deps
 
-        #TODO Do we need to make an index.html?
-        - name: Make index.html
-          run: echo "indexfile" > ./target/docs/index.html
+      #TODO Do we need to make an index.html?
+      - name: Make index.html
+        run: echo "indexfile" > ./target/docs/index.html
 
-        - name: Deploy documentation
-          uses: peaceiris/actions-gh-pages@v3
-          with:
-            # TODO we'll need at add this key in github
-            deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-            publish_branch: gh-pages
-            publish_dir: ./target/doc
-            keep_files: true
+      - name: Deploy documentation
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          # TODO we'll need at add this key in github
+          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          publish_branch: gh-pages
+          publish_dir: ./target/doc
+          keep_files: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,7 @@
 name: Publish Rust Docs
 
 on:
-  #TODO we really only want to publish on pushes to master.
-  # But for now I'm testing the ci
-  pull_request:
+  push:
     branches:
       - master
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,11 +44,8 @@ jobs:
           args: --all --no-deps
 
       #TODO Do we need to make an index.html?
-      # See if this works when I explicitly create the file first.
-      # - name: Make index.html
-      #   run: |
-      #     touch ./target/docs/index.html
-      #     echo "indexfile" > ./target/docs/index.html
+      - name: Make index.html
+        run: echo "indexfile" > ./target/doc/index.html
 
       - name: Deploy documentation
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,8 +48,6 @@ jobs:
       - name: Deploy documentation
         uses: peaceiris/actions-gh-pages@v3
         with:
-          # TODO we'll need at add this key in github
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: ./target/doc
-          keep_files: true


### PR DESCRIPTION
### What does it do?

This PR adds a CI job to build and publish the rustdocs for our codebase to github pages. This technique is largely copied from https://github.com/paritytech/frontier/blob/master/.github/workflows/docs.yml

### What important points reviewers should know?

The generated docs are not stored in our repo (except on a separate `gh-pages` branch that we never need to interact with). They are generated on-the-fly and copied to the hosting (which is the separate `gh-pages` branch).

### What alternative implementations were considered?

Having the ops run a server to host the docs. This is preferable if it works because we incur no hosting cost.

### Is there something for Followup?

* Add a link to our repo readme. (https://github.com/PureStake/moonbeam/pull/289)
* Actually fill in a bunch of missing docs. When you see it hosted, you see how much is missing.

## Checklist

- :x: Does it require a purge of the network?
- :x: You bumped the runtime version if there are breaking changes in the **runtime** ?
- :x:  Does it require changes in documentation/tutorials ?
