### PR TITLE
Genesis funded accounts by mnemonic

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -27,6 +27,9 @@ serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0"
 jsonrpc-core = "15.0.0"
 jsonrpc-pubsub = "15.0.0"
+sha3 = { version = "0.8", default-features = false }
+tiny-hderive = { version = "0.3.0", default-features = false }
+tiny-bip39 = {version = "0.6", default-features = false}
 
 # Moonbeam dependencies
 moonbeam-runtime = { path = "../runtime" }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -13,8 +13,9 @@
 
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
-
+use bip39::{Language, Mnemonic, Seed};
 use cumulus_primitives::ParaId;
+use log::debug;
 use moonbeam_runtime::{
 	AccountId, Balance, BalancesConfig, DemocracyConfig, EVMConfig, EthereumChainIdConfig,
 	EthereumConfig, GenesisConfig, ParachainInfoConfig, SchedulerConfig, StakeConfig, SudoConfig,
@@ -24,9 +25,63 @@ use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
 use sc_telemetry::TelemetryEndpoints;
 use serde::{Deserialize, Serialize};
-use sp_runtime::Perbill;
+use sha3::{Digest, Keccak256};
+
+use sp_core::{ecdsa, Pair, Public, H160, H256};
+use sp_runtime::{
+	traits::{BlakeTwo256, Hash},
+	Perbill,
+};
 use stake::{InflationInfo, Range};
+use std::convert::TryInto;
 use std::{collections::BTreeMap, str::FromStr};
+use tiny_hderive::bip32::ExtendedPrivKey;
+
+/// Helper function to derive `num_accounts` child pairs from mnemonics
+/// Substrate derive function cannot be used because the derivation is different than Ethereum's
+/// https://substrate.dev/rustdocs/v2.0.0/src/sp_core/ecdsa.rs.html#460-470
+pub fn derive_bip44_pairs_from_mnemonic<TPublic: Public>(
+	mnemonic: &str,
+	num_accounts: u32,
+) -> Vec<TPublic::Pair> {
+	let seed = Mnemonic::from_phrase(mnemonic, Language::English)
+		.map(|x| Seed::new(&x, ""))
+		.expect("Wrong mnemonic provided");
+
+	let mut childs = Vec::new();
+	for i in 0..num_accounts {
+		if let Some(child_pair) =
+			ExtendedPrivKey::derive(seed.as_bytes(), format!("m/44'/60'/0'/0/{}", i).as_ref())
+				.ok()
+				.map(|account| TPublic::Pair::from_seed_slice(&account.secret()).ok())
+				.flatten()
+		{
+			childs.push(child_pair);
+		} else {
+			log::error!("An error ocurred while deriving key {} from parent", i)
+		}
+	}
+	childs
+}
+
+/// Helper function to get an AccountId from Key Pair
+/// We need the full decompressed public key to derive an ethereum-style account
+/// Substrate does not provide a method to obtain the full decompressed public key
+/// Therefore, this function uses the secp256k1_ecdsa_recover method to recover the full key
+/// A solution without using the private key would imply solving the secp256k1 curve equation
+/// The latter is currently not possible with current substrate methods
+pub fn get_account_id_from_pair<TPublic: Public>(pair: TPublic::Pair) -> Option<AccountId> {
+	let test_message = [1u8; 32];
+	let signature: [u8; 65] = pair.sign(&test_message).as_ref().try_into().ok()?;
+	let pubkey = sp_io::crypto::secp256k1_ecdsa_recover(
+		&signature,
+		BlakeTwo256::hash_of(&test_message).as_fixed_bytes(),
+	)
+	.ok()?;
+	Some(H160::from(H256::from_slice(
+		Keccak256::digest(&pubkey).as_slice(),
+	)))
+}
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig, Extensions>;
@@ -48,8 +103,35 @@ impl Extensions {
 	}
 }
 
+/// Function to generate accounts given a mnemonic and a number of child accounts to be generated
+/// Defaults to a default mnemonic if no mnemonic is supplied
+pub fn generate_accounts(mnemonic: String, num_accounts: u32) -> Vec<AccountId> {
+	let childs = derive_bip44_pairs_from_mnemonic::<ecdsa::Public>(&mnemonic, num_accounts);
+	debug!("Account Generation");
+	childs
+		.iter()
+		.map(|par| {
+			let account = get_account_id_from_pair::<ecdsa::Public>(par.clone());
+			debug!(
+				"private_key {} --------> Account {:x?}",
+				sp_core::hexdisplay::HexDisplay::from(&par.clone().seed()),
+				account
+			);
+			account
+		})
+		.flatten()
+		.collect()
+}
+
 /// Generate a chain spec for use with the development service.
-pub fn development_chain_spec() -> ChainSpec {
+pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32>) -> ChainSpec {
+	// Default mnemonic if none was provided
+	let parent_mnemonic = mnemonic.unwrap_or(
+		"bottom drive obey lake curtain smoke basket hold race lonely fit walk".to_string(),
+	);
+	let mut accounts = generate_accounts(parent_mnemonic, num_accounts.unwrap_or(10));
+	// We add Gerald here
+	accounts.push(AccountId::from_str("6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b").unwrap());
 	ChainSpec::from_genesis(
 		"Moonbase Development Testnet",
 		"development",
@@ -64,7 +146,7 @@ pub fn development_chain_spec() -> ChainSpec {
 					1_000 * GLMR,
 				)],
 				moonbeam_inflation_config(),
-				vec![AccountId::from_str("6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b").unwrap()],
+				accounts.clone(),
 				Default::default(), // para_id
 				1281,               //ChainId
 			)

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -256,3 +256,36 @@ fn testnet_genesis(
 		}),
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	#[test]
+	fn test_derived_pairs_1() {
+		let mnemonic = "bottom drive obey lake curtain smoke basket hold race lonely fit walk".to_string();
+		let accounts = 10;
+		let pairs = derive_bip44_pairs_from_mnemonic::<ecdsa::Public>(&mnemonic, accounts);
+		let first_account = get_account_id_from_pair::<ecdsa::Public>(pairs.first().unwrap().clone()).unwrap();
+		let last_account = get_account_id_from_pair::<ecdsa::Public>(pairs.last().unwrap().clone()).unwrap();
+
+		let expected_first_account = AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap();
+		let expected_last_account = AccountId::from_str("2898FE7a42Be376C8BC7AF536A940F7Fd5aDd423").unwrap();
+		assert_eq!(first_account, expected_first_account);
+		assert_eq!(last_account, expected_last_account);
+		assert_eq!(pairs.len(), 10);
+	}
+	#[test]
+	fn test_derived_pairs_2() {
+		let mnemonic = "slab nerve salon plastic filter inherit valve ozone crash thumb quality whale".to_string();
+		let accounts = 20;
+		let pairs = derive_bip44_pairs_from_mnemonic::<ecdsa::Public>(&mnemonic, accounts);
+		let first_account = get_account_id_from_pair::<ecdsa::Public>(pairs.first().unwrap().clone()).unwrap();
+		let last_account = get_account_id_from_pair::<ecdsa::Public>(pairs.last().unwrap().clone()).unwrap();
+
+		let expected_first_account = AccountId::from_str("1e56ca71b596f2b784a27a2fdffef053dbdeff83").unwrap();
+		let expected_last_account = AccountId::from_str("4148202BF0c0Ad7697Cff87EbB83340C80c947f8").unwrap();
+		assert_eq!(first_account, expected_first_account);
+		assert_eq!(last_account, expected_last_account);
+		assert_eq!(pairs.len(), 20);
+	}
+}

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -262,28 +262,39 @@ mod tests {
 	use super::*;
 	#[test]
 	fn test_derived_pairs_1() {
-		let mnemonic = "bottom drive obey lake curtain smoke basket hold race lonely fit walk".to_string();
+		let mnemonic =
+			"bottom drive obey lake curtain smoke basket hold race lonely fit walk".to_string();
 		let accounts = 10;
 		let pairs = derive_bip44_pairs_from_mnemonic::<ecdsa::Public>(&mnemonic, accounts);
-		let first_account = get_account_id_from_pair::<ecdsa::Public>(pairs.first().unwrap().clone()).unwrap();
-		let last_account = get_account_id_from_pair::<ecdsa::Public>(pairs.last().unwrap().clone()).unwrap();
+		let first_account =
+			get_account_id_from_pair::<ecdsa::Public>(pairs.first().unwrap().clone()).unwrap();
+		let last_account =
+			get_account_id_from_pair::<ecdsa::Public>(pairs.last().unwrap().clone()).unwrap();
 
-		let expected_first_account = AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap();
-		let expected_last_account = AccountId::from_str("2898FE7a42Be376C8BC7AF536A940F7Fd5aDd423").unwrap();
+		let expected_first_account =
+			AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap();
+		let expected_last_account =
+			AccountId::from_str("2898FE7a42Be376C8BC7AF536A940F7Fd5aDd423").unwrap();
 		assert_eq!(first_account, expected_first_account);
 		assert_eq!(last_account, expected_last_account);
 		assert_eq!(pairs.len(), 10);
 	}
 	#[test]
 	fn test_derived_pairs_2() {
-		let mnemonic = "slab nerve salon plastic filter inherit valve ozone crash thumb quality whale".to_string();
+		let mnemonic =
+			"slab nerve salon plastic filter inherit valve ozone crash thumb quality whale"
+				.to_string();
 		let accounts = 20;
 		let pairs = derive_bip44_pairs_from_mnemonic::<ecdsa::Public>(&mnemonic, accounts);
-		let first_account = get_account_id_from_pair::<ecdsa::Public>(pairs.first().unwrap().clone()).unwrap();
-		let last_account = get_account_id_from_pair::<ecdsa::Public>(pairs.last().unwrap().clone()).unwrap();
+		let first_account =
+			get_account_id_from_pair::<ecdsa::Public>(pairs.first().unwrap().clone()).unwrap();
+		let last_account =
+			get_account_id_from_pair::<ecdsa::Public>(pairs.last().unwrap().clone()).unwrap();
 
-		let expected_first_account = AccountId::from_str("1e56ca71b596f2b784a27a2fdffef053dbdeff83").unwrap();
-		let expected_last_account = AccountId::from_str("4148202BF0c0Ad7697Cff87EbB83340C80c947f8").unwrap();
+		let expected_first_account =
+			AccountId::from_str("1e56ca71b596f2b784a27a2fdffef053dbdeff83").unwrap();
+		let expected_last_account =
+			AccountId::from_str("4148202BF0c0Ad7697Cff87EbB83340C80c947f8").unwrap();
 		assert_eq!(first_account, expected_first_account);
 		assert_eq!(last_account, expected_last_account);
 		assert_eq!(pairs.len(), 20);

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -18,8 +18,6 @@ use sp_core::H160;
 use std::path::PathBuf;
 use std::str::FromStr;
 use structopt::StructOpt;
-
-/// Sub-commands supported by the collator.
 #[derive(Debug, StructOpt)]
 pub enum Subcommand {
 	/// Export the genesis state of the parachain.
@@ -31,7 +29,7 @@ pub enum Subcommand {
 	ExportGenesisWasm(ExportGenesisWasmCommand),
 
 	/// Build a chain specification.
-	BuildSpec(sc_cli::BuildSpecCmd),
+	BuildSpec(BuildSpecCommand),
 
 	/// Validate blocks.
 	CheckBlock(sc_cli::CheckBlockCmd),
@@ -50,6 +48,20 @@ pub enum Subcommand {
 
 	/// Revert the chain to a previous state.
 	Revert(sc_cli::RevertCmd),
+}
+
+#[derive(Debug, StructOpt)]
+pub struct BuildSpecCommand {
+	#[structopt(flatten)]
+	pub base: sc_cli::BuildSpecCmd,
+
+	/// Number of accounts to be funded in the genesis
+	#[structopt(long)]
+	pub accounts: Option<u32>,
+
+	/// Mnemonic from which we can derive funded accounts in the genesis
+	#[structopt(long)]
+	pub mnemonic: Option<String>,
 }
 
 /// Command for exporting the genesis state of the parachain

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -18,6 +18,8 @@ use sp_core::H160;
 use std::path::PathBuf;
 use std::str::FromStr;
 use structopt::StructOpt;
+
+/// Sub-commands supported by the collator.
 #[derive(Debug, StructOpt)]
 pub enum Subcommand {
 	/// Export the genesis state of the parachain.
@@ -56,11 +58,13 @@ pub struct BuildSpecCommand {
 	pub base: sc_cli::BuildSpecCmd,
 
 	/// Number of accounts to be funded in the genesis
-	#[structopt(long)]
+	/// Warning: This flag implies a development spec and overrides any explicitly supplied spec
+	#[structopt(long, conflicts_with = "chain")]
 	pub accounts: Option<u32>,
 
 	/// Mnemonic from which we can derive funded accounts in the genesis
-	#[structopt(long)]
+	/// Warning: This flag implies a development spec and overrides any explicitly supplied spec
+	#[structopt(long, conflicts_with = "chain")]
 	pub mnemonic: Option<String>,
 }
 

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -41,7 +41,6 @@ fn load_spec(
 	id: &str,
 	para_id: ParaId,
 ) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-
 	match id {
 		"alphanet" => Ok(Box::new(chain_spec::ChainSpec::from_json_bytes(
 			&include_bytes!("../../specs/alphanet/parachain-embedded-specs-v6.json")[..],
@@ -49,12 +48,7 @@ fn load_spec(
 		"stagenet" => Ok(Box::new(chain_spec::ChainSpec::from_json_bytes(
 			&include_bytes!("../../specs/stagenet/parachain-embedded-specs-v6.json")[..],
 		)?)),
-		"dev" | "development" =>  {
-			Ok(Box::new(chain_spec::development_chain_spec(
-				None,
-				None,
-			)))
-		},
+		"dev" | "development" => Ok(Box::new(chain_spec::development_chain_spec(None, None))),
 		"local" => Ok(Box::new(chain_spec::get_chain_spec(para_id))),
 		"" => Err(
 			"You have not specified what chain to sync. In the future, this will default to \
@@ -99,10 +93,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-		load_spec(
-			id,
-			self.run.parachain_id.unwrap_or(1000).into(),
-		)
+		load_spec(id, self.run.parachain_id.unwrap_or(1000).into())
 	}
 
 	fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
@@ -178,10 +169,13 @@ pub fn run() -> Result<()> {
 			runner.sync_run(|config| {
 				if params.mnemonic.is_some() || params.accounts.is_some() {
 					params.base.run(
-						Box::new(chain_spec::development_chain_spec(params.mnemonic.clone(), params.accounts)),
-						config.network)
-				}
-				else {
+						Box::new(chain_spec::development_chain_spec(
+							params.mnemonic.clone(),
+							params.accounts,
+						)),
+						config.network,
+					)
+				} else {
 					params.base.run(config.chain_spec, config.network)
 				}
 			})


### PR DESCRIPTION
### What does it do?
It adds support for supplying a mnemonic and a number of accounts from the command line in --dev mode, as _mnemonic_ and _accounts_. This should generate _accounts_ child accounts from the parent generated with the _mnemonic_
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
