### PR TITLE
Allow purging relay and para separately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-client-cli"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#9d89ed653217203810822483ae86fd8867f59620"
+dependencies = [
+ "sc-cli",
+ "sc-service",
+ "structopt",
+]
+
+[[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=rococo-v1#9d89ed653217203810822483ae86fd8867f59620"
@@ -4333,6 +4343,7 @@ dependencies = [
  "assert_cmd",
  "async-io",
  "author-inherent",
+ "cumulus-client-cli",
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-consensus-relay-chain",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -85,6 +85,7 @@ fc-db = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonb
 fc-mapping-sync = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
 
 # Cumulus dependencies
+cumulus-client-cli = { git = "https://github.com/paritytech/cumulus", branch = "rococo-v1" }
 cumulus-client-consensus-common = { git = "https://github.com/paritytech/cumulus", branch = "rococo-v1" }
 cumulus-client-collator = { git = "https://github.com/paritytech/cumulus", branch = "rococo-v1" }
 cumulus-client-network = { git = "https://github.com/paritytech/cumulus", branch = "rococo-v1" }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -23,6 +23,7 @@ use sp_core::H160;
 use std::path::PathBuf;
 use std::str::FromStr;
 use structopt::StructOpt;
+use crate::chain_spec;
 
 /// Sub-commands supported by the collator.
 #[derive(Debug, StructOpt)]
@@ -51,7 +52,7 @@ pub enum Subcommand {
 	ImportBlocks(sc_cli::ImportBlocksCmd),
 
 	/// Remove the whole chain.
-	PurgeChain(sc_cli::PurgeChainCmd),
+	PurgeChain(cumulus_client_cli::PurgeChainCmd),
 
 	/// Revert the chain to a previous state.
 	Revert(sc_cli::RevertCmd),
@@ -193,12 +194,17 @@ pub struct RelayChainCli {
 }
 
 impl RelayChainCli {
-	/// Create a new instance of `Self`.
+	/// Parse the relay chain CLI parameters using the para chain `Configuration`.
 	pub fn new<'a>(
-		base_path: Option<PathBuf>,
-		chain_id: Option<String>,
+		para_config: &sc_service::Configuration,
 		relay_chain_args: impl Iterator<Item = &'a String>,
 	) -> Self {
+		let extension = chain_spec::Extensions::try_get(&*para_config.chain_spec);
+		let chain_id = extension.map(|e| e.relay_chain.clone());
+		let base_path = para_config
+			.base_path
+			.as_ref()
+			.map(|x| x.path().join("polkadot"));
 		Self {
 			base_path,
 			chain_id,

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -19,11 +19,11 @@
 //! This module defines the Moonbeam node's Command Line Interface (CLI)
 //! It is built using structopt and inherits behavior from Substrate's sc_cli crate.
 
+use crate::chain_spec;
 use sp_core::H160;
 use std::path::PathBuf;
 use std::str::FromStr;
 use structopt::StructOpt;
-use crate::chain_spec;
 
 /// Sub-commands supported by the collator.
 #[derive(Debug, StructOpt)]

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -242,7 +242,24 @@ pub fn run() -> Result<()> {
 		}
 		Some(Subcommand::PurgeChain(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
-			runner.sync_run(|config| cmd.run(config.database))
+
+			runner.sync_run(|config| {
+				let polkadot_cli = RelayChainCli::new(
+					&config,
+					[RelayChainCli::executable_name().to_string()]
+						.iter()
+						.chain(cli.relaychain_args.iter()),
+				);
+
+				let polkadot_config = SubstrateCli::create_configuration(
+					&polkadot_cli,
+					&polkadot_cli,
+					config.task_executor.clone(),
+				)
+				.map_err(|err| format!("Relay chain argument error: {}", err))?;
+
+				cmd.run(config, polkadot_config)
+			})
 		}
 		Some(Subcommand::Revert(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
@@ -348,9 +365,8 @@ pub fn run() -> Result<()> {
 					}
 
 					let polkadot_cli = RelayChainCli::new(
-						config.base_path.as_ref().map(|x| x.path().join("polkadot")),
-						relay_chain_id,
-						[RelayChainCli::executable_name()]
+						&config,
+						[RelayChainCli::executable_name().to_string()]
 							.iter()
 							.chain(cli.relaychain_args.iter()),
 					);


### PR DESCRIPTION
This is a companion PR for https://github.com/paritytech/cumulus/pull/306

It brings the ability to purge the parachain or relay chain individually into moonbeam. This PR contains relatively little new code, the real logic is upstream in cumulus.

### What value does it bring to the blockchain users?

As a node operator, when the parachain database gets corrupted (or needs to be purged because of a breaking change) it is no longer necessary to re-sync the entire relay chain.

## Checklist

- :x: Does it require a purge of the network?
- :x: You bumped the runtime version if there are breaking changes in the **runtime** ?
- :heavy_check_mark:  Does it require changes in documentation/tutorials ?
