### PR TITLE
Rename local spec ids

### DIFF
--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -90,7 +90,7 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		// or not. We should decide the proper strings, and update Apps accordingly.
 		// Or maybe Apps can be smart enough to say if the string contains "moonbeam" at all...
 		"Moonbase Development Testnet",
-		"local_testnet",
+		"moonbase_local",
 		ChainType::Local,
 		move || {
 			testnet_genesis(

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -90,7 +90,7 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		// or not. We should decide the proper strings, and update Apps accordingly.
 		// Or maybe Apps can be smart enough to say if the string contains "moonbeam" at all...
 		"Moonbase Development Testnet",
-		"local_testnet",
+		"moonbeam_local",
 		ChainType::Local,
 		move || {
 			testnet_genesis(

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -90,7 +90,7 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		// or not. We should decide the proper strings, and update Apps accordingly.
 		// Or maybe Apps can be smart enough to say if the string contains "moonbeam" at all...
 		"Moonriver Development Testnet",
-		"local_testnet",
+		"moonriver_local",
 		ChainType::Local,
 		move || {
 			testnet_genesis(

--- a/node/service/src/chain_spec/moonshadow.rs
+++ b/node/service/src/chain_spec/moonshadow.rs
@@ -90,7 +90,7 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		// or not. We should decide the proper strings, and update Apps accordingly.
 		// Or maybe Apps can be smart enough to say if the string contains "moonbeam" at all...
 		"Moonshadow Development Testnet",
-		"local_testnet",
+		"moonshadow_local",
 		ChainType::Local,
 		move || {
 			testnet_genesis(


### PR DESCRIPTION
Correctly set prefixes for local chain specs (`moon*_local`)