### PR TITLE
Add missing code to tracer extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4437,6 +4437,7 @@ dependencies = [
  "evm",
  "evm-core",
  "fp-evm",
+ "frame-support",
  "moonbeam-rpc-primitives-debug",
  "pallet-evm",
  "sp-core",

--- a/runtime/extensions/evm/Cargo.toml
+++ b/runtime/extensions/evm/Cargo.toml
@@ -15,6 +15,7 @@ evm-core = { version = "0.26.0", default-features = false, features = ["with-cod
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1" }
 sp-io = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1" }
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1" }
 moonbeam-rpc-primitives-debug = { path = "../../../primitives/rpc/debug", default-features = false }
 ethereum-types = { version = "0.11.0", default-features = false }

--- a/runtime/extensions/evm/src/runner/stack.rs
+++ b/runtime/extensions/evm/src/runner/stack.rs
@@ -24,12 +24,19 @@ use evm::{
 	executor::{StackExecutor, StackState as StackStateT, StackSubstateMetadata},
 	gasometer, Capture, Config as EvmConfig, Context, CreateScheme, Transfer,
 };
+use frame_support::ensure;
 use pallet_evm::{
 	runner::stack::{Runner, SubstrateStackState},
-	Config, ExitError, ExitReason, PrecompileSet, Vicinity,
+	Config, Error, ExitError, ExitReason, Module, OnChargeEVMTransaction, PrecompileSet, Vicinity,
 };
 
+pub enum TraceRunnerError<T: Config> {
+	EvmExitError(ExitError),
+	RuntimeExitError(Error<T>),
+}
+
 pub trait TraceRunner<T: Config> {
+	/// Handle an Executor wrapper `call`.
 	fn execute_call<'config, F>(
 		executor: &'config mut StackExecutor<'config, SubstrateStackState<'_, 'config, T>>,
 		trace_type: TraceType,
@@ -41,7 +48,7 @@ pub trait TraceRunner<T: Config> {
 			&mut TraceExecutorWrapper<'config, SubstrateStackState<'_, 'config, T>>,
 		) -> Capture<(ExitReason, Vec<u8>), Infallible>;
 
-	/// Handle an Executor wrapper `create`. Used by `trace_create`.
+	/// Handle an Executor wrapper `create`.
 	fn execute_create<'config, F>(
 		executor: &'config mut StackExecutor<'config, SubstrateStackState<'_, 'config, T>>,
 		trace_type: TraceType,
@@ -52,25 +59,18 @@ pub trait TraceRunner<T: Config> {
 			&mut TraceExecutorWrapper<'config, SubstrateStackState<'_, 'config, T>>,
 		) -> Capture<(ExitReason, Option<H160>, Vec<u8>), Infallible>;
 
-	/// Context creation for `call`. Typically called by the Runtime Api.
-	fn trace_call(
+	/// Interfaces runtime api and executor wrapper.
+	fn trace(
 		source: H160,
-		target: H160,
+		target: Option<H160>,
 		input: Vec<u8>,
 		value: U256,
 		gas_limit: u64,
+		gas_price: U256,
+		nonce: U256,
 		config: &EvmConfig,
 		trace_type: TraceType,
-	) -> Result<TransactionTrace, ExitError>;
-
-	fn trace_create(
-		source: H160,
-		init: Vec<u8>,
-		value: U256,
-		gas_limit: u64,
-		config: &EvmConfig,
-		trace_type: TraceType,
-	) -> Result<TransactionTrace, ExitError>;
+	) -> Result<TransactionTrace, TraceRunnerError<T>>;
 }
 
 impl<T: Config> TraceRunner<T> for Runner<T> {
@@ -141,87 +141,110 @@ impl<T: Config> TraceRunner<T> for Runner<T> {
 		}
 	}
 
-	fn trace_call(
+	fn trace(
 		source: H160,
-		target: H160,
+		target: Option<H160>,
 		input: Vec<u8>,
 		value: U256,
 		gas_limit: u64,
+		gas_price: U256,
+		nonce: U256,
 		config: &EvmConfig,
 		trace_type: TraceType,
-	) -> Result<TransactionTrace, ExitError> {
+	) -> Result<TransactionTrace, TraceRunnerError<T>> {
 		let vicinity = Vicinity {
-			gas_price: U256::zero(),
+			gas_price,
 			origin: source,
 		};
+
 		let metadata = StackSubstateMetadata::new(gas_limit, &config);
 		let state = SubstrateStackState::new(&vicinity, metadata);
+
 		let mut executor =
 			StackExecutor::new_with_precompile(state, config, T::Precompiles::execute);
+
+		let total_fee = gas_price
+			.checked_mul(U256::from(gas_limit))
+			.ok_or(TraceRunnerError::RuntimeExitError(Error::<T>::FeeOverflow))?;
+
+		let total_payment =
+			value
+				.checked_add(total_fee)
+				.ok_or(TraceRunnerError::RuntimeExitError(
+					Error::<T>::PaymentOverflow,
+				))?;
+		let source_account = Module::<T>::account_basic(&source);
+		ensure!(
+			source_account.balance >= total_payment,
+			TraceRunnerError::RuntimeExitError(Error::<T>::BalanceLow)
+		);
+
+		ensure!(
+			source_account.nonce == nonce,
+			TraceRunnerError::RuntimeExitError(Error::<T>::InvalidNonce)
+		);
+
+		// Deduct fee from the `source` account.
+		let fee = T::OnChargeTransaction::withdraw_fee(&source, total_fee)
+			.map_err(|e| TraceRunnerError::RuntimeExitError(e))?;
 
 		let transaction_cost = gasometer::create_transaction_cost(&input);
 		let _ = executor
 			.state_mut()
 			.metadata_mut()
 			.gasometer_mut()
-			.record_transaction(transaction_cost)?;
+			.record_transaction(transaction_cost)
+			.map_err(|e| TraceRunnerError::EvmExitError(e))?;
 
-		let context = Context {
-			caller: source,
-			address: target,
-			apparent_value: value,
-		};
+		let mut actual_fee: U256 = U256::default();
 
-		Self::execute_call(
-			&mut executor,
-			trace_type,
-			T::Precompiles::execute,
-			|executor| {
-				executor.trace_call(
-					target,
-					Some(Transfer {
-						source,
-						target,
-						value,
-					}),
-					input,
-					Some(gas_limit as u64),
-					false,
-					false,
-					false,
-					context,
+		let res = {
+			if let Some(target) = target {
+				// Call context
+				let context = Context {
+					caller: source,
+					address: target,
+					apparent_value: value,
+				};
+				Self::execute_call(
+					&mut executor,
+					trace_type,
+					T::Precompiles::execute,
+					|executor| {
+						let res = executor.trace_call(
+							target,
+							Some(Transfer {
+								source,
+								target,
+								value,
+							}),
+							input,
+							Some(gas_limit as u64),
+							false,
+							false,
+							false,
+							context,
+						);
+						actual_fee = executor.inner.fee(gas_price);
+						res
+					},
 				)
-			},
-		)
-	}
-
-	fn trace_create(
-		source: H160,
-		init: Vec<u8>,
-		value: U256,
-		gas_limit: u64,
-		config: &EvmConfig,
-		trace_type: TraceType,
-	) -> Result<TransactionTrace, ExitError> {
-		let vicinity = Vicinity {
-			gas_price: U256::zero(),
-			origin: source,
+				.map_err(|e| TraceRunnerError::EvmExitError(e))?
+			} else {
+				// Create context
+				let scheme = CreateScheme::Legacy { caller: source };
+				Self::execute_create(&mut executor, trace_type, |executor| {
+					let res =
+						executor.trace_create(source, scheme, value, input, Some(gas_limit as u64));
+					actual_fee = executor.inner.fee(gas_price);
+					res
+				})
+				.map_err(|e| TraceRunnerError::EvmExitError(e))?
+			}
 		};
-
-		let metadata = StackSubstateMetadata::new(gas_limit, &config);
-		let state = SubstrateStackState::new(&vicinity, metadata);
-		let mut executor =
-			StackExecutor::new_with_precompile(state, config, T::Precompiles::execute);
-		let transaction_cost = gasometer::create_transaction_cost(&init);
-		let _ = executor
-			.state_mut()
-			.metadata_mut()
-			.gasometer_mut()
-			.record_transaction(transaction_cost)?;
-
-		let scheme = CreateScheme::Legacy { caller: source };
-		Self::execute_create(&mut executor, trace_type, |executor| {
-			executor.trace_create(source, scheme, value, init, Some(gas_limit as u64))
-		})
+		// Refund fees to the `source` account if deducted more before,
+		T::OnChargeTransaction::correct_and_deposit_fee(&source, actual_fee, fee)
+			.map_err(|e| TraceRunnerError::RuntimeExitError(e))?;
+		Ok(res)
 	}
 }

--- a/runtime/extensions/evm/src/runner/stack.rs
+++ b/runtime/extensions/evm/src/runner/stack.rs
@@ -22,7 +22,7 @@ use moonbeam_rpc_primitives_debug::single::{TraceType, TransactionTrace};
 use ethereum_types::{H160, U256};
 use evm::{
 	executor::{StackExecutor, StackState as StackStateT, StackSubstateMetadata},
-	Capture, Config as EvmConfig, Context, CreateScheme, gasometer, Transfer,
+	gasometer, Capture, Config as EvmConfig, Context, CreateScheme, Transfer,
 };
 use pallet_evm::{
 	runner::stack::{Runner, SubstrateStackState},

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -695,12 +695,14 @@ impl_runtime_apis! {
 			// TraceExecutorResult.
 			match transaction.action {
 				TransactionAction::Call(to) => {
-					if let Ok(res) = <Runtime as pallet_evm::Config>::Runner::trace_call(
+					if let Ok(res) = <Runtime as pallet_evm::Config>::Runner::trace(
 						from,
-						to,
+						Some(to),
 						transaction.input.clone(),
 						transaction.value,
 						transaction.gas_limit.low_u64(),
+						transaction.gas_price,
+						transaction.nonce,
 						config.as_ref().unwrap_or(<Runtime as pallet_evm::Config>::config()),
 						trace_type,
 					) {
@@ -710,11 +712,14 @@ impl_runtime_apis! {
 					}
 				},
 				TransactionAction::Create => {
-					if let Ok(res) = <Runtime as pallet_evm::Config>::Runner::trace_create(
+					if let Ok(res) = <Runtime as pallet_evm::Config>::Runner::trace(
 						from,
+						None,
 						transaction.input.clone(),
 						transaction.value,
 						transaction.gas_limit.low_u64(),
+						transaction.gas_price,
+						transaction.nonce,
 						config.as_ref().unwrap_or(<Runtime as pallet_evm::Config>::config()),
 						trace_type,
 					) {
@@ -767,23 +772,28 @@ impl_runtime_apis! {
 						// return the TraceExecutorResult.
 						let tx_traces = match transaction.action {
 							TransactionAction::Call(to) => {
-								<Runtime as pallet_evm::Config>::Runner::trace_call(
+								<Runtime as pallet_evm::Config>::Runner::trace(
 									from,
-									to,
+									Some(to),
 									transaction.input.clone(),
 									transaction.value,
 									transaction.gas_limit.low_u64(),
+									transaction.gas_price,
+									transaction.nonce,
 									&config,
 									single::TraceType::CallList,
 								).map_err(|_| sp_runtime::DispatchError::Other("Evm error"))?
 
 							},
 							TransactionAction::Create => {
-								<Runtime as pallet_evm::Config>::Runner::trace_create(
+								<Runtime as pallet_evm::Config>::Runner::trace(
 									from,
+									None,
 									transaction.input.clone(),
 									transaction.value,
 									transaction.gas_limit.low_u64(),
+									transaction.gas_price,
+									transaction.nonce,
 									&config,
 									single::TraceType::CallList,
 								).map_err(|_| sp_runtime::DispatchError::Other("Evm error"))?


### PR DESCRIPTION
### What does it do?

Refactors the runner `trace_call` and `trace_create` in  a single `trace` function.

 And adds missing:
 
 - Handling for precompile on `call` contexts.
 - Record transaction cost.
 - Fee handling and account pre-checks.

### What important points reviewers should know?

For missing precompile handling we have 2 options:

- PR a new accessor on the EVM repo, and use it to access the `evm::StackExecutor::precompile`.
- Pass `EvmConfig::Precompile::execute` to the executor wrapper in our side.

I decided to use the latter because we have access to it, and in both cases we are using the same PrecompileSet.

### Is there something left for follow-up PRs?

EVM side is really not compatible with tracing. We enabled some accessors there to be able to mock it's internals, but we still need to duplicate a bunch of code on our side to make sure we behave trace in the same way that the original call was executed.

This PR is a clear demonstration that @nanocryk 's hook is better solution to avoid this type of situations. 

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
