### PR TITLE
Parachain staking UI experiment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,351 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'moonbeam-runtime'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=moonbeam-runtime"
+                ],
+                "filter": {
+                    "name": "moonbeam-runtime",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'account'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=account"
+                ],
+                "filter": {
+                    "name": "account",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'author-inherent'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=author-inherent"
+                ],
+                "filter": {
+                    "name": "author-inherent",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'moonbeam-extensions-evm'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=moonbeam-extensions-evm"
+                ],
+                "filter": {
+                    "name": "moonbeam-extensions-evm",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'moonbeam-rpc-primitives-debug'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=moonbeam-rpc-primitives-debug"
+                ],
+                "filter": {
+                    "name": "moonbeam-rpc-primitives-debug",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'moonbeam-rpc-primitives-txpool'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=moonbeam-rpc-primitives-txpool"
+                ],
+                "filter": {
+                    "name": "moonbeam-rpc-primitives-txpool",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'pallet-author-filter'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=pallet-author-filter"
+                ],
+                "filter": {
+                    "name": "pallet-author-filter",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'parachain-staking'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=parachain-staking"
+                ],
+                "filter": {
+                    "name": "parachain-staking",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'pallet-ethereum-chain-id'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=pallet-ethereum-chain-id"
+                ],
+                "filter": {
+                    "name": "pallet-ethereum-chain-id",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'precompiles'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=precompiles"
+                ],
+                "filter": {
+                    "name": "precompiles",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'moonbeam'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=moonbeam"
+                ],
+                "filter": {
+                    "name": "moonbeam",
+                    "kind": "bin"
+                }
+            },
+            "args": [
+                "--dev",
+                "--tmp"
+            ],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'moonbeam'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=moonbeam",
+                    "--package=moonbeam"
+                ],
+                "filter": {
+                    "name": "moonbeam",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'moonbeam-rpc-debug'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=moonbeam-rpc-debug"
+                ],
+                "filter": {
+                    "name": "moonbeam-rpc-debug",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'moonbeam-rpc-core-debug'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=moonbeam-rpc-core-debug"
+                ],
+                "filter": {
+                    "name": "moonbeam-rpc-core-debug",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'moonbeam-rpc-trace'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=moonbeam-rpc-trace"
+                ],
+                "filter": {
+                    "name": "moonbeam-rpc-trace",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'moonbeam-rpc-core-trace'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=moonbeam-rpc-core-trace"
+                ],
+                "filter": {
+                    "name": "moonbeam-rpc-core-trace",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'moonbeam-rpc-txpool'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=moonbeam-rpc-txpool"
+                ],
+                "filter": {
+                    "name": "moonbeam-rpc-txpool",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'moonbeam-rpc-core-txpool'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=moonbeam-rpc-core-txpool"
+                ],
+                "filter": {
+                    "name": "moonbeam-rpc-core-txpool",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.101", optional = true }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 
-[dev-dependencies]
+# [dev-dependencies]
 sp-io = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "rococo-v1", default-features = false }
 
@@ -30,4 +30,6 @@ std = [
 	"serde",
 	"sp-std/std",
 	"sp-runtime/std",
+	"sp-core/std",
+	"sp-io/std",
 ]

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -48,8 +48,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod inflation;
-#[cfg(test)]
-mod mock;
+// #[cfg(test)]
+pub mod mock;
 mod set;
 #[cfg(test)]
 mod tests;
@@ -508,7 +508,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn nominator_state)]
 	/// Get nominator state associated with an account if account is nominating else None
-	type NominatorState<T: Config> = StorageMap<
+	pub type NominatorState<T: Config> = StorageMap<
 		_,
 		Twox64Concat,
 		T::AccountId,

--- a/pallets/parachain-staking/src/main.rs
+++ b/pallets/parachain-staking/src/main.rs
@@ -1,0 +1,76 @@
+//! Simple binary to let users poke at the staking state machine directly without
+//! the overhead of a blockchain service.
+//!
+//! My end-game is to compile this to wasm and let users eplore it through the browser.
+
+
+use parachain_staking::mock::{
+	two_collators_four_nominators,
+    Origin,
+    Stake,
+    AccountId, Balance,
+    Test,
+};
+use sp_io::TestExternalities;
+// use sp_runtime::{traits::Zero, DispatchError};
+
+/// A state machine that the user will poke at when running the cli. Maybe there is a better
+/// name for this thing.
+pub struct StateMachine {
+    /// The test externalities that this state amchine will use
+    ext: TestExternalities,
+}
+
+impl StateMachine {
+    /// Create a new Parachain Staking state machine with two colaltors and four nominators.
+    /// TODO could use more of a builder pattern here.
+    pub fn new() -> Self {
+        Self {
+            ext: two_collators_four_nominators(),
+        }
+    }
+
+    /// Make a new nomination
+    pub fn nominate(&mut self, nominator: AccountId, collator: AccountId, amount: Balance) -> bool {
+        self.ext.execute_with(|| {
+            // TODO should I actually make an outer call and dispatch it here?
+            match Stake::nominate(Origin::signed(nominator), collator, amount) {
+                Ok(_) => true,
+                Err(_e) => {
+                    println!("It failed");
+                    false
+                }
+            }
+        })
+    }
+
+    /// See who all the current nominators are
+    /// Although we need a mutable reference to call `execute_with` this function should not
+    /// do any mutations
+    /// TODO is there a bette rthing than `execute_with`?
+    pub fn get_nominators(&mut self) -> Vec<AccountId> {
+        self.ext.execute_with(|| {
+            parachain_staking::NominatorState::<Test>::iter()
+            .map(|(x, _)| x)
+            .collect()
+        })
+    }
+}
+fn main() {
+    println!("Welcome to the parachain staking test util.");
+
+    // Create a State Machine to use as long as this program is running
+    let mut machine = StateMachine::new();
+    
+    // Print current nominators
+    println!("Nominators are: {:?}", machine.get_nominators());
+
+    // Nominate new
+    let success = machine.nominate(7, 1, 100);
+    println!("Did the nominate call succeed? {:?}", success);
+
+    // Print current nominators
+    println!("Nominators are: {:?}", machine.get_nominators());
+
+    println!("Leaving staking test util");
+}

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -154,7 +154,7 @@ fn genesis(
 	ext
 }
 
-pub(crate) fn two_collators_four_nominators() -> sp_io::TestExternalities {
+pub fn two_collators_four_nominators() -> sp_io::TestExternalities {
 	genesis(
 		vec![
 			(1, 1000),


### PR DESCRIPTION
This exploratory and WIP PR is the manifestation of a realization I had during test week. A test suite consumes small isolated pieces of our code individually. his is similar to scaffolding a learning experience for a student who should understand each piece individually and then compose them. I don't naturally think in the cargo testing worldview (yet) but I do naturally think in terms of presenting small educational concepts to user/learners.

This PR currently introduces a CLI tool to interact with Parachain Staking's mock runtime without any blockchain context. My hope is that I can use wasm-bindgen to package the underlying state machine into a web-browser-compatible wasm binary and make a web app for it. This will facilitate fast and isolated **manual** testing, interaction, and learning of **just** parachain staking.

This could lead to a very helpful tool to educate Moonbeam's users and citizens about how the staking solution works. It is also a nice opportunity for me to really understand externalities and how they are used.

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
