### PR TITLE
Crystalin fixes ci wrong exit

### DIFF
--- a/scripts/generate-parachain-specs.sh
+++ b/scripts/generate-parachain-specs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 source scripts/_init_var.sh
 
 echo "=================== Alphanet ==================="

--- a/scripts/generate-relay-specs.sh
+++ b/scripts/generate-relay-specs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 source scripts/_init_var.sh
 
 if [ -z "$POLKADOT_VERSION" ]; then

--- a/specs/alphanet/parachain-specs-template.json
+++ b/specs/alphanet/parachain-specs-template.json
@@ -82,7 +82,15 @@
         ]
       },
       "palletScheduler": {},
-      "palletDemocracy": {}
+      "palletDemocracy": {},
+      "palletCollectiveInstance1": {
+        "phantom": null,
+        "members": []
+      },
+      "palletCollectiveInstance2": {
+        "phantom": null,
+        "members": []
+      }
     }
   }
 }

--- a/specs/stagenet/parachain-specs-template.json
+++ b/specs/stagenet/parachain-specs-template.json
@@ -78,7 +78,15 @@
         ]
       },
       "palletScheduler": {},
-      "palletDemocracy": {}
+      "palletDemocracy": {},
+      "palletCollectiveInstance1": {
+        "phantom": null,
+        "members": []
+      },
+      "palletCollectiveInstance2": {
+        "phantom": null,
+        "members": []
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes the CI by making spec generation fail if one of the command fails