### PR TITLE
Add benchmarking to CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
             false
           fi
       - name: Ensure benchmarking compiles
-        run: cargo build --release --features=runtime-benchmarks
+        run: cargo check --release --features=runtime-benchmarks
       - name: Unit tests
         run: cargo test --release --all
       - name: Stop sccache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,8 @@ jobs:
             echo $DIFF_INDEX | grep Cargo.lock
             false
           fi
+      - name: Ensure benchmarking compiles
+        run: cargo build --release --features=runtime-benchmarks
       - name: Unit tests
         run: cargo test --release --all
       - name: Stop sccache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4845,9 +4845,11 @@ dependencies = [
  "moonbeam-cli",
  "moonbeam-service",
  "nix",
+ "pallet-xcm",
  "serde",
  "serde_json",
  "tempfile",
+ "xcm-builder",
 ]
 
 [[package]]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,10 +23,17 @@ assert_cmd = "0.12"
 nix = "0.17"
 tempfile = "3.2.0"
 hex = "0.4.3"
+# required for benchmarking
+pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.4" }
+xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.4" }
 
 [features]
 default = []
 
 test-spec = []
 
-runtime-benchmarks = ["moonbeam-cli/runtime-benchmarks"]
+runtime-benchmarks = [
+	"moonbeam-cli/runtime-benchmarks",
+	"pallet-xcm/runtime-benchmarks",
+	"xcm-builder/runtime-benchmarks",
+]

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1216,9 +1216,9 @@ impl_runtime_apis! {
 			let params = (&config, &whitelist);
 
 			add_benchmark!(params, batches, parachain_staking, ParachainStakingBench::<Runtime>);
-			add_benchmark!(
-				params, batches, pallet_crowdloan_rewards, PalletCrowdloanRewardsBench::<Runtime>
-			);
+			// add_benchmark!(
+			// 	params, batches, pallet_crowdloan_rewards, PalletCrowdloanRewardsBench::<Runtime>
+			// );
 			add_benchmark!(params, batches, frame_system, SystemBench::<Runtime>);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1239,9 +1239,9 @@ impl_runtime_apis! {
 			let params = (&config, &whitelist);
 
 			add_benchmark!(params, batches, parachain_staking, ParachainStakingBench::<Runtime>);
-			add_benchmark!(
-				params, batches, pallet_crowdloan_rewards, PalletCrowdloanRewardsBench::<Runtime>
-			);
+			// add_benchmark!(
+			// 	params, batches, pallet_crowdloan_rewards, PalletCrowdloanRewardsBench::<Runtime>
+			// );
 			add_benchmark!(params, batches, frame_system, SystemBench::<Runtime>);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1260,9 +1260,9 @@ impl_runtime_apis! {
 			let params = (&config, &whitelist);
 
 			add_benchmark!(params, batches, parachain_staking, ParachainStakingBench::<Runtime>);
-			add_benchmark!(
-				params, batches, pallet_crowdloan_rewards, PalletCrowdloanRewardsBench::<Runtime>
-			);
+			// add_benchmark!(
+			// 	params, batches, pallet_crowdloan_rewards, PalletCrowdloanRewardsBench::<Runtime>
+			// );
 			add_benchmark!(params, batches, frame_system, SystemBench::<Runtime>);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -1238,9 +1238,9 @@ impl_runtime_apis! {
 			let params = (&config, &whitelist);
 
 			add_benchmark!(params, batches, parachain_staking, ParachainStakingBench::<Runtime>);
-			add_benchmark!(
-				params, batches, pallet_crowdloan_rewards, PalletCrowdloanRewardsBench::<Runtime>
-			);
+			// add_benchmark!(
+			// 	params, batches, pallet_crowdloan_rewards, PalletCrowdloanRewardsBench::<Runtime>
+			// );
 			add_benchmark!(params, batches, frame_system, SystemBench::<Runtime>);
 
 			if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }


### PR DESCRIPTION
### What does it do?

Adds a check to the CI to ensure the node compiles with features `runtime-benchmarks`. Adding this check to the CI implies maintaining benchmarking capability for the node.

We need to make sure that the compilation step happens in parallel with the tests and/or release build check or it will ~double the time for the CI (CC @notlesh )

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- Does it require a purge of the network? No
- You bumped the runtime version if there are breaking changes in the **runtime** ? No
- Does it require changes in documentation/tutorials ? No
