### PR TITLE
Proactive Call Filtering

### DIFF
--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 38,
+	spec_version: 39,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -831,14 +831,8 @@ impl_runtime_apis! {
 			source: TransactionSource,
 			tx: <Block as BlockT>::Extrinsic,
 		) -> TransactionValidity {
-			let mut allowed = match &tx.function {
-				Call::Balances(_) => false,
-				Call::CrowdloanRewards(_) => false,
-				Call::Democracy(_) => false,
-				Call::Ethereum(_) => false,
-				Call::EVM(_) => false,
-				_ => true,
-			};
+			let mut allowed = <Runtime as frame_system::Config>
+				::BaseCallFilter::filter(&tx.function);
 			// only exception is if caller is root
 			if !allowed {
 				match &tx.signature {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -57,7 +57,7 @@ use sp_core::{u32_trait::*, OpaqueMetadata, H160, H256, U256};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{BlakeTwo256, Block as BlockT, IdentityLookup},
-	transaction_validity::{TransactionSource, TransactionValidity},
+	transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidity},
 	AccountId32, ApplyExtrinsicResult, Perbill, Permill,
 };
 use sp_std::{convert::TryFrom, prelude::*};
@@ -831,7 +831,14 @@ impl_runtime_apis! {
 			source: TransactionSource,
 			tx: <Block as BlockT>::Extrinsic,
 		) -> TransactionValidity {
-			Executive::validate_transaction(source, tx)
+			match &tx.function {
+				Call::Balances(_) => InvalidTransaction::Call.into(),
+				Call::CrowdloanRewards(_) => InvalidTransaction::Call.into(),
+				Call::Democracy(_) => InvalidTransaction::Call.into(),
+				Call::Ethereum(_) => InvalidTransaction::Call.into(),
+				Call::EVM(_) => InvalidTransaction::Call.into(),
+				_ => Executive::validate_transaction(source, tx),
+			}
 		}
 	}
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -831,13 +831,13 @@ impl_runtime_apis! {
 			source: TransactionSource,
 			tx: <Block as BlockT>::Extrinsic,
 		) -> TransactionValidity {
+			// filtered calls should never enter the tx pool so they never enter a block
 			let mut allowed = <Runtime as frame_system::Config>
 				::BaseCallFilter::filter(&tx.function);
-			// only exception is if caller is root
+			// filtered calls are still allowed if source is sudo
 			if !allowed {
 				match &tx.signature {
 					Some((account, ..)) => if &Sudo::key() == account {
-						// no need to verify signature because validate_transaction does so
 						allowed = true;
 					},
 					_ => (),

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -830,13 +830,13 @@ impl_runtime_apis! {
 			source: TransactionSource,
 			tx: <Block as BlockT>::Extrinsic,
 		) -> TransactionValidity {
+			// filtered calls should never enter the tx pool so they never enter a block
 			let mut allowed = <Runtime as frame_system::Config>
 				::BaseCallFilter::filter(&tx.function);
-			// only exception is if caller is root
+			// filtered calls are still allowed if source is sudo
 			if !allowed {
 				match &tx.signature {
 					Some((account, ..)) => if &Sudo::key() == account {
-						// no need to verify signature because validate_transaction does so
 						allowed = true;
 					},
 					_ => (),

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -57,7 +57,7 @@ use sp_core::{u32_trait::*, OpaqueMetadata, H160, H256, U256};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{BlakeTwo256, Block as BlockT, IdentityLookup},
-	transaction_validity::{TransactionSource, TransactionValidity},
+	transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidity},
 	AccountId32, ApplyExtrinsicResult, Perbill, Permill,
 };
 use sp_std::{convert::TryFrom, prelude::*};
@@ -114,7 +114,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 38,
+	spec_version: 39,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -830,7 +830,23 @@ impl_runtime_apis! {
 			source: TransactionSource,
 			tx: <Block as BlockT>::Extrinsic,
 		) -> TransactionValidity {
-			Executive::validate_transaction(source, tx)
+			let mut allowed = <Runtime as frame_system::Config>
+				::BaseCallFilter::filter(&tx.function);
+			// only exception is if caller is root
+			if !allowed {
+				match &tx.signature {
+					Some((account, ..)) => if &Sudo::key() == account {
+						// no need to verify signature because validate_transaction does so
+						allowed = true;
+					},
+					_ => (),
+				}
+			}
+			if allowed {
+				Executive::validate_transaction(source, tx)
+			} else {
+				InvalidTransaction::Call.into()
+			}
 		}
 	}
 

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -830,13 +830,13 @@ impl_runtime_apis! {
 			source: TransactionSource,
 			tx: <Block as BlockT>::Extrinsic,
 		) -> TransactionValidity {
+			// filtered calls should never enter the tx pool so they never enter a block
 			let mut allowed = <Runtime as frame_system::Config>
 				::BaseCallFilter::filter(&tx.function);
-			// only exception is if caller is root
+			// filtered calls are still allowed if source is sudo
 			if !allowed {
 				match &tx.signature {
 					Some((account, ..)) => if &Sudo::key() == account {
-						// no need to verify signature because validate_transaction does so
 						allowed = true;
 					},
 					_ => (),


### PR DESCRIPTION
https://github.com/PureStake/moonbeam/pull/420 introduced `BaseFilter`

```rust
/// Returns if calls are allowed through the filter
pub struct BaseFilter;
impl Filter<Call> for BaseFilter {
	fn filter(c: &Call) -> bool {
		match c {
			Call::Balances(_) => false,
			Call::CrowdloanRewards(_) => false,
			Call::Democracy(_) => false,
			Call::Ethereum(_) => false,
			Call::EVM(_) => false,
			_ => true,
		}
	}
}
```

which was added as the assigned associated type `BaseCallFilter` for the `frame_system::Config` impl of the `Runtime`. The purpose of this filter is to ensure that all Calls for which filter returns false will fail. However, the filter does NOT prevent inclusion into a block because we cannot prevent filling blocks with failing transactions (we can only ensure that they don't succeed).

This PR adds an additional filter before the transaction pool to prevent any of the aforementioned Calls from entering a block. This sounds like some node client-side filtering, but because the change is in the runtime, the same version is enforced for all nodes so all nodes will have to use this (can you confirm this @JoshOrndorff ?).

The filter in this PR checks the extrinsic passed as a parameter in `validate_transaction`. If the extrinsic is any of the `Call`s returned false by `BaseFilter` AND is not sent by root, then `validate_transaction` return the error [`InvalidTransaction::Call`](https://substrate.dev/rustdocs/v3.0.0/sp_runtime/transaction_validity/enum.InvalidTransaction.html). This ensures that no extrinsic which is of this `Call` can be included in the transaction pool and therefore any block.

### What important points reviewers should know?

There was discussion over whether the `BaseCallFilter` was sufficient, but **this PR was deemed necessary to prevent the user experience wherein they submit an extrinsic which seems to be allowed, pay fees, and then learn that it's not allowed.**

### Is there something left for follow-up PRs?

Verify that the `BaseFilter` added in #420 does not filter Root calls cc @shawntabrizi do you know if `BaseCallFilter` is also applied to Root calls or is it just for non-Root calls? I had trouble finding this code and you had suggested using this call filter.

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- Does it require changes in documentation/tutorials ?
