### PR TITLE
remove hooks and call from pallet-ethereum-chain-id

### DIFF
--- a/pallets/ethereum-chain-id/src/lib.rs
+++ b/pallets/ethereum-chain-id/src/lib.rs
@@ -26,7 +26,6 @@ pub use pallet::*;
 pub mod pallet {
 
 	use frame_support::pallet_prelude::*;
-	use frame_system::pallet_prelude::*;
 
 	/// The Ethereum Chain Id Pallet
 	#[pallet::pallet]
@@ -41,12 +40,6 @@ pub mod pallet {
 			Self::chain_id()
 		}
 	}
-
-	#[pallet::hooks]
-	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
-
-	#[pallet::call]
-	impl<T: Config> Pallet<T> {}
 
 	#[pallet::storage]
 	#[pallet::getter(fn chain_id)]


### PR DESCRIPTION
This PR removes the no-longer-necessary `hooks` and `calls` sections from pallet-ethereum-chain-id. Solves MON-552

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
