### PR TITLE
Use cumulus's `RunCmd` (make --collator same as --validator)

### DIFF
--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -116,7 +116,7 @@ pub struct ExportGenesisWasmCommand {
 #[derive(Debug, StructOpt)]
 pub struct RunCmd {
 	#[structopt(flatten)]
-	pub base: sc_cli::RunCmd,
+	pub base: cumulus_client_cli::RunCmd,
 
 	/// Id of the parachain this collator collates for.
 	#[structopt(long)]
@@ -179,7 +179,7 @@ pub struct RunCmd {
 }
 
 impl std::ops::Deref for RunCmd {
-	type Target = sc_cli::RunCmd;
+	type Target = cumulus_client_cli::RunCmd;
 
 	fn deref(&self) -> &Self::Target {
 		&self.base
@@ -198,12 +198,6 @@ pub struct Cli {
 
 	#[structopt(flatten)]
 	pub run: RunCmd,
-
-	/// Run node as collator.
-	///
-	/// Note that this is the same as running with `--validator`.
-	#[structopt(long, conflicts_with = "validator")]
-	pub collator: bool,
 
 	/// Relaychain arguments
 	#[structopt(raw = true)]

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -442,7 +442,7 @@ pub fn run() -> Result<()> {
 			}
 		}
 		None => {
-			let runner = cli.create_runner(&*cli.run)?;
+			let runner = cli.create_runner(&(*cli.run).normalize())?;
 			runner.run_node_until_exit(|config| async move {
 				let key = sp_core::Pair::generate().0;
 


### PR DESCRIPTION
This PR uses `cumulus_client_clis`'s `RunCmd` rather than `sc_cli`'s. This is a companion for https://github.com/paritytech/cumulus/pull/380

The user-facing change is that the `--collator` flag is now exactly the same as the `--validator` flag.

## Checklist

- Does it require a purge of the network?
- You bumped the runtime version if there are breaking changes in the **runtime** ?
- Does it require changes in documentation/tutorials ?
