### PR TITLE
Kill old author mapping storage and upgrade

### DIFF
--- a/pallets/author-mapping/Cargo.toml
+++ b/pallets/author-mapping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-author-mapping"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["PureStake"]
 edition = "2018"
 description = "Maps AuthorIds to AccountIds Useful for associating consensus authors with in-runtime accounts"

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -73,30 +73,6 @@ pub mod pallet {
 		fn can_register(account: &Self::AccountId) -> bool;
 	}
 
-	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> Weight {
-			// This upgrade needs a value to use as the deposit for any registrations that were made
-			// before deposit amounts were tracked. The most 100% correct thing would be to add an
-			// associated type. But since we know this pallet on only used by moonbeam and we know
-			// the old deposit is the same for all accounts, I'll save us some headache by just
-			// defining it here.
-			let old_deposit_amount = 100u32;
-
-			for (author_id, account_id) in Mapping::<T>::drain() {
-				let info = RegistrationInfo {
-					account: account_id,
-					deposit: old_deposit_amount.into(),
-				};
-				MappingWithDeposit::<T>::insert(author_id, info);
-			}
-
-			// No idea about the real weight. Probably not worrying about because this will
-			// definitely fit in one of Moonbeam's almost-empty blocks.
-			10_000
-		}
-	}
-
 	/// An error that can occur while executing the mapping pallet's logic.
 	#[pallet::error]
 	pub enum Error<T> {
@@ -258,13 +234,6 @@ pub mod pallet {
 			Ok(())
 		}
 	}
-
-	#[pallet::storage]
-	#[pallet::getter(fn old_account_id_of)]
-	// This is the old storage item used in the old version of the pallet. The type is being kept
-	// for now to enable easier migration of the data. This storage item should be removed from the
-	// code after on-chain data has been migrated.
-	type Mapping<T: Config> = StorageMap<_, Twox64Concat, T::AuthorId, T::AccountId, OptionQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn account_and_deposit_of)]

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase"),
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 3,
-	spec_version: 44,
+	spec_version: 45,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 45,
+	spec_version: 46,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 45,
+	spec_version: 46,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonshadow"),
 	impl_name: create_runtime_str!("moonshadow"),
 	authoring_version: 3,
-	spec_version: 45,
+	spec_version: 46,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
This PR is a followup to #461 puts the final touches on our author mapping migration. It removes the old storage item and the migration path introduced in #461

## Checklist

- [ ] Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
