### PR TITLE
Block Signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "sc-cli",
  "sc-service",
@@ -1271,7 +1271,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1295,7 +1295,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "derive_more",
  "futures 0.3.14",
@@ -1344,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -1369,7 +1369,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
@@ -1399,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.1",
@@ -1416,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -1434,7 +1434,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -4974,7 +4974,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5206,7 +5206,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -5215,6 +5215,7 @@ dependencies = [
  "nimbus-primitives",
  "parity-scale-codec",
  "sp-api",
+ "sp-application-crypto",
  "sp-authorship",
  "sp-inherents",
  "sp-runtime",
@@ -5237,7 +5238,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -5983,7 +5984,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus#9f16c89475d9b27ac1ba7ebec9f5670d61ddf72d"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus#838c2b2b1eef8c009225b9f2ae82b99ee26a543b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",


### PR DESCRIPTION
Prior to this PR, Moonbeam's blocks were not cryptographically signed. This was true of both the dev service and the collator. After this PR, blocks are signed by the collator, and those signatures are verified by both the parachain nodes, and relay chain validators.

This means that the block authorship information inserted via the author inherent is now guaranteed and can be used for slashing and other reputation systems.

This change primarily happens upstream in nimbus so this PR is mostly just a dependency bump from the Moonbeam perspective.

Blocks continue to not be signed by the dev service.

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
