### PR TITLE
added example test for frontier

### DIFF
--- a/tests/non_ci_tests/test-frontier.ts
+++ b/tests/non_ci_tests/test-frontier.ts
@@ -1,20 +1,23 @@
 import { expect } from "chai";
 
-import { customRequest } from "./util";
-import { GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY, TEST_ACCOUNT } from "./constants";
-import { createAndFinalizeBlockWithFrontier, describeWithFrontier } from "./util/testWithFrontier";
+import { customRequest } from "../tests/util";
+import { GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY, TEST_ACCOUNT } from "../tests/constants";
+import {
+  createAndFinalizeBlockWithFrontier,
+  describeWithFrontier,
+} from "../tests/util/testWithFrontier";
 
 const FRONTIER_GENESIS_ACCOUNT_BALANCE = "340282366920938463463374607431768211455";
 
 // This is an example of a Frontier test. It requires to have a clone of frontier in the same repo
 // The binary needs to be built with `cargo build --no-default-features --features=manual-seal`
 describeWithFrontier("Frontier RPC (Balance)", `frontier-specs.json`, (context) => {
-  it.skip("genesis balance is setup correctly (web3)", async function () {
+  it("genesis balance is setup correctly (web3)", async function () {
     expect(await context.web3.eth.getBalance(GENESIS_ACCOUNT)).to.equal(
       FRONTIER_GENESIS_ACCOUNT_BALANCE
     );
   });
-  it.skip("balance to be updated after transfer", async function () {
+  it("balance to be updated after transfer", async function () {
     this.timeout(15000);
 
     const tx = await context.web3.eth.accounts.signTransaction(

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test-with-logs": "mocha  --printlogs -r ts-node/register 'tests/**/*.ts'",
-    "test": "mocha -r ts-node/register 'tests/**/*.ts'"
+    "test": "mocha -r ts-node/register 'tests/**/*.ts'",
+    "non-ci-test": "mocha -r ts-node/register 'non_ci_tests/**/*.ts'"
   },
   "author": "",
   "license": "ISC",

--- a/tests/tests/test-frontier.ts
+++ b/tests/tests/test-frontier.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+
+import { customRequest } from "./util";
+import { GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY, TEST_ACCOUNT } from "./constants";
+import { createAndFinalizeBlockWithFrontier, describeWithFrontier } from "./util/testWithFrontier";
+
+const FRONTIER_GENESIS_ACCOUNT_BALANCE = "340282366920938463463374607431768211455";
+
+// This is an example of a Frontier test. It requires to have a clone of frontier in the same repo
+// The binary needs to be built with `cargo build --no-default-features --features=manual-seal`
+describeWithFrontier("Frontier RPC (Balance)", `frontier-specs.json`, (context) => {
+  it.skip("genesis balance is setup correctly (web3)", async function () {
+    expect(await context.web3.eth.getBalance(GENESIS_ACCOUNT)).to.equal(
+      FRONTIER_GENESIS_ACCOUNT_BALANCE
+    );
+  });
+  it.skip("balance to be updated after transfer", async function () {
+    this.timeout(15000);
+
+    const tx = await context.web3.eth.accounts.signTransaction(
+      {
+        from: GENESIS_ACCOUNT,
+        to: TEST_ACCOUNT,
+        value: "0x200", // Must be higher than ExistentialDeposit (0)
+        gasPrice: "0x01",
+        gas: "0x100000",
+      },
+      GENESIS_ACCOUNT_PRIVATE_KEY
+    );
+    await customRequest(context.web3, "eth_sendRawTransaction", [tx.rawTransaction]);
+    await createAndFinalizeBlockWithFrontier(context.web3);
+    expect(await context.web3.eth.getBalance(GENESIS_ACCOUNT)).to.equal(
+      "340282366920938463463374607431768189943"
+    );
+    expect(await context.web3.eth.getBalance(TEST_ACCOUNT)).to.equal("512");
+  });
+});

--- a/tests/tests/util/testWithFrontier.ts
+++ b/tests/tests/util/testWithFrontier.ts
@@ -40,9 +40,7 @@ export async function startFrontierNode(
 
   binary.on("error", (err) => {
     if ((err as any).errno == "ENOENT") {
-      console.error(
-        `\x1b[31mMissing Frontier binary (${BINARY_PATH}).\nPlease compile the Frontier project:\ncargo build\x1b[0m`
-      );
+      console.error(`\x1b[31mMissing Frontier binary (${BINARY_PATH})`);
     } else {
       console.error(err);
     }

--- a/tests/tests/util/testWithFrontier.ts
+++ b/tests/tests/util/testWithFrontier.ts
@@ -1,0 +1,125 @@
+import Web3 from "web3";
+
+import { spawn, ChildProcess } from "child_process";
+import { DISPLAY_LOG, PORT, RPC_PORT, SPAWNING_TIME, WS_PORT } from "../constants";
+import { customRequest } from "./web3Requests";
+
+const SPECS_PATH = `./moonbeam-test-specs`;
+
+const FRONTIER_LOG = process.env.FRONTIER_LOG || "info";
+
+const BINARY_PATH = `../../frontier/target/debug/frontier-template-node`;
+
+// Build with `cargo build --no-default-features --features=manual-seal`
+export async function startFrontierNode(
+  specFilename: string,
+  provider?: string
+): Promise<{ web3: Web3; binary: ChildProcess }> {
+  var web3;
+  if (!provider || provider == "http") {
+    web3 = new Web3(`http://localhost:${RPC_PORT}`);
+  }
+
+  const cmd = BINARY_PATH;
+  const args = [
+    `--chain=${SPECS_PATH}/${specFilename}`,
+    `--validator`, // Required by manual sealing to author the blocks
+    `--execution=Native`, // Faster execution using native
+    `--no-telemetry`,
+    `--no-prometheus`,
+    `--sealing=Manual`,
+    `--no-grandpa`,
+    `--force-authoring`,
+    `-l${FRONTIER_LOG}`,
+    `--port=${PORT}`,
+    `--rpc-port=${RPC_PORT}`,
+    `--ws-port=${WS_PORT}`,
+    `--tmp`,
+  ];
+  const binary = spawn(cmd, args);
+
+  binary.on("error", (err) => {
+    if ((err as any).errno == "ENOENT") {
+      console.error(
+        `\x1b[31mMissing Frontier binary (${BINARY_PATH}).\nPlease compile the Frontier project:\ncargo build\x1b[0m`
+      );
+    } else {
+      console.error(err);
+    }
+    process.exit(1);
+  });
+
+  const binaryLogs = [];
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      console.error(`\x1b[31m Failed to start Frontier Template Node.\x1b[0m`);
+      console.error(`Command: ${cmd} ${args.join(" ")}`);
+      console.error(`Logs:`);
+      console.error(binaryLogs.map((chunk) => chunk.toString()).join("\n"));
+      process.exit(1);
+    }, SPAWNING_TIME - 2000);
+
+    const onData = async (chunk) => {
+      if (DISPLAY_LOG) {
+        console.log(chunk.toString());
+      }
+      binaryLogs.push(chunk);
+      if (chunk.toString().match(/Manual Seal Ready/)) {
+        if (!provider || provider == "http") {
+          // This is needed as the EVM runtime needs to warmup with a first call
+          await web3.eth.getChainId();
+        }
+
+        clearTimeout(timer);
+        if (!DISPLAY_LOG) {
+          binary.stderr.off("data", onData);
+          binary.stdout.off("data", onData);
+        }
+        // console.log(`\x1b[31m Starting RPC\x1b[0m`);
+        resolve();
+      }
+    };
+    binary.stderr.on("data", onData);
+    binary.stdout.on("data", onData);
+  });
+
+  if (provider == "ws") {
+    web3 = new Web3(`ws://localhost:${WS_PORT}`);
+  }
+
+  return { web3, binary };
+}
+export function describeWithFrontier(
+  title: string,
+  specFilename: string,
+  cb: (context: { web3: Web3 }) => void,
+  provider?: string
+) {
+  describe(title, () => {
+    let context: { web3: Web3 } = { web3: null };
+    let binary: ChildProcess;
+    // Making sure the Frontier node has started
+    before("Starting Frontier Test Node", async function () {
+      this.timeout(SPAWNING_TIME);
+      const init = await startFrontierNode(specFilename, provider);
+      context.web3 = init.web3;
+      binary = init.binary;
+    });
+
+    after(async function () {
+      //console.log(`\x1b[31m Killing RPC\x1b[0m`);
+      binary ? binary.kill() : null;
+    });
+
+    cb(context);
+  });
+}
+
+// Create a block and finalize it.
+// It will include all previously executed transactions since the last finalized block.
+export async function createAndFinalizeBlockWithFrontier(web3: Web3) {
+  const response = await customRequest(web3, "engine_createBlock", [true, true, null]);
+  if (!response.result) {
+    throw new Error(`Unexpected result: ${JSON.stringify(response)}`);
+  }
+}

--- a/tests/tests/util/testWithMoonbeam.ts
+++ b/tests/tests/util/testWithMoonbeam.ts
@@ -117,7 +117,7 @@ export async function startMoonbeamNode(
 
 // Kill all processes when exiting.
 process.on("exit", function () {
-  runningNode.kill();
+  runningNode ? runningNode.kill() : null;
 });
 
 // Handle ctrl+c to trigger `exit`.


### PR DESCRIPTION
### What does it do?
- adds describeWithFrontier test utils to run a test against frontier
- adds example test in non-ci-test folder (skipped because it requires frontier in the same repo)
- adds new command `npm run non-ci-test` to run tests that shouldn't be included in the CI

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
