### PR TITLE
Add bn128 bounds check tests

### DIFF
--- a/tests/tests/test-bn-128-bounds.ts
+++ b/tests/tests/test-bn-128-bounds.ts
@@ -1,0 +1,100 @@
+import { expect } from "chai";
+import { describeDevMoonbeam } from "../util/setup-dev-tests";
+import { createContract } from "../util/transactions";
+import { GENESIS_ACCOUNT, GENESIS_ACCOUNT_PRIVATE_KEY } from "../util/constants";
+import { customWeb3Request } from "../util/providers";
+
+/*
+ * These test cases trigger bugs in the bn128 precompiles which perform a from_slice()
+ * call on unchecked input.
+ *
+ * Fixed by:
+ * https://github.com/paritytech/frontier/pull/394
+ */
+
+describeDevMoonbeam("bn128 precompile bounds check", (context) => {
+  it("should fail gracefully (case 1)", async () => {
+
+    const from = "0xed6cd71d72b116dda4e31f562f15116c34d084f9";
+    // some call data which will cause bn128 to be called with insufficient input. this
+    // presumably was generated through fuzzing.
+    const data =
+        "0x608060405234801561001057600080fd5b5060008060405180608001604052807f2243525c5eda"
+        "1401003c45ac0ca3fe4dd85e830a4ce6b65fa1eeaee202839703815260207f6e01001d33be6da800"
+        "00002bcc35964723180eed75f91a010001007d48f195c91581526020017f18b18acfb4c2c30276db"
+        "5411000000000000000b4691610c5d3b00010001b17f81526020017f063c909c4720840cb5134cb9"
+        "f546c80200579d040100d32efc0d288197f37266815246475b6100bf61044d505b6040604b808460"
+        "006007600019f1925082610142576000000000acd401000000000000000000000000000000000000"
+        "000000000000000000008152600401808060200182810300192c748252601e8152602001887f656c"
+        "6c967074000381327572766520616464ad74696f6e206661696c6564000081525060200191500000"
+        "000000000009fd5b7f2bd3e6d0f3b142924f5ca7b49ce5b9d585420400ae5648e61d02268b1a0a9f"
+        "b7816000600202020202020202020202020202020202fd0202020203020202020202020202020202"
+        "0202fb02020a02020202020202020202020202020202020202020202020202020202020202020202"
+        "02020202020200000000000000000a1c000000000000000000000000000000000000000901010037"
+        "190100000000000000000000f81a0100000002020202020202020202020202020202020202028a30"
+        "a82123b27db75200aedc4a45a0e84fbd1f9f3621350bb778119630350eb7a7e613058daf51e9f514"
+        "8ea65715eaac3d8019f80498112fc4860a020202020202020202fd02020202020202020202020202"
+        "02020202020202020202020202020202020202020202020202020202020202020202020202020212"
+        "02020202020202020202010202fd0202020202020202020202020202020202020202020202020202"
+        "020202020202020202020202005f02d2020202020202020202020202020202020202020202020202"
+        "02020202020202020202020302020202020202020202020202020202020202020202020202020202"
+        "0302020202020202020202020202";
+    const value = "0x0";
+    const gas_limit = "0x100000";
+    const gas_price = "0x01";
+
+    const tx = await context.web3.eth.accounts.signTransaction(
+      {
+        from: GENESIS_ACCOUNT,
+        to: null,
+        value: value,
+        gas: gas_limit,
+        gasPrice: gas_price,
+        data: data
+      },
+      GENESIS_ACCOUNT_PRIVATE_KEY
+    );
+
+    const txResults = await customWeb3Request(context.web3, "eth_sendRawTransaction", [
+      tx.rawTransaction,
+    ]);
+    await context.createBlock();
+
+    console.log("txResults: ", txResults);
+
+    const receipt = await context.web3.eth.getTransactionReceipt(txResults.result);
+    expect(receipt.status).to.be.false;
+  });
+
+  it("should fail gracefully (case 2)", async () => {
+    const from = "0xed6cd71d72b116dda4e31f562f15116c34d084f9";
+    const to = "0x0000000000000000000000000000000000000007";
+    // similar to the above call data, although triggers a slightly different bug
+    const data = "0x0000000000000000000000000000000000000000050000000000008303d0300d901401";
+    const value = "0x0";
+    const gas_limit = "0x100000";
+    const gas_price = "0x01";
+
+    const tx = await context.web3.eth.accounts.signTransaction(
+      {
+        from: GENESIS_ACCOUNT,
+        to: to,
+        value: value,
+        gas: gas_limit,
+        gasPrice: gas_price,
+        data: data
+      },
+      GENESIS_ACCOUNT_PRIVATE_KEY
+    );
+
+    const txResults = await customWeb3Request(context.web3, "eth_sendRawTransaction", [
+      tx.rawTransaction,
+    ]);
+    await context.createBlock();
+
+    console.log("txResults: ", txResults);
+
+    const receipt = await context.web3.eth.getTransactionReceipt(txResults.result);
+    expect(receipt.status).to.be.false;
+  });
+});


### PR DESCRIPTION
### What does it do?

Adds tests which reproduce the bug fixed by this PR:

https://github.com/paritytech/frontier/pull/394

This could either be merged after picking up this update in `frontier` or could be merged with `it.skip()` now.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

https://github.com/paritytech/frontier/pull/394

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
