### PR TITLE
Mock relay block number in dev service.

### DIFF
--- a/node/service/src/inherents.rs
+++ b/node/service/src/inherents.rs
@@ -104,9 +104,10 @@ impl InherentDataProvider for MockValidationDataInherentDataProvider {
 		// Use the "sproof" (spoof proof) builder to build valid mock state root and proof.
 		let (relay_storage_root, proof) =
 			RelayStateSproofBuilder::default().into_state_root_and_proof();
-		
+
 		// Calculate the mocked relay block based on the current para block
-		let relay_parent_number = self.relay_offset + self.relay_blocks_per_para_block * self.current_para_block;
+		let relay_parent_number =
+			self.relay_offset + self.relay_blocks_per_para_block * self.current_para_block;
 
 		let data = ParachainInherentData {
 			validation_data: PersistedValidationData {

--- a/node/service/src/inherents.rs
+++ b/node/service/src/inherents.rs
@@ -79,7 +79,21 @@ use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 ///
 /// This is useful when running a node that is not actually backed by any relay chain.
 /// For example when running a local node, or running integration tests.
-pub struct MockValidationDataInherentDataProvider;
+///
+/// We mock a relay chain block number as follows:
+/// relay_block_number = offset + relay_blocks_per_para_block * current_para_block
+/// To simulate a parachai nthat starts in relay block 1000 and gets a block in every other relay
+/// block, use 1000 and 2
+pub struct MockValidationDataInherentDataProvider {
+	/// The current block number of the local block chain (the parachain)
+	pub current_para_block: u32,
+	/// The relay block in which this parachain appeared to start. This will be the relay block
+	/// number in para block #P1
+	pub relay_offset: u32,
+	/// The number of relay blocks that elapses between each parablock. Probably set this to 1 or 2
+	/// to simulate optimistic or realistic relay chain behavior.
+	pub relay_blocks_per_para_block: u32,
+}
 
 #[async_trait::async_trait]
 impl InherentDataProvider for MockValidationDataInherentDataProvider {
@@ -90,12 +104,15 @@ impl InherentDataProvider for MockValidationDataInherentDataProvider {
 		// Use the "sproof" (spoof proof) builder to build valid mock state root and proof.
 		let (relay_storage_root, proof) =
 			RelayStateSproofBuilder::default().into_state_root_and_proof();
+		
+		// Calculate the mocked relay block based on the current para block
+		let relay_parent_number = self.relay_offset + self.relay_blocks_per_para_block * self.current_para_block;
 
 		let data = ParachainInherentData {
 			validation_data: PersistedValidationData {
 				parent_head: Default::default(),
 				relay_parent_storage_root: relay_storage_root,
-				relay_parent_number: Default::default(),
+				relay_parent_number,
 				max_pov_size: Default::default(),
 			},
 			downward_messages: Default::default(),

--- a/node/service/src/inherents.rs
+++ b/node/service/src/inherents.rs
@@ -82,7 +82,7 @@ use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 ///
 /// We mock a relay chain block number as follows:
 /// relay_block_number = offset + relay_blocks_per_para_block * current_para_block
-/// To simulate a parachai nthat starts in relay block 1000 and gets a block in every other relay
+/// To simulate a parachaint hat starts in relay block 1000 and gets a block in every other relay
 /// block, use 1000 and 2
 pub struct MockValidationDataInherentDataProvider {
 	/// The current block number of the local block chain (the parachain)

--- a/node/service/src/inherents.rs
+++ b/node/service/src/inherents.rs
@@ -82,7 +82,7 @@ use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 ///
 /// We mock a relay chain block number as follows:
 /// relay_block_number = offset + relay_blocks_per_para_block * current_para_block
-/// To simulate a parachaint hat starts in relay block 1000 and gets a block in every other relay
+/// To simulate a parachain that starts in relay block 1000 and gets a block in every other relay
 /// block, use 1000 and 2
 pub struct MockValidationDataInherentDataProvider {
 	/// The current block number of the local block chain (the parachain)

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -861,10 +861,15 @@ pub fn new_dev(
 				commands_stream,
 				select_chain,
 				consensus_data_provider: None,
-				create_inherent_data_providers: move |_, _| async move {
+				//TODO I need a type annotation on the block type here. What type should I use?
+				create_inherent_data_providers: move |block, ()| async move {
 					let time = sp_timestamp::InherentDataProvider::from_system_time();
 
-					let mocked_parachain = inherents::MockValidationDataInherentDataProvider;
+					let mocked_parachain = inherents::MockValidationDataInherentDataProvider{
+						current_para_block: block.header().number().into(),
+						relay_offset: 1000,
+						relay_blocks_per_para_block: 2,
+					};
 
 					//TODO I want to use the value from a variable above.
 					let author = nimbus_primitives::InherentDataProvider::<NimbusId>(

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -852,6 +852,8 @@ pub fn new_dev(
 				Therefore, a `LongestChainRule` is present. qed.",
 		);
 
+		let client_set_aside_for_cidp = client.clone();
+
 		task_manager.spawn_essential_handle().spawn_blocking(
 			"authorship_task",
 			run_manual_seal(ManualSealParams {
@@ -863,8 +865,7 @@ pub fn new_dev(
 				select_chain,
 				consensus_data_provider: None,
 				create_inherent_data_providers: move |block: H256, ()| {
-					let current_para_block = client
-						.clone()
+					let current_para_block = client_set_aside_for_cidp
 						.number(block)
 						.expect("Header lookup should succeed")
 						.expect("Header passed in as parent should be present in backend.");


### PR DESCRIPTION
Currently the dev service always injects the relay chain block number of 0. This is fine for many purposes, but the more our para logic depends on the relay block number the less suitable this becomes.

We now have at least three concrete cases that could benefit from a more realistically-mocked block number.

1. Crowdloan rewards are vested based on relay block number.
2. Runtime upgrades are allowed (or not) based on relay block number
3. Nimbus slots are triggered based on relay block number.

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
