### PR TITLE
Fixes node scripts to prevent authority discovery issues

### DIFF
--- a/scripts/run-alphanet-parachain.sh
+++ b/scripts/run-alphanet-parachain.sh
@@ -85,7 +85,7 @@ http-port: $((PARACHAIN_PORT + 10 + 1)), ws-port: $((PARACHAIN_PORT + 10 + 2))"
 sha256sum $CHAIN
 $MOONBEAM_BINARY \
   --node-key ${PARACHAIN_NODE_KEYS[$PARACHAIN_INDEX]} \
-  --port $((PARACHAIN_PORT + 10)) \
+  --listen-addr "/ip4/0.0.0.0/tcp/$((PARACHAIN_PORT + 10))" \
   --rpc-port $((PARACHAIN_PORT + 10 + 1)) \
   --ws-port $((PARACHAIN_PORT + 10 + 2)) \
   --collator \
@@ -102,8 +102,9 @@ $MOONBEAM_BINARY \
   -- \
     --node-key ${PARACHAIN_NODE_KEYS[$PARACHAIN_INDEX]} \
     $PARACHAIN_BASE_PATH \
-    --port $((PARACHAIN_PORT)) \
+    --listen-addr "/ip4/0.0.0.0/tcp/$((PARACHAIN_PORT))" \
     --rpc-port $((PARACHAIN_PORT + 1)) \
     --ws-port $((PARACHAIN_PORT + 2)) \
     --chain $ROCOCO_LOCAL_RAW_SPEC \
   $RELAY_BOOTNODES_ARGS;
+  

--- a/scripts/run-rococo-local.sh
+++ b/scripts/run-rococo-local.sh
@@ -66,7 +66,7 @@ docker run \
       --unsafe-rpc-external \
       --unsafe-ws-external \
       --rpc-cors all \
-      --port $((RELAY_PORT)) \
+      --listen-addr /ip4/0.0.0.0/tcp/$((RELAY_PORT)) \
       --rpc-port $((RELAY_PORT + 1)) \
       --ws-port $((RELAY_PORT + 2)) \
       $BOOTNODES_ARGS \


### PR DESCRIPTION
Uses `listen-addr` instead of `port` to ensure the node is not starting with p2p using websocket instead of native tcp

Was suggested by pierre-tomaka