### PR TITLE
Remove useless exception in transaction pool filter

### DIFF
--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 45,
+	spec_version: 46,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -839,18 +839,10 @@ impl_runtime_apis! {
 			source: TransactionSource,
 			tx: <Block as BlockT>::Extrinsic,
 		) -> TransactionValidity {
-			// filtered calls should never enter the tx pool so they never enter a block
-			let mut allowed = <Runtime as frame_system::Config>
+			// Filtered calls should not enter the tx pool as they'll fail if inserted.
+			let allowed = <Runtime as frame_system::Config>
 				::BaseCallFilter::filter(&tx.function);
-			// filtered calls are still allowed if source is sudo
-			if !allowed {
-				match &tx.signature {
-					Some((account, ..)) => if &Sudo::key() == account {
-						allowed = true;
-					},
-					_ => (),
-				}
-			}
+
 			if allowed {
 				Executive::validate_transaction(source, tx)
 			} else {

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 45,
+	spec_version: 46,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -838,18 +838,10 @@ impl_runtime_apis! {
 			source: TransactionSource,
 			tx: <Block as BlockT>::Extrinsic,
 		) -> TransactionValidity {
-			// filtered calls should never enter the tx pool so they never enter a block
-			let mut allowed = <Runtime as frame_system::Config>
+			// Filtered calls should not enter the tx pool as they'll fail if inserted.
+			let allowed = <Runtime as frame_system::Config>
 				::BaseCallFilter::filter(&tx.function);
-			// filtered calls are still allowed if source is sudo
-			if !allowed {
-				match &tx.signature {
-					Some((account, ..)) => if &Sudo::key() == account {
-						allowed = true;
-					},
-					_ => (),
-				}
-			}
+
 			if allowed {
 				Executive::validate_transaction(source, tx)
 			} else {

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -118,7 +118,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonshadow"),
 	impl_name: create_runtime_str!("moonshadow"),
 	authoring_version: 3,
-	spec_version: 45,
+	spec_version: 46,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -838,18 +838,10 @@ impl_runtime_apis! {
 			source: TransactionSource,
 			tx: <Block as BlockT>::Extrinsic,
 		) -> TransactionValidity {
-			// filtered calls should never enter the tx pool so they never enter a block
-			let mut allowed = <Runtime as frame_system::Config>
+			// Filtered calls should not enter the tx pool as they'll fail if inserted.
+			let allowed = <Runtime as frame_system::Config>
 				::BaseCallFilter::filter(&tx.function);
-			// filtered calls are still allowed if source is sudo
-			if !allowed {
-				match &tx.signature {
-					Some((account, ..)) => if &Sudo::key() == account {
-						allowed = true;
-					},
-					_ => (),
-				}
-			}
+
 			if allowed {
 				Executive::validate_transaction(source, tx)
 			} else {


### PR DESCRIPTION
### What does it do?

Pool  `validate_transaction` (filtering what is inserted in the transactions pool) had a special case to not refuse calls with origin `Sudo::key()` even if it would be refused when inserted in the block. Leaving this case only allows this key owner to burn fees if he wants to.

As long as Sudo pallet calls are not filtered out (it's not) this case is useless.

> Suggestion : In `BaseFilter` the Sudo variant could explicitly be listed as `true` in case we set the `_` pattern return `true` and forget it contains Sudo.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- ❌ Does it require a purge of the network?
- ✅ You bumped the runtime version if there are breaking changes in the **runtime** ?
- ❌ Does it require changes in documentation/tutorials ?
