### PR TITLE
Use `frontier_backend_client` and remove duplicated code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4484,6 +4484,7 @@ dependencies = [
  "ethereum-types",
  "fc-consensus",
  "fc-db",
+ "fc-rpc",
  "fp-rpc",
  "jsonrpc-core 15.1.0",
  "moonbeam-rpc-core-debug",
@@ -4532,6 +4533,7 @@ dependencies = [
  "ethereum 0.6.0",
  "ethereum-types",
  "fc-consensus",
+ "fc-rpc",
  "fc-rpc-core",
  "fp-rpc",
  "futures 0.3.13",
@@ -4561,6 +4563,7 @@ version = "0.6.0"
 dependencies = [
  "ethereum 0.7.1",
  "ethereum-types",
+ "fc-rpc",
  "frame-system",
  "jsonrpc-core 15.1.0",
  "moonbeam-rpc-core-txpool",
@@ -5241,18 +5244,6 @@ dependencies = [
  "num",
  "sp-core",
  "sp-io",
-]
-
-[[package]]
-name = "pallet-evm-precompile-sha3fips"
-version = "3.0.0"
-source = "git+https://github.com/purestake/frontier?branch=notlesh-moonbeam-v0.7#cce4b72d351056e5d63332af3e0a5bab67738417"
-dependencies = [
- "evm",
- "fp-evm",
- "sp-core",
- "sp-io",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -7121,7 +7112,6 @@ dependencies = [
  "pallet-evm-precompile-bn128",
  "pallet-evm-precompile-dispatch",
  "pallet-evm-precompile-modexp",
- "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",
  "rand 0.5.6",
  "rustc-hex",

--- a/client/rpc/debug/Cargo.toml
+++ b/client/rpc/debug/Cargo.toml
@@ -23,4 +23,5 @@ moonbeam-rpc-core-debug = { path = "../../rpc-core/debug" }
 moonbeam-rpc-primitives-debug = { path = "../../../primitives/rpc/debug" }
 fc-consensus = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
 fc-db = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
 fp-rpc = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -21,13 +21,13 @@ use fc_rpc::{frontier_backend_client, internal_err};
 use fp_rpc::EthereumRuntimeRPCApi;
 use jsonrpc_core::Result as RpcResult;
 use moonbeam_rpc_primitives_debug::{single, DebugRuntimeApi};
-use sc_client_api::backend::{AuxStore, Backend, StateBackend};
+use sc_client_api::backend::Backend;
 use sp_api::{BlockId, HeaderT, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{
 	Backend as BlockchainBackend, Error as BlockChainError, HeaderBackend, HeaderMetadata,
 };
-use sp_runtime::traits::{BlakeTwo256, Block as BlockT};
+use sp_runtime::traits::Block as BlockT;
 use std::{str::FromStr, sync::Arc};
 
 pub struct Debug<B: BlockT, C, BE> {
@@ -49,9 +49,7 @@ impl<B: BlockT, C, BE> Debug<B, C, BE> {
 impl<B, C, BE> DebugT for Debug<B, C, BE>
 where
 	BE: Backend<B> + 'static,
-	BE::State: StateBackend<BlakeTwo256>,
-	BE::Blockchain: BlockchainBackend<B>,
-	C: ProvideRuntimeApi<B> + AuxStore,
+	C: ProvideRuntimeApi<B>,
 	C: HeaderMetadata<B, Error = BlockChainError> + HeaderBackend<B>,
 	C: Send + Sync + 'static,
 	B: BlockT<Hash = H256> + Send + Sync + 'static,

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -17,9 +17,9 @@
 pub use moonbeam_rpc_core_debug::{Debug as DebugT, DebugServer, TraceParams};
 
 use ethereum_types::{H128, H256};
+use fc_rpc::{frontier_backend_client, internal_err};
 use fp_rpc::EthereumRuntimeRPCApi;
 use jsonrpc_core::Result as RpcResult;
-use jsonrpc_core::{Error as RpcError, ErrorCode};
 use moonbeam_rpc_primitives_debug::{single, DebugRuntimeApi};
 use sc_client_api::backend::{AuxStore, Backend, StateBackend};
 use sp_api::{BlockId, HeaderT, ProvideRuntimeApi};
@@ -28,15 +28,7 @@ use sp_blockchain::{
 	Backend as BlockchainBackend, Error as BlockChainError, HeaderBackend, HeaderMetadata,
 };
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT};
-use std::{marker::PhantomData, str::FromStr, sync::Arc};
-
-pub fn internal_err<T: ToString>(message: T) -> RpcError {
-	RpcError {
-		code: ErrorCode::InternalError,
-		message: message.to_string(),
-		data: None,
-	}
-}
+use std::{str::FromStr, sync::Arc};
 
 pub struct Debug<B: BlockT, C, BE> {
 	client: Arc<C>,
@@ -50,75 +42,6 @@ impl<B: BlockT, C, BE> Debug<B, C, BE> {
 			client,
 			backend,
 			frontier_backend,
-		}
-	}
-}
-
-impl<B, C, BE> Debug<B, C, BE>
-where
-	BE: Backend<B> + 'static,
-	BE::State: StateBackend<BlakeTwo256>,
-	BE::Blockchain: BlockchainBackend<B>,
-	C: ProvideRuntimeApi<B> + AuxStore,
-	C: HeaderMetadata<B, Error = BlockChainError> + HeaderBackend<B>,
-	C: Send + Sync + 'static,
-	B: BlockT<Hash = H256> + Send + Sync + 'static,
-	C::Api: BlockBuilder<B>,
-	C::Api: DebugRuntimeApi<B>,
-	C::Api: EthereumRuntimeRPCApi<B>,
-{
-	// Asumes there is only one mapped canonical block in the AuxStore, otherwise something is wrong
-	fn load_hash(&self, hash: H256) -> RpcResult<Option<BlockId<B>>> {
-		let hashes = self
-			.frontier_backend
-			.mapping()
-			.block_hashes(&hash)
-			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?;
-		let out: Vec<H256> = hashes
-			.into_iter()
-			.filter_map(|h| if self.is_canon(h) { Some(h) } else { None })
-			.collect();
-
-		if out.len() == 1 {
-			return Ok(Some(BlockId::Hash(out[0])));
-		}
-		Ok(None)
-	}
-
-	fn is_canon(&self, target_hash: H256) -> bool {
-		if let Ok(Some(number)) = self.client.number(target_hash) {
-			if let Ok(Some(header)) = self.client.header(BlockId::Number(number)) {
-				return header.hash() == target_hash;
-			}
-		}
-		false
-	}
-
-	fn load_transactions(&self, transaction_hash: H256) -> RpcResult<Option<(H256, u32)>> {
-		let transaction_metadata = self
-			.frontier_backend
-			.mapping()
-			.transaction_metadata(&transaction_hash)
-			.map_err(|err| internal_err(format!("fetch aux store failed: {:?}", err)))?;
-
-		if transaction_metadata.len() == 1 {
-			Ok(Some((
-				transaction_metadata[0].ethereum_block_hash,
-				transaction_metadata[0].ethereum_index,
-			)))
-		} else if transaction_metadata.len() > 1 {
-			transaction_metadata
-				.iter()
-				.find(|meta| self.is_canon(meta.block_hash))
-				.map_or(
-					Ok(Some((
-						transaction_metadata[0].ethereum_block_hash,
-						transaction_metadata[0].ethereum_index,
-					))),
-					|meta| Ok(Some((meta.ethereum_block_hash, meta.ethereum_index))),
-				)
-		} else {
-			Ok(None)
 		}
 	}
 }
@@ -141,17 +64,23 @@ where
 		transaction_hash: H256,
 		params: Option<TraceParams>,
 	) -> RpcResult<single::TransactionTrace> {
-		let (hash, index) = match self
-			.load_transactions(transaction_hash)
-			.map_err(|err| internal_err(format!("{:?}", err)))?
+		let (hash, index) = match frontier_backend_client::load_transactions::<B, C>(
+			self.client.as_ref(),
+			self.frontier_backend.as_ref(),
+			transaction_hash,
+		)
+		.map_err(|err| internal_err(format!("{:?}", err)))?
 		{
 			Some((hash, index)) => (hash, index as usize),
 			None => return Err(internal_err("Transaction hash not found".to_string())),
 		};
 
-		let reference_id = match self
-			.load_hash(hash)
-			.map_err(|err| internal_err(format!("{:?}", err)))?
+		let reference_id = match frontier_backend_client::load_hash::<B, C>(
+			self.client.as_ref(),
+			self.frontier_backend.as_ref(),
+			hash,
+		)
+		.map_err(|err| internal_err(format!("{:?}", err)))?
 		{
 			Some(hash) => hash,
 			_ => return Err(internal_err("Block hash not found".to_string())),

--- a/client/rpc/trace/Cargo.toml
+++ b/client/rpc/trace/Cargo.toml
@@ -36,6 +36,7 @@ jsonrpc-core = "15.0.0"
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1" }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1" }
 sc-transaction-graph = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
 fc-consensus = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
 fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
 moonbeam-rpc-core-trace = { path = "../../rpc-core/trace" }

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -31,16 +31,13 @@ use std::{
 use tokio::{sync::oneshot, time::delay_for};
 
 use jsonrpc_core::Result;
-use sc_client_api::{
-	backend::{AuxStore, Backend, StateBackend},
-	StorageProvider,
-};
+use sc_client_api::backend::Backend;
 use sp_api::{ApiRef, BlockId, HeaderT, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{
 	Backend as BlockchainBackend, Error as BlockChainError, HeaderBackend, HeaderMetadata,
 };
-use sp_runtime::traits::{BlakeTwo256, Block as BlockT};
+use sp_runtime::traits::Block as BlockT;
 use sp_utils::mpsc::TracingUnboundedSender;
 
 use ethereum_types::H256;
@@ -101,13 +98,9 @@ pub struct TraceFilterCache<B, C, BE>(PhantomData<(B, C, BE)>);
 impl<B, C, BE> TraceFilterCache<B, C, BE>
 where
 	BE: Backend<B> + 'static,
-	BE::State: StateBackend<BlakeTwo256>,
-	BE::Blockchain: BlockchainBackend<B>,
-	C: ProvideRuntimeApi<B> + AuxStore,
+	C: ProvideRuntimeApi<B>,
 	C: HeaderMetadata<B, Error = BlockChainError> + HeaderBackend<B>,
 	C: Send + Sync + 'static,
-	C: StorageProvider<B, BE>,
-	C: HeaderMetadata<B, Error = BlockChainError> + 'static,
 	B: BlockT<Hash = H256> + Send + Sync + 'static,
 	B::Header: HeaderT<Number = u32>,
 	C::Api: BlockBuilder<B>,

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -30,7 +30,7 @@ use std::{
 };
 use tokio::{sync::oneshot, time::delay_for};
 
-use jsonrpc_core::{Error as RpcError, ErrorCode, Result};
+use jsonrpc_core::Result;
 use sc_client_api::{
 	backend::{AuxStore, Backend, StateBackend},
 	StorageProvider,
@@ -44,6 +44,7 @@ use sp_runtime::traits::{BlakeTwo256, Block as BlockT};
 use sp_utils::mpsc::TracingUnboundedSender;
 
 use ethereum_types::H256;
+use fc_rpc::internal_err;
 use fp_rpc::EthereumRuntimeRPCApi;
 
 pub use moonbeam_rpc_core_trace::{
@@ -88,14 +89,6 @@ impl TraceT for Trace {
 		}
 		.boxed()
 		.compat()
-	}
-}
-
-fn internal_err<T: ToString>(message: T) -> RpcError {
-	RpcError {
-		code: ErrorCode::InternalError,
-		message: message.to_string(),
-		data: None,
 	}
 }
 

--- a/client/rpc/txpool/Cargo.toml
+++ b/client/rpc/txpool/Cargo.toml
@@ -23,3 +23,4 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "roco
 serde = { version = "1.0", features = ["derive"] }
 
 moonbeam-rpc-primitives-txpool = { path = "../../../primitives/rpc/txpool" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }


### PR DESCRIPTION
### What does it do?

Uses the recently created `frontier_backend_client` and removes duplicated code.

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

https://github.com/paritytech/frontier/pull/331

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
