### PR TITLE
Improve CI stability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,7 @@ jobs:
           npm install
           cd ../tests
           npm install
-          npm run test -- -j 1;
+          npm run test -- -j $(($(nproc) / 2));
       - name: Save parachain binary
         run: |
           mkdir -p build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,6 +110,7 @@ jobs:
     runs-on: self-hosted
     env:
       CARGO_SCCACHE_VERSION: 0.2.14-alpha.0-parity
+      MOONBEAM_LOG: info
     outputs:
       RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
     steps:
@@ -176,7 +177,7 @@ jobs:
           npm install
           cd ../tests
           npm install
-          npm run test -- -j $(($(nproc) / 2));
+          npm run test -- -j 1;
       - name: Save parachain binary
         run: |
           mkdir -p build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
     env:
       CARGO_SCCACHE_VERSION: 0.2.14-alpha.0-parity
       # MOONBEAM_LOG: info
-      DEBUG: "test*"
+      # DEBUG: "test*"
     outputs:
       RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
     env:
       CARGO_SCCACHE_VERSION: 0.2.14-alpha.0-parity
       MOONBEAM_LOG: info
+      DEBUG: test*
     outputs:
       RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
     steps:
@@ -177,7 +178,7 @@ jobs:
           npm install
           cd ../tests
           npm install
-          npm run test -- -j $(($(nproc) / 2));
+          npm run test -- -j $(($(nproc) / 2 - 2));
       - name: Save parachain binary
         run: |
           mkdir -p build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,8 +110,8 @@ jobs:
     runs-on: self-hosted
     env:
       CARGO_SCCACHE_VERSION: 0.2.14-alpha.0-parity
-      MOONBEAM_LOG: info
-      DEBUG: test*
+      # MOONBEAM_LOG: info
+      DEBUG: "test*"
     outputs:
       RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
     steps:

--- a/tests/util/dev-node.ts
+++ b/tests/util/dev-node.ts
@@ -1,6 +1,7 @@
 import tcpPortUsed from "tcp-port-used";
 import { spawn, ChildProcess } from "child_process";
 import { BINARY_PATH, DISPLAY_LOG, MOONBEAM_LOG, SPAWNING_TIME } from "./constants";
+const debug = require("debug")("test:dev-node");
 
 export async function findAvailablePorts() {
   const availablePorts = await Promise.all(
@@ -66,6 +67,7 @@ export async function startMoonbeamDevNode(): Promise<{
     `--ws-port=${wsPort}`,
     `--tmp`,
   ];
+  debug(`Starting dev node: --port=${p2pPort} --rpc-port=${rpcPort} --ws-port=${wsPort}`);
 
   const onProcessExit = function () {
     runningNode && runningNode.kill();
@@ -83,6 +85,7 @@ export async function startMoonbeamDevNode(): Promise<{
     process.removeListener("exit", onProcessExit);
     process.removeListener("SIGINT", onProcessInterrupt);
     nodeStarted = false;
+    debug(`Exiting dev node: --port=${p2pPort} --rpc-port=${rpcPort} --ws-port=${wsPort}`);
   });
 
   runningNode.on("error", (err) => {

--- a/tests/util/setup-dev-tests.ts
+++ b/tests/util/setup-dev-tests.ts
@@ -14,6 +14,7 @@ import { ChildProcess } from "child_process";
 import { createAndFinalizeBlock } from "./block";
 import { SPAWNING_TIME, DEBUG_MODE } from "./constants";
 import { HttpProvider } from "web3-core";
+const debug = require("debug")("test:setup");
 
 export interface BlockCreation {
   parentHash?: BlockHash;
@@ -118,6 +119,12 @@ export function describeDevMoonbeam(title: string, cb: (context: DevTestContext)
           block,
         };
       };
+
+      debug(
+        `Setup ready [${/:([0-9]+)$/.exec((context.web3.currentProvider as any).host)[1]}] for ${
+          this.currentTest.title
+        }`
+      );
     });
 
     after(async function () {

--- a/tests/util/transactions.ts
+++ b/tests/util/transactions.ts
@@ -45,14 +45,24 @@ export const createTransaction = async (
     nonce: options.nonce,
     data: options.data,
   };
-  debug("Sending transaction", {
-    ...data,
-    data: !data.data
-      ? ""
-      : data.data.length < 80
-      ? data.data
-      : data.data.substr(0, 7) + "..." + data.data.substr(data.data.length - 5),
-  });
+  debug(
+    `Tx [${/:([0-9]+)$/.exec((web3.currentProvider as any).host)[1]}] ` +
+      `from: ${data.from.substr(0, 5) + "..." + data.from.substr(data.from.length - 3)}, ` +
+      (data.to
+        ? `to: ${data.to.substr(0, 5) + "..." + data.to.substr(data.to.length - 3)}, `
+        : "") +
+      (data.value ? `value: ${data.value.toString()}, ` : "") +
+      `gasPrice: ${data.gasPrice.toString()}, ` +
+      (data.gas ? `gas: ${data.gas.toString()}, ` : "") +
+      (data.nonce ? `nonce: ${data.nonce.toString()}, ` : "") +
+      (!data.data
+        ? ""
+        : `data: ${
+            data.data.length < 50
+              ? data.data
+              : data.data.substr(0, 5) + "..." + data.data.substr(data.data.length - 3)
+          }`)
+  );
   const tx = await web3.eth.accounts.signTransaction(data, privateKey);
   return tx.rawTransaction;
 };


### PR DESCRIPTION
Reduces the amount of thread to guarantee enough resources for CI TS tests.
The threads were limited to CPU/2 for mocha, but each mocha process spawns also a moonbeam node, so all the CPUs were used by the workers and the master process was also trying to use it.

This seems to trigger an issue where a create block is not fully imported when responding to the RPC and so the next TX query would return null.