### PR TITLE
Remove democracy filter

### DIFF
--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -143,7 +143,6 @@ impl Filter<Call> for BaseFilter {
 		match c {
 			Call::Balances(_) => false,
 			Call::CrowdloanRewards(_) => false,
-			Call::Democracy(_) => false,
 			Call::Ethereum(_) => false,
 			Call::EVM(_) => false,
 			_ => true,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -142,7 +142,6 @@ impl Filter<Call> for BaseFilter {
 		match c {
 			Call::Balances(_) => false,
 			Call::CrowdloanRewards(_) => false,
-			Call::Democracy(_) => false,
 			Call::Ethereum(_) => false,
 			Call::EVM(_) => false,
 			_ => true,

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -142,7 +142,6 @@ impl Filter<Call> for BaseFilter {
 		match c {
 			Call::Balances(_) => false,
 			Call::CrowdloanRewards(_) => false,
-			Call::Democracy(_) => false,
 			Call::Ethereum(_) => false,
 			Call::EVM(_) => false,
 			_ => true,


### PR DESCRIPTION
The `validate_transaction` filter uses `BaseCallFilter` so removing it from this place removes it from there as well.