### PR TITLE
make staking constants storage items configurable by root

### DIFF
--- a/pallets/parachain-staking/src/inflation.rs
+++ b/pallets/parachain-staking/src/inflation.rs
@@ -15,8 +15,8 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Helper methods for computing issuance based on inflation
-use crate::pallet::{BalanceOf, Config};
-use frame_support::traits::{Currency, Get};
+use crate::pallet::{BalanceOf, Config, Pallet};
+use frame_support::traits::Currency;
 use parity_scale_codec::{Decode, Encode};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,8 @@ const SECONDS_PER_BLOCK: u32 = 6;
 const BLOCKS_PER_YEAR: u32 = SECONDS_PER_YEAR / SECONDS_PER_BLOCK;
 
 fn rounds_per_year<T: Config>() -> u32 {
-	BLOCKS_PER_YEAR / T::BlocksPerRound::get()
+	let blocks_per_round = <Pallet<T>>::round().length;
+	BLOCKS_PER_YEAR / blocks_per_round
 }
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -459,7 +459,7 @@ pub mod pallet {
 		/// Round inflation range set with the provided annual inflation range
 		RoundInflationSet(Perbill, Perbill, Perbill),
 		/// Staking expectations set
-		SetStakeExpectations(BalanceOf<T>, BalanceOf<T>, BalanceOf<T>),
+		StakeExpectationsSet(BalanceOf<T>, BalanceOf<T>, BalanceOf<T>),
 		/// Set total selected candidates to this value [old, new]
 		TotalSelectedSet(u32, u32),
 		/// Set blocks per round [current_round, first_block, old, new]
@@ -659,7 +659,7 @@ pub mod pallet {
 			ensure!(expectations.is_valid(), Error::<T>::InvalidSchedule);
 			let mut config = <InflationConfig<T>>::get();
 			config.set_expectations(expectations);
-			Self::deposit_event(Event::SetStakeExpectations(
+			Self::deposit_event(Event::StakeExpectationsSet(
 				config.expect.min,
 				config.expect.ideal,
 				config.expect.max,

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -95,7 +95,7 @@ impl pallet_balances::Config for Test {
 	type WeightInfo = ();
 }
 parameter_types! {
-	pub const BlocksPerRound: u32 = 5;
+	pub const MinBlocksPerRound: u32 = 5;
 	pub const BondDuration: u32 = 2;
 	pub const MinSelectedCandidates: u32 = 5;
 	pub const MaxNominatorsPerCollator: u32 = 4;
@@ -108,7 +108,8 @@ parameter_types! {
 impl crate::pallet::Config for Test {
 	type Event = MetaEvent;
 	type Currency = Balances;
-	type BlocksPerRound = BlocksPerRound;
+	type MinBlocksPerRound = MinBlocksPerRound;
+	type DefaultBlocksPerRound = MinBlocksPerRound;
 	type BondDuration = BondDuration;
 	type MinSelectedCandidates = MinSelectedCandidates;
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -97,7 +97,7 @@ impl pallet_balances::Config for Test {
 parameter_types! {
 	pub const BlocksPerRound: u32 = 5;
 	pub const BondDuration: u32 = 2;
-	pub const TotalSelectedCandidates: u32 = 5;
+	pub const MinSelectedCandidates: u32 = 5;
 	pub const MaxNominatorsPerCollator: u32 = 4;
 	pub const MaxCollatorsPerNominator: u32 = 4;
 	pub const MaxFee: Perbill = Perbill::from_percent(50);
@@ -110,7 +110,7 @@ impl crate::pallet::Config for Test {
 	type Currency = Balances;
 	type BlocksPerRound = BlocksPerRound;
 	type BondDuration = BondDuration;
-	type TotalSelectedCandidates = TotalSelectedCandidates;
+	type MinSelectedCandidates = MinSelectedCandidates;
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;
 	type MaxCollatorsPerNominator = MaxCollatorsPerNominator;
 	type MaxFee = MaxFee;

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -95,7 +95,8 @@ impl pallet_balances::Config for Test {
 	type WeightInfo = ();
 }
 parameter_types! {
-	pub const MinBlocksPerRound: u32 = 5;
+	pub const MinBlocksPerRound: u32 = 3;
+	pub const DefaultBlocksPerRound: u32 = 5;
 	pub const BondDuration: u32 = 2;
 	pub const MinSelectedCandidates: u32 = 5;
 	pub const MaxNominatorsPerCollator: u32 = 4;
@@ -109,7 +110,7 @@ impl crate::pallet::Config for Test {
 	type Event = MetaEvent;
 	type Currency = Balances;
 	type MinBlocksPerRound = MinBlocksPerRound;
-	type DefaultBlocksPerRound = MinBlocksPerRound;
+	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type BondDuration = BondDuration;
 	type MinSelectedCandidates = MinSelectedCandidates;
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -110,7 +110,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 25,
+	spec_version: 26,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -380,8 +380,10 @@ impl parachain_info::Config for Runtime {}
 pub const GLMR: Balance = 1_000_000_000_000_000_000;
 
 parameter_types! {
-	/// Moonbeam starts a new round every hour (600 * block_time)
-	pub const BlocksPerRound: u32 = 600;
+	/// Minimum round length is 2 minutes (20 * 6 second block times)
+	pub const MinBlocksPerRound: u32 = 20;
+	/// Default BlocksPerRound is every hour (600 * 6 second block times)
+	pub const DefaultBlocksPerRound: u32 = 600;
 	/// Reward payments and validator exit requests are delayed by 2 hours (2 * 600 * block_time)
 	pub const BondDuration: u32 = 2;
 	/// Maximum 8 valid block authors at any given time
@@ -398,7 +400,8 @@ parameter_types! {
 impl parachain_staking::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
-	type BlocksPerRound = BlocksPerRound;
+	type MinBlocksPerRound = MinBlocksPerRound;
+	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type BondDuration = BondDuration;
 	type MinSelectedCandidates = MinSelectedCandidates;
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -385,7 +385,7 @@ parameter_types! {
 	/// Reward payments and validator exit requests are delayed by 2 hours (2 * 600 * block_time)
 	pub const BondDuration: u32 = 2;
 	/// Maximum 8 valid block authors at any given time
-	pub const TotalSelectedCandidates: u32 = 8;
+	pub const MinSelectedCandidates: u32 = 8;
 	/// Maximum 10 nominators per validator
 	pub const MaxNominatorsPerCollator: u32 = 10;
 	/// The maximum percent a validator can take off the top of its rewards is 50%
@@ -400,9 +400,9 @@ impl parachain_staking::Config for Runtime {
 	type Currency = Balances;
 	type BlocksPerRound = BlocksPerRound;
 	type BondDuration = BondDuration;
-	type TotalSelectedCandidates = TotalSelectedCandidates;
+	type MinSelectedCandidates = MinSelectedCandidates;
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;
-	type MaxCollatorsPerNominator = TotalSelectedCandidates;
+	type MaxCollatorsPerNominator = MinSelectedCandidates;
 	type MaxFee = MaxFee;
 	type MinCollatorStk = MinCollatorStk;
 	type MinCollatorCandidateStk = MinCollatorStk;


### PR DESCRIPTION
### What does it do?

- [x] `TotalSelectedCandidates` becomes the storage item `TotalSelected` (so root can now call `set_total_selected(u32)` to set the total collators selected every round)
- [x]  make `BlocksPerRound` a configurable storage item

### What important points reviewers should know?

### Is there something left for follow-up PRs?

See what other config constants can be moved to storage.

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- Does it require changes in documentation/tutorials ?
