### PR TITLE
Remove unused `build_inherent_data_providers` function

### DIFF
--- a/node/service/src/inherents.rs
+++ b/node/service/src/inherents.rs
@@ -14,12 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-//! This module is responsible for building the inherent data providers that a Moonbeam node needs.
-//!
-//! A service builder can call the `build_inherent_data_providers` function to get the providers
-//! the node needs based on the parameters it passed in.
-//!
-//! This module also includes a MOCK inherent data provider for the validataion
+//! This module houses a MOCK inherent data provider for the validataion
 //! data inherent. This mock provider provides stub data that does not represent anything "real"
 //! about the external world, but can pass the runtime's checks. This is useful in testing
 //! for example, running the --dev service without a relay chain backbone.
@@ -29,51 +24,6 @@ use cumulus_primitives_parachain_inherent::{ParachainInherentData, INHERENT_IDEN
 use sp_inherents::{InherentData, InherentDataProvider};
 
 use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
-
-// TODO it would be nice to re-enable this function and use it in both cases from lib.rs
-// It's signature may need to change significantly. For now I've written
-// individual closures in lib.rs
-
-// /// Build the inherent data providers for the node.
-// ///
-// /// Not all nodes will need all inherent data providers:
-// /// - The author provider is only necessary for block producing nodes
-// /// - The validation data provider can be mocked.
-// pub fn build_inherent_data_providers(
-// 	author: Option<nimbus_primitives::NimbusId>,
-// 	mock: bool,
-// ) -> Result<InherentDataProviders, sc_service::Error> {
-// 	let providers = InherentDataProviders::new();
-
-// 	// Timestamp provider. Needed in all nodes.
-// 	providers
-// 		.register_provider(sp_timestamp::InherentDataProvider)
-// 		.map_err(Into::into)
-// 		.map_err(sp_consensus::error::Error::InherentData)?;
-
-// 	// Author ID Provider for use in dev-service authoring nodes only
-// 	if let Some(account) = author {
-// 		//TODO move inherent data provider to nimbus primitives
-// 		providers
-// 			.register_provider(pallet_author_inherent::InherentDataProvider(account))
-// 			.map_err(Into::into)
-// 			.map_err(sp_consensus::error::Error::InherentData)?;
-// 	}
-
-// 	// Parachain inherent provider, only for dev-service nodes.
-// 	if mock {
-// 		providers
-// 			.register_provider(MockValidationDataInherentDataProvider)
-// 			.map_err(Into::into)
-// 			.map_err(sp_consensus::error::Error::InherentData)?;
-// 	}
-
-// 	// When we are not mocking the validation data, we do not register a real validation data
-// 	// provider here. The validation data inherent is inserted manually by the cumulus colaltor
-// 	// https://github.com/paritytech/cumulus/blob/c3e3f443/collator/src/lib.rs#L274-L321
-
-// 	Ok(providers)
-// }
 
 /// Inherent data provider that supplies mocked validation data.
 ///


### PR DESCRIPTION
This function was used before https://github.com/paritytech/substrate/pull/8526. I kept it around thinking maybe we could reinstate it, but doing so would de-duplicate very little code and make our node look less like the templates.

Additionally, keeping them separate will allow easier splitting of the dev service node into a separate binary in the future.