### PR TITLE
Prune unused dependencies from the former standalone node.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
  "concurrent-queue",
  "fastrand",
  "futures-lite",
- "once_cell",
+ "once_cell 1.5.2",
  "vec-arena",
 ]
 
@@ -240,7 +240,7 @@ dependencies = [
  "async-io",
  "futures-lite",
  "num_cpus",
- "once_cell",
+ "once_cell 1.5.2",
 ]
 
 [[package]]
@@ -255,7 +255,7 @@ dependencies = [
  "libc",
  "log",
  "nb-connect",
- "once_cell",
+ "once_cell 1.5.2",
  "parking",
  "polling",
  "vec-arena",
@@ -283,7 +283,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "event-listener",
  "futures-lite",
- "once_cell",
+ "once_cell 1.5.2",
  "signal-hook",
  "winapi 0.3.9",
 ]
@@ -310,7 +310,7 @@ dependencies = [
  "log",
  "memchr",
  "num_cpus",
- "once_cell",
+ "once_cell 1.5.2",
  "pin-project-lite 0.2.4",
  "pin-utils",
  "slab",
@@ -573,7 +573,7 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-lite",
- "once_cell",
+ "once_cell 1.5.2",
 ]
 
 [[package]]
@@ -1968,7 +1968,7 @@ dependencies = [
  "frame-support-procedural",
  "impl-trait-for-tuples 0.2.0",
  "log",
- "once_cell",
+ "once_cell 1.5.2",
  "parity-scale-codec",
  "paste",
  "serde",
@@ -2213,7 +2213,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
 dependencies = [
- "once_cell",
+ "once_cell 1.5.2",
 ]
 
 [[package]]
@@ -2429,6 +2429,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92c171d55b98633f4ed3860808f004099b36c1cc29c42cfc53aa8591b21efcf2"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
+dependencies = [
+ "byteorder",
+ "scopeguard 0.3.3",
 ]
 
 [[package]]
@@ -2759,7 +2769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg 1.0.1",
- "hashbrown",
+ "hashbrown 0.9.1",
  "serde",
 ]
 
@@ -3730,7 +3740,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aae342b73d57ad0b8b364bd12584819f2c1fe9114285dfcf8b0722607671635"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -3819,7 +3829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "814bbecfc0451fc314eeea34f05bbcd5b98a7ad7af37faee088b86a1e633f1d4"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.9.1",
  "parity-util-mem",
 ]
 
@@ -3846,6 +3856,12 @@ checksum = "cc29ba65898edc4fdc252cb31cd3925f37c1a8ba25bb46eec883569984976530"
 dependencies = [
  "rustc-serialize",
 ]
+
+[[package]]
+name = "memzero"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c0d11ac30a033511ae414355d80f70d9f29a44a49140face477117a1ee90db"
 
 [[package]]
 name = "merlin"
@@ -4048,6 +4064,7 @@ dependencies = [
  "sc-transaction-pool",
  "serde",
  "serde_json",
+ "sha3 0.8.2",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
@@ -4065,6 +4082,8 @@ dependencies = [
  "substrate-frame-rpc-system",
  "substrate-test-client",
  "substrate-test-runtime-client",
+ "tiny-bip39 0.6.2",
+ "tiny-hderive",
  "tokio 0.2.24",
  "trie-root 0.15.2",
 ]
@@ -4131,14 +4150,12 @@ dependencies = [
  "hex-literal",
  "log",
  "moonbeam-rpc-primitives-txpool",
- "pallet-aura",
  "pallet-author-filter",
  "pallet-balances",
  "pallet-democracy",
  "pallet-ethereum",
  "pallet-ethereum-chain-id",
  "pallet-evm",
- "pallet-grandpa",
  "pallet-randomness-collective-flip",
  "pallet-scheduler",
  "pallet-sudo",
@@ -4151,7 +4168,6 @@ dependencies = [
  "serde",
  "sp-api",
  "sp-block-builder",
- "sp-consensus-aura",
  "sp-core",
  "sp-inherents",
  "sp-io",
@@ -4469,6 +4485,15 @@ checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "once_cell"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532c29a261168a45ce28948f9537ddd7a5dd272cc513b3017b1e82a88f962c37"
+dependencies = [
+ "parking_lot 0.7.1",
+]
+
+[[package]]
+name = "once_cell"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
@@ -4516,24 +4541,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "pallet-aura"
-version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate#965950969f3fca2d9e225e4988afbc0a6b851a56"
-dependencies = [
- "frame-support",
- "frame-system",
- "pallet-session",
- "pallet-timestamp",
- "parity-scale-codec",
- "sp-application-crypto",
- "sp-consensus-aura",
- "sp-inherents",
- "sp-runtime",
- "sp-std",
- "sp-timestamp",
 ]
 
 [[package]]
@@ -5264,7 +5271,7 @@ checksum = "664a8c6b8e62d8f9f2f937e391982eb433ab285b4cd9545b342441e04a906e42"
 dependencies = [
  "cfg-if 1.0.0",
  "ethereum-types",
- "hashbrown",
+ "hashbrown 0.9.1",
  "impl-trait-for-tuples 0.2.0",
  "lru",
  "parity-util-mem-derive",
@@ -7213,7 +7220,7 @@ checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
 dependencies = [
  "cc",
  "libc",
- "once_cell",
+ "once_cell 1.5.2",
  "spin",
  "untrusted",
  "web-sys",
@@ -7586,7 +7593,7 @@ dependencies = [
  "sp-version",
  "structopt",
  "thiserror",
- "tiny-bip39",
+ "tiny-bip39 0.8.0",
  "tokio 0.2.24",
 ]
 
@@ -8362,7 +8369,7 @@ dependencies = [
  "erased-serde",
  "lazy_static",
  "log",
- "once_cell",
+ "once_cell 1.5.2",
  "parking_lot 0.11.1",
  "regex",
  "rustc-hash",
@@ -9092,7 +9099,7 @@ dependencies = [
  "sp-storage",
  "substrate-bip39",
  "thiserror",
- "tiny-bip39",
+ "tiny-bip39 0.8.0",
  "tiny-keccak",
  "twox-hash",
  "wasmi",
@@ -9983,13 +9990,28 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c5676413eaeb1ea35300a0224416f57abc3bd251657e0fafc12c47ff98c060"
+dependencies = [
+ "failure",
+ "hashbrown 0.1.8",
+ "hmac 0.7.1",
+ "once_cell 0.1.8",
+ "pbkdf2 0.3.0",
+ "rand 0.6.5",
+ "sha2 0.8.2",
+]
+
+[[package]]
+name = "tiny-bip39"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9e44c4759bae7f1032e286a7ef990bd9ed23fe831b7eeba0beb97484c2e59b8"
 dependencies = [
  "anyhow",
  "hmac 0.8.1",
- "once_cell",
+ "once_cell 1.5.2",
  "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",
@@ -9997,6 +10019,19 @@ dependencies = [
  "thiserror",
  "unicode-normalization",
  "zeroize",
+]
+
+[[package]]
+name = "tiny-hderive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b874a4992538d4b2f4fbbac11b9419d685f4b39bdc3fed95b04e07bfd76040"
+dependencies = [
+ "base58",
+ "hmac 0.7.1",
+ "libsecp256k1",
+ "memzero",
+ "sha2 0.8.2",
 ]
 
 [[package]]
@@ -10412,7 +10447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc176c377eb24d652c9c69c832c832019011b6106182bf84276c66b66d5c9a6"
 dependencies = [
  "hash-db",
- "hashbrown",
+ "hashbrown 0.9.1",
  "log",
  "rustc-hex",
  "smallvec 1.6.1",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -20,7 +20,6 @@ stake = { path = "../pallets/stake", default-features = false }
 pallet-author-filter = { path = "../pallets/author-filter", default-features = false }
 
 # Substrate dependencies
-pallet-aura = { git = "https://github.com/paritytech/substrate.git", default-features = false, branch = "master", optional = true }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
@@ -45,9 +44,6 @@ pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", 
 frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "v0.6-moonbeam" }
-
-sp-consensus-aura = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master", optional = true }
-pallet-grandpa = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "master", optional = true }
 
 pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "v0.6-moonbeam" }
 fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "v0.6-moonbeam" }


### PR DESCRIPTION
This PR prunes a few no longer used dependencies that were missed in https://github.com/PureStake/moonbeam/pull/204
