### PR TITLE
Detect git problems in lockfile CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,9 +112,6 @@ jobs:
       # 2. Using grep to reduce the list to only Cargo.lock files
       # 3. Counting the number of lines of output
 
-      - name: Intentionally break git to check CI (REMOVE THIS!!!)
-        run: rm -rf .git/
-
       - name: Check Cargo Toml
         run: |
           # Make sure git is working, and if not abort early. Whe ngit is not working it looks like:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
           # $ git diff-index --name-only HEAD
           # fatal: not a git repository (or any of the parent directories): .git
           DIFF_INDEX=$(git diff-index --name-only HEAD)
-          if [[ ${DIFF_INDEX:0:5} == "fatal" ]]
+          if [[ ${DIFF_INDEX:0:5} == "fatal" ]]; then
             echo "There was an error with the git checkout. Can't check Cargo.lock file."
             false
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Check Cargo Toml
         run: |
-          # Make sure git is working, and if not abort early. Whe ngit is not working it looks like:
+          # Make sure git is working, and if not abort early. When git is not working it looks like:
           # $ git diff-index --name-only HEAD
           # fatal: not a git repository (or any of the parent directories): .git
           DIFF_INDEX=$(git diff-index --name-only HEAD)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,17 +112,23 @@ jobs:
       # 2. Using grep to reduce the list to only Cargo.lock files
       # 3. Counting the number of lines of output
 
-      #TODO make sure git diff-index actually works
-      #$ git diff-index --name-only HEAD
-      #fatal: not a git repository (or any of the parent directories): .git
       - name: Check Cargo Toml
         run: |
-          FILECOUNT=$(git diff-index --name-only HEAD | grep Cargo.lock | wc -l)
+          # Make sure git is working, and if not abort early. Whe ngit is not working it looks like:
+          # $ git diff-index --name-only HEAD
+          # fatal: not a git repository (or any of the parent directories): .git
+          DIFF_INDEX=$(git diff-index --name-only HEAD)
+          if [[ ${DIFF_INDEX:0:5} == "fatal" ]]
+            echo "There was an error with the git checkout. Can't check Cargo.lock file."
+            false
+          fi
+
+          FILECOUNT=$(echo $DIFF_INDEX | grep Cargo.lock | wc -l)
           if [[ $FILECOUNT -eq 0 ]]; then
             echo "All lock files are valid"
           else
             echo "The following Cargo.lock files have uncommitted changes"
-            git diff-index --name-only HEAD | grep Cargo.lock
+            echo $DIFF_INDEX | grep Cargo.lock
             false
           fi
       - name: Unit tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,10 @@ jobs:
       # 1. Asking git for a list of all modified files
       # 2. Using grep to reduce the list to only Cargo.lock files
       # 3. Counting the number of lines of output
+
+      #TODO make sure git diff-index actually works
+      #$ git diff-index --name-only HEAD
+      #fatal: not a git repository (or any of the parent directories): .git
       - name: Check Cargo Toml
         run: |
           FILECOUNT=$(git diff-index --name-only HEAD | grep Cargo.lock | wc -l)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,9 @@ jobs:
       # 2. Using grep to reduce the list to only Cargo.lock files
       # 3. Counting the number of lines of output
 
+      - name: Intentionally break git to check CI (REMOVE THIS!!!)
+        run: rm -rf .git/
+
       - name: Check Cargo Toml
         run: |
           # Make sure git is working, and if not abort early. Whe ngit is not working it looks like:


### PR DESCRIPTION
This PR addresses https://github.com/PureStake/moonbeam/pull/493#issuecomment-856945529 so that if there are problems with git the CI will fail. Previously git issues led to the CI passing without doing its actual check.

According to https://github.com/actions/checkout

> When Git 2.18 or higher is not in your PATH, falls back to the REST API to download the files.

That explains the issue. So there are two parts:
1. Upgrade git so this works again - Mario did that yesterday
2. Change the CI so it _fails_ when `.git` is not present. - This PR does this.
