### PR TITLE
Better PrecompileSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5244,18 +5244,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-evm-precompile-sha3fips"
-version = "3.0.0"
-source = "git+https://github.com/purestake/frontier?branch=notlesh-moonbeam-v0.7#cce4b72d351056e5d63332af3e0a5bab67738417"
-dependencies = [
- "evm",
- "fp-evm",
- "sp-core",
- "sp-io",
- "tiny-keccak",
-]
-
-[[package]]
 name = "pallet-evm-precompile-simple"
 version = "3.0.0"
 source = "git+https://github.com/purestake/frontier?branch=notlesh-moonbeam-v0.7#cce4b72d351056e5d63332af3e0a5bab67738417"
@@ -7116,13 +7104,15 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 name = "precompiles"
 version = "0.6.0"
 dependencies = [
+ "evm",
+ "frame-support",
  "log",
  "pallet-evm",
  "pallet-evm-precompile-bn128",
  "pallet-evm-precompile-dispatch",
  "pallet-evm-precompile-modexp",
- "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",
+ "parity-scale-codec",
  "rand 0.5.6",
  "rustc-hex",
  "sp-core",

--- a/runtime/precompiles/Cargo.toml
+++ b/runtime/precompiles/Cargo.toml
@@ -11,6 +11,9 @@ log = "0.4"
 rand = { version = "0.5.6", default-features = false }
 rustc-hex = { version = "2.0.1", default-features = false }
 
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
+evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "notlesh-moonbeam-v0.7" }
@@ -22,6 +25,9 @@ pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", 
 [features]
 default = [ "std" ]
 std = [
+	"codec/std",
+	"frame-support/std",
+	"evm/std",
 	"sp-std/std",
 	"sp-core/std",
 	"rand/std",

--- a/runtime/precompiles/src/lib.rs
+++ b/runtime/precompiles/src/lib.rs
@@ -16,10 +16,16 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use evm::{ExitSucceed, ExitError, Context};
+use pallet_evm::{Precompile, PrecompileSet, Config};
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_dispatch::Dispatch;
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_simple::{ECRecover, Identity, Ripemd160, Sha256};
+use sp_core::H160;
+use frame_support::{dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo}, weights::{Pays, DispatchClass}};
+use codec::Decode;
+use sp_std::{vec::Vec, marker::PhantomData};
 
 /// The PrecompileSet installed in the Moonbeam runtime.
 /// We include the nine Istanbul precompiles
@@ -28,14 +34,38 @@ use pallet_evm_precompile_simple::{ECRecover, Identity, Ripemd160, Sha256};
 ///
 /// TODO I had trouble getting the BN precompiles to compile.
 /// Also, Why are the BN precompiles in geth called bn256*, but in Frontier they are called Bn128*
-pub type MoonbeamPrecompiles<Runtime> = (
-	ECRecover,
-	Sha256,
-	Ripemd160,
-	Identity,
-	Modexp,
-	Bn128Add,
-	Bn128Mul,
-	Bn128Pairing,
-	Dispatch<Runtime>,
-);
+#[derive(Debug, Clone, Copy)]
+pub struct MoonbeamPrecompiles<R> (PhantomData<R>);
+
+impl<R> PrecompileSet for MoonbeamPrecompiles<R>
+where
+	R: Config,	
+	R::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo + Decode,
+    <R::Call as Dispatchable>::Origin: From<Option<R::AccountId>>{
+	fn execute(
+        address: H160, 
+        input: &[u8], 
+        target_gas: Option<u64>, 
+        context: &Context
+    ) -> Option<Result<(ExitSucceed, Vec<u8>, u64), ExitError>> {
+		match address {
+			// Ethereum precompiles :
+			a if a == hash(1) => Some(ECRecover::execute(input, target_gas, context)),
+			a if a == hash(2) => Some(Sha256::execute(input, target_gas, context)),
+			a if a == hash(3) => Some(Ripemd160::execute(input, target_gas, context)),
+			a if a == hash(4) => Some(Identity::execute(input, target_gas, context)),
+			a if a == hash(5) => Some(Modexp::execute(input, target_gas, context)),
+			a if a == hash(6) => Some(Bn128Add::execute(input, target_gas, context)),
+			a if a == hash(7) => Some(Bn128Mul::execute(input, target_gas, context)),
+			a if a == hash(8) => Some(Bn128Pairing::execute(input, target_gas, context)),
+			// Moonbeam precompiles :
+			a if a == hash(255) => Some(Dispatch::<R>::execute(input, target_gas, context)),
+			_ => None,
+		}
+	}
+}
+
+
+fn hash(a: u64) -> H160 {
+	H160::from_low_u64_be(a)
+}

--- a/runtime/precompiles/src/lib.rs
+++ b/runtime/precompiles/src/lib.rs
@@ -34,9 +34,6 @@ use sp_std::{marker::PhantomData, vec::Vec};
 /// We include the nine Istanbul precompiles
 /// (https://github.com/ethereum/go-ethereum/blob/3c46f557/core/vm/contracts.go#L69)
 /// as well as a special precompile for dispatching Substrate extrinsics
-///
-/// TODO I had trouble getting the BN precompiles to compile.
-/// Also, Why are the BN precompiles in geth called bn256*, but in Frontier they are called Bn128*
 #[derive(Debug, Clone, Copy)]
 pub struct MoonbeamPrecompiles<R>(PhantomData<R>);
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -113,7 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 30,
+	spec_version: 31,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
### What does it do?

Replace the tuple of precompiles by a custom implementation, allowing to include Moonbeam specific precompiles while
leaving room for future new Ethereum precompiles.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
