### PR TITLE
Dedicated `rpc::spawn_tasks`

### DIFF
--- a/node/cli-opt/src/lib.rs
+++ b/node/cli-opt/src/lib.rs
@@ -67,7 +67,8 @@ impl FromStr for EthApi {
 	}
 }
 
-pub struct RpcParams {
+pub struct RpcConfig {
+	pub ethapi: Vec<EthApi>,
 	pub ethapi_max_permits: u32,
 	pub ethapi_trace_max_count: u32,
 	pub ethapi_trace_cache_duration: u64,

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -17,7 +17,7 @@
 //! This module constructs and executes the appropriate service components for the given subcommand
 
 use crate::cli::{Cli, RelayChainCli, RunCmd, Subcommand};
-use cli_opt::RpcParams;
+use cli_opt::RpcConfig;
 use cumulus_client_service::genesis::generate_genesis_block;
 use cumulus_primitives_core::ParaId;
 use log::info;
@@ -449,7 +449,8 @@ pub fn run() -> Result<()> {
 				let extension = chain_spec::Extensions::try_get(&*config.chain_spec);
 				let para_id = extension.map(|e| e.para_id);
 
-				let rpc_params = RpcParams {
+				let rpc_config = RpcConfig {
+					ethapi: cli.run.ethapi,
 					ethapi_max_permits: cli.run.ethapi_max_permits,
 					ethapi_trace_max_count: cli.run.ethapi_trace_max_count,
 					ethapi_trace_cache_duration: cli.run.ethapi_trace_cache_duration,
@@ -475,14 +476,8 @@ pub fn run() -> Result<()> {
 						"Alice",
 					));
 
-					return service::new_dev(
-						config,
-						author_id,
-						cli.run.sealing,
-						cli.run.ethapi,
-						rpc_params,
-					)
-					.map_err(Into::into);
+					return service::new_dev(config, author_id, cli.run.sealing, rpc_config)
+						.map_err(Into::into);
 				}
 
 				let polkadot_cli = RelayChainCli::new(
@@ -532,7 +527,7 @@ pub fn run() -> Result<()> {
 					service::start_node::<
 						service::moonbeam_runtime::RuntimeApi,
 						service::MoonbeamExecutor,
-					>(config, key, polkadot_config, id, cli.run.ethapi, rpc_params)
+					>(config, key, polkadot_config, id, rpc_config)
 					.await
 					.map(|r| r.0)
 					.map_err(Into::into)
@@ -540,7 +535,7 @@ pub fn run() -> Result<()> {
 					service::start_node::<
 						service::moonriver_runtime::RuntimeApi,
 						service::MoonriverExecutor,
-					>(config, key, polkadot_config, id, cli.run.ethapi, rpc_params)
+					>(config, key, polkadot_config, id, rpc_config)
 					.await
 					.map(|r| r.0)
 					.map_err(Into::into)
@@ -548,7 +543,7 @@ pub fn run() -> Result<()> {
 					service::start_node::<
 						service::moonshadow_runtime::RuntimeApi,
 						service::MoonshadowExecutor,
-					>(config, key, polkadot_config, id, cli.run.ethapi, rpc_params)
+					>(config, key, polkadot_config, id, rpc_config)
 					.await
 					.map(|r| r.0)
 					.map_err(Into::into)
@@ -556,7 +551,7 @@ pub fn run() -> Result<()> {
 					service::start_node::<
 						service::moonbase_runtime::RuntimeApi,
 						service::MoonbaseExecutor,
-					>(config, key, polkadot_config, id, cli.run.ethapi, rpc_params)
+					>(config, key, polkadot_config, id, rpc_config)
 					.await
 					.map(|r| r.0)
 					.map_err(Into::into)

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -478,12 +478,14 @@ where
 
 	let spawned_requesters = rpc::spawn_tasks(
 		&rpc_config,
-		&task_manager,
-		client.clone(),
-		backend.clone(),
-		frontier_backend.clone(),
-		pending_transactions.clone(),
-		filter_pool.clone(),
+		rpc::SpawnTasksParams {
+			task_manager: &task_manager,
+			client: client.clone(),
+			substrate_backend: backend.clone(),
+			frontier_backend: frontier_backend.clone(),
+			pending_transactions: pending_transactions.clone(),
+			filter_pool: filter_pool.clone(),
+		},
 	);
 
 	let rpc_extensions_builder = {
@@ -821,12 +823,14 @@ pub fn new_dev(
 
 	let spawned_requesters = rpc::spawn_tasks(
 		&rpc_config,
-		&task_manager,
-		client.clone(),
-		backend.clone(),
-		frontier_backend.clone(),
-		pending_transactions.clone(),
-		filter_pool.clone(),
+		rpc::SpawnTasksParams {
+			task_manager: &task_manager,
+			client: client.clone(),
+			substrate_backend: backend.clone(),
+			frontier_backend: frontier_backend.clone(),
+			pending_transactions: pending_transactions.clone(),
+			filter_pool: filter_pool.clone(),
+		},
 	);
 
 	let rpc_extensions_builder = {


### PR DESCRIPTION
### What does it do?

- Wraps all rpc config under the `cli_opt::RpcConfig` struct.
- Move all service background tasks spawning to `rpc::spawn_tasks`.

The motivation for this is to have a clear in-code reference on where this tasks are spawned in our service and avoid duplication.

### Is there something left for follow-up PRs?

There is coupling between `FullDeps::create_full` and the new `spawn_tasks` response. Will work on redesigning that in a separate PR.
