### PR TITLE
Remove telemetry from dev spec

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -29,7 +29,6 @@ use moonbeam_runtime::{
 };
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use sc_service::ChainType;
-use sc_telemetry::TelemetryEndpoints;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -157,10 +157,7 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 			)
 		},
 		vec![],
-		Some(
-			TelemetryEndpoints::new(vec![("wss://telemetry.polkadot.io/submit/".to_string(), 0)])
-				.expect("Polkadot Staging telemetry url is valid; qed"),
-		),
+		None,
 		None,
 		Some(serde_json::from_str("{\"tokenDecimals\": 18}").expect("Provided valid json map")),
 		Extensions {


### PR DESCRIPTION
### What does it do?

Removes the telemetry endpoint from the dev spec. Solves MOON-407

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

No error about telemetry timeout when using `--dev` and less data streaming to the telemetry endpoint.

## Checklist

- :x: Does it require a purge of the network?
- :x: You bumped the runtime version if there are breaking changes in the **runtime** ?
- :x: Does it require changes in documentation/tutorials ?
