### PR TITLE
Set min gas price one

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -245,6 +245,7 @@ pub const GAS_PER_SECOND: u64 = 40_000_000;
 /// u64 works for approximations because Weight is a very small unit compared to gas.
 pub const WEIGHT_PER_GAS: u64 = WEIGHT_PER_SECOND / GAS_PER_SECOND;
 
+/// A linear GasWeightMapping for Moonbeam using experimentally determined values.
 pub struct MoonbeamGasWeightMapping;
 
 impl pallet_evm::GasWeightMapping for MoonbeamGasWeightMapping {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -256,8 +256,17 @@ impl pallet_evm::GasWeightMapping for MoonbeamGasWeightMapping {
 	}
 }
 
+/// A FeeCalculator for Moonbeam that sets the minimum gas price to one.
+pub struct MinGasPriceOne;
+
+impl FeeCalculator for MinGasPriceOne {
+	fn min_gas_price() -> U256 {
+		U256::one()
+	}
+}
+
 impl pallet_evm::Config for Runtime {
-	type FeeCalculator = ();
+	type FeeCalculator = MinGasPriceOne;
 	type GasWeightMapping = MoonbeamGasWeightMapping;
 	type CallOrigin = EnsureAddressSame;
 	type WithdrawOrigin = EnsureAddressNever<AccountId>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -112,7 +112,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 24,
+	spec_version: 25,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION

This PR increases the minimum gas price from zero to one. EVM Users will now have to have some tokens to make evm calls. This is a much more realistic scenario. This may help us discover bugs we haven't seen before. It will also help our user community get used to the idea of paying fees which will be necessary on value-bearing networks.

## Checklist

- :x: Does it require a purge of the network?
- :heavy_check_mark:  You bumped the runtime version if there are breaking changes in the **runtime** ?
- :heavy_check_mark:  Does it require changes in documentation/tutorials ?
