### PR TITLE
Update `TransactionByteFee`

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -241,7 +241,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
+	pub const TransactionByteFee: Balance = currency::deposit(0, 1);
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -241,7 +241,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 1;
+	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -81,8 +81,10 @@ pub mod currency {
 	pub const GRAND: Balance = UNITS * 1_000;
 	pub const MILLICENTS: Balance = CENTS / 1_000;
 
+	pub const BYTE_FEE: Balance = 10 * MILLICENTS;
+
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 100 * CENTS + (bytes as Balance) * 10 * MILLICENTS
+		items as Balance * 100 * CENTS + (bytes as Balance) * BYTE_FEE
 	}
 }
 
@@ -241,7 +243,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = currency::deposit(0, 1);
+	pub const TransactionByteFee: Balance = currency::BYTE_FEE;
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -116,7 +116,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase"),
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 3,
-	spec_version: 43,
+	spec_version: 44,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 44,
+	spec_version: 45,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -257,7 +257,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 1;
+	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -257,7 +257,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
+	pub const TransactionByteFee: Balance = currency::deposit(0, 1);
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -81,8 +81,10 @@ pub mod currency {
 	pub const GRAND: Balance = GLMR * 1_000;
 	pub const MILLICENTS: Balance = CENTS / 1_000;
 
+	pub const BYTE_FEE: Balance = 10 * MILLICENTS;
+
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 100 * CENTS + (bytes as Balance) * 10 * MILLICENTS
+		items as Balance * 100 * CENTS + (bytes as Balance) * BYTE_FEE
 	}
 }
 
@@ -257,7 +259,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = currency::deposit(0, 1);
+	pub const TransactionByteFee: Balance = currency::BYTE_FEE;
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -116,7 +116,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 44,
+	spec_version: 45,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -81,8 +81,10 @@ pub mod currency {
 	pub const GRAND: Balance = MOVR * 1_000;
 	pub const MILLICENTS: Balance = CENTS / 1_000;
 
+	pub const BYTE_FEE: Balance = 10 * MILLICENTS;
+
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 100 * CENTS + (bytes as Balance) * 10 * MILLICENTS
+		items as Balance * 100 * CENTS + (bytes as Balance) * BYTE_FEE
 	}
 }
 
@@ -256,7 +258,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = currency::deposit(0, 1);
+	pub const TransactionByteFee: Balance = currency::BYTE_FEE;
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -256,7 +256,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
+	pub const TransactionByteFee: Balance = currency::deposit(0, 1);
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -256,7 +256,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 1;
+	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -116,7 +116,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonshadow"),
 	impl_name: create_runtime_str!("moonshadow"),
 	authoring_version: 3,
-	spec_version: 44,
+	spec_version: 45,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -81,8 +81,10 @@ pub mod currency {
 	pub const GRAND: Balance = MSHD * 1_000;
 	pub const MILLICENTS: Balance = CENTS / 1_000;
 
+	pub const BYTE_FEE: Balance = 10 * MILLICENTS;
+
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 100 * CENTS + (bytes as Balance) * 10 * MILLICENTS
+		items as Balance * 100 * CENTS + (bytes as Balance) * BYTE_FEE
 	}
 }
 
@@ -256,7 +258,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = currency::deposit(0, 1);
+	pub const TransactionByteFee: Balance = currency::BYTE_FEE;
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -256,7 +256,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
+	pub const TransactionByteFee: Balance = currency::deposit(0, 1);
 }
 
 impl pallet_transaction_payment::Config for Runtime {

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -256,7 +256,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = 1;
+	pub const TransactionByteFee: Balance = 10 * MILLICENTS;
 }
 
 impl pallet_transaction_payment::Config for Runtime {


### PR DESCRIPTION
### What does it do?

Sets the transaction byte fee for `pallet_transaction_payment` to 10 millicents.

## Checklist

- [ ] Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
