### PR TITLE
Adds delay in subscription test (prevent CI to fail)

### DIFF
--- a/tests/tests/test-subscription.ts
+++ b/tests/tests/test-subscription.ts
@@ -29,6 +29,9 @@ describeDevMoonbeam("Subscription - Block headers", (context) => {
   it("should send notification on new block", async function () {
     const subscription = web3Subscribe(web3Ws, "newBlockHeaders");
     await new Promise((resolve) => subscription.once("connected", resolve));
+    // TODO this should not be needed. test seems to fail when the block is created to quickly
+    // after the subscription
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
     await context.createBlock({
       transactions: [


### PR DESCRIPTION
This solves an issue with CI on github servers.
I suspect it is due to an issue with subscription request and if the block is created to quickly after but we can ignore it for now.