### PR TITLE
Add `[Parachain]` log prefix

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -407,7 +407,7 @@ impl fp_rpc::ConvertTransaction<moonbeam_core_primitives::UncheckedExtrinsic>
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
 ///
 /// This is the actual implementation that is abstract over the executor and the runtime api.
-#[sc_tracing::logging::prefix_logs_with("Parachain")]
+#[sc_tracing::logging::prefix_logs_with("")]
 async fn start_node_impl<RuntimeApi, Executor>(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -407,6 +407,7 @@ impl fp_rpc::ConvertTransaction<moonbeam_core_primitives::UncheckedExtrinsic>
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
 ///
 /// This is the actual implementation that is abstract over the executor and the runtime api.
+#[sc_tracing::logging::prefix_logs_with("Parachain")]
 async fn start_node_impl<RuntimeApi, Executor>(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -407,7 +407,7 @@ impl fp_rpc::ConvertTransaction<moonbeam_core_primitives::UncheckedExtrinsic>
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
 ///
 /// This is the actual implementation that is abstract over the executor and the runtime api.
-#[sc_tracing::logging::prefix_logs_with("")]
+#[sc_tracing::logging::prefix_logs_with("🌗")]
 async fn start_node_impl<RuntimeApi, Executor>(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,


### PR DESCRIPTION
This PR adds the prefix `[Parachain]` to log lines that come from the parachain side.

Missing this line manifested itself in two ways that are now fixed.
1. Missing prefixes on most lines
2. Incorrect `[Relaychain]` prefixes on authoring-related lines.

cc @purestakeoskar 