### PR TITLE
Fix `trace_filter` fields name

### DIFF
--- a/primitives/rpc/debug/src/block.rs
+++ b/primitives/rpc/debug/src/block.rs
@@ -62,11 +62,11 @@ pub enum TransactionTraceAction {
 	},
 	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 	Create {
-		create_method: super::CreateType,
+		creation_method: super::CreateType,
 		from: H160,
 		gas: U256,
 		#[cfg_attr(feature = "std", serde(serialize_with = "bytes_0x_serialize"))]
-		input: Vec<u8>,
+		init: Vec<u8>,
 		value: U256,
 	},
 	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]

--- a/primitives/rpc/debug/src/block.rs
+++ b/primitives/rpc/debug/src/block.rs
@@ -93,7 +93,7 @@ pub enum TransactionTraceResult {
 	Call {
 		gas_used: U256,
 		#[cfg_attr(feature = "std", serde(serialize_with = "bytes_0x_serialize"))]
-		res: Vec<u8>,
+		output: Vec<u8>,
 	},
 	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 	Create {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -814,11 +814,11 @@ impl_runtime_apis! {
 									// Can't be known here, must be inserted upstream.
 									block_number: 0,
 									output: match res {
-										CallResult::Output(res) => {
+										CallResult::Output(output) => {
 											block::TransactionTraceOutput::Result(
 												block::TransactionTraceResult::Call {
 													gas_used: trace.gas_used,
-													res
+													output
 												})
 										},
 										CallResult::Error(error) =>

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -832,10 +832,10 @@ impl_runtime_apis! {
 								},
 								single::CallInner::Create { init, res } => block::TransactionTrace {
 									action: block::TransactionTraceAction::Create {
-										create_method: CreateType::Create,
+										creation_method: CreateType::Create,
 										from: trace.from,
 										gas: trace.gas,
-										input: init,
+										init,
 										value: trace.value,
 									},
 									// Can't be known here, must be inserted upstream.

--- a/tests/tests/test-trace-filter.ts
+++ b/tests/tests/test-trace-filter.ts
@@ -48,10 +48,10 @@ describeWithMoonbeam("Moonbeam RPC (trace_filter)", `simple-specs.json`, (contex
     // console.log(JSON.stringify(response));
 
     expect(response.result.length).to.equal(1);
-    expect(response.result[0].action.createMethod).to.equal("create");
+    expect(response.result[0].action.creationMethod).to.equal("create");
     expect(response.result[0].action.from).to.equal("0x6be02d1d3665660d22ff9624b7be0551ee1ac91b");
     expect(response.result[0].action.gas).to.equal("0x4ffead");
-    expect(response.result[0].action.input).to.be.a("string");
+    expect(response.result[0].action.init).to.be.a("string");
     expect(response.result[0].action.value).to.equal("0x0");
     expect(response.result[0].blockHash).to.be.a("string");
     expect(response.result[0].blockNumber).to.equal(1);
@@ -104,10 +104,10 @@ describeWithMoonbeam("Moonbeam RPC (trace_filter)", `simple-specs.json`, (contex
     // console.log(JSON.stringify(response));
 
     expect(response.result.length).to.equal(1);
-    expect(response.result[0].action.createMethod).to.equal("create");
+    expect(response.result[0].action.creationMethod).to.equal("create");
     expect(response.result[0].action.from).to.equal("0x6be02d1d3665660d22ff9624b7be0551ee1ac91b");
     expect(response.result[0].action.gas).to.equal("0x4fff44");
-    expect(response.result[0].action.input).to.be.a("string");
+    expect(response.result[0].action.init).to.be.a("string");
     expect(response.result[0].action.value).to.equal("0x0");
     expect(response.result[0].blockHash).to.be.a("string");
     expect(response.result[0].blockNumber).to.equal(2);


### PR DESCRIPTION
### What does it do?

Some fields of the RuntimeAPI/RPC output were incorrectly named.
As this is only renaming fields, it is yet to be determined if it changes the produced WASM runtime.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
