### PR TITLE
Add "key" subcommand

### DIFF
--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -59,6 +59,9 @@ pub enum Subcommand {
 	/// The custom benchmark subcommmand benchmarking runtime pallets.
 	#[structopt(name = "benchmark", about = "Benchmark runtime pallets.")]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
+
+	/// Key management cli utilities
+	Key(sc_cli::KeySubcommand),
 }
 
 #[derive(Debug, StructOpt)]

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -448,6 +448,7 @@ pub fn run() -> Result<()> {
 					.into())
 			}
 		}
+		Some(Subcommand::Key(cmd)) => Ok(cmd.run(&cli)?),
 		None => {
 			let runner = cli.create_runner(&(*cli.run).normalize())?;
 			runner.run_node_until_exit(|config| async move {


### PR DESCRIPTION
### What does it do?

Adds `key` subcommand like in polkadot binary.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- ❌ Does it require a purge of the network?
- ❌ You bumped the runtime version if there are breaking changes in the **runtime** ?
- ❓ Does it require changes in documentation/tutorials ?
  If tutorials explain using `polkadot key` then it should be equivalent to use `moonbeam key`.
