### PR TITLE
See whether CI can reproduce test harness build failure

### DIFF
--- a/.github/workflows/reproduce-cargo-weirdness.yml
+++ b/.github/workflows/reproduce-cargo-weirdness.yml
@@ -3,7 +3,6 @@ name: Reproduce weird cargo test behavior
 on: ["push"]
 
 jobs:
-
   reproduce-carg-weirdness:
     runs-on: ubuntu-latest
     steps:
@@ -14,19 +13,19 @@ jobs:
       # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
       - name: Setup Rust toolchain
         run: rustup show
-      
+
       # This compiles
       - name: cargo test --bin moonbeam
         run: cargo test --bin moonbeam
 
       # This compiles
       - name: cargo test --lib moonbeam
-        run cargo test --lib moonbeam
-      
+        run: cargo test --lib moonbeam
+
       # This compiles (does this actually run the tests from the moonbeam binary?)
       - name: cargo test
-        run cargo test
-        
+        run: cargo test
+
       # This doesn't compile. I don't understand why.
       - name: cargo test -p moonbeam
         run: cargo test -p moonbeam

--- a/.github/workflows/reproduce-cargo-weirdness.yml
+++ b/.github/workflows/reproduce-cargo-weirdness.yml
@@ -4,7 +4,7 @@ on: ["push"]
 
 jobs:
 
-  build:
+  reproduce-carg-weirdness:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/reproduce-cargo-weirdness.yml
+++ b/.github/workflows/reproduce-cargo-weirdness.yml
@@ -1,0 +1,32 @@
+name: Reproduce weird cargo test behavior
+
+on: ["push"]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
+      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
+      - name: Setup Rust toolchain
+        run: rustup show
+      
+      # This compiles
+      - name: cargo test --bin moonbeam
+        run: cargo test --bin moonbeam
+
+      # This compiles
+      - name: cargo test --lib moonbeam
+        run cargo test --lib moonbeam
+      
+      # This compiles (does this actually run the tests from the moonbeam binary?)
+      - name: cargo test
+        run cargo test
+        
+      # This doesn't compile. I don't understand why.
+      - name: cargo test -p moonbeam
+        run: cargo test -p moonbeam

--- a/client/rpc-core/txpool/Cargo.toml
+++ b/client/rpc-core/txpool/Cargo.toml
@@ -16,4 +16,4 @@ jsonrpc-derive = "14.0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }

--- a/client/rpc/debug/Cargo.toml
+++ b/client/rpc/debug/Cargo.toml
@@ -21,7 +21,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo
 
 moonbeam-rpc-core-debug = { path = "../../rpc-core/debug" }
 moonbeam-rpc-primitives-debug = { path = "../../../primitives/rpc/debug" }
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-fc-db = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
+fc-consensus = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+fc-db = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }

--- a/client/rpc/trace/Cargo.toml
+++ b/client/rpc/trace/Cargo.toml
@@ -28,7 +28,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1"
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1" }
 sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1" }
 sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1" }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
 moonbeam-rpc-primitives-debug = { path = "../../../primitives/rpc/debug" }
 
 # Client and RPC
@@ -36,7 +36,7 @@ jsonrpc-core = "15.0.0"
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1" }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1" }
 sc-transaction-graph = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+fc-consensus = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
 moonbeam-rpc-core-trace = { path = "../../rpc-core/trace" }

--- a/client/rpc/txpool/Cargo.toml
+++ b/client/rpc/txpool/Cargo.toml
@@ -23,4 +23,4 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "roco
 serde = { version = "1.0", features = ["derive"] }
 
 moonbeam-rpc-primitives-txpool = { path = "../../../primitives/rpc/txpool" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -76,16 +76,16 @@ pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrat
 sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1" }
 sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1" }
 
-evm = { package = "pallet-evm", git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-ethereum = { package = "pallet-ethereum", git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
+evm = { package = "pallet-evm", git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+ethereum = { package = "pallet-ethereum", git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
 
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-fp-consensus = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-fc-db = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-fc-mapping-sync = { git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
+fc-consensus = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+fp-consensus = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+fc-db = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+fc-mapping-sync = { git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
 
 # Cumulus dependencies
 cumulus-client-cli = { git = "https://github.com/paritytech/cumulus", branch = "rococo-v1" }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -45,11 +45,11 @@ pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", 
 
 frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "notlesh-moonbeam-v0.7" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "update-substrate-bn-128" }
 pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 
-pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
-fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "notlesh-moonbeam-v0.7" }
+pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
+fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "update-substrate-bn-128" }
 
 pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }

--- a/runtime/account/Cargo.toml
+++ b/runtime/account/Cargo.toml
@@ -24,7 +24,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "notlesh-moonbeam-v0.7" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "update-substrate-bn-128" }
 
 
 [features]

--- a/runtime/extensions/evm/Cargo.toml
+++ b/runtime/extensions/evm/Cargo.toml
@@ -8,8 +8,8 @@ license = 'GPL-3.0-only'
 repository = 'https://github.com/PureStake/moonbeam/'
 
 [dependencies]
-fp-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "notlesh-moonbeam-v0.7" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "notlesh-moonbeam-v0.7" }
+fp-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "update-substrate-bn-128" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "update-substrate-bn-128" }
 evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 evm-core = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1" }

--- a/runtime/precompiles/Cargo.toml
+++ b/runtime/precompiles/Cargo.toml
@@ -16,11 +16,11 @@ frame-support = { git = "https://github.com/paritytech/substrate", branch = "roc
 evm = { version = "0.26.0", default-features = false, features = ["with-codec"] }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-v1" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "notlesh-moonbeam-v0.7" }
-pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", default-features = false, branch = "notlesh-moonbeam-v0.7" }
-pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", default-features = false, branch = "notlesh-moonbeam-v0.7" }
-pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", default-features = false, branch = "notlesh-moonbeam-v0.7" }
-pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", default-features = false, branch = "notlesh-moonbeam-v0.7" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "update-substrate-bn-128" }
+pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", default-features = false, branch = "update-substrate-bn-128" }
+pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", default-features = false, branch = "update-substrate-bn-128" }
+pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", default-features = false, branch = "update-substrate-bn-128" }
+pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", default-features = false, branch = "update-substrate-bn-128" }
 
 [features]
 default = [ "std" ]

--- a/runtime/precompiles/Cargo.toml
+++ b/runtime/precompiles/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 log = "0.4"
 # This is need to overcome the double importing of rand 0.5.6 in substrate-bn with and without std
 # https://github.com/rust-random/rand/issues/645
-rand = { version = "0.5.6", default-features = false }
 rustc-hex = { version = "2.0.1", default-features = false }
 
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
@@ -30,7 +29,6 @@ std = [
 	"evm/std",
 	"sp-std/std",
 	"sp-core/std",
-	"rand/std",
 	"pallet-evm-precompile-bn128/std",
 	"pallet-evm-precompile-dispatch/std",
 	"pallet-evm-precompile-modexp/std",


### PR DESCRIPTION
Adds `cargo test -p moonbeam` to the CI to see if it can reproduce a build error I get locally. If it can, the question is why the previous CI didn't catch it. We already did `cargo test --release --verbose --all`