### PR TITLE
Patch staking underflow bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6636,7 +6636,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-staking"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parachain-staking"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["PureStake"]
 edition = "2018"
 description = "parachain staking pallet for collator selection and reward distribution"

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -508,32 +508,26 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		// This upgrade fixes a bug that may have led to an inconsistency between the `Total` storage
-		// and the other storage items. To work around this we
+		// and the other storage items.
 		fn on_runtime_upgrade() -> Weight {
 			let old_total = Total::<T>::get();
-			let mut new_total: BalanceOf<T> = 0.into();
+			let mut new_total: BalanceOf<T> = 0u32.into();
 
 			for collator_state in CollatorState::<T>::iter_values() {
 				new_total += collator_state.total;
 			}
 
-			//Wait, actually I don't think we even need to iterate the nominators as long as the
-			// collator.total is not affected by the bug.
-			// for nominator_state in NominatorState::<T>::iter_values() {
-			// 	new_total += ...;
-			// }
-
 			Total::<T>::put(new_total);
 
-			log!(
-				"Finished migrating storage.\nOld Total : {}\nNew Total : {}\n---------------\nDifference:{}",
+			log::trace!(
+				target: "staking",
+				"Finished migrating storage.\nOld Total : {:?}\nNew Total : {:?}",
 				new_total,
 				old_total,
-				new_total - old_total,
 			);
 
 			10_000 // Same comment as always about the weight. I don't know how much this will weigh.
-			// Hopefully not very much :)
+			 // Hopefully not very much :)
 		}
 
 		fn on_finalize(n: T::BlockNumber) {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -507,8 +507,7 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		// This upgrade fixes a bug that may have led to an inconsistency between the `Total` storage
-		// and the other storage items.
+		// This upgrade fixes a bug that may have led to an incorrect `Total` (total staked)
 		fn on_runtime_upgrade() -> Weight {
 			let old_total = Total::<T>::get();
 			let mut new_total: BalanceOf<T> = 0u32.into();
@@ -526,8 +525,7 @@ pub mod pallet {
 				old_total,
 			);
 
-			10_000 // Same comment as always about the weight. I don't know how much this will weigh.
-			 // Hopefully not very much :)
+			10_000
 		}
 
 		fn on_finalize(n: T::BlockNumber) {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -525,7 +525,7 @@ pub mod pallet {
 				new_total,
 			);
 
-			10_000
+			300_000_000_000 // Three fifths of the max block weight
 		}
 
 		fn on_finalize(n: T::BlockNumber) {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -73,7 +73,7 @@ pub mod pallet {
 	use frame_system::pallet_prelude::*;
 	use parity_scale_codec::{Decode, Encode};
 	use sp_runtime::{
-		traits::{AtLeast32BitUnsigned, Zero},
+		traits::{AtLeast32BitUnsigned, Saturating, Zero},
 		Perbill, Percent, RuntimeDebug,
 	};
 	use sp_std::{cmp::Ordering, prelude::*};
@@ -890,10 +890,10 @@ pub mod pallet {
 			);
 			T::Currency::reserve(&acc, bond)?;
 			let candidate = Collator::new(acc.clone(), bond);
-			let new_total = <Total<T>>::get() + bond;
-			<Total<T>>::put(new_total);
 			<CollatorState<T>>::insert(&acc, candidate);
 			<CandidatePool<T>>::put(candidates);
+			let new_total = <Total<T>>::get().saturating_add(bond);
+			<Total<T>>::put(new_total);
 			Self::deposit_event(Event::JoinedCollatorCandidates(acc, bond, new_total));
 			Ok(().into())
 		}
@@ -985,6 +985,8 @@ pub mod pallet {
 				Self::update_active(collator.clone(), state.total);
 			}
 			<CollatorState<T>>::insert(&collator, state);
+			let new_total = <Total<T>>::get().saturating_add(more);
+			<Total<T>>::put(new_total);
 			Self::deposit_event(Event::CollatorBondedMore(collator, before, after));
 			Ok(().into())
 		}
@@ -1010,6 +1012,8 @@ pub mod pallet {
 				Self::update_active(collator.clone(), state.total);
 			}
 			<CollatorState<T>>::insert(&collator, state);
+			let new_total_staked = <Total<T>>::get().saturating_sub(less);
+			<Total<T>>::put(new_total_staked);
 			Self::deposit_event(Event::CollatorBondedLess(collator, before, after));
 			Ok(().into())
 		}
@@ -1119,6 +1123,8 @@ pub mod pallet {
 			}
 			<CollatorState<T>>::insert(&candidate, collator);
 			<NominatorState<T>>::insert(&nominator, nominations);
+			let new_total_staked = <Total<T>>::get().saturating_add(more);
+			<Total<T>>::put(new_total_staked);
 			Self::deposit_event(Event::NominationIncreased(
 				nominator, candidate, before, after,
 			));
@@ -1157,6 +1163,8 @@ pub mod pallet {
 			}
 			<CollatorState<T>>::insert(&candidate, collator);
 			<NominatorState<T>>::insert(&nominator, nominations);
+			let new_total_staked = <Total<T>>::get().saturating_sub(less);
+			<Total<T>>::put(new_total_staked);
 			Self::deposit_event(Event::NominationDecreased(
 				nominator, candidate, before, after,
 			));
@@ -1344,13 +1352,13 @@ pub mod pallet {
 							}
 							// return stake to collator
 							T::Currency::unreserve(&state.id, state.bond);
-							let new_total = <Total<T>>::get() - state.total;
-							<Total<T>>::put(new_total);
 							<CollatorState<T>>::remove(&x.owner);
+							let new_total_staked = <Total<T>>::get().saturating_sub(state.total);
+							<Total<T>>::put(new_total_staked);
 							Self::deposit_event(Event::CollatorLeft(
 								x.owner,
 								state.total,
-								new_total,
+								new_total_staked,
 							));
 						}
 						None

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -521,8 +521,8 @@ pub mod pallet {
 			log::trace!(
 				target: "staking",
 				"Finished migrating storage.\nOld Total : {:?}\nNew Total : {:?}",
-				new_total,
 				old_total,
+				new_total,
 			);
 
 			10_000

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -712,7 +712,10 @@ fn collators_bond() {
 				Stake::candidate_bond_more(Origin::signed(6), 50),
 				Error::<Test>::CandidateDNE
 			);
+			let mut total = Stake::total();
 			assert_ok!(Stake::candidate_bond_more(Origin::signed(1), 50));
+			total += 50;
+			assert_eq!(Stake::total(), total);
 			assert_noop!(
 				Stake::candidate_bond_more(Origin::signed(1), 40),
 				DispatchError::Module {
@@ -728,13 +731,21 @@ fn collators_bond() {
 				Error::<Test>::CannotActivateIfLeaving
 			);
 			roll_to(30);
+			total -= 100;
+			assert_eq!(Stake::total(), total);
 			assert_noop!(
 				Stake::candidate_bond_more(Origin::signed(1), 40),
 				Error::<Test>::CandidateDNE
 			);
 			assert_ok!(Stake::candidate_bond_more(Origin::signed(2), 80));
+			total += 80;
+			assert_eq!(Stake::total(), total);
 			assert_ok!(Stake::candidate_bond_less(Origin::signed(2), 90));
+			total -= 90;
+			assert_eq!(Stake::total(), total);
 			assert_ok!(Stake::candidate_bond_less(Origin::signed(3), 10));
+			total -= 10;
+			assert_eq!(Stake::total(), total);
 			assert_noop!(
 				Stake::candidate_bond_less(Origin::signed(2), 11),
 				Error::<Test>::CannotBondLessGEQTotalBond
@@ -752,6 +763,8 @@ fn collators_bond() {
 				Error::<Test>::ValBondBelowMin
 			);
 			assert_ok!(Stake::candidate_bond_less(Origin::signed(4), 10));
+			total -= 10;
+			assert_eq!(Stake::total(), total);
 		});
 }
 
@@ -781,6 +794,7 @@ fn nominators_bond() {
 		.build()
 		.execute_with(|| {
 			roll_to(4);
+			let mut total = Stake::total();
 			assert_noop!(
 				Stake::nominator_bond_more(Origin::signed(1), 2, 50),
 				Error::<Test>::NominatorDNE
@@ -806,6 +820,8 @@ fn nominators_bond() {
 				Error::<Test>::NomBondBelowMin
 			);
 			assert_ok!(Stake::nominator_bond_more(Origin::signed(6), 1, 10));
+			total += 10;
+			assert_eq!(Stake::total(), total);
 			assert_noop!(
 				Stake::nominator_bond_less(Origin::signed(6), 2, 5),
 				Error::<Test>::NominationDNE
@@ -822,7 +838,10 @@ fn nominators_bond() {
 			roll_to(9);
 			assert_eq!(Balances::reserved_balance(&6), 20);
 			assert_ok!(Stake::leave_candidates(Origin::signed(1)));
+			assert_eq!(Stake::total(), total);
 			roll_to(31);
+			total -= 60;
+			assert_eq!(Stake::total(), total);
 			assert!(!Stake::is_nominator(&6));
 			assert_eq!(Balances::reserved_balance(&6), 0);
 			assert_eq!(Balances::free_balance(&6), 100);

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -119,8 +119,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase"),
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 3,
-	spec_version: 48,
-	impl_version: 2,
+	spec_version: 49,
+	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 };

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 3,
 	spec_version: 48,
-	impl_version: 1,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 };

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -121,7 +121,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
 	spec_version: 49,
-	impl_version: 1,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 };

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -120,8 +120,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 49,
-	impl_version: 2,
+	spec_version: 50,
+	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 };

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
 	spec_version: 50,
-	impl_version: 1,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 };

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -122,8 +122,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 50,
-	impl_version: 2,
+	spec_version: 51,
+	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 };

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: create_runtime_str!("moonshadow"),
 	authoring_version: 3,
 	spec_version: 49,
-	impl_version: 1,
+	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 };

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -119,8 +119,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonshadow"),
 	impl_name: create_runtime_str!("moonshadow"),
 	authoring_version: 3,
-	spec_version: 49,
-	impl_version: 2,
+	spec_version: 50,
+	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 };


### PR DESCRIPTION
### What does it do?

follows suggested mitigation: https://github.com/PureStake/sr-moonbeam/issues/11

## Checklist

- Does it require a purge of the network? It may, depending on how many times `bond_more` or `bond_less` was called. Basically the `Total` counter needs to be reset in any storage migration if these methods have been called.
- [x] You bumped the runtime version if there are breaking changes in the **runtime** ?
- Does it require changes in documentation/tutorials ?
