### PR TITLE
Pin Ethers JS to 5.0.32

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -15,7 +15,7 @@
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.2.2",
     "chai": "^4.3.4",
-    "ethers": "^5.0.28",
+    "ethers": "5.0.32",
     "mocha": "^8.3.2",
     "mocha-steps": "^1.3.0",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
### What does it do?

This PR specifies a fixed version of ethers js.

### What important points reviewers should know?

The newly released 5.1.0 breaks our integration tests.

### Is there something left for follow-up PRs?

We should fix our tests to work with  the latest ethers
