### PR TITLE
Update support URL

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -85,7 +85,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn support_url() -> String {
-		"support.anonymous.an".into()
+		"https://github.com/PureStake/moonbeam/issues/new".into()
 	}
 
 	fn copyright_start_year() -> i32 {
@@ -123,7 +123,7 @@ impl SubstrateCli for RelayChainCli {
 	}
 
 	fn support_url() -> String {
-		"support.anonymous.an".into()
+		"https://github.com/PureStake/moonbeam/issues/new".into()
 	}
 
 	fn copyright_start_year() -> i32 {


### PR DESCRIPTION
Solves MOON-191

This PR changes the support URL that is printed to the terminal when the node crashes. The text printed reads "This is a bug. Please report it at ___".
