### PR TITLE
Minor cleanups to servie

### DIFF
--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -451,8 +451,6 @@ pub fn run() -> Result<()> {
 		None => {
 			let runner = cli.create_runner(&(*cli.run).normalize())?;
 			runner.run_node_until_exit(|config| async move {
-				let key = sp_core::Pair::generate().0;
-
 				let extension = chain_spec::Extensions::try_get(&*config.chain_spec);
 				let para_id = extension.map(|e| e.para_id);
 
@@ -534,7 +532,7 @@ pub fn run() -> Result<()> {
 					service::start_node::<
 						service::moonbeam_runtime::RuntimeApi,
 						service::MoonbeamExecutor,
-					>(config, key, polkadot_config, id, rpc_config)
+					>(config, polkadot_config, id, rpc_config)
 					.await
 					.map(|r| r.0)
 					.map_err(Into::into)
@@ -542,7 +540,7 @@ pub fn run() -> Result<()> {
 					service::start_node::<
 						service::moonriver_runtime::RuntimeApi,
 						service::MoonriverExecutor,
-					>(config, key, polkadot_config, id, rpc_config)
+					>(config, polkadot_config, id, rpc_config)
 					.await
 					.map(|r| r.0)
 					.map_err(Into::into)
@@ -550,7 +548,7 @@ pub fn run() -> Result<()> {
 					service::start_node::<
 						service::moonshadow_runtime::RuntimeApi,
 						service::MoonshadowExecutor,
-					>(config, key, polkadot_config, id, rpc_config)
+					>(config, polkadot_config, id, rpc_config)
 					.await
 					.map(|r| r.0)
 					.map_err(Into::into)
@@ -558,7 +556,7 @@ pub fn run() -> Result<()> {
 					service::start_node::<
 						service::moonbase_runtime::RuntimeApi,
 						service::MoonbaseExecutor,
-					>(config, key, polkadot_config, id, rpc_config)
+					>(config, polkadot_config, id, rpc_config)
 					.await
 					.map(|r| r.0)
 					.map_err(Into::into)

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -644,13 +644,7 @@ where
 		RuntimeApiCollection<StateBackend = sc_client_api::StateBackendFor<FullBackend, Block>>,
 	Executor: NativeExecutionDispatch + 'static,
 {
-	start_node_impl(
-		parachain_config,
-		polkadot_config,
-		id,
-		rpc_config,
-	)
-	.await
+	start_node_impl(parachain_config, polkadot_config, id, rpc_config).await
 }
 
 /// Builds a new development service. This service uses manual seal, and mocks
@@ -797,9 +791,7 @@ pub fn new_dev(
 							relay_blocks_per_para_block: 2,
 						};
 
-						let author = nimbus_primitives::InherentDataProvider::<NimbusId>(
-							author_id,
-						);
+						let author = nimbus_primitives::InherentDataProvider::<NimbusId>(author_id);
 
 						Ok((time, mocked_parachain, author))
 					}

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -45,8 +45,6 @@ use cumulus_client_service::{
 use nimbus_consensus::{build_nimbus_consensus, BuildNimbusConsensusParams};
 use nimbus_primitives::NimbusId;
 
-// use inherents::build_inherent_data_providers;
-use polkadot_primitives::v0::CollatorPair;
 pub use sc_executor::NativeExecutor;
 use sc_executor::{native_executor_instance, NativeExecutionDispatch};
 use sc_service::{
@@ -410,7 +408,6 @@ impl fp_rpc::ConvertTransaction<moonbeam_core_primitives::UncheckedExtrinsic>
 /// This is the actual implementation that is abstract over the executor and the runtime api.
 async fn start_node_impl<RuntimeApi, Executor>(
 	parachain_config: Configuration,
-	collator_key: CollatorPair,
 	polkadot_config: Configuration,
 	id: polkadot_primitives::v0::Id,
 	rpc_config: RpcConfig,
@@ -636,7 +633,6 @@ where
 /// Start a normal parachain node.
 pub async fn start_node<RuntimeApi, Executor>(
 	parachain_config: Configuration,
-	collator_key: CollatorPair,
 	polkadot_config: Configuration,
 	id: polkadot_primitives::v0::Id,
 	rpc_config: RpcConfig,
@@ -650,7 +646,6 @@ where
 {
 	start_node_impl(
 		parachain_config,
-		collator_key,
 		polkadot_config,
 		id,
 		rpc_config,
@@ -717,9 +712,6 @@ pub fn new_dev(
 	let collator = config.role.is_authority();
 
 	if collator {
-		//TODO Actually even tthe following TODO isn't relevant.
-		// I ran into some issues with ownership in the closure below,
-		// so this variabel isn't even used yet.
 		//TODO For now, all dev service nodes use Alith's nimbus id in their author inherent.
 		// This could and perhaps should be made more flexible. Here are some options:
 		// 1. a dedicated `--dev-author-id` flag that only works with the dev service
@@ -727,7 +719,7 @@ pub fn new_dev(
 		//    in the parachain context
 		// 3. check the keystore like we do in nimbus. Actually, maybe the keystore-checking could
 		//    be exported as a helper function from nimbus.
-		// let author_id = chain_spec::get_from_seed::<NimbusId>("Alice");
+		let author_id = chain_spec::get_from_seed::<NimbusId>("Alice");
 
 		let env = sc_basic_authorship::ProposerFactory::new(
 			task_manager.spawn_handle(),
@@ -794,6 +786,7 @@ pub fn new_dev(
 						.number(block)
 						.expect("Header lookup should succeed")
 						.expect("Header passed in as parent should be present in backend.");
+					let author_id = author_id.clone();
 
 					async move {
 						let time = sp_timestamp::InherentDataProvider::from_system_time();
@@ -804,9 +797,8 @@ pub fn new_dev(
 							relay_blocks_per_para_block: 2,
 						};
 
-						//TODO I want to use the value from a variable above.
 						let author = nimbus_primitives::InherentDataProvider::<NimbusId>(
-							chain_spec::get_from_seed::<NimbusId>("Alice"),
+							author_id,
 						);
 
 						Ok((time, mocked_parachain, author))


### PR DESCRIPTION
This PR cleans up two loose ends in the service:

1. It properly clones the author_id into the inherent data providers in the dev service
2. It stops creating a temporary collator key as this has been handled in https://github.com/paritytech/cumulus/pull/459
