### PR TITLE
Genesis funded accounts by mnemonic

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -27,6 +27,9 @@ serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0"
 jsonrpc-core = "15.0.0"
 jsonrpc-pubsub = "15.0.0"
+sha3 = { version = "0.8", default-features = false }
+tiny-hderive = { version = "0.3.0", default-features = false }
+tiny-bip39 = {version = "0.6", default-features = false}
 
 # Moonbeam dependencies
 moonbeam-runtime = { path = "../runtime" }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -13,8 +13,9 @@
 
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
-
+use bip39::{Language, Mnemonic, Seed};
 use cumulus_primitives::ParaId;
+use log::debug;
 use moonbeam_runtime::{
 	AccountId, Balance, BalancesConfig, DemocracyConfig, EVMConfig, EthereumChainIdConfig,
 	EthereumConfig, GenesisConfig, ParachainInfoConfig, SchedulerConfig, StakeConfig, SudoConfig,
@@ -24,11 +25,59 @@ use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use sc_telemetry::TelemetryEndpoints;
 use serde::{Deserialize, Serialize};
-use sp_runtime::Perbill;
-use stake::{InflationInfo, Range};
-use std::{collections::BTreeMap, str::FromStr};
+use sha3::{Digest, Keccak256};
 
-/// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
+use sp_core::{ecdsa, Pair, Public, H160, H256};
+use sp_runtime::{Perbill, traits::{BlakeTwo256, Hash}};
+use stake::{InflationInfo, Range};
+use std::convert::TryInto;
+use std::{collections::BTreeMap, str::FromStr};
+use tiny_hderive::bip32::ExtendedPrivKey;
+
+/// Helper function to derive a num_accounts child pairs from mnemonics
+/// Substrate derive function cannot be used because the derivation is different than Ethereum's
+pub fn derive_pairs_from_mnemonic<TPublic: Public>(
+	mnemonic: &str,
+	num_accounts: u32,
+) -> Vec<TPublic::Pair> {
+	let seed = Mnemonic::from_phrase(mnemonic, Language::English)
+		.map(|x| Seed::new(&x, ""))
+		.expect("Wrong mnemonic provided");
+
+	let mut childs = Vec::new();
+	for i in 0..num_accounts {
+		if let Some(child_pair) =
+			ExtendedPrivKey::derive(seed.as_bytes(), format!("m/44'/60'/0'/0/{}", i).as_ref())
+				.ok()
+				.map(|account| TPublic::Pair::from_seed_slice(&account.secret()).ok())
+				.flatten()
+		{
+			childs.push(child_pair);
+		} else {
+			log::error!("An error ocurred while deriving key {} from parent", i)
+		}
+	}
+	childs
+}
+
+/// Helper function to get an AccountId from Key Pair
+/// We need the full decompressed public key to derive an ethereum-style account
+/// Substrate does not provide a method to obtain the full decompressed public key
+/// Therefore, this function uses the secp256k1_ecdsa_recover method to recover the full key
+pub fn get_account_id_from_pair<TPublic: Public>(pair: TPublic::Pair) -> Option<AccountId> {
+	let test_message = [1u8; 32];
+	let signature: [u8; 65] = pair.sign(&test_message).as_ref().try_into().ok()?;
+	let pubkey = sp_io::crypto::secp256k1_ecdsa_recover(
+		&signature,
+		BlakeTwo256::hash_of(&test_message).as_fixed_bytes(),
+	)
+	.ok()?;
+	Some(H160::from(H256::from_slice(
+		Keccak256::digest(&pubkey).as_slice(),
+	)))
+}
+
+/// Specialized `ChainSpec`. This is a specialiwhere <TPublic::Pair as sp_core::Pair>::Seed: std::fmt::Debugzation of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig, Extensions>;
 
 /// The extensions for the [`ChainSpec`].
@@ -48,8 +97,35 @@ impl Extensions {
 	}
 }
 
+/// Function to generate accounts given a mnemonic and a number of child accounts to be generated
+/// Defaults to a default mnemonic if no mnemonic is supplied
+pub fn generate_accounts(mnemonic: Option<String>, num_accounts: u32) -> Vec<AccountId> {
+	let parent_mnemonic = mnemonic.unwrap_or(
+		"bottom drive obey lake curtain smoke basket hold race lonely fit walk".to_string(),
+	);
+	let childs = derive_pairs_from_mnemonic::<ecdsa::Public>(&parent_mnemonic, num_accounts);
+	debug!("Account Generation");
+	let mut accounts: Vec<AccountId>;
+	accounts = childs
+		.iter()
+		.map(|par| {
+			let account = get_account_id_from_pair::<ecdsa::Public>(par.clone());
+			debug!(
+				"private_key {} --------> Account {:x?}",
+				sp_core::hexdisplay::HexDisplay::from(&par.clone().seed()),
+				account
+			);
+			account
+		})
+		.flatten()
+		.collect();
+	accounts.push(AccountId::from_str("6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b").unwrap());
+	accounts
+}
+
 /// Generate a chain spec for use with the development service.
-pub fn development_chain_spec() -> ChainSpec {
+pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: u32) -> ChainSpec {
+	let accounts = generate_accounts(mnemonic, num_accounts);
 	ChainSpec::from_genesis(
 		"Moonbase Development Testnet",
 		"development",
@@ -64,7 +140,7 @@ pub fn development_chain_spec() -> ChainSpec {
 					1_000 * GLMR,
 				)],
 				moonbeam_inflation_config(),
-				vec![AccountId::from_str("6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b").unwrap()],
+				accounts.clone(),
 				Default::default(), // para_id
 				1281,               //ChainId
 			)

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -70,6 +70,14 @@ pub struct ExportGenesisStateCommand {
 	/// The name of the chain for that the genesis state should be exported.
 	#[structopt(long)]
 	pub chain: Option<String>,
+
+	/// Number of accounts to be funded in the genesis in dev mode (default 10)
+	#[structopt(long, default_value = "10")]
+	pub accounts: u32,
+
+	/// Mnemonic from which we can derive funded accounts in the genesis
+	#[structopt(long)]
+	pub mnemonic: Option<String>,
 }
 
 /// Command for exporting the genesis wasm file.
@@ -86,6 +94,14 @@ pub struct ExportGenesisWasmCommand {
 	/// The name of the chain for that the genesis wasm file should be exported.
 	#[structopt(long)]
 	pub chain: Option<String>,
+
+	/// Number of accounts to be funded in the genesis in dev mode (default 10)
+	#[structopt(long, default_value = "10")]
+	pub accounts: u32,
+
+	/// Mnemonic from which we can derive funded accounts in the genesis
+	#[structopt(long)]
+	pub mnemonic: Option<String>,
 }
 
 #[derive(Debug, StructOpt)]
@@ -110,6 +126,14 @@ pub struct RunCmd {
 	/// Public identity for participating in staking and receiving rewards
 	#[structopt(long, parse(try_from_str = parse_h160))]
 	pub author_id: Option<H160>,
+
+	/// Number of accounts to be funded in the genesis in dev mode (default 10)
+	#[structopt(long, default_value = "10")]
+	pub accounts: u32,
+
+	/// Mnemonic from which we can derive funded accounts in the genesis
+	#[structopt(long)]
+	pub mnemonic: Option<String>,
 }
 
 fn parse_h160(input: &str) -> Result<H160, String> {


### PR DESCRIPTION
### What does it do?
It allows for two new parameters in dev-mode, namely _accounts_ and _mnemonic_, that will fund _accounts_ child accounts derived from  _mnemonic_ in the genesis block in dev mode.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
