### PR TITLE
Test host functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4382,6 +4382,7 @@ dependencies = [
  "jsonrpc-core 15.1.0",
  "jsonrpc-pubsub 15.1.0",
  "log",
+ "moonbeam-primitives-ext",
  "moonbeam-rpc-debug",
  "moonbeam-rpc-primitives-debug",
  "moonbeam-rpc-primitives-txpool",
@@ -4454,11 +4455,21 @@ dependencies = [
  "evm",
  "evm-core",
  "fp-evm",
+ "moonbeam-primitives-ext",
  "moonbeam-rpc-primitives-debug",
  "pallet-evm",
  "sp-core",
  "sp-io",
  "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "moonbeam-primitives-ext"
+version = "0.1.0"
+dependencies = [
+ "sp-externalities",
+ "sp-runtime-interface",
  "sp-std",
 ]
 
@@ -4631,6 +4642,7 @@ dependencies = [
  "hex-literal",
  "log",
  "moonbeam-extensions-evm",
+ "moonbeam-primitives-ext",
  "moonbeam-rpc-primitives-debug",
  "moonbeam-rpc-primitives-txpool",
  "pallet-author-filter",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "0.2.13", features = ["macros", "sync"] }
 moonbeam-runtime = { path = "../runtime" }
 moonbeam-rpc-txpool = { path = "../client/rpc/txpool" }
 moonbeam-rpc-primitives-txpool = { path = "../primitives/rpc/txpool" }
+moonbeam-primitives-ext = { path = "../primitives/ext" }
 moonbeam-rpc-debug = { path = "../client/rpc/debug" }
 moonbeam-rpc-primitives-debug = { path = "../primitives/rpc/debug" }
 moonbeam-rpc-trace = { path = "../client/rpc/trace" }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -65,7 +65,8 @@ native_executor_instance!(
 	pub Executor,
 	moonbeam_runtime::api::dispatch,
 	moonbeam_runtime::native_version,
-	frame_benchmarking::benchmarking::HostFunctions,
+	// Make the executor aware of the custom host functions.
+	(frame_benchmarking::benchmarking::HostFunctions, moonbeam_primitives_ext::moonbeam_ext::HostFunctions),
 );
 use sc_telemetry::{Telemetry, TelemetryWorker, TelemetryWorkerHandle};
 

--- a/primitives/ext/Cargo.toml
+++ b/primitives/ext/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "moonbeam-primitives-ext"
+version = '0.1.0'
+authors = ['PureStake']
+edition = '2018'
+homepage = 'https://moonbeam.network'
+license = 'GPL-3.0-only'
+repository = 'https://github.com/PureStake/moonbeam/'
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sp-runtime-interface = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1",default-features = false }
+
+[features]
+default = ["std"]
+std = [
+	"sp-runtime-interface/std",
+]

--- a/primitives/ext/Cargo.toml
+++ b/primitives/ext/Cargo.toml
@@ -11,9 +11,13 @@ repository = 'https://github.com/PureStake/moonbeam/'
 
 [dependencies]
 sp-runtime-interface = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1",default-features = false }
+sp-externalities = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1",default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1",default-features = false }
 
 [features]
 default = ["std"]
 std = [
 	"sp-runtime-interface/std",
+	"sp-externalities/std",
+	"sp-std/std",
 ]

--- a/primitives/ext/src/lib.rs
+++ b/primitives/ext/src/lib.rs
@@ -1,0 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_runtime_interface::runtime_interface;
+
+#[runtime_interface]
+pub trait MoonbeamExt {
+    fn foo() {
+        println!("Called from the runtime!");
+    }
+}

--- a/primitives/ext/src/lib.rs
+++ b/primitives/ext/src/lib.rs
@@ -1,10 +1,44 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-
 use sp_runtime_interface::runtime_interface;
+#[cfg(feature = "std")]
+use sp_externalities::ExternalitiesExt;
+use sp_std::prelude::Vec;
+
+pub struct RawTracer {
+    items: Vec<u8>
+}
+
+impl RawTracer {
+    pub fn new() -> Self {
+        RawTracer {
+            items: Vec::new()
+        }
+    }
+    pub fn push(&mut self, step: u8) {
+        self.items.push(step);
+    }
+    pub fn get(&self) -> Vec<u8> {
+        self.items.clone()
+    }
+}
+
+#[cfg(feature = "std")]
+sp_externalities::decl_extension! {
+	pub struct RawTracerExt(RawTracer);
+}
 
 #[runtime_interface]
 pub trait MoonbeamExt {
-    fn foo() {
-        println!("Called from the runtime!");
+    fn start_trace_raw(&mut self) {
+        // TODO: pass RawTracer instance
+        self.register_extension(RawTracerExt(RawTracer::new()))
+			.expect("Failed to register required extension: `RawTracerExt`");
     }
+    fn record_raw_step(&mut self, step: u8) {
+        let ext = self.extension::<RawTracerExt>()
+            .expect("Cannot find registered extension: `RawTracerExt`");
+		
+        ext.push(step);
+        println!("Items: {:?}", ext.get());
+	}
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -58,6 +58,7 @@ pallet-collective = { git = "https://github.com/paritytech/substrate", default-f
 moonbeam-extensions-evm = { path = "extensions/evm", default-features = false }
 moonbeam-rpc-primitives-debug = { path = "../primitives/rpc/debug", default-features = false }
 moonbeam-rpc-primitives-txpool = { path = "../primitives/rpc/txpool", default-features = false }
+moonbeam-primitives-ext = { path = "../primitives/ext", default-features = false  }
 
 # Cumulus dependencies
 cumulus-pallet-parachain-system = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "rococo-v1" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -918,6 +918,8 @@ impl_runtime_apis! {
 
 	impl fp_rpc::EthereumRuntimeRPCApi<Block> for Runtime {
 		fn chain_id() -> u64 {
+			// Just find some place in the runtime to call it.
+			moonbeam_primitives_ext::moonbeam_ext::foo();
 			<Runtime as pallet_evm::Config>::ChainId::get()
 		}
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -918,8 +918,10 @@ impl_runtime_apis! {
 
 	impl fp_rpc::EthereumRuntimeRPCApi<Block> for Runtime {
 		fn chain_id() -> u64 {
-			// Just find some place in the runtime to call it.
-			moonbeam_primitives_ext::moonbeam_ext::foo();
+			moonbeam_primitives_ext::moonbeam_ext::start_trace_raw();
+			moonbeam_primitives_ext::moonbeam_ext::record_raw_step(1u8);
+			moonbeam_primitives_ext::moonbeam_ext::record_raw_step(2u8);
+			moonbeam_primitives_ext::moonbeam_ext::record_raw_step(3u8);
 			<Runtime as pallet_evm::Config>::ChainId::get()
 		}
 


### PR DESCRIPTION
@nanocryk just a test of using `runtime_interface` macro to extend the executor Externalities, so from the runtime wasm we can interface with the native code in the node using host functions.

There are of course restrictions on types you can use back and forth, this is described [here](https://crates.parity.io/sp_runtime_interface/index.html).

Please `cd primitives/ext && cargo expand` to see the magic behind the macro.
