### PR TITLE
Cleanly deploy bytecode under precompiles

### DIFF
--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -28,8 +28,8 @@ use moonbase_runtime::{
 	currency::UNITS, AccountId, AuthorFilterConfig, AuthorMappingConfig, Balance, BalancesConfig,
 	CouncilCollectiveConfig, CrowdloanRewardsConfig, DemocracyConfig, EVMConfig,
 	EthereumChainIdConfig, EthereumConfig, GenesisConfig, InflationInfo, ParachainInfoConfig,
-	ParachainStakingConfig, Range, SchedulerConfig, SudoConfig, SystemConfig,
-	TechComitteeCollectiveConfig, Precompiles, WASM_BINARY,
+	ParachainStakingConfig, Precompiles, Range, SchedulerConfig, SudoConfig, SystemConfig,
+	TechComitteeCollectiveConfig, WASM_BINARY,
 };
 use nimbus_primitives::NimbusId;
 use sc_service::ChainType;

--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -29,13 +29,12 @@ use moonbase_runtime::{
 	CouncilCollectiveConfig, CrowdloanRewardsConfig, DemocracyConfig, EVMConfig,
 	EthereumChainIdConfig, EthereumConfig, GenesisConfig, InflationInfo, ParachainInfoConfig,
 	ParachainStakingConfig, Range, SchedulerConfig, SudoConfig, SystemConfig,
-	TechComitteeCollectiveConfig, WASM_BINARY,
+	TechComitteeCollectiveConfig, Precompiles, WASM_BINARY,
 };
 use nimbus_primitives::NimbusId;
 use sc_service::ChainType;
 #[cfg(test)]
 use sp_core::ecdsa;
-use sp_core::H160;
 use sp_runtime::Perbill;
 use std::str::FromStr;
 
@@ -154,10 +153,7 @@ pub fn testnet_genesis(
 	// within contracts. TODO We should have a test to ensure this is the right bytecode.
 	// (PUSH1 0x00 PUSH1 0x00 REVERT)
 	let revert_bytecode = vec![0x60, 0x00, 0x60, 0x00, 0xFD];
-	// TODO consider whether this should be imported from moonbeam precompiles
-	let precompile_addresses = vec![1, 2, 3, 4, 5, 6, 7, 8, 1024, 1025, 2048]
-		.into_iter()
-		.map(H160::from_low_u64_be);
+
 	GenesisConfig {
 		frame_system: SystemConfig {
 			code: WASM_BINARY
@@ -183,15 +179,10 @@ pub fn testnet_genesis(
 		pallet_evm: EVMConfig {
 			// We need _some_ code inserted at the precompile address so that
 			// the evm will actually call the address.
-			// TODO Cleanly fetch the addresses from
-			// the runtime/moonbeam precompiles and systematically fill them with code
-			// that will revert if it is called by accident (it shouldn't be because
-			// it is shadowed by the precompile).
-			// This one is for the parachain staking precompile wrappers
-			accounts: precompile_addresses
-				.map(|a| {
+			accounts: Precompiles::used_addresses()
+				.map(|addr| {
 					(
-						a,
+						addr,
 						GenesisAccount {
 							nonce: Default::default(),
 							balance: Default::default(),

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -29,13 +29,12 @@ use moonbeam_runtime::{
 	CouncilCollectiveConfig, CrowdloanRewardsConfig, DemocracyConfig, EVMConfig,
 	EthereumChainIdConfig, EthereumConfig, GenesisConfig, InflationInfo, ParachainInfoConfig,
 	ParachainStakingConfig, Range, SchedulerConfig, SudoConfig, SystemConfig,
-	TechComitteeCollectiveConfig, WASM_BINARY,
+	TechComitteeCollectiveConfig, Precompiles, WASM_BINARY,
 };
 use nimbus_primitives::NimbusId;
 use sc_service::ChainType;
 #[cfg(test)]
 use sp_core::ecdsa;
-use sp_core::H160;
 use sp_runtime::Perbill;
 use std::str::FromStr;
 
@@ -154,10 +153,7 @@ pub fn testnet_genesis(
 	// within contracts. TODO We should have a test to ensure this is the right bytecode.
 	// (PUSH1 0x00 PUSH1 0x00 REVERT)
 	let revert_bytecode = vec![0x60, 0x00, 0x60, 0x00, 0xFD];
-	// TODO consider whether this should be imported from moonbeam precompiles
-	let precompile_addresses = vec![1, 2, 3, 4, 5, 6, 7, 8, 1024, 1025, 2048]
-		.into_iter()
-		.map(H160::from_low_u64_be);
+
 	GenesisConfig {
 		frame_system: SystemConfig {
 			code: WASM_BINARY
@@ -183,15 +179,10 @@ pub fn testnet_genesis(
 		pallet_evm: EVMConfig {
 			// We need _some_ code inserted at the precompile address so that
 			// the evm will actually call the address.
-			// TODO Cleanly fetch the addresses from
-			// the runtime/moonbeam precompiles and systematically fill them with code
-			// that will revert if it is called by accident (it shouldn't be because
-			// it is shadowed by the precompile).
-			// This one is for the parachain staking precompile wrappers
-			accounts: precompile_addresses
-				.map(|a| {
+			accounts: Precompiles::used_addresses()
+				.map(|addr| {
 					(
-						a,
+						addr,
 						GenesisAccount {
 							nonce: Default::default(),
 							balance: Default::default(),

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -28,8 +28,8 @@ use moonbeam_runtime::{
 	currency::GLMR, AccountId, AuthorFilterConfig, AuthorMappingConfig, Balance, BalancesConfig,
 	CouncilCollectiveConfig, CrowdloanRewardsConfig, DemocracyConfig, EVMConfig,
 	EthereumChainIdConfig, EthereumConfig, GenesisConfig, InflationInfo, ParachainInfoConfig,
-	ParachainStakingConfig, Range, SchedulerConfig, SudoConfig, SystemConfig,
-	TechComitteeCollectiveConfig, Precompiles, WASM_BINARY,
+	ParachainStakingConfig, Precompiles, Range, SchedulerConfig, SudoConfig, SystemConfig,
+	TechComitteeCollectiveConfig, WASM_BINARY,
 };
 use nimbus_primitives::NimbusId;
 use sc_service::ChainType;

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -29,13 +29,12 @@ use moonriver_runtime::{
 	CouncilCollectiveConfig, CrowdloanRewardsConfig, DemocracyConfig, EVMConfig,
 	EthereumChainIdConfig, EthereumConfig, GenesisConfig, InflationInfo, ParachainInfoConfig,
 	ParachainStakingConfig, Range, SchedulerConfig, SudoConfig, SystemConfig,
-	TechComitteeCollectiveConfig, WASM_BINARY,
+	TechComitteeCollectiveConfig, Precompiles, WASM_BINARY,
 };
 use nimbus_primitives::NimbusId;
 use sc_service::ChainType;
 #[cfg(test)]
 use sp_core::ecdsa;
-use sp_core::H160;
 use sp_runtime::Perbill;
 use std::str::FromStr;
 
@@ -154,10 +153,7 @@ pub fn testnet_genesis(
 	// within contracts. TODO We should have a test to ensure this is the right bytecode.
 	// (PUSH1 0x00 PUSH1 0x00 REVERT)
 	let revert_bytecode = vec![0x60, 0x00, 0x60, 0x00, 0xFD];
-	// TODO consider whether this should be imported from moonbeam precompiles
-	let precompile_addresses = vec![1, 2, 3, 4, 5, 6, 7, 8, 1024, 1025, 2048]
-		.into_iter()
-		.map(H160::from_low_u64_be);
+
 	GenesisConfig {
 		frame_system: SystemConfig {
 			code: WASM_BINARY
@@ -183,15 +179,10 @@ pub fn testnet_genesis(
 		pallet_evm: EVMConfig {
 			// We need _some_ code inserted at the precompile address so that
 			// the evm will actually call the address.
-			// TODO Cleanly fetch the addresses from
-			// the runtime/moonbeam precompiles and systematically fill them with code
-			// that will revert if it is called by accident (it shouldn't be because
-			// it is shadowed by the precompile).
-			// This one is for the parachain staking precompile wrappers
-			accounts: precompile_addresses
-				.map(|a| {
+			accounts: Precompiles::used_addresses()
+				.map(|addr| {
 					(
-						a,
+						addr,
 						GenesisAccount {
 							nonce: Default::default(),
 							balance: Default::default(),

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -28,8 +28,8 @@ use moonriver_runtime::{
 	currency::MOVR, AccountId, AuthorFilterConfig, AuthorMappingConfig, Balance, BalancesConfig,
 	CouncilCollectiveConfig, CrowdloanRewardsConfig, DemocracyConfig, EVMConfig,
 	EthereumChainIdConfig, EthereumConfig, GenesisConfig, InflationInfo, ParachainInfoConfig,
-	ParachainStakingConfig, Range, SchedulerConfig, SudoConfig, SystemConfig,
-	TechComitteeCollectiveConfig, Precompiles, WASM_BINARY,
+	ParachainStakingConfig, Precompiles, Range, SchedulerConfig, SudoConfig, SystemConfig,
+	TechComitteeCollectiveConfig, WASM_BINARY,
 };
 use nimbus_primitives::NimbusId;
 use sc_service::ChainType;

--- a/node/service/src/chain_spec/moonshadow.rs
+++ b/node/service/src/chain_spec/moonshadow.rs
@@ -29,13 +29,12 @@ use moonshadow_runtime::{
 	CouncilCollectiveConfig, CrowdloanRewardsConfig, DemocracyConfig, EVMConfig,
 	EthereumChainIdConfig, EthereumConfig, GenesisConfig, InflationInfo, ParachainInfoConfig,
 	ParachainStakingConfig, Range, SchedulerConfig, SudoConfig, SystemConfig,
-	TechComitteeCollectiveConfig, WASM_BINARY,
+	TechComitteeCollectiveConfig, Precompiles, WASM_BINARY,
 };
 use nimbus_primitives::NimbusId;
 use sc_service::ChainType;
 #[cfg(test)]
 use sp_core::ecdsa;
-use sp_core::H160;
 use sp_runtime::Perbill;
 use std::str::FromStr;
 
@@ -154,10 +153,7 @@ pub fn testnet_genesis(
 	// within contracts. TODO We should have a test to ensure this is the right bytecode.
 	// (PUSH1 0x00 PUSH1 0x00 REVERT)
 	let revert_bytecode = vec![0x60, 0x00, 0x60, 0x00, 0xFD];
-	// TODO consider whether this should be imported from moonbeam precompiles
-	let precompile_addresses = vec![1, 2, 3, 4, 5, 6, 7, 8, 1024, 1025, 2048]
-		.into_iter()
-		.map(H160::from_low_u64_be);
+
 	GenesisConfig {
 		frame_system: SystemConfig {
 			code: WASM_BINARY
@@ -183,15 +179,10 @@ pub fn testnet_genesis(
 		pallet_evm: EVMConfig {
 			// We need _some_ code inserted at the precompile address so that
 			// the evm will actually call the address.
-			// TODO Cleanly fetch the addresses from
-			// the runtime/moonbeam precompiles and systematically fill them with code
-			// that will revert if it is called by accident (it shouldn't be because
-			// it is shadowed by the precompile).
-			// This one is for the parachain staking precompile wrappers
-			accounts: precompile_addresses
-				.map(|a| {
+			accounts: Precompiles::used_addresses()
+				.map(|addr| {
 					(
-						a,
+						addr,
 						GenesisAccount {
 							nonce: Default::default(),
 							balance: Default::default(),

--- a/node/service/src/chain_spec/moonshadow.rs
+++ b/node/service/src/chain_spec/moonshadow.rs
@@ -28,8 +28,8 @@ use moonshadow_runtime::{
 	currency::MSHD, AccountId, AuthorFilterConfig, AuthorMappingConfig, Balance, BalancesConfig,
 	CouncilCollectiveConfig, CrowdloanRewardsConfig, DemocracyConfig, EVMConfig,
 	EthereumChainIdConfig, EthereumConfig, GenesisConfig, InflationInfo, ParachainInfoConfig,
-	ParachainStakingConfig, Range, SchedulerConfig, SudoConfig, SystemConfig,
-	TechComitteeCollectiveConfig, Precompiles, WASM_BINARY,
+	ParachainStakingConfig, Precompiles, Range, SchedulerConfig, SudoConfig, SystemConfig,
+	TechComitteeCollectiveConfig, WASM_BINARY,
 };
 use nimbus_primitives::NimbusId;
 use sc_service::ChainType;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -40,6 +40,7 @@ pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, Balance, BlockNumber, DigestItem, Hash, Header, Index,
 	Signature,
 };
+use precompiles::MoonbeamPrecompiles;
 use moonbeam_rpc_primitives_txpool::TxPoolResponse;
 use pallet_balances::NegativeImbalance;
 use pallet_ethereum::Call::transact;
@@ -68,6 +69,8 @@ use nimbus_primitives::{CanAuthor, NimbusId};
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
+
+pub type Precompiles = MoonbeamPrecompiles<Runtime>;
 
 /// UNITS, the native token, uses 18 decimals of precision.
 pub mod currency {
@@ -297,7 +300,7 @@ impl pallet_evm::Config for Runtime {
 	type Currency = Balances;
 	type Event = Event;
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
-	type Precompiles = precompiles::MoonbeamPrecompiles<Self>;
+	type Precompiles = MoonbeamPrecompiles<Self>;
 	type ChainId = EthereumChainId;
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -40,7 +40,6 @@ pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, Balance, BlockNumber, DigestItem, Hash, Header, Index,
 	Signature,
 };
-use precompiles::MoonbeamPrecompiles;
 use moonbeam_rpc_primitives_txpool::TxPoolResponse;
 use pallet_balances::NegativeImbalance;
 use pallet_ethereum::Call::transact;
@@ -52,6 +51,7 @@ use pallet_evm::{
 use pallet_transaction_payment::CurrencyAdapter;
 pub use parachain_staking::{InflationInfo, Range};
 use parity_scale_codec::{Decode, Encode};
+use precompiles::MoonbeamPrecompiles;
 use sp_api::impl_runtime_apis;
 use sp_core::{u32_trait::*, OpaqueMetadata, H160, H256, U256};
 use sp_runtime::{

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -36,7 +36,6 @@ use frame_support::{
 	PalletId,
 };
 use frame_system::{EnsureOneOf, EnsureRoot};
-use precompiles::MoonbeamPrecompiles;
 pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, Balance, BlockNumber, DigestItem, Hash, Header, Index,
 	Signature,
@@ -52,6 +51,7 @@ use pallet_evm::{
 use pallet_transaction_payment::CurrencyAdapter;
 pub use parachain_staking::{InflationInfo, Range};
 use parity_scale_codec::{Decode, Encode};
+use precompiles::MoonbeamPrecompiles;
 use sp_api::impl_runtime_apis;
 use sp_core::{u32_trait::*, OpaqueMetadata, H160, H256, U256};
 use sp_runtime::{

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -36,6 +36,7 @@ use frame_support::{
 	PalletId,
 };
 use frame_system::{EnsureOneOf, EnsureRoot};
+use precompiles::MoonbeamPrecompiles;
 pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, Balance, BlockNumber, DigestItem, Hash, Header, Index,
 	Signature,
@@ -68,6 +69,8 @@ use nimbus_primitives::{CanAuthor, NimbusId};
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
+
+pub type Precompiles = MoonbeamPrecompiles<Runtime>;
 
 /// MOVR, the native token, uses 18 decimals of precision.
 pub mod currency {
@@ -313,7 +316,7 @@ impl pallet_evm::Config for Runtime {
 	type Currency = Balances;
 	type Event = Event;
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
-	type Precompiles = precompiles::MoonbeamPrecompiles<Self>;
+	type Precompiles = MoonbeamPrecompiles<Self>;
 	type ChainId = EthereumChainId;
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -36,6 +36,7 @@ use frame_support::{
 	PalletId,
 };
 use frame_system::{EnsureOneOf, EnsureRoot};
+use precompiles::MoonbeamPrecompiles;
 pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, Balance, BlockNumber, DigestItem, Hash, Header, Index,
 	Signature,
@@ -68,6 +69,8 @@ use nimbus_primitives::{CanAuthor, NimbusId};
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
+
+pub type Precompiles = MoonbeamPrecompiles<Runtime>;
 
 /// MOVR, the native token, uses 18 decimals of precision.
 pub mod currency {
@@ -312,7 +315,7 @@ impl pallet_evm::Config for Runtime {
 	type Currency = Balances;
 	type Event = Event;
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
-	type Precompiles = precompiles::MoonbeamPrecompiles<Self>;
+	type Precompiles = MoonbeamPrecompiles<Self>;
 	type ChainId = EthereumChainId;
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -36,7 +36,6 @@ use frame_support::{
 	PalletId,
 };
 use frame_system::{EnsureOneOf, EnsureRoot};
-use precompiles::MoonbeamPrecompiles;
 pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, Balance, BlockNumber, DigestItem, Hash, Header, Index,
 	Signature,
@@ -52,6 +51,7 @@ use pallet_evm::{
 use pallet_transaction_payment::CurrencyAdapter;
 pub use parachain_staking::{InflationInfo, Range};
 use parity_scale_codec::{Decode, Encode};
+use precompiles::MoonbeamPrecompiles;
 use sp_api::impl_runtime_apis;
 use sp_core::{u32_trait::*, OpaqueMetadata, H160, H256, U256};
 use sp_runtime::{

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -36,6 +36,7 @@ use frame_support::{
 	PalletId,
 };
 use frame_system::{EnsureOneOf, EnsureRoot};
+use precompiles::MoonbeamPrecompiles;
 pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, Balance, BlockNumber, DigestItem, Hash, Header, Index,
 	Signature,
@@ -68,6 +69,8 @@ use nimbus_primitives::{CanAuthor, NimbusId};
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
+
+pub type Precompiles = MoonbeamPrecompiles<Runtime>;
 
 /// MSHD, the native token, uses 18 decimals of precision.
 pub mod currency {
@@ -312,7 +315,7 @@ impl pallet_evm::Config for Runtime {
 	type Currency = Balances;
 	type Event = Event;
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
-	type Precompiles = precompiles::MoonbeamPrecompiles<Self>;
+	type Precompiles = MoonbeamPrecompiles<Self>;
 	type ChainId = EthereumChainId;
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -36,7 +36,6 @@ use frame_support::{
 	PalletId,
 };
 use frame_system::{EnsureOneOf, EnsureRoot};
-use precompiles::MoonbeamPrecompiles;
 pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, Balance, BlockNumber, DigestItem, Hash, Header, Index,
 	Signature,
@@ -52,6 +51,7 @@ use pallet_evm::{
 use pallet_transaction_payment::CurrencyAdapter;
 pub use parachain_staking::{InflationInfo, Range};
 use parity_scale_codec::{Decode, Encode};
+use precompiles::MoonbeamPrecompiles;
 use sp_api::impl_runtime_apis;
 use sp_core::{u32_trait::*, OpaqueMetadata, H160, H256, U256};
 use sp_runtime::{

--- a/runtime/precompiles/src/lib.rs
+++ b/runtime/precompiles/src/lib.rs
@@ -37,9 +37,6 @@ type BalanceOf<Runtime> = <<Runtime as parachain_staking::Config>::Currency as C
 	<Runtime as frame_system::Config>::AccountId,
 >>::Balance;
 
-//TODO Maybe we don't need to / shouldn't be generic over the runtime.
-// Pros: Would simplify trait bounds and speed up compile time (maybe not noticeably).
-// Cons: Would proclude using this precompile set in mocked Runtimes.
 /// The PrecompileSet installed in the Moonbeam runtime.
 /// We include the nine Istanbul precompiles
 /// (https://github.com/ethereum/go-ethereum/blob/3c46f557/core/vm/contracts.go#L69)
@@ -47,17 +44,13 @@ type BalanceOf<Runtime> = <<Runtime as parachain_staking::Config>::Currency as C
 #[derive(Debug, Clone, Copy)]
 pub struct MoonbeamPrecompiles<R>(PhantomData<R>);
 
-// The idea here is that we won't have to list the addresses in this file and the chain spec.
-// Unfortunately we still have to type it twice in this file.
 impl<R: frame_system::Config> MoonbeamPrecompiles<R>
 where
 	R::AccountId: From<H160>,
 {
 	/// Return all addresses that contain precompiles. This can be used to populate dummy code
-	/// under the precompile, and potentially in the future to prevent using accounts that have
-	/// precompiles at their addresses explicitly using something like SignedExtra.
-	#[allow(dead_code)]
-	fn used_addresses() -> impl Iterator<Item = R::AccountId> {
+	/// under the precompile.
+	pub fn used_addresses() -> impl Iterator<Item = R::AccountId> {
 		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 1024, 1025, 2048]
 			.into_iter()
 			.map(|x| hash(x).into())


### PR DESCRIPTION
This PR cleans up some loose ends around how we deploy dummy bytecode underneath our precompiles.

Specifically it uses a method implemented on the `MoonbeamPrecompiles` struct to etch the precompile addresses.

This is still not perfect, but it is much cleaner than it was.
