### PR TITLE
Sha3 precompile is moved to 1024

### DIFF
--- a/runtime/precompiles/src/lib.rs
+++ b/runtime/precompiles/src/lib.rs
@@ -94,8 +94,8 @@ where
 			a if a == hash(7) => Some(Bn128Mul::execute(input, target_gas, context)),
 			a if a == hash(8) => Some(Bn128Pairing::execute(input, target_gas, context)),
 			// Non-Moonbeam specific nor Ethereum precompiles :
-			a if a == hash(1024) => Some(Dispatch::<R>::execute(input, target_gas, context)),
-			a if a == hash(1025) => Some(Sha3FIPS256::execute(input, target_gas, context)),
+			a if a == hash(1024) => Some(Sha3FIPS256::execute(input, target_gas, context)),
+			a if a == hash(1025) => Some(Dispatch::<R>::execute(input, target_gas, context)),
 			// Moonbeam specific precompiles :
 			a if a == hash(2048) => Some(ParachainStakingWrapper::<R>::execute(
 				input, target_gas, context,

--- a/tests/tests/test-precompile-sha3fips.ts
+++ b/tests/tests/test-precompile-sha3fips.ts
@@ -12,7 +12,7 @@ describeDevMoonbeam("Precompiles - sha3fips", (context) => {
         value: "0x0",
         gas: "0x10000",
         gasPrice: "0x01",
-        to: "0x0000000000000000000000000000000000000401",
+        to: "0x0000000000000000000000000000000000000400",
         data:
           "0x0448250ebe88d77e0a12bcf530fe6a2cf1ac176945638d309b840d631940c93b78c2bd6d16f227a8877e" +
           "3f1604cd75b9c5a8ab0cac95174a8a0a0f8ea9e4c10bca",


### PR DESCRIPTION
Sha3FIPS256 is being moved to address 1024 which will match our future standard

(Dispatch precompiles is still included but needs to be scoped in the future standard)