### PR TITLE
Moves tests to self hosted CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
         run: cargo fmt -- --check
 
   typescript-tests:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: build
     steps:
       - name: Checkout
@@ -190,7 +190,7 @@ jobs:
           npm install
           cd ../tests
           npm install
-          node_modules/.bin/mocha -r ts-node/register 'tests/**/test-*.ts'
+          node_modules/.bin/mocha -j 7 -r ts-node/register 'tests/**/test-*.ts'
 
   ####### Prepare and Deploy Docker images #######
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
           npm install
           cd ../tests
           npm install
-          node_modules/.bin/mocha -j 7 -r ts-node/register 'tests/**/test-*.ts'
+          node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tests/**/test-*.ts'
 
   ####### Prepare and Deploy Docker images #######
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 # Rust directories
 **/target
 **/scripts/tmp
+
+# Typescript directories
 **/node_modules
+**/.yarn
 
 # Spec/Wasm build directory
 /build/


### PR DESCRIPTION
CI tests were moved to the github servers until proper CI servers were in place. 
It is now stable enough to be moved back to our CI servers