### PR TITLE
Update copyright years

### DIFF
--- a/client/rpc-core/txpool/src/lib.rs
+++ b/client/rpc-core/txpool/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc-core/txpool/src/types/content.rs
+++ b/client/rpc-core/txpool/src/types/content.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc-core/txpool/src/types/inspect.rs
+++ b/client/rpc-core/txpool/src/types/inspect.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc-core/txpool/src/types/mod.rs
+++ b/client/rpc-core/txpool/src/types/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/client/rpc/txpool/src/lib.rs
+++ b/client/rpc/txpool/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/build.rs
+++ b/node/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify
@@ -89,7 +89,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn copyright_start_year() -> i32 {
-		2017
+		2019
 	}
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
@@ -127,7 +127,7 @@ impl SubstrateCli for RelayChainCli {
 	}
 
 	fn copyright_start_year() -> i32 {
-		2017
+		2019
 	}
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {

--- a/node/src/inherents.rs
+++ b/node/src/inherents.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/author-filter/src/lib.rs
+++ b/pallets/author-filter/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/author-inherent/src/lib.rs
+++ b/pallets/author-inherent/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/ethereum-chain-id/src/lib.rs
+++ b/pallets/ethereum-chain-id/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/parachain-info/src/lib.rs
+++ b/pallets/parachain-info/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/stake/src/inflation.rs
+++ b/pallets/stake/src/inflation.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/stake/src/lib.rs
+++ b/pallets/stake/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/stake/src/mock.rs
+++ b/pallets/stake/src/mock.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/stake/src/set.rs
+++ b/pallets/stake/src/set.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/stake/src/tests.rs
+++ b/pallets/stake/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/token-dealer/src/lib.rs
+++ b/pallets/token-dealer/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/primitives/rpc/txpool/src/lib.rs
+++ b/primitives/rpc/txpool/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/account/src/lib.rs
+++ b/runtime/account/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/precompiles/src/lib.rs
+++ b/runtime/precompiles/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2021 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/tools/generate-rpc-types.ts
+++ b/tools/generate-rpc-types.ts
@@ -1,6 +1,3 @@
-// Copyright 2017-2020 @polkadot/apps-config authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 //import { DefinitionRpc, DefinitionRpcParam } from "@polkadot/types/types";
 export declare type DefinitionTypeType = string;
 export declare type DefinitionTypeEnum =


### PR DESCRIPTION
This PR updates copyright information in three places in the repo.

1. Changes the dates from `2019-2020` -> `2019-2021` in all Rust file headers. (This is the primary change)
2. Changes the copyright start year in the `SubstrateCLI` impls to 2019 to match the license. (It was previously 2017; probably copied from Cumulus)
3. Removes an incorrect copyright header in one of our JS utilities that was probably copied from polkadot-js

Reviewers: These were the changes I could find after looking for about 15 min. If you know of other places this info should be updated, please let me know.
