### PR TITLE
Unskip tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,3 @@ members = [
 
 [profile.release]
 panic = 'unwind'
-opt-level = 0

--- a/tests/tests/test-block.ts
+++ b/tests/tests/test-block.ts
@@ -42,8 +42,7 @@ describeWithMoonbeam("Moonbeam RPC (Block)", `simple-specs.json`, (context) => {
     expect(block.timestamp).to.be.a("number");
   });
 
-  // TODO: unskip this when https://github.com/paritytech/frontier/pull/279 is merged
-  it.skip("fetch genesis block by hash", async function () {
+  step("fetch genesis block by hash", async function () {
     //fetch block again using hash
     const block = await context.web3.eth.getBlock(0);
     const blockByHash = await context.web3.eth.getBlock(block.hash);
@@ -51,7 +50,7 @@ describeWithMoonbeam("Moonbeam RPC (Block)", `simple-specs.json`, (context) => {
       author: "0x0000000000000000000000000000000000000000",
       difficulty: "0",
       extraData: "0x",
-      gasLimit: 4294967295,
+      gasLimit: 15000000,
       gasUsed: 0,
       logsBloom: `0x${"0".repeat(512)}`,
       number: 0,

--- a/tests/tests/test-block.ts
+++ b/tests/tests/test-block.ts
@@ -134,7 +134,7 @@ describeWithMoonbeam("Moonbeam RPC (Block)", `simple-specs.json`, (context) => {
     expect(Number(await context.web3.eth.getBalance(GENESIS_ACCOUNT))).to.gte(512 * 100000);
   });
 
-  it.skip("should be able to fill a block with a 1 tx", async function () {
+  it("should be able to fill a block with a 1 tx", async function () {
     this.timeout(15000);
 
     let { txPassedFirstBlock } = await fillBlockWithTx(context, 1);

--- a/tests/tests/test-block.ts
+++ b/tests/tests/test-block.ts
@@ -63,7 +63,6 @@ describeWithMoonbeam("Moonbeam RPC (Block)", `simple-specs.json`, (context) => {
 
   let firstBlockCreated = false;
   step("should be at block 1 after block production", async function () {
-    this.timeout(15000);
     await createAndFinalizeBlock(context.polkadotApi);
     expect(await context.web3.eth.getBlockNumber()).to.equal(1);
     firstBlockCreated = true;
@@ -125,7 +124,6 @@ describeWithMoonbeam("Moonbeam RPC (Block)", `simple-specs.json`, (context) => {
   });
 
   step("should include previous block hash as parent (block 2)", async function () {
-    this.timeout(15000);
     await createAndFinalizeBlock(context.polkadotApi);
     const block = await context.web3.eth.getBlock("latest");
     expect(block.hash).to.not.equal(previousBlock.hash);
@@ -141,7 +139,6 @@ describeWithMoonbeam("Moonbeam RPC (Block)", `simple-specs.json`, (context) => {
   // the maximum number of tx/ blocks is not constant but is always around 1500
 
   it("should be able to fill a block with a 1 tx", async function () {
-    this.timeout(15000);
     let { txPassedFirstBlock } = await fillBlockWithTx(context, 1);
     expect(txPassedFirstBlock).to.eq(1);
   });

--- a/tests/tests/test-block.ts
+++ b/tests/tests/test-block.ts
@@ -130,44 +130,39 @@ describeWithMoonbeam("Moonbeam RPC (Block)", `simple-specs.json`, (context) => {
     expect(block.parentHash).to.equal(previousBlock.hash);
   });
 
-  // tx/block tests
-
   step("genesis balance enough to make all the transfers", async function () {
     expect(Number(await context.web3.eth.getBalance(GENESIS_ACCOUNT))).to.gte(512 * 100000);
   });
 
-  // the maximum number of tx/ blocks is not constant but is always around 1500
+  it.skip("should be able to fill a block with a 1 tx", async function () {
+    this.timeout(15000);
 
-  it("should be able to fill a block with a 1 tx", async function () {
     let { txPassedFirstBlock } = await fillBlockWithTx(context, 1);
     expect(txPassedFirstBlock).to.eq(1);
   });
 
-  it.skip("should be able to fill a block with 260 tx", async function () {
+  it("should be able to fill a block with 576 tx", async function () {
     this.timeout(15000);
-    // We have 6_000_000 Gas available for transactions per block.
-    // Each transaction needs 2_000 (extrinsic cost) + 21_000 (eth cost)
-    // 6_000_000 / 23_000 = ~260.86
-    // The test will send 261 tx and verify the first block contains only 260.
-    let { txPassed, txPassedFirstBlock } = await fillBlockWithTx(context, 261);
-    expect(txPassedFirstBlock).to.eq(260);
-    expect(txPassed).to.eq(261); // including all blocks
+    // We have 15_000_000 Gas available for transactions per block.
+    // Each transaction needs 26_000 gas: 5_000 (extrinsic cost) + 21_000 (eth cost).
+    // 5_000 is the equivalent gas of ExtrinsicBaseWeight (125_000_000 / 25_000)
+    // We expect a capacity of 576.92 transactions in a block (15_000_000 / 26_000).
+    let { txPassed, txPassedFirstBlock } = await fillBlockWithTx(context, 577);
+    expect(txPassedFirstBlock).to.eq(576);
+    expect(txPassed).to.eq(577); // including all blocks
   });
 
-  it.skip("should be able to fill a block with 64 contract creations tx", async function () {
+  it("should be able to fill a block with 156 contract creations tx", async function () {
     this.timeout(15000);
-    // We have 6_000_000 Gas available for transactions per block.
-    // Each transaction needs 2_000 (extrinsic cost) + 91019 (contract cost)
-    // 6_000_000 / 92_019 = ~64.50
-
-    // The test will send 65 contract tx and verify the first block contains only 64.
-    let { txPassedFirstBlock } = await fillBlockWithTx(context, 65, contractCreation);
-    expect(txPassedFirstBlock).to.eq(64);
+    // We have 15_000_000 Gas available for transactions per block.
+    // Each transaction needs 5_000 (extrinsic cost) + 91_019 (contract cost)
+    // 15_000_000 / 96_019 = 156.22
+    let { txPassedFirstBlock } = await fillBlockWithTx(context, 157, contractCreation);
+    expect(txPassedFirstBlock).to.eq(156);
   });
 
   // 8192 is the number of tx that can be sent to the Pool
   // before it throws an error and drops all tx
-
   it.skip("should be able to send 8192 tx to the pool and have them all published\
   within the following blocks", async function () {
     this.timeout(120000);


### PR DESCRIPTION
### What does it do?

Unskips:

- fetch genesis block by hash
- should be able to fill a block with 576 tx
- should be able to fill a block with 156 contract creations tx

### What important points reviewers should know?

Block gas limit is calculated to be 15,000,000, the base extrinsic cost is the equivalent to 5,000 gas.

### Is there something left for follow-up PRs?

We may want to unskip also the tests that verify the 8192 transaction pool limit. However I left them skipped as they require a lot of time to process. Please leave a comment regarding this.