### PR TITLE
Remove NetApi TODO

### DIFF
--- a/node/service/src/rpc.rs
+++ b/node/service/src/rpc.rs
@@ -170,8 +170,6 @@ where
 	io.extend_with(NetApiServer::to_delegate(NetApi::new(
 		client.clone(),
 		network.clone(),
-		// TODO This is the new peer_cout_as_hex field. Obviously this will compile,
-		// but I forget whether we want it in hex or not.
 		true,
 	)));
 	io.extend_with(Web3ApiServer::to_delegate(Web3Api::new(client.clone())));

--- a/tests/tests/test-web3api.ts
+++ b/tests/tests/test-web3api.ts
@@ -19,7 +19,7 @@ describeDevMoonbeam("Web3Api Information", (context) => {
     expect(hash.result).to.be.equal(localhash);
   });
 
-  it.skip("should report peer count in hex", async function () {
+  it("should report peer count in hex", async function () {
     // this tests that the "net_peerCount" response comes back in hex and not decimal.
     // this seems a bit inconsistent amongst Ethereum APIs, but hex seems to be most common.
 


### PR DESCRIPTION
### What does it do?

Removes a TODO that was leftover from our recent deps update and enables a test case against `net_peerCount`. This test case passes now because we picked up a "fix" in Frontier (`677548c` and `78fb3bc`).

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
