### PR TITLE
AuthorMapping: Track deposit amounts.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-author-mapping"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/moonbeam-types-bundle/index.ts
+++ b/moonbeam-types-bundle/index.ts
@@ -1,3 +1,4 @@
+import { ACCOUNT_ID_PREFIX } from "@polkadot/types/ethereum/LookupSource";
 import {
   OverrideBundleDefinition,
   OverrideBundleType,
@@ -343,7 +344,7 @@ export const moonbeamDefinitions = {
       },
     },
     {
-      minmax: [37, undefined],
+      minmax: [37, 42],
       types: {
         AccountId: "EthereumAccountId",
         AccountId32: "H256",
@@ -449,6 +450,120 @@ export const moonbeamDefinitions = {
           claimed_reward: "Balance",
           last_paid: "BlockNumber",
           free_claim_done: "bool",
+        },
+      },
+    },
+    {
+      minmax: [43, undefined],
+      types: {
+        AccountId: "EthereumAccountId",
+        AccountId32: "H256",
+        AccountInfo: "AccountInfoWithTripleRefCount",
+        Address: "AccountId",
+        AuthorId: "H256",
+        Balance: "u128",
+        LookupSource: "AccountId",
+        Account: {
+          nonce: "U256",
+          balance: "u128",
+        },
+        ExtrinsicSignature: "EthereumSignature",
+        RoundIndex: "u32",
+        Candidate: {
+          id: "AccountId",
+          fee: "Perbill",
+          bond: "Balance",
+          nominators: "Vec<Bond>",
+          total: "Balance",
+          state: "CollatorStatus",
+        },
+        Nominator: {
+          nominations: "Vec<Bond>",
+          total: "Balance",
+        },
+        Bond: {
+          owner: "AccountId",
+          amount: "Balance",
+        },
+        CollatorStatus: {
+          _enum: ["Active", "Idle", { Leaving: "RoundIndex" }],
+        },
+        TxPoolResultContent: {
+          pending: "HashMap<H160, HashMap<U256, PoolTransaction>>",
+          queued: "HashMap<H160, HashMap<U256, PoolTransaction>>",
+        },
+        TxPoolResultInspect: {
+          pending: "HashMap<H160, HashMap<U256, Summary>>",
+          queued: "HashMap<H160, HashMap<U256, Summary>>",
+        },
+        TxPoolResultStatus: {
+          pending: "U256",
+          queued: "U256",
+        },
+        Summary: "Bytes",
+        PoolTransaction: {
+          hash: "H256",
+          nonce: "U256",
+          block_hash: "Option<H256>",
+          block_number: "Option<U256>",
+          from: "H160",
+          to: "Option<H160>",
+          value: "U256",
+          gas_price: "U256",
+          gas: "U256",
+          input: "Bytes",
+        },
+        // Staking inflation
+        Range: "RangeBalance",
+        RangeBalance: {
+          min: "Balance",
+          ideal: "Balance",
+          max: "Balance",
+        },
+        RangePerbill: {
+          min: "Perbill",
+          ideal: "Perbill",
+          max: "Perbill",
+        },
+        InflationInfo: {
+          expect: "RangeBalance",
+          annual: "RangePerbill",
+          round: "RangePerbill",
+        },
+        OrderedSet: "Vec<Bond>",
+        Collator: {
+          id: "AccountId",
+          bond: "Balance",
+          nominators: "Vec<Bond>",
+          total: "Balance",
+          state: "CollatorStatus",
+        },
+        CollatorSnapshot: {
+          bond: "Balance",
+          nominators: "Vec<Bond>",
+          total: "Balance",
+        },
+        SystemInherentData: {
+          validation_data: "PersistedValidationData",
+          relay_chain_state: "StorageProof",
+          downward_messages: "Vec<InboundDownwardMessage>",
+          horizontal_messages: "BTreeMap<ParaId, Vec<InboundHrmpMessage>>",
+        },
+        RelayChainAccountId: "AccountId32",
+        RoundInfo: {
+          current: "RoundIndex",
+          first: "BlockNumber",
+          length: "u32",
+        },
+        RewardInfo: {
+          total_reward: "Balance",
+          claimed_reward: "Balance",
+          last_paid: "BlockNumber",
+          free_claim_done: "bool",
+        },
+        RegistrationInfo: {
+          account: "AccountId",
+          deposit: "Balance",
         },
       },
     },

--- a/pallets/author-mapping/Cargo.toml
+++ b/pallets/author-mapping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-author-mapping"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["PureStake"]
 edition = "2018"
 description = "Maps AuthorIds to AccountIds Useful for associating consensus authors with in-runtime accounts"

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -91,8 +91,9 @@ pub mod pallet {
 				MappingWithDeposit::<T>::insert(author_id, info);
 			}
 
-			10_000 // No idea about the real weight. Probably not worrying about because this wil
-			 // definitely fit in one of Moonbeam's almost-empty blocks.
+			// No idea about the real weight. Probably not worrying about because this will
+			// definitely fit in one of Moonbeam's almost-empty blocks.
+			10_000 
 		}
 	}
 

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -93,7 +93,7 @@ pub mod pallet {
 
 			// No idea about the real weight. Probably not worrying about because this will
 			// definitely fit in one of Moonbeam's almost-empty blocks.
-			10_000 
+			10_000
 		}
 	}
 

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -77,7 +77,7 @@ pub mod pallet {
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_runtime_upgrade() -> Weight {
 			// This upgrade needs a value to use as the deposit for any registrations that were made
-			// before eposit amounts were tracked. The most 100% correct thing would be to add an
+			// before deposit amounts were tracked. The most 100% correct thing would be to add an
 			// associated type. But since we know this pallet on only used by moonbeam and we know
 			// the old deposit is the same for all accounts, I'll save us some headache by just
 			// defining it here.
@@ -261,7 +261,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn old_account_id_of)]
-	// This is the old storage item used in the old versio nof the pallet. The type is being kept
+	// This is the old storage item used in the old version of the pallet. The type is being kept
 	// for now to enable easier migration of the data. This storage item should be removed from the
 	// code after on-chain data has been migrated.
 	type Mapping<T: Config> = StorageMap<_, Twox64Concat, T::AuthorId, T::AccountId, OptionQuery>;

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -76,14 +76,12 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_runtime_upgrade() -> Weight {
-
 			// This upgrade needs a value to use as the deposit for any registrations that were made
 			// before eposit amounts were tracked. The most 100% correct thing would be to add an
 			// associated type. But since we know this pallet on only used by moonbeam and we know
 			// the old deposit is the same for all accounts, I'll save us some headache by just
 			// defining it here.
 			let old_deposit_amount = 100u32;
-
 
 			for (author_id, account_id) in Mapping::<T>::drain() {
 				let info = RegistrationInfo {
@@ -94,7 +92,7 @@ pub mod pallet {
 			}
 
 			10_000 // No idea about the real weight. Probably not worrying about because this wil
-			       // definitely fit in one of Moonbeam's almost-empty blocks.
+			 // definitely fit in one of Moonbeam's almost-empty blocks.
 		}
 	}
 
@@ -168,7 +166,10 @@ pub mod pallet {
 			let stored_info = MappingWithDeposit::<T>::try_get(&old_author_id)
 				.map_err(|_| Error::<T>::AssociationNotFound)?;
 
-			ensure!(account_id == stored_info.account, Error::<T>::NotYourAssociation);
+			ensure!(
+				account_id == stored_info.account,
+				Error::<T>::NotYourAssociation
+			);
 
 			MappingWithDeposit::<T>::insert(&new_author_id, &stored_info);
 			MappingWithDeposit::<T>::remove(&old_author_id);
@@ -189,10 +190,13 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let account_id = ensure_signed(origin)?;
 
-			let stored_info =
-				MappingWithDeposit::<T>::try_get(&author_id).map_err(|_| Error::<T>::AssociationNotFound)?;
+			let stored_info = MappingWithDeposit::<T>::try_get(&author_id)
+				.map_err(|_| Error::<T>::AssociationNotFound)?;
 
-			ensure!(account_id == stored_info.account, Error::<T>::NotYourAssociation);
+			ensure!(
+				account_id == stored_info.account,
+				Error::<T>::NotYourAssociation
+			);
 
 			MappingWithDeposit::<T>::remove(&author_id);
 
@@ -240,7 +244,6 @@ pub mod pallet {
 			author_id: &T::AuthorId,
 			account_id: &T::AccountId,
 		) -> DispatchResult {
-
 			let info = RegistrationInfo {
 				account: account_id.clone(),
 				deposit: T::DepositAmount::get(),
@@ -266,7 +269,13 @@ pub mod pallet {
 	#[pallet::getter(fn account_and_deposit_of)]
 	/// We maintain a mapping from the AuthorIds used in the consensus layer
 	/// to the AccountIds runtime (including this staking pallet).
-	type MappingWithDeposit<T: Config> = StorageMap<_, Twox64Concat, T::AuthorId, RegistrationInfo<T::AccountId, BalanceOf<T>>, OptionQuery>;
+	type MappingWithDeposit<T: Config> = StorageMap<
+		_,
+		Twox64Concat,
+		T::AuthorId,
+		RegistrationInfo<T::AccountId, BalanceOf<T>>,
+		OptionQuery,
+	>;
 
 	#[pallet::genesis_config]
 	/// Genesis config for author mapping pallet

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -306,7 +306,7 @@ pub mod pallet {
 
 	impl<T: Config> AccountLookup<T::AuthorId, T::AccountId> for Pallet<T> {
 		fn lookup_account(author: &T::AuthorId) -> Option<T::AccountId> {
-			Mapping::<T>::get(author)
+			Self::account_id_of(author)
 		}
 	}
 

--- a/pallets/author-mapping/src/tests.rs
+++ b/pallets/author-mapping/src/tests.rs
@@ -32,8 +32,8 @@ fn genesis_builder_works() {
 			assert!(System::events().is_empty());
 			assert_eq!(Balances::free_balance(&1), 900);
 			assert_eq!(Balances::reserved_balance(&1), 100);
-			assert_eq!(AuthorMapping::account_id_of(TestAuthor::Alice), Some(1));
-			assert_eq!(AuthorMapping::account_id_of(TestAuthor::Bob), None);
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Alice), Some(1));
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Bob), None);
 		})
 }
 
@@ -50,7 +50,7 @@ fn eligible_account_can_register() {
 
 			assert_eq!(Balances::free_balance(&2), 900);
 			assert_eq!(Balances::reserved_balance(&2), 100);
-			assert_eq!(AuthorMapping::account_id_of(TestAuthor::Bob), Some(2));
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Bob), Some(2));
 
 			assert_eq!(
 				last_event(),
@@ -71,7 +71,7 @@ fn ineligible_account_cannot_register() {
 			);
 
 			assert_eq!(Balances::free_balance(&1), 1000);
-			assert_eq!(AuthorMapping::account_id_of(TestAuthor::Alice), None);
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Alice), None);
 		})
 }
 
@@ -87,7 +87,7 @@ fn cannot_register_without_deposit() {
 			);
 
 			assert_eq!(Balances::free_balance(&2), 10);
-			assert_eq!(AuthorMapping::account_id_of(TestAuthor::Alice), None);
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Alice), None);
 		})
 }
 
@@ -105,7 +105,7 @@ fn double_registration_costs_twice_as_much() {
 
 			assert_eq!(Balances::free_balance(&2), 900);
 			assert_eq!(Balances::reserved_balance(&2), 100);
-			assert_eq!(AuthorMapping::account_id_of(TestAuthor::Bob), Some(2));
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Bob), Some(2));
 
 			assert_eq!(
 				last_event(),
@@ -120,7 +120,7 @@ fn double_registration_costs_twice_as_much() {
 
 			assert_eq!(Balances::free_balance(&2), 800);
 			assert_eq!(Balances::reserved_balance(&2), 200);
-			assert_eq!(AuthorMapping::account_id_of(TestAuthor::Alice), Some(2));
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Alice), Some(2));
 
 			assert_eq!(
 				last_event(),
@@ -128,7 +128,7 @@ fn double_registration_costs_twice_as_much() {
 			);
 
 			// Should still be registered as Bob as well
-			assert_eq!(AuthorMapping::account_id_of(TestAuthor::Bob), Some(2));
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Bob), Some(2));
 		})
 }
 
@@ -146,7 +146,7 @@ fn registered_account_can_clear() {
 
 			assert_eq!(Balances::free_balance(&1), 1000);
 			assert_eq!(Balances::reserved_balance(&1), 0);
-			assert_eq!(AuthorMapping::account_id_of(TestAuthor::Alice), None);
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Alice), None);
 
 			assert_eq!(
 				last_event(),
@@ -206,8 +206,8 @@ fn registered_can_rotate() {
 				TestAuthor::Charlie
 			));
 
-			assert_eq!(AuthorMapping::account_id_of(TestAuthor::Bob), None);
-			assert_eq!(AuthorMapping::account_id_of(TestAuthor::Charlie), Some(2));
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Bob), None);
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Charlie), Some(2));
 
 			// Should still only ahve paid a single security deposit
 			assert_eq!(Balances::free_balance(&2), 900);
@@ -268,7 +268,7 @@ fn no_longer_eligible_account_cannot_rotate() {
 			);
 
 			assert_eq!(Balances::free_balance(&1), 900);
-			assert_eq!(AuthorMapping::account_id_of(TestAuthor::Alice), Some(1));
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Alice), Some(1));
 		})
 }
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -113,7 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase"),
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 3,
-	spec_version: 42,
+	spec_version: 43,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -114,7 +114,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 43,
+	spec_version: 44,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -113,7 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 43,
+	spec_version: 44,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -113,7 +113,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonshadow"),
 	impl_name: create_runtime_str!("moonshadow"),
 	authoring_version: 3,
-	spec_version: 43,
+	spec_version: 44,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
This PR changes pallet author mapping so that it tracks the security deposit amount reserved for each registration. This allows the pallet to gracefully handle the case where the deposit amount changes after some registrations have already been set.

It also provides a migration from the previous storage that did not track deposit amounts.

## Checklist

- [ ] Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [x] Does it require changes in documentation/tutorials ?
