### PR TITLE
Unoptimize the build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,7 @@ jobs:
         run: |
           echo "::set-output name=rustc::$(rustc --version)"
       - name: Build Node
-        run: cargo build --release --verbose --all
+        run: RUSTFLAGS="-C opt-level=3" cargo build --release --verbose --all
       # We determine whether there are unmodified Cargo.lock files by:
       # 1. Asking git for a list of all modified files
       # 2. Using grep to reduce the list to only Cargo.lock files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ members = [
 
 [profile.release]
 panic = 'unwind'
+opt-level = 0


### PR DESCRIPTION
### What does it do?

This causes a normal `cargo build` to use the lowest optimization level (0) in `--release` mode but overrides this (back to 3, the default for `--release`) in CI.

Because my basement wasn't warm enough, I did some testing with various optimization switches. Here are my results:

```
- with opt-level = 0 in toml file:
    Finished release [unoptimized] target(s) in 4m 19s
    peaked around 10GB RAM
    artifact sizes:
        494M    target/release/moonbeam
        1.9M    target/release/wbuild/moonbeam-runtime/moonbeam_runtime.compact.wasm
        2.1M    target/release/wbuild/moonbeam-runtime/moonbeam_runtime.wasm

- default (opt-level = 3):
    Finished release [optimized] target(s) in 6m 56s
    peaked at 20.4GB RAM

- with opt-level = 0 in toml file BUT with RUSTFLAGS="-C opt-level=3"
    Finished release [unoptimized] target(s) in 7m 29s
    peaked around 20GB RAM
    artifact sizes:
        221M    target/release/moonbeam
        1.9M    target/release/wbuild/moonbeam-runtime/moonbeam_runtime.compact.wasm
        2.1M    target/release/wbuild/moonbeam-runtime/moonbeam_runtime.wasm

- with opt-level = 0s:
    Finished release [unoptimized] target(s) in 5m 54s
    peaked at 22.1GB RAM
    artifact sizes:
        256M    target/release/moonbeam
        1.9M    target/release/wbuild/moonbeam-runtime/moonbeam_runtime.compact.wasm
        2.1M    target/release/wbuild/moonbeam-runtime/moonbeam_runtime.wasm
```

Takeaways:
1) `0s` is worthless in our case. Note that there's a `0z`, a more aggressive size optimization.
2) The `wasm` artifact sizes seem unaffected by optimization levels.
3) Compared with `opt-level = 3` (default), `opt-level = 0` uses about half as much RAM  and is roughly 40% faster.