### PR TITLE
Avoid panicking in trace RPC

### DIFF
--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -857,15 +857,17 @@ where
 		for trace in traces.iter_mut() {
 			trace.block_hash = eth_block_hash;
 			trace.block_number = height;
-			trace.transaction_hash = eth_transactions
-				.get(trace.transaction_position as usize)
-				.ok_or_else(|| {
-					internal_err(format!(
+			trace.transaction_hash =
+				eth_transactions
+					.get(trace.transaction_position as usize)
+					.ok_or_else(|| {
+						tracing::warn!("Bug: A transaction has been replayed while it shouldn't (in block {}).", height);
+						internal_err(format!(
 						"Bug: A transaction has been replayed while it shouldn't (in block {}).",
 						height
 					))
-				})?
-				.transaction_hash;
+					})?
+					.transaction_hash;
 
 			// Reformat error messages.
 			if let block::TransactionTraceOutput::Error(ref mut error) = trace.output {

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -824,8 +824,18 @@ where
 		let extrinsics = backend
 			.blockchain()
 			.body(substrate_block_id)
-			.unwrap()
-			.unwrap();
+			.map_err(|e| {
+				internal_err(format!(
+					"Blockchain error when fetching extrinsics of block {} : {:?}",
+					height, e
+				))
+			})?
+			.ok_or_else(|| {
+				internal_err(format!(
+					"Could not find block {} when fetching extrinsics.",
+					height
+				))
+			})?;
 
 		// Trace the block.
 		let mut traces: Vec<_> = api
@@ -849,7 +859,12 @@ where
 			trace.block_number = height;
 			trace.transaction_hash = eth_transactions
 				.get(trace.transaction_position as usize)
-				.expect("amount of eth transactions should match")
+				.ok_or_else(|| {
+					internal_err(format!(
+						"Bug: A transaction has been replayed while it shouldn't (in block {}).",
+						height
+					))
+				})?
 				.transaction_hash;
 
 			// Reformat error messages.

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -857,17 +857,20 @@ where
 		for trace in traces.iter_mut() {
 			trace.block_hash = eth_block_hash;
 			trace.block_number = height;
-			trace.transaction_hash =
-				eth_transactions
-					.get(trace.transaction_position as usize)
-					.ok_or_else(|| {
-						tracing::warn!("Bug: A transaction has been replayed while it shouldn't (in block {}).", height);
-						internal_err(format!(
+			trace.transaction_hash = eth_transactions
+				.get(trace.transaction_position as usize)
+				.ok_or_else(|| {
+					tracing::warn!(
+						"Bug: A transaction has been replayed while it shouldn't (in block {}).",
+						height
+					);
+
+					internal_err(format!(
 						"Bug: A transaction has been replayed while it shouldn't (in block {}).",
 						height
 					))
-					})?
-					.transaction_hash;
+				})?
+				.transaction_hash;
 
 			// Reformat error messages.
 			if let block::TransactionTraceOutput::Error(ref mut error) = trace.output {


### PR DESCRIPTION
### What does it do?

In case of problems an RPC handler should return an error and log a warning instead of panicking.
(The source problem which caused the panic will be fixed in the tracing runtime API rewrite)

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- ❌ Does it require a purge of the network?
- ❌ You bumped the runtime version if there are breaking changes in the **runtime** ?
- ❌ Does it require changes in documentation/tutorials ?
