### PR TITLE
Change fork test behavior. Test now retrieves re-inserted tx at new c…

### DIFF
--- a/tests/tests/test-fork-chain.ts
+++ b/tests/tests/test-fork-chain.ts
@@ -39,14 +39,15 @@ describeDevMoonbeam("Fork", (context) => {
       transactions: [await createTransfer(context.web3, TEST_ACCOUNT, 512)],
     });
     const insertedTx = txResults[0].result;
-    let retractedTx = await context.web3.eth.getTransaction(insertedTx)
+    let retractedTx = await context.web3.eth.getTransaction(insertedTx);
     expect(retractedTx).to.not.be.null;
 
     // Fork 4 blocks 0-1-2-3-4
     let parentHash = await context.polkadotApi.rpc.chain.getBlockHash(0);
     parentHash = (await context.createBlock({ parentHash, finalize: false })).block.hash;
     parentHash = (await context.createBlock({ parentHash, finalize: false })).block.hash;
-    // This next block defines a new best chain. Substrate will insert the retracted block's txs in the tx pool
+    // This next block defines a new best chain.
+    // Substrate will insert the retracted block's txs in the tx pool
     parentHash = (await context.createBlock({ parentHash, finalize: false })).block.hash;
     // All the transactions that were in the pool are now on-chain
     parentHash = (await context.createBlock({ parentHash, finalize: true })).block.hash;

--- a/tests/tests/test-fork-chain.ts
+++ b/tests/tests/test-fork-chain.ts
@@ -31,7 +31,7 @@ describeDevMoonbeam("Fork", (context) => {
 });
 
 describeDevMoonbeam("Fork", (context) => {
-  it("should discard lost transaction on fork", async function () {
+  it("should re-insert Tx from retracted fork on new canonical chain", async function () {
     // Creation of the best chain so far, with blocks 0-1-2 and a transfer in block 2
     await context.createBlock({ finalize: false });
     const { txResults } = await context.createBlock({
@@ -39,14 +39,23 @@ describeDevMoonbeam("Fork", (context) => {
       transactions: [await createTransfer(context.web3, TEST_ACCOUNT, 512)],
     });
     const insertedTx = txResults[0].result;
-    expect(await context.web3.eth.getTransaction(insertedTx)).to.not.be.null;
+    let retractedTx = await context.web3.eth.getTransaction(insertedTx)
+    expect(retractedTx).to.not.be.null;
 
-    // Fork
+    // Fork 4 blocks 0-1-2-3-4
     let parentHash = await context.polkadotApi.rpc.chain.getBlockHash(0);
     parentHash = (await context.createBlock({ parentHash, finalize: false })).block.hash;
     parentHash = (await context.createBlock({ parentHash, finalize: false })).block.hash;
+    // This next block defines a new best chain. Substrate will insert the retracted block's txs in the tx pool
     parentHash = (await context.createBlock({ parentHash, finalize: false })).block.hash;
-
-    expect(await context.web3.eth.getTransaction(insertedTx)).to.be.null;
+    // All the transactions that were in the pool are now on-chain
+    parentHash = (await context.createBlock({ parentHash, finalize: true })).block.hash;
+    let finalTx = await context.web3.eth.getTransaction(insertedTx);
+    let currentHeight = await context.web3.eth.getBlockNumber();
+    // The Tx should have been inserted in the last block
+    expect(finalTx.blockNumber).to.equal(currentHeight);
+    // The Tx should have the hash of the latest canonical chain
+    expect(finalTx.blockHash).to.not.equal(retractedTx.blockHash);
+    expect(finalTx.blockHash).to.equal((await context.web3.eth.getBlock(currentHeight)).hash);
   });
 });

--- a/tests/tests/test-fork-chain.ts
+++ b/tests/tests/test-fork-chain.ts
@@ -39,7 +39,7 @@ describeDevMoonbeam("Fork", (context) => {
       transactions: [await createTransfer(context.web3, TEST_ACCOUNT, 512)],
     });
     const insertedTx = txResults[0].result;
-    let retractedTx = await context.web3.eth.getTransaction(insertedTx);
+    const retractedTx = await context.web3.eth.getTransaction(insertedTx);
     expect(retractedTx).to.not.be.null;
 
     // Fork 4 blocks 0-1-2-3-4
@@ -51,8 +51,8 @@ describeDevMoonbeam("Fork", (context) => {
     parentHash = (await context.createBlock({ parentHash, finalize: false })).block.hash;
     // All the transactions that were in the pool are now on-chain
     parentHash = (await context.createBlock({ parentHash, finalize: true })).block.hash;
-    let finalTx = await context.web3.eth.getTransaction(insertedTx);
-    let currentHeight = await context.web3.eth.getBlockNumber();
+    const finalTx = await context.web3.eth.getTransaction(insertedTx);
+    const currentHeight = await context.web3.eth.getBlockNumber();
     // The Tx should have been inserted in the last block
     expect(finalTx.blockNumber).to.equal(currentHeight);
     // The Tx should have the hash of the latest canonical chain


### PR DESCRIPTION
…anonical chain

### What does it do?
Changes the behavior of the fork test, since it was wrongly expressed. The Tx from the retracted block should be re-inserted once we have a new best chain

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
