### PR TITLE
Improve pending pool test

### DIFF
--- a/tests/tests/test-pending-pool.ts
+++ b/tests/tests/test-pending-pool.ts
@@ -14,9 +14,9 @@ describeWithMoonbeam("Frontier RPC (Pending Pool)", `simple-specs.json`, (contex
     information before they are included in a block.
 
     We want to test that:
-      - We can write to this collection in parallel.
-      - We can read from this collection in parallel.
-      - We can get the final transaction data once it leaves the pending collection.
+      - We resolve multiple promises in parallel that will write in this collection on the rpc-side
+      - We resolve multiple promises in parallel that will read from this collection on the rpc-side
+      - We can get the final transaction data once it leaves the pending collection
   */
   it("should handle pending transactions", async function () {
     const NBR_TXNS = 10;


### PR DESCRIPTION
### What does it do?

Adds additional logic to verify the internals of how the pending pool is handled at rpc-level. In frontier side, the pending pool is a Mutex and locks on read/write.

We keep our original assertions (we expect to be able to request transaction metadata before is included in a block) but we modify the test to resolve all send transaction promises at once and the same for requesting this transactions by hash.