### PR TITLE
Make ParachainBondTreasury an Account Set in Staking Storage Instead of a Treasury

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-author-mapping"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5732,7 +5732,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-author-mapping"
-version = "2.0.1"
+version = "2.0.0"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -243,8 +243,7 @@ pub fn testnet_genesis(
 				.map(|(account_id, author_id, _)| (author_id, account_id))
 				.collect(),
 		},
-		pallet_treasury_Instance1: Default::default(),
-		pallet_treasury_Instance2: Default::default(),
+		pallet_treasury: Default::default(),
 	}
 }
 

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -242,8 +242,7 @@ pub fn testnet_genesis(
 				.map(|(account_id, author_id, _)| (author_id, account_id))
 				.collect(),
 		},
-		pallet_treasury_Instance1: Default::default(),
-		pallet_treasury_Instance2: Default::default(),
+		pallet_treasury: Default::default(),
 	}
 }
 

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -242,8 +242,7 @@ pub fn testnet_genesis(
 				.map(|(account_id, author_id, _)| (author_id, account_id))
 				.collect(),
 		},
-		pallet_treasury_Instance1: Default::default(),
-		pallet_treasury_Instance2: Default::default(),
+		pallet_treasury: Default::default(),
 	}
 }
 

--- a/node/service/src/chain_spec/moonshadow.rs
+++ b/node/service/src/chain_spec/moonshadow.rs
@@ -242,8 +242,7 @@ pub fn testnet_genesis(
 				.map(|(account_id, author_id, _)| (author_id, account_id))
 				.collect(),
 		},
-		pallet_treasury_Instance1: Default::default(),
-		pallet_treasury_Instance2: Default::default(),
+		pallet_treasury: Default::default(),
 	}
 }
 

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -394,6 +394,7 @@ pub mod pallet {
 		/// Commission due to collators, set at genesis
 		type DefaultCollatorCommission: Get<Perbill>;
 		/// Percent of inflation set aside for parachain bond account
+		// TODO: change to default
 		type ParachainBondReserveRatio: Get<Percent>;
 		/// Minimum stake required for any account to be in `SelectedCandidates` for the round
 		type MinCollatorStk: Get<BalanceOf<Self>>;

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -684,7 +684,7 @@ pub mod pallet {
 			<CollatorCommission<T>>::put(T::DefaultCollatorCommission::get());
 			// Set parachain bond config to default config
 			<ParachainBondInfo<T>>::put(ParachainBondConfig {
-				// must be set immediately or the due inflation will not be sent anywhere
+				// must be set soon; if not => due inflation will be sent to collators/nominators
 				account: T::AccountId::default(),
 				percent: T::DefaultParachainBondReservePercent::get(),
 			});

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -478,6 +478,8 @@ pub mod pallet {
 		NominatorLeftCollator(T::AccountId, T::AccountId, BalanceOf<T>, BalanceOf<T>),
 		/// Paid the account (nominator or collator) the balance as liquid rewards
 		Rewarded(T::AccountId, BalanceOf<T>),
+		/// Transferred to account which holds funds reserved for parachain bond
+		ReservedForParachainBond(T::AccountId, BalanceOf<T>),
 		/// Account (re)set for parachain bond treasury [old, new]
 		ParachainBondAccountSet(T::AccountId, T::AccountId),
 		/// Percent of inflation reserved for parachain bond (re)set [old, new]
@@ -1285,6 +1287,10 @@ pub mod pallet {
 				{
 					// update round issuance iff transfer succeeds
 					issuance -= imb.peek();
+					Self::deposit_event(Event::ReservedForParachainBond(
+						bond_config.account,
+						imb.peek(),
+					));
 				}
 				for (val, pts) in <AwardedPts<T>>::drain_prefix(round_to_payout) {
 					let pct_due = Perbill::from_rational(pts, total);

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1277,6 +1277,10 @@ pub mod pallet {
 			if next > duration {
 				let round_to_payout = next - duration;
 				let total = <Points<T>>::get(round_to_payout);
+				if total.is_zero() {
+					// return early, no issuance
+					return;
+				}
 				let total_staked = <Staked<T>>::get(round_to_payout);
 				let mut issuance = Self::compute_issuance(total_staked);
 				// reserve portion of issuance for parachain bond account

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -102,7 +102,7 @@ parameter_types! {
 	pub const MaxNominatorsPerCollator: u32 = 4;
 	pub const MaxCollatorsPerNominator: u32 = 4;
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
-	pub const ParachainBondReserveRatio: Percent = Percent::from_percent(30);
+	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
 	pub const MinCollatorStk: u128 = 10;
 	pub const MinNominatorStk: u128 = 5;
 	pub const MinNomination: u128 = 3;
@@ -117,7 +117,7 @@ impl Config for Test {
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;
 	type MaxCollatorsPerNominator = MaxCollatorsPerNominator;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
-	type ParachainBondReserveRatio = ParachainBondReserveRatio;
+	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
 	type MinCollatorStk = MinCollatorStk;
 	type MinCollatorCandidateStk = MinCollatorStk;
 	type MinNominatorStk = MinNominatorStk;

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -27,7 +27,7 @@ use sp_io;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
-	Perbill,
+	Perbill, Percent,
 };
 
 pub type AccountId = u64;
@@ -102,6 +102,7 @@ parameter_types! {
 	pub const MaxNominatorsPerCollator: u32 = 4;
 	pub const MaxCollatorsPerNominator: u32 = 4;
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
+	pub const ParachainBondReserveRatio: Percent = Percent::from_percent(30);
 	pub const MinCollatorStk: u128 = 10;
 	pub const MinNominatorStk: u128 = 5;
 	pub const MinNomination: u128 = 3;
@@ -116,6 +117,7 @@ impl Config for Test {
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;
 	type MaxCollatorsPerNominator = MaxCollatorsPerNominator;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
+	type ParachainBondReserveRatio = ParachainBondReserveRatio;
 	type MinCollatorStk = MinCollatorStk;
 	type MinCollatorCandidateStk = MinCollatorStk;
 	type MinNominatorStk = MinNominatorStk;

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -1320,12 +1320,14 @@ fn parachain_bond_reserve_works() {
 			roll_to(16);
 			// distribute total issuance to collator 1 and its nominators 6, 7, 19
 			let mut new = vec![
+				Event::ReservedForParachainBond(11, 15),
 				Event::CollatorChosen(3, 1, 50),
 				Event::CollatorChosen(3, 2, 40),
 				Event::CollatorChosen(3, 4, 20),
 				Event::CollatorChosen(3, 3, 20),
 				Event::CollatorChosen(3, 5, 10),
 				Event::NewRound(10, 3, 5, 140),
+				Event::ReservedForParachainBond(11, 15),
 				Event::Rewarded(1, 19),
 				Event::Rewarded(6, 6),
 				Event::Rewarded(7, 6),
@@ -1354,6 +1356,7 @@ fn parachain_bond_reserve_works() {
 			let mut new2 = vec![
 				Event::NominatorLeftCollator(6, 1, 10, 40),
 				Event::NominatorLeft(6, 10),
+				Event::ReservedForParachainBond(11, 16),
 				Event::Rewarded(1, 19),
 				Event::Rewarded(6, 6),
 				Event::Rewarded(7, 6),
@@ -1381,6 +1384,7 @@ fn parachain_bond_reserve_works() {
 					Percent::from_percent(30),
 					Percent::from_percent(50),
 				),
+				Event::ReservedForParachainBond(11, 28),
 				Event::Rewarded(1, 15),
 				Event::Rewarded(6, 4),
 				Event::Rewarded(7, 4),
@@ -1399,6 +1403,7 @@ fn parachain_bond_reserve_works() {
 			roll_to(31);
 			// no more paying 6
 			let mut new4 = vec![
+				Event::ReservedForParachainBond(11, 29),
 				Event::Rewarded(1, 18),
 				Event::Rewarded(7, 6),
 				Event::Rewarded(10, 6),
@@ -1418,6 +1423,7 @@ fn parachain_bond_reserve_works() {
 			// new nomination is not rewarded yet
 			let mut new5 = vec![
 				Event::Nomination(8, 10, 1, 50),
+				Event::ReservedForParachainBond(11, 31),
 				Event::Rewarded(1, 18),
 				Event::Rewarded(7, 6),
 				Event::Rewarded(10, 6),
@@ -1435,6 +1441,7 @@ fn parachain_bond_reserve_works() {
 			roll_to(41);
 			// new nomination is still not rewarded yet
 			let mut new6 = vec![
+				Event::ReservedForParachainBond(11, 32),
 				Event::Rewarded(1, 20),
 				Event::Rewarded(7, 6),
 				Event::Rewarded(10, 6),
@@ -1451,6 +1458,7 @@ fn parachain_bond_reserve_works() {
 			roll_to(46);
 			// new nomination is rewarded for first time, 2 rounds after joining (`BondDuration` = 2)
 			let mut new7 = vec![
+				Event::ReservedForParachainBond(11, 34),
 				Event::Rewarded(1, 18),
 				Event::Rewarded(7, 5),
 				Event::Rewarded(8, 5),

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -1320,7 +1320,6 @@ fn parachain_bond_reserve_works() {
 			roll_to(16);
 			// distribute total issuance to collator 1 and its nominators 6, 7, 19
 			let mut new = vec![
-				Event::ReservedForParachainBond(11, 15),
 				Event::CollatorChosen(3, 1, 50),
 				Event::CollatorChosen(3, 2, 40),
 				Event::CollatorChosen(3, 4, 20),
@@ -1328,7 +1327,7 @@ fn parachain_bond_reserve_works() {
 				Event::CollatorChosen(3, 5, 10),
 				Event::NewRound(10, 3, 5, 140),
 				Event::ReservedForParachainBond(11, 15),
-				Event::Rewarded(1, 19),
+				Event::Rewarded(1, 18),
 				Event::Rewarded(6, 6),
 				Event::Rewarded(7, 6),
 				Event::Rewarded(10, 6),
@@ -1341,7 +1340,7 @@ fn parachain_bond_reserve_works() {
 			];
 			expected.append(&mut new);
 			assert_eq!(events(), expected);
-			assert_eq!(Balances::free_balance(&11), 31);
+			assert_eq!(Balances::free_balance(&11), 16);
 			// ~ set block author as 1 for all blocks this round
 			set_author(3, 1, 100);
 			set_author(4, 1, 100);
@@ -1370,7 +1369,7 @@ fn parachain_bond_reserve_works() {
 			];
 			expected.append(&mut new2);
 			assert_eq!(events(), expected);
-			assert_eq!(Balances::free_balance(&11), 47);
+			assert_eq!(Balances::free_balance(&11), 32);
 			assert_ok!(Stake::set_parachain_bond_reserve_percent(
 				Origin::root(),
 				Percent::from_percent(50)
@@ -1384,7 +1383,7 @@ fn parachain_bond_reserve_works() {
 					Percent::from_percent(30),
 					Percent::from_percent(50),
 				),
-				Event::ReservedForParachainBond(11, 28),
+				Event::ReservedForParachainBond(11, 27),
 				Event::Rewarded(1, 15),
 				Event::Rewarded(6, 4),
 				Event::Rewarded(7, 4),
@@ -1398,13 +1397,13 @@ fn parachain_bond_reserve_works() {
 			];
 			expected.append(&mut new3);
 			assert_eq!(events(), expected);
-			assert_eq!(Balances::free_balance(&11), 75);
+			assert_eq!(Balances::free_balance(&11), 59);
 			set_author(6, 1, 100);
 			roll_to(31);
 			// no more paying 6
 			let mut new4 = vec![
 				Event::ReservedForParachainBond(11, 29),
-				Event::Rewarded(1, 18),
+				Event::Rewarded(1, 17),
 				Event::Rewarded(7, 6),
 				Event::Rewarded(10, 6),
 				Event::CollatorChosen(7, 2, 40),
@@ -1416,14 +1415,14 @@ fn parachain_bond_reserve_works() {
 			];
 			expected.append(&mut new4);
 			assert_eq!(events(), expected);
-			assert_eq!(Balances::free_balance(&11), 104);
+			assert_eq!(Balances::free_balance(&11), 88);
 			set_author(7, 1, 100);
 			assert_ok!(Stake::nominate(Origin::signed(8), 1, 10));
 			roll_to(36);
 			// new nomination is not rewarded yet
 			let mut new5 = vec![
 				Event::Nomination(8, 10, 1, 50),
-				Event::ReservedForParachainBond(11, 31),
+				Event::ReservedForParachainBond(11, 30),
 				Event::Rewarded(1, 18),
 				Event::Rewarded(7, 6),
 				Event::Rewarded(10, 6),
@@ -1436,13 +1435,13 @@ fn parachain_bond_reserve_works() {
 			];
 			expected.append(&mut new5);
 			assert_eq!(events(), expected);
-			assert_eq!(Balances::free_balance(&11), 135);
+			assert_eq!(Balances::free_balance(&11), 118);
 			set_author(8, 1, 100);
 			roll_to(41);
 			// new nomination is still not rewarded yet
 			let mut new6 = vec![
 				Event::ReservedForParachainBond(11, 32),
-				Event::Rewarded(1, 20),
+				Event::Rewarded(1, 19),
 				Event::Rewarded(7, 6),
 				Event::Rewarded(10, 6),
 				Event::CollatorChosen(9, 1, 50),
@@ -1454,11 +1453,11 @@ fn parachain_bond_reserve_works() {
 			];
 			expected.append(&mut new6);
 			assert_eq!(events(), expected);
-			assert_eq!(Balances::free_balance(&11), 167);
+			assert_eq!(Balances::free_balance(&11), 150);
 			roll_to(46);
 			// new nomination is rewarded for first time, 2 rounds after joining (`BondDuration` = 2)
 			let mut new7 = vec![
-				Event::ReservedForParachainBond(11, 34),
+				Event::ReservedForParachainBond(11, 33),
 				Event::Rewarded(1, 18),
 				Event::Rewarded(7, 5),
 				Event::Rewarded(8, 5),
@@ -1472,6 +1471,6 @@ fn parachain_bond_reserve_works() {
 			];
 			expected.append(&mut new7);
 			assert_eq!(events(), expected);
-			assert_eq!(Balances::free_balance(&11), 201);
+			assert_eq!(Balances::free_balance(&11), 183);
 		});
 }

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -58,7 +58,7 @@ use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{BlakeTwo256, Block as BlockT, IdentityLookup},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	AccountId32, ApplyExtrinsicResult, Perbill, Permill,
+	AccountId32, ApplyExtrinsicResult, Perbill, Percent, Permill,
 };
 use sp_std::{convert::TryFrom, prelude::*};
 #[cfg(feature = "std")]
@@ -228,8 +228,8 @@ impl pallet_balances::Config for Runtime {
 pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
 impl<R> OnUnbalanced<NegativeImbalance<R>> for DealWithFees<R>
 where
-	R: pallet_balances::Config + pallet_treasury::Config<pallet_treasury::Instance1>,
-	pallet_treasury::Module<R, pallet_treasury::Instance1>: OnUnbalanced<NegativeImbalance<R>>,
+	R: pallet_balances::Config + pallet_treasury::Config,
+	pallet_treasury::Module<R>: OnUnbalanced<NegativeImbalance<R>>,
 {
 	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance<R>>) {
 		if let Some(fees) = fees_then_tips.next() {
@@ -237,8 +237,7 @@ where
 			let (_, to_treasury) = fees.ration(80, 20);
 			// Balances module automatically burns dropped Negative Imbalances by decreasing
 			// total_supply accordingly
-			<pallet_treasury::Module<R, pallet_treasury::Instance1> as OnUnbalanced<_>>
-				::on_unbalanced(to_treasury);
+			<pallet_treasury::Module<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
 		}
 	}
 }
@@ -441,16 +440,12 @@ parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 1 * currency::UNITS;
 	pub const SpendPeriod: BlockNumber = 6 * DAYS;
-	pub const CommunityTreasuryId: PalletId = PalletId(*b"pc/trsry");
-	pub const ParachainBondPalletId: PalletId = PalletId(*b"pb/trsry");
+	pub const TreasuryId: PalletId = PalletId(*b"pc/trsry");
 	pub const MaxApprovals: u32 = 100;
 }
 
-type CommunityTreasuryInstance = pallet_treasury::Instance1;
-type ParachainBondTreasuryInstance = pallet_treasury::Instance2;
-
-impl pallet_treasury::Config<CommunityTreasuryInstance> for Runtime {
-	type PalletId = CommunityTreasuryId;
+impl pallet_treasury::Config for Runtime {
+	type PalletId = TreasuryId;
 	type Currency = Balances;
 	// Democracy dispatches Root
 	type ApproveOrigin = EnsureRoot<AccountId>;
@@ -458,25 +453,7 @@ impl pallet_treasury::Config<CommunityTreasuryInstance> for Runtime {
 	type RejectOrigin = EnsureRoot<AccountId>;
 	type Event = Event;
 	// If spending proposal rejected, transfer proposer bond to treasury
-	type OnSlash = CommunityTreasury;
-	type ProposalBond = ProposalBond;
-	type ProposalBondMinimum = ProposalBondMinimum;
-	type SpendPeriod = SpendPeriod;
-	type Burn = ();
-	type BurnDestination = ();
-	type MaxApprovals = MaxApprovals;
-	type WeightInfo = pallet_treasury::weights::SubstrateWeight<Runtime>;
-	type SpendFunds = ();
-}
-
-impl pallet_treasury::Config<ParachainBondTreasuryInstance> for Runtime {
-	type PalletId = ParachainBondPalletId;
-	type Currency = Balances;
-	type ApproveOrigin = EnsureRoot<AccountId>;
-	type RejectOrigin = EnsureRoot<AccountId>;
-	type Event = Event;
-	// If spending proposal rejected, transfer proposer bond to treasury
-	type OnSlash = ParachainBondTreasury;
+	type OnSlash = Treasury;
 	type ProposalBond = ProposalBond;
 	type ProposalBondMinimum = ProposalBondMinimum;
 	type SpendPeriod = SpendPeriod;
@@ -549,6 +526,8 @@ parameter_types! {
 	pub const MaxCollatorsPerNominator: u32 = 25;
 	/// The fixed percent a collator takes off the top of due rewards is 20%
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
+	/// The percent of inflation set aside for parachain bond every round
+	pub const ParachainBondReserveRatio: Percent = Percent::from_percent(30);
 	/// Minimum stake required to be reserved to be a collator is 1_000
 	pub const MinCollatorStk: u128 = 1_000 * currency::UNITS;
 	/// Minimum stake required to be reserved to be a nominator is 5
@@ -564,6 +543,7 @@ impl parachain_staking::Config for Runtime {
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;
 	type MaxCollatorsPerNominator = MaxCollatorsPerNominator;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
+	type ParachainBondReserveRatio = ParachainBondReserveRatio;
 	type MinCollatorStk = MinCollatorStk;
 	type MinCollatorCandidateStk = MinCollatorStk;
 	type MinNomination = MinNominatorStk;
@@ -737,9 +717,7 @@ construct_runtime! {
 			pallet_collective::<Instance1>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>},
 		TechComitteeCollective:
 			pallet_collective::<Instance2>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>},
-		CommunityTreasury: pallet_treasury::<Instance1>::{Pallet, Storage, Config, Event<T>, Call},
-		ParachainBondTreasury:
-			pallet_treasury::<Instance2>::{Pallet, Storage, Config, Event<T>, Call},
+		Treasury: pallet_treasury::{Pallet, Storage, Config, Event<T>, Call},
 		AuthorInherent: pallet_author_inherent::{Pallet, Call, Storage, Inherent},
 		AuthorFilter: pallet_author_slot_filter::{Pallet, Call, Storage, Event, Config},
 		CrowdloanRewards: pallet_crowdloan_rewards::{Pallet, Call, Config<T>, Storage, Event<T>},

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -524,10 +524,10 @@ parameter_types! {
 	pub const MaxNominatorsPerCollator: u32 = 10;
 	/// Maximum 25 collators per nominator
 	pub const MaxCollatorsPerNominator: u32 = 25;
-	/// The fixed percent a collator takes off the top of due rewards is 20%
+	/// Default fixed percent a collator takes off the top of due rewards is 20%
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
-	/// The percent of inflation set aside for parachain bond every round
-	pub const ParachainBondReserveRatio: Percent = Percent::from_percent(30);
+	/// Default percent of inflation set aside for parachain bond every round
+	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
 	/// Minimum stake required to be reserved to be a collator is 1_000
 	pub const MinCollatorStk: u128 = 1_000 * currency::UNITS;
 	/// Minimum stake required to be reserved to be a nominator is 5
@@ -543,7 +543,7 @@ impl parachain_staking::Config for Runtime {
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;
 	type MaxCollatorsPerNominator = MaxCollatorsPerNominator;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
-	type ParachainBondReserveRatio = ParachainBondReserveRatio;
+	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
 	type MinCollatorStk = MinCollatorStk;
 	type MinCollatorCandidateStk = MinCollatorStk;
 	type MinNomination = MinNominatorStk;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase"),
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 3,
-	spec_version: 46,
+	spec_version: 47,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -212,15 +212,15 @@ fn reward_block_authors_with_parachain_bond_reserved() {
 	ExtBuilder::default()
 		.with_balances(vec![
 			// Alice gets 100 extra tokens for her mapping deposit
-			(AccountId::from(ALICE), 2_100 * MSHD),
-			(AccountId::from(BOB), 1_000 * MSHD),
-			(AccountId::from(CHARLIE), MSHD),
+			(AccountId::from(ALICE), 2_100 * UNITS),
+			(AccountId::from(BOB), 1_000 * UNITS),
+			(AccountId::from(CHARLIE), UNITS),
 		])
-		.with_collators(vec![(AccountId::from(ALICE), 1_000 * MSHD)])
+		.with_collators(vec![(AccountId::from(ALICE), 1_000 * UNITS)])
 		.with_nominations(vec![(
 			AccountId::from(BOB),
 			AccountId::from(ALICE),
-			500 * MSHD,
+			500 * UNITS,
 		)])
 		.with_mappings(vec![(
 			NimbusId::from_slice(&ALICE_NIMBUS),
@@ -238,9 +238,9 @@ fn reward_block_authors_with_parachain_bond_reserved() {
 				run_to_block(x);
 			}
 			// no rewards doled out yet
-			assert_eq!(Balances::free_balance(AccountId::from(ALICE)), 1_000 * MSHD,);
-			assert_eq!(Balances::free_balance(AccountId::from(BOB)), 500 * MSHD,);
-			assert_eq!(Balances::free_balance(AccountId::from(CHARLIE)), MSHD,);
+			assert_eq!(Balances::free_balance(AccountId::from(ALICE)), 1_000 * UNITS,);
+			assert_eq!(Balances::free_balance(AccountId::from(BOB)), 500 * UNITS,);
+			assert_eq!(Balances::free_balance(AccountId::from(CHARLIE)), UNITS,);
 			set_author(NimbusId::from_slice(&ALICE_NIMBUS));
 			run_to_block(601);
 			// rewards minted and distributed

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -238,7 +238,10 @@ fn reward_block_authors_with_parachain_bond_reserved() {
 				run_to_block(x);
 			}
 			// no rewards doled out yet
-			assert_eq!(Balances::free_balance(AccountId::from(ALICE)), 1_000 * UNITS,);
+			assert_eq!(
+				Balances::free_balance(AccountId::from(ALICE)),
+				1_000 * UNITS,
+			);
 			assert_eq!(Balances::free_balance(AccountId::from(BOB)), 500 * UNITS,);
 			assert_eq!(Balances::free_balance(AccountId::from(CHARLIE)), UNITS,);
 			set_author(NimbusId::from_slice(&ALICE_NIMBUS));

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -208,6 +208,59 @@ fn reward_block_authors() {
 }
 
 #[test]
+fn reward_block_authors_with_parachain_bond_reserved() {
+	ExtBuilder::default()
+		.with_balances(vec![
+			// Alice gets 100 extra tokens for her mapping deposit
+			(AccountId::from(ALICE), 2_100 * MSHD),
+			(AccountId::from(BOB), 1_000 * MSHD),
+			(AccountId::from(CHARLIE), MSHD),
+		])
+		.with_collators(vec![(AccountId::from(ALICE), 1_000 * MSHD)])
+		.with_nominations(vec![(
+			AccountId::from(BOB),
+			AccountId::from(ALICE),
+			500 * MSHD,
+		)])
+		.with_mappings(vec![(
+			NimbusId::from_slice(&ALICE_NIMBUS),
+			AccountId::from(ALICE),
+		)])
+		.build()
+		.execute_with(|| {
+			set_parachain_inherent_data();
+			assert_ok!(ParachainStaking::set_parachain_bond_account(
+				root_origin(),
+				AccountId::from(CHARLIE),
+			),);
+			for x in 2..601 {
+				set_author(NimbusId::from_slice(&ALICE_NIMBUS));
+				run_to_block(x);
+			}
+			// no rewards doled out yet
+			assert_eq!(Balances::free_balance(AccountId::from(ALICE)), 1_000 * MSHD,);
+			assert_eq!(Balances::free_balance(AccountId::from(BOB)), 500 * MSHD,);
+			assert_eq!(Balances::free_balance(AccountId::from(CHARLIE)), MSHD,);
+			set_author(NimbusId::from_slice(&ALICE_NIMBUS));
+			run_to_block(601);
+			// rewards minted and distributed
+			assert_eq!(
+				Balances::free_balance(AccountId::from(ALICE)),
+				1079592333275448000000,
+			);
+			assert_eq!(
+				Balances::free_balance(AccountId::from(BOB)),
+				528942666637724000000,
+			);
+			// 30% reserved for parachain bond
+			assert_eq!(
+				Balances::free_balance(AccountId::from(CHARLIE)),
+				47515000000000000000,
+			);
+		});
+}
+
+#[test]
 fn initialize_crowdloan_addresses_with_batch_and_pay() {
 	ExtBuilder::default()
 		.with_balances(vec![
@@ -279,7 +332,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 			let expected_fail = Event::pallet_utility(pallet_utility::Event::BatchInterrupted(
 				0,
 				DispatchError::Module {
-					index: 21,
+					index: 20,
 					error: 8,
 					message: None,
 				},

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 47,
+	spec_version: 48,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -58,7 +58,7 @@ use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{BlakeTwo256, Block as BlockT, IdentityLookup},
 	transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidity},
-	AccountId32, ApplyExtrinsicResult, Perbill, Permill,
+	AccountId32, ApplyExtrinsicResult, Perbill, Percent, Permill,
 };
 use sp_std::{convert::TryFrom, prelude::*};
 #[cfg(feature = "std")]
@@ -243,8 +243,8 @@ impl pallet_balances::Config for Runtime {
 pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
 impl<R> OnUnbalanced<NegativeImbalance<R>> for DealWithFees<R>
 where
-	R: pallet_balances::Config + pallet_treasury::Config<pallet_treasury::Instance1>,
-	pallet_treasury::Module<R, pallet_treasury::Instance1>: OnUnbalanced<NegativeImbalance<R>>,
+	R: pallet_balances::Config + pallet_treasury::Config,
+	pallet_treasury::Module<R>: OnUnbalanced<NegativeImbalance<R>>,
 {
 	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance<R>>) {
 		if let Some(fees) = fees_then_tips.next() {
@@ -252,8 +252,7 @@ where
 			let (_, to_treasury) = fees.ration(80, 20);
 			// Balances module automatically burns dropped Negative Imbalances by decreasing
 			// total_supply accordingly
-			<pallet_treasury::Module<R, pallet_treasury::Instance1> as OnUnbalanced<_>>
-				::on_unbalanced(to_treasury);
+			<pallet_treasury::Module<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
 		}
 	}
 }
@@ -456,16 +455,12 @@ parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 1 * currency::GLMR;
 	pub const SpendPeriod: BlockNumber = 6 * DAYS;
-	pub const CommunityTreasuryId: PalletId = PalletId(*b"pc/trsry");
-	pub const ParachainBondPalletId: PalletId = PalletId(*b"pb/trsry");
+	pub const TreasuryId: PalletId = PalletId(*b"pc/trsry");
 	pub const MaxApprovals: u32 = 100;
 }
 
-type CommunityTreasuryInstance = pallet_treasury::Instance1;
-type ParachainBondTreasuryInstance = pallet_treasury::Instance2;
-
-impl pallet_treasury::Config<CommunityTreasuryInstance> for Runtime {
-	type PalletId = CommunityTreasuryId;
+impl pallet_treasury::Config for Runtime {
+	type PalletId = TreasuryId;
 	type Currency = Balances;
 	// Democracy dispatches Root
 	type ApproveOrigin = EnsureRoot<AccountId>;
@@ -473,25 +468,7 @@ impl pallet_treasury::Config<CommunityTreasuryInstance> for Runtime {
 	type RejectOrigin = EnsureRoot<AccountId>;
 	type Event = Event;
 	// If spending proposal rejected, transfer proposer bond to treasury
-	type OnSlash = CommunityTreasury;
-	type ProposalBond = ProposalBond;
-	type ProposalBondMinimum = ProposalBondMinimum;
-	type SpendPeriod = SpendPeriod;
-	type Burn = ();
-	type BurnDestination = ();
-	type MaxApprovals = MaxApprovals;
-	type WeightInfo = pallet_treasury::weights::SubstrateWeight<Runtime>;
-	type SpendFunds = ();
-}
-
-impl pallet_treasury::Config<ParachainBondTreasuryInstance> for Runtime {
-	type PalletId = ParachainBondPalletId;
-	type Currency = Balances;
-	type ApproveOrigin = EnsureRoot<AccountId>;
-	type RejectOrigin = EnsureRoot<AccountId>;
-	type Event = Event;
-	// If spending proposal rejected, transfer proposer bond to treasury
-	type OnSlash = ParachainBondTreasury;
+	type OnSlash = Treasury;
 	type ProposalBond = ProposalBond;
 	type ProposalBondMinimum = ProposalBondMinimum;
 	type SpendPeriod = SpendPeriod;
@@ -564,6 +541,8 @@ parameter_types! {
 	pub const MaxCollatorsPerNominator: u32 = 25;
 	/// The fixed percent a collator takes off the top of due rewards is 20%
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
+	/// The percent of inflation set aside for parachain bond every round
+	pub const ParachainBondReserveRatio: Percent = Percent::from_percent(30);
 	/// Minimum stake required to be reserved to be a collator is 1_000
 	pub const MinCollatorStk: u128 = 1_000 * currency::GLMR;
 	/// Minimum stake required to be reserved to be a nominator is 5
@@ -579,6 +558,7 @@ impl parachain_staking::Config for Runtime {
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;
 	type MaxCollatorsPerNominator = MaxCollatorsPerNominator;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
+	type ParachainBondReserveRatio = ParachainBondReserveRatio;
 	type MinCollatorStk = MinCollatorStk;
 	type MinCollatorCandidateStk = MinCollatorStk;
 	type MinNomination = MinNominatorStk;
@@ -752,9 +732,7 @@ construct_runtime! {
 			pallet_collective::<Instance1>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>},
 		TechComitteeCollective:
 			pallet_collective::<Instance2>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>},
-		CommunityTreasury: pallet_treasury::<Instance1>::{Pallet, Storage, Config, Event<T>, Call},
-		ParachainBondTreasury:
-			pallet_treasury::<Instance2>::{Pallet, Storage, Config, Event<T>, Call},
+		Treasury: pallet_treasury::{Pallet, Storage, Config, Event<T>, Call},
 		AuthorInherent: pallet_author_inherent::{Pallet, Call, Storage, Inherent},
 		AuthorFilter: pallet_author_slot_filter::{Pallet, Call, Storage, Event, Config},
 		CrowdloanRewards: pallet_crowdloan_rewards::{Pallet, Call, Config<T>, Storage, Event<T>},

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -539,10 +539,10 @@ parameter_types! {
 	pub const MaxNominatorsPerCollator: u32 = 10;
 	/// Maximum 25 collators per nominator
 	pub const MaxCollatorsPerNominator: u32 = 25;
-	/// The fixed percent a collator takes off the top of due rewards is 20%
+	/// Default fixed percent a collator takes off the top of due rewards is 20%
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
-	/// The percent of inflation set aside for parachain bond every round
-	pub const ParachainBondReserveRatio: Percent = Percent::from_percent(30);
+	/// Default percent of inflation set aside for parachain bond every round
+	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
 	/// Minimum stake required to be reserved to be a collator is 1_000
 	pub const MinCollatorStk: u128 = 1_000 * currency::GLMR;
 	/// Minimum stake required to be reserved to be a nominator is 5
@@ -558,7 +558,7 @@ impl parachain_staking::Config for Runtime {
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;
 	type MaxCollatorsPerNominator = MaxCollatorsPerNominator;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
-	type ParachainBondReserveRatio = ParachainBondReserveRatio;
+	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
 	type MinCollatorStk = MinCollatorStk;
 	type MinCollatorCandidateStk = MinCollatorStk;
 	type MinNomination = MinNominatorStk;

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -209,15 +209,15 @@ fn reward_block_authors_with_parachain_bond_reserved() {
 	ExtBuilder::default()
 		.with_balances(vec![
 			// Alice gets 100 extra tokens for her mapping deposit
-			(AccountId::from(ALICE), 2_100 * MSHD),
-			(AccountId::from(BOB), 1_000 * MSHD),
-			(AccountId::from(CHARLIE), MSHD),
+			(AccountId::from(ALICE), 2_100 * GLMR),
+			(AccountId::from(BOB), 1_000 * GLMR),
+			(AccountId::from(CHARLIE), GLMR),
 		])
-		.with_collators(vec![(AccountId::from(ALICE), 1_000 * MSHD)])
+		.with_collators(vec![(AccountId::from(ALICE), 1_000 * GLMR)])
 		.with_nominations(vec![(
 			AccountId::from(BOB),
 			AccountId::from(ALICE),
-			500 * MSHD,
+			500 * GLMR,
 		)])
 		.with_mappings(vec![(
 			NimbusId::from_slice(&ALICE_NIMBUS),
@@ -235,9 +235,9 @@ fn reward_block_authors_with_parachain_bond_reserved() {
 				run_to_block(x);
 			}
 			// no rewards doled out yet
-			assert_eq!(Balances::free_balance(AccountId::from(ALICE)), 1_000 * MSHD,);
-			assert_eq!(Balances::free_balance(AccountId::from(BOB)), 500 * MSHD,);
-			assert_eq!(Balances::free_balance(AccountId::from(CHARLIE)), MSHD,);
+			assert_eq!(Balances::free_balance(AccountId::from(ALICE)), 1_000 * GLMR,);
+			assert_eq!(Balances::free_balance(AccountId::from(BOB)), 500 * GLMR,);
+			assert_eq!(Balances::free_balance(AccountId::from(CHARLIE)), GLMR,);
 			set_author(NimbusId::from_slice(&ALICE_NIMBUS));
 			run_to_block(601);
 			// rewards minted and distributed

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -58,7 +58,7 @@ use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{BlakeTwo256, Block as BlockT, IdentityLookup},
 	transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidity},
-	AccountId32, ApplyExtrinsicResult, Perbill, Permill,
+	AccountId32, ApplyExtrinsicResult, Perbill, Percent, Permill,
 };
 use sp_std::{convert::TryFrom, prelude::*};
 #[cfg(feature = "std")]
@@ -242,8 +242,8 @@ impl pallet_balances::Config for Runtime {
 pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
 impl<R> OnUnbalanced<NegativeImbalance<R>> for DealWithFees<R>
 where
-	R: pallet_balances::Config + pallet_treasury::Config<pallet_treasury::Instance1>,
-	pallet_treasury::Module<R, pallet_treasury::Instance1>: OnUnbalanced<NegativeImbalance<R>>,
+	R: pallet_balances::Config + pallet_treasury::Config,
+	pallet_treasury::Module<R>: OnUnbalanced<NegativeImbalance<R>>,
 {
 	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance<R>>) {
 		if let Some(fees) = fees_then_tips.next() {
@@ -251,8 +251,7 @@ where
 			let (_, to_treasury) = fees.ration(80, 20);
 			// Balances module automatically burns dropped Negative Imbalances by decreasing
 			// total_supply accordingly
-			<pallet_treasury::Module<R, pallet_treasury::Instance1> as OnUnbalanced<_>>
-				::on_unbalanced(to_treasury);
+			<pallet_treasury::Module<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
 		}
 	}
 }
@@ -455,16 +454,12 @@ parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 1 * currency::MOVR;
 	pub const SpendPeriod: BlockNumber = 6 * DAYS;
-	pub const CommunityTreasuryId: PalletId = PalletId(*b"pc/trsry");
-	pub const ParachainBondPalletId: PalletId = PalletId(*b"pb/trsry");
+	pub const TreasuryId: PalletId = PalletId(*b"pc/trsry");
 	pub const MaxApprovals: u32 = 100;
 }
 
-type CommunityTreasuryInstance = pallet_treasury::Instance1;
-type ParachainBondTreasuryInstance = pallet_treasury::Instance2;
-
-impl pallet_treasury::Config<CommunityTreasuryInstance> for Runtime {
-	type PalletId = CommunityTreasuryId;
+impl pallet_treasury::Config for Runtime {
+	type PalletId = TreasuryId;
 	type Currency = Balances;
 	// Democracy dispatches Root
 	type ApproveOrigin = EnsureRoot<AccountId>;
@@ -472,25 +467,7 @@ impl pallet_treasury::Config<CommunityTreasuryInstance> for Runtime {
 	type RejectOrigin = EnsureRoot<AccountId>;
 	type Event = Event;
 	// If spending proposal rejected, transfer proposer bond to treasury
-	type OnSlash = CommunityTreasury;
-	type ProposalBond = ProposalBond;
-	type ProposalBondMinimum = ProposalBondMinimum;
-	type SpendPeriod = SpendPeriod;
-	type Burn = ();
-	type BurnDestination = ();
-	type MaxApprovals = MaxApprovals;
-	type WeightInfo = pallet_treasury::weights::SubstrateWeight<Runtime>;
-	type SpendFunds = ();
-}
-
-impl pallet_treasury::Config<ParachainBondTreasuryInstance> for Runtime {
-	type PalletId = ParachainBondPalletId;
-	type Currency = Balances;
-	type ApproveOrigin = EnsureRoot<AccountId>;
-	type RejectOrigin = EnsureRoot<AccountId>;
-	type Event = Event;
-	// If spending proposal rejected, transfer proposer bond to treasury
-	type OnSlash = ParachainBondTreasury;
+	type OnSlash = Treasury;
 	type ProposalBond = ProposalBond;
 	type ProposalBondMinimum = ProposalBondMinimum;
 	type SpendPeriod = SpendPeriod;
@@ -563,6 +540,8 @@ parameter_types! {
 	pub const MaxCollatorsPerNominator: u32 = 25;
 	/// The fixed percent a collator takes off the top of due rewards is 20%
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
+	/// The percent of inflation set aside for parachain bond every round
+	pub const ParachainBondReserveRatio: Percent = Percent::from_percent(30);
 	/// Minimum stake required to be reserved to be a collator is 1_000
 	pub const MinCollatorStk: u128 = 1_000 * currency::MOVR;
 	/// Minimum stake required to be reserved to be a nominator is 5
@@ -578,6 +557,7 @@ impl parachain_staking::Config for Runtime {
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;
 	type MaxCollatorsPerNominator = MaxCollatorsPerNominator;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
+	type ParachainBondReserveRatio = ParachainBondReserveRatio;
 	type MinCollatorStk = MinCollatorStk;
 	type MinCollatorCandidateStk = MinCollatorStk;
 	type MinNomination = MinNominatorStk;
@@ -751,9 +731,7 @@ construct_runtime! {
 			pallet_collective::<Instance1>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>},
 		TechComitteeCollective:
 			pallet_collective::<Instance2>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>},
-		CommunityTreasury: pallet_treasury::<Instance1>::{Pallet, Storage, Config, Event<T>, Call},
-		ParachainBondTreasury:
-			pallet_treasury::<Instance2>::{Pallet, Storage, Config, Event<T>, Call},
+		Treasury: pallet_treasury::{Pallet, Storage, Config, Event<T>, Call},
 		AuthorInherent: pallet_author_inherent::{Pallet, Call, Storage, Inherent},
 		AuthorFilter: pallet_author_slot_filter::{Pallet, Call, Storage, Event, Config},
 		CrowdloanRewards: pallet_crowdloan_rewards::{Pallet, Call, Config<T>, Storage, Event<T>},

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 47,
+	spec_version: 48,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -538,10 +538,10 @@ parameter_types! {
 	pub const MaxNominatorsPerCollator: u32 = 10;
 	/// Maximum 25 collators per nominator
 	pub const MaxCollatorsPerNominator: u32 = 25;
-	/// The fixed percent a collator takes off the top of due rewards is 20%
+	/// Default fixed percent a collator takes off the top of due rewards is 20%
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
-	/// The percent of inflation set aside for parachain bond every round
-	pub const ParachainBondReserveRatio: Percent = Percent::from_percent(30);
+	/// Default percent of inflation set aside for parachain bond every round
+	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
 	/// Minimum stake required to be reserved to be a collator is 1_000
 	pub const MinCollatorStk: u128 = 1_000 * currency::MOVR;
 	/// Minimum stake required to be reserved to be a nominator is 5
@@ -557,7 +557,7 @@ impl parachain_staking::Config for Runtime {
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;
 	type MaxCollatorsPerNominator = MaxCollatorsPerNominator;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
-	type ParachainBondReserveRatio = ParachainBondReserveRatio;
+	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
 	type MinCollatorStk = MinCollatorStk;
 	type MinCollatorCandidateStk = MinCollatorStk;
 	type MinNomination = MinNominatorStk;

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -201,6 +201,59 @@ fn reward_block_authors() {
 }
 
 #[test]
+fn reward_block_authors_with_parachain_bond_reserved() {
+	ExtBuilder::default()
+		.with_balances(vec![
+			// Alice gets 100 extra tokens for her mapping deposit
+			(AccountId::from(ALICE), 2_100 * MSHD),
+			(AccountId::from(BOB), 1_000 * MSHD),
+			(AccountId::from(CHARLIE), MSHD),
+		])
+		.with_collators(vec![(AccountId::from(ALICE), 1_000 * MSHD)])
+		.with_nominations(vec![(
+			AccountId::from(BOB),
+			AccountId::from(ALICE),
+			500 * MSHD,
+		)])
+		.with_mappings(vec![(
+			NimbusId::from_slice(&ALICE_NIMBUS),
+			AccountId::from(ALICE),
+		)])
+		.build()
+		.execute_with(|| {
+			set_parachain_inherent_data();
+			assert_ok!(ParachainStaking::set_parachain_bond_account(
+				root_origin(),
+				AccountId::from(CHARLIE),
+			),);
+			for x in 2..601 {
+				set_author(NimbusId::from_slice(&ALICE_NIMBUS));
+				run_to_block(x);
+			}
+			// no rewards doled out yet
+			assert_eq!(Balances::free_balance(AccountId::from(ALICE)), 1_000 * MSHD,);
+			assert_eq!(Balances::free_balance(AccountId::from(BOB)), 500 * MSHD,);
+			assert_eq!(Balances::free_balance(AccountId::from(CHARLIE)), MSHD,);
+			set_author(NimbusId::from_slice(&ALICE_NIMBUS));
+			run_to_block(601);
+			// rewards minted and distributed
+			assert_eq!(
+				Balances::free_balance(AccountId::from(ALICE)),
+				1079592333275448000000,
+			);
+			assert_eq!(
+				Balances::free_balance(AccountId::from(BOB)),
+				528942666637724000000,
+			);
+			// 30% reserved for parachain bond
+			assert_eq!(
+				Balances::free_balance(AccountId::from(CHARLIE)),
+				47515000000000000000,
+			);
+		});
+}
+
+#[test]
 fn initialize_crowdloan_addresses_with_batch_and_pay() {
 	ExtBuilder::default()
 		.with_balances(vec![
@@ -269,7 +322,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 			let expected_fail = Event::pallet_utility(pallet_utility::Event::BatchInterrupted(
 				0,
 				DispatchError::Module {
-					index: 21,
+					index: 20,
 					error: 8,
 					message: None,
 				},

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -205,15 +205,15 @@ fn reward_block_authors_with_parachain_bond_reserved() {
 	ExtBuilder::default()
 		.with_balances(vec![
 			// Alice gets 100 extra tokens for her mapping deposit
-			(AccountId::from(ALICE), 2_100 * MSHD),
-			(AccountId::from(BOB), 1_000 * MSHD),
-			(AccountId::from(CHARLIE), MSHD),
+			(AccountId::from(ALICE), 2_100 * MOVR),
+			(AccountId::from(BOB), 1_000 * MOVR),
+			(AccountId::from(CHARLIE), MOVR),
 		])
-		.with_collators(vec![(AccountId::from(ALICE), 1_000 * MSHD)])
+		.with_collators(vec![(AccountId::from(ALICE), 1_000 * MOVR)])
 		.with_nominations(vec![(
 			AccountId::from(BOB),
 			AccountId::from(ALICE),
-			500 * MSHD,
+			500 * MOVR,
 		)])
 		.with_mappings(vec![(
 			NimbusId::from_slice(&ALICE_NIMBUS),
@@ -231,9 +231,9 @@ fn reward_block_authors_with_parachain_bond_reserved() {
 				run_to_block(x);
 			}
 			// no rewards doled out yet
-			assert_eq!(Balances::free_balance(AccountId::from(ALICE)), 1_000 * MSHD,);
-			assert_eq!(Balances::free_balance(AccountId::from(BOB)), 500 * MSHD,);
-			assert_eq!(Balances::free_balance(AccountId::from(CHARLIE)), MSHD,);
+			assert_eq!(Balances::free_balance(AccountId::from(ALICE)), 1_000 * MOVR,);
+			assert_eq!(Balances::free_balance(AccountId::from(BOB)), 500 * MOVR,);
+			assert_eq!(Balances::free_balance(AccountId::from(CHARLIE)), MOVR,);
 			set_author(NimbusId::from_slice(&ALICE_NIMBUS));
 			run_to_block(601);
 			// rewards minted and distributed

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -538,10 +538,10 @@ parameter_types! {
 	pub const MaxNominatorsPerCollator: u32 = 10;
 	/// Maximum 25 collators per nominator
 	pub const MaxCollatorsPerNominator: u32 = 25;
-	/// The fixed percent a collator takes off the top of due rewards is 20%
+	/// Default fixed percent a collator takes off the top of due rewards is 20%
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
-	/// The percent of inflation set aside for parachain bond every round
-	pub const ParachainBondReserveRatio: Percent = Percent::from_percent(30);
+	/// Default percent of inflation set aside for parachain bond every round
+	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
 	/// Minimum stake required to be reserved to be a collator is 1_000
 	pub const MinCollatorStk: u128 = 1_000 * currency::MSHD;
 	/// Minimum stake required to be reserved to be a nominator is 5
@@ -557,7 +557,7 @@ impl parachain_staking::Config for Runtime {
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;
 	type MaxCollatorsPerNominator = MaxCollatorsPerNominator;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
-	type ParachainBondReserveRatio = ParachainBondReserveRatio;
+	type DefaultParachainBondReservePercent = DefaultParachainBondReservePercent;
 	type MinCollatorStk = MinCollatorStk;
 	type MinCollatorCandidateStk = MinCollatorStk;
 	type MinNomination = MinNominatorStk;

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonshadow"),
 	impl_name: create_runtime_str!("moonshadow"),
 	authoring_version: 3,
-	spec_version: 47,
+	spec_version: 48,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -58,7 +58,7 @@ use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{BlakeTwo256, Block as BlockT, IdentityLookup},
 	transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidity},
-	AccountId32, ApplyExtrinsicResult, Perbill, Permill,
+	AccountId32, ApplyExtrinsicResult, Perbill, Percent, Permill,
 };
 use sp_std::{convert::TryFrom, prelude::*};
 #[cfg(feature = "std")]
@@ -242,8 +242,8 @@ impl pallet_balances::Config for Runtime {
 pub struct DealWithFees<R>(sp_std::marker::PhantomData<R>);
 impl<R> OnUnbalanced<NegativeImbalance<R>> for DealWithFees<R>
 where
-	R: pallet_balances::Config + pallet_treasury::Config<pallet_treasury::Instance1>,
-	pallet_treasury::Module<R, pallet_treasury::Instance1>: OnUnbalanced<NegativeImbalance<R>>,
+	R: pallet_balances::Config + pallet_treasury::Config,
+	pallet_treasury::Module<R>: OnUnbalanced<NegativeImbalance<R>>,
 {
 	fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance<R>>) {
 		if let Some(fees) = fees_then_tips.next() {
@@ -251,8 +251,7 @@ where
 			let (_, to_treasury) = fees.ration(80, 20);
 			// Balances module automatically burns dropped Negative Imbalances by decreasing
 			// total_supply accordingly
-			<pallet_treasury::Module<R, pallet_treasury::Instance1> as OnUnbalanced<_>>
-				::on_unbalanced(to_treasury);
+			<pallet_treasury::Module<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
 		}
 	}
 }
@@ -455,16 +454,12 @@ parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 1 * currency::MSHD;
 	pub const SpendPeriod: BlockNumber = 6 * DAYS;
-	pub const CommunityTreasuryId: PalletId = PalletId(*b"pc/trsry");
-	pub const ParachainBondPalletId: PalletId = PalletId(*b"pb/trsry");
+	pub const TreasuryId: PalletId = PalletId(*b"pc/trsry");
 	pub const MaxApprovals: u32 = 100;
 }
 
-type CommunityTreasuryInstance = pallet_treasury::Instance1;
-type ParachainBondTreasuryInstance = pallet_treasury::Instance2;
-
-impl pallet_treasury::Config<CommunityTreasuryInstance> for Runtime {
-	type PalletId = CommunityTreasuryId;
+impl pallet_treasury::Config for Runtime {
+	type PalletId = TreasuryId;
 	type Currency = Balances;
 	// Democracy dispatches Root
 	type ApproveOrigin = EnsureRoot<AccountId>;
@@ -472,25 +467,7 @@ impl pallet_treasury::Config<CommunityTreasuryInstance> for Runtime {
 	type RejectOrigin = EnsureRoot<AccountId>;
 	type Event = Event;
 	// If spending proposal rejected, transfer proposer bond to treasury
-	type OnSlash = CommunityTreasury;
-	type ProposalBond = ProposalBond;
-	type ProposalBondMinimum = ProposalBondMinimum;
-	type SpendPeriod = SpendPeriod;
-	type Burn = ();
-	type BurnDestination = ();
-	type MaxApprovals = MaxApprovals;
-	type WeightInfo = pallet_treasury::weights::SubstrateWeight<Runtime>;
-	type SpendFunds = ();
-}
-
-impl pallet_treasury::Config<ParachainBondTreasuryInstance> for Runtime {
-	type PalletId = ParachainBondPalletId;
-	type Currency = Balances;
-	type ApproveOrigin = EnsureRoot<AccountId>;
-	type RejectOrigin = EnsureRoot<AccountId>;
-	type Event = Event;
-	// If spending proposal rejected, transfer proposer bond to treasury
-	type OnSlash = ParachainBondTreasury;
+	type OnSlash = Treasury;
 	type ProposalBond = ProposalBond;
 	type ProposalBondMinimum = ProposalBondMinimum;
 	type SpendPeriod = SpendPeriod;
@@ -563,6 +540,8 @@ parameter_types! {
 	pub const MaxCollatorsPerNominator: u32 = 25;
 	/// The fixed percent a collator takes off the top of due rewards is 20%
 	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
+	/// The percent of inflation set aside for parachain bond every round
+	pub const ParachainBondReserveRatio: Percent = Percent::from_percent(30);
 	/// Minimum stake required to be reserved to be a collator is 1_000
 	pub const MinCollatorStk: u128 = 1_000 * currency::MSHD;
 	/// Minimum stake required to be reserved to be a nominator is 5
@@ -578,6 +557,7 @@ impl parachain_staking::Config for Runtime {
 	type MaxNominatorsPerCollator = MaxNominatorsPerCollator;
 	type MaxCollatorsPerNominator = MaxCollatorsPerNominator;
 	type DefaultCollatorCommission = DefaultCollatorCommission;
+	type ParachainBondReserveRatio = ParachainBondReserveRatio;
 	type MinCollatorStk = MinCollatorStk;
 	type MinCollatorCandidateStk = MinCollatorStk;
 	type MinNomination = MinNominatorStk;
@@ -751,9 +731,7 @@ construct_runtime! {
 			pallet_collective::<Instance1>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>},
 		TechComitteeCollective:
 			pallet_collective::<Instance2>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>},
-		CommunityTreasury: pallet_treasury::<Instance1>::{Pallet, Storage, Config, Event<T>, Call},
-		ParachainBondTreasury:
-			pallet_treasury::<Instance2>::{Pallet, Storage, Config, Event<T>, Call},
+		Treasury: pallet_treasury::{Pallet, Storage, Config, Event<T>, Call},
 		AuthorInherent: pallet_author_inherent::{Pallet, Call, Storage, Inherent},
 		AuthorFilter: pallet_author_slot_filter::{Pallet, Call, Storage, Event, Config},
 		CrowdloanRewards: pallet_crowdloan_rewards::{Pallet, Call, Config<T>, Storage, Event<T>},

--- a/runtime/moonshadow/tests/integration_test.rs
+++ b/runtime/moonshadow/tests/integration_test.rs
@@ -201,6 +201,59 @@ fn reward_block_authors() {
 }
 
 #[test]
+fn reward_block_authors_with_parachain_bond_reserved() {
+	ExtBuilder::default()
+		.with_balances(vec![
+			// Alice gets 100 extra tokens for her mapping deposit
+			(AccountId::from(ALICE), 2_100 * MSHD),
+			(AccountId::from(BOB), 1_000 * MSHD),
+			(AccountId::from(CHARLIE), MSHD),
+		])
+		.with_collators(vec![(AccountId::from(ALICE), 1_000 * MSHD)])
+		.with_nominations(vec![(
+			AccountId::from(BOB),
+			AccountId::from(ALICE),
+			500 * MSHD,
+		)])
+		.with_mappings(vec![(
+			NimbusId::from_slice(&ALICE_NIMBUS),
+			AccountId::from(ALICE),
+		)])
+		.build()
+		.execute_with(|| {
+			set_parachain_inherent_data();
+			assert_ok!(ParachainStaking::set_parachain_bond_account(
+				root_origin(),
+				AccountId::from(CHARLIE),
+			),);
+			for x in 2..601 {
+				set_author(NimbusId::from_slice(&ALICE_NIMBUS));
+				run_to_block(x);
+			}
+			// no rewards doled out yet
+			assert_eq!(Balances::free_balance(AccountId::from(ALICE)), 1_000 * MSHD,);
+			assert_eq!(Balances::free_balance(AccountId::from(BOB)), 500 * MSHD,);
+			assert_eq!(Balances::free_balance(AccountId::from(CHARLIE)), MSHD,);
+			set_author(NimbusId::from_slice(&ALICE_NIMBUS));
+			run_to_block(601);
+			// rewards minted and distributed
+			assert_eq!(
+				Balances::free_balance(AccountId::from(ALICE)),
+				1079592333275448000000,
+			);
+			assert_eq!(
+				Balances::free_balance(AccountId::from(BOB)),
+				528942666637724000000,
+			);
+			// 30% reserved for parachain bond
+			assert_eq!(
+				Balances::free_balance(AccountId::from(CHARLIE)),
+				47515000000000000000,
+			);
+		});
+}
+
+#[test]
 fn initialize_crowdloan_addresses_with_batch_and_pay() {
 	ExtBuilder::default()
 		.with_balances(vec![
@@ -269,7 +322,7 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 			let expected_fail = Event::pallet_utility(pallet_utility::Event::BatchInterrupted(
 				0,
 				DispatchError::Module {
-					index: 21,
+					index: 20,
 					error: 8,
 					message: None,
 				},

--- a/specs/alphanet/parachain-specs-template.json
+++ b/specs/alphanet/parachain-specs-template.json
@@ -188,8 +188,7 @@
           ]
         ]
       },
-      "palletTreasuryInstance1": {},
-      "palletTreasuryInstance2": {},
+      "palletTreasury": {},
       "palletScheduler": null
     }
   }

--- a/tests/tests/test-author-mapping.ts
+++ b/tests/tests/test-author-mapping.ts
@@ -88,7 +88,7 @@ describeDevMoonbeam("Author Mapping - simple association", (context) => {
             .true;
           expect(context.polkadotApi.events.system.NewAccount.is(events[2])).to.be.true;
           expect(context.polkadotApi.events.balances.Endowed.is(events[3])).to.be.true;
-          expect(context.polkadotApi.events.communityTreasury.Deposit.is(events[4])).to.be.true;
+          expect(context.polkadotApi.events.treasury.Deposit.is(events[4])).to.be.true;
           expect(context.polkadotApi.events.system.ExtrinsicSuccess.is(events[5])).to.be.true;
           break;
         default:
@@ -144,7 +144,7 @@ describeDevMoonbeam("Author Mapping - Fail to reassociate alice", (context) => {
           expect(events.length === 4);
           expect(context.polkadotApi.events.system.NewAccount.is(events[0])).to.be.true;
           expect(context.polkadotApi.events.balances.Endowed.is(events[1])).to.be.true;
-          expect(context.polkadotApi.events.communityTreasury.Deposit.is(events[2])).to.be.true;
+          expect(context.polkadotApi.events.treasury.Deposit.is(events[2])).to.be.true;
           expect(context.polkadotApi.events.system.ExtrinsicFailed.is(events[3])).to.be.true;
           break;
         default:
@@ -203,7 +203,7 @@ describeDevMoonbeam("Author Mapping - Fail without deposit", (context) => {
           expect(events.length === 4);
           expect(context.polkadotApi.events.system.NewAccount.is(events[0])).to.be.true;
           expect(context.polkadotApi.events.balances.Endowed.is(events[1])).to.be.true;
-          expect(context.polkadotApi.events.communityTreasury.Deposit.is(events[2])).to.be.true;
+          expect(context.polkadotApi.events.treasury.Deposit.is(events[2])).to.be.true;
           expect(context.polkadotApi.events.system.ExtrinsicFailed.is(events[3])).to.be.true;
           break;
         default:
@@ -296,7 +296,7 @@ describeDevMoonbeam("Author Mapping - registered author can clear (de register)"
           expect(context.polkadotApi.events.balances.Unreserved.is(events[0])).to.be.true;
           expect(context.polkadotApi.events.authorMapping.AuthorDeRegistered.is(events[1])).to.be
             .true;
-          expect(context.polkadotApi.events.communityTreasury.Deposit.is(events[2])).to.be.true;
+          expect(context.polkadotApi.events.treasury.Deposit.is(events[2])).to.be.true;
           expect(context.polkadotApi.events.system.ExtrinsicSuccess.is(events[3])).to.be.true;
           break;
         default:
@@ -348,7 +348,7 @@ describeDevMoonbeam("Author Mapping - unregistered author cannot clear associati
           expect(events.length === 4);
           expect(context.polkadotApi.events.system.NewAccount.is(events[0])).to.be.true;
           expect(context.polkadotApi.events.balances.Endowed.is(events[1])).to.be.true;
-          expect(context.polkadotApi.events.communityTreasury.Deposit.is(events[2])).to.be.true;
+          expect(context.polkadotApi.events.treasury.Deposit.is(events[2])).to.be.true;
           expect(context.polkadotApi.events.system.ExtrinsicFailed.is(events[3])).to.be.true;
           break;
         default:
@@ -403,7 +403,7 @@ describeDevMoonbeam("Author Mapping - non author clearing", (context) => {
         case 3:
           expect(section === "authorMapping" && method === "clearAssociation").to.be.true;
           expect(events.length === 2);
-          expect(context.polkadotApi.events.communityTreasury.Deposit.is(events[0])).to.be.true;
+          expect(context.polkadotApi.events.treasury.Deposit.is(events[0])).to.be.true;
           expect(context.polkadotApi.events.system.ExtrinsicFailed.is(events[1])).to.be.true;
           break;
         default:


### PR DESCRIPTION
### What does it do?

*TODO: update description based on new, similar design*

It creates a new storage item in staking which holds the account which will receive funds set aside from inflation to pay the parachain bond. The percent of funds set aside from inflation will be set to 30%, configured as a `Pallet::Config` associated type `ParachainBondReserveRatio: Get<Percent>`

It also adds a new setter runtime method for setting this storage item (by root only). I don't know if this is necessary, but it seems like it would be helpful if the set account was lost or compromised somehow.

TODO:
- [x] make tests pass
- [x] remove parachainBondTreasury configuration (treasury instancing)
- [x] set new `staking::Config::ParachainBondReserveRatio` to 30%

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- Does it require a purge of the network?
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- Does it require changes in documentation/tutorials ?
