### PR TITLE
Bot allowing certain users to use the faucet with no limit

### DIFF
--- a/tools/bots/mission-control-bot.ts
+++ b/tools/bots/mission-control-bot.ts
@@ -218,6 +218,9 @@ const botActionFaucetSend = async (
   messageContent: string,
   interval: number
 ) => {
+  // set default value of lastReceived at 0
+  if (!receivers[authorId]) receivers[authorId] = 0;
+
   if (!canReceiveTokensAgain(authorId, interval)) {
     const errorEmbed = new MessageEmbed()
       .setColor(EMBED_COLOR_ERROR)


### PR DESCRIPTION
### What does it do?
Includes a new parameter that holds the list of user IDs that don't need to wait the interval (right now 24h) to request funds again, they can request funds every time. In addition, to handle multiple requests of funds that happen in a same block time, a FIFO queue has been included to process entering tx one by one, only going for the next when the previous has been processed.

### What important points reviewers should know?

The user with this rights will be the one used to monitor the faucet

### Is there something left for follow-up PRs?
The FIFO queue approach can only process one tx per block confirmation, other approaches may be considered to achieve a better throughput.

### What alternative implementations were considered?
None

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
_Concurrent_ requests to the faucet are correctly handled

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
