### PR TITLE
Update nimbus comment to reflect current code

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -787,7 +787,7 @@ runtime_common::impl_runtime_apis_plus_common! {
 	}
 }
 
-// Notice we're using Nimbus's Executive wrapper to pop (and in the future verify) the seal digest.
+// Nimbus's Executive wrapper allows relay validators to verify the seal digest
 cumulus_pallet_parachain_system::register_validate_block!(
 	Runtime,
 	pallet_author_inherent::BlockExecutor<Runtime, Executive>

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -811,7 +811,7 @@ runtime_common::impl_runtime_apis_plus_common! {
 	}
 }
 
-// Notice we're using Nimbus's Executive wrapper to pop (and in the future verify) the seal digest.
+// Nimbus's Executive wrapper allows relay validators to verify the seal digest
 cumulus_pallet_parachain_system::register_validate_block!(
 	Runtime,
 	pallet_author_inherent::BlockExecutor<Runtime, Executive>

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -835,7 +835,7 @@ runtime_common::impl_runtime_apis_plus_common! {
 	}
 }
 
-// Notice we're using Nimbus's Executive wrapper to pop (and in the future verify) the seal digest.
+// Nimbus's Executive wrapper allows relay validators to verify the seal digest
 cumulus_pallet_parachain_system::register_validate_block!(
 	Runtime,
 	pallet_author_inherent::BlockExecutor<Runtime, Executive>

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -810,7 +810,7 @@ runtime_common::impl_runtime_apis_plus_common! {
 	}
 }
 
-// Notice we're using Nimbus's Executive wrapper to pop (and in the future verify) the seal digest.
+// Nimbus's Executive wrapper allows relay validators to verify the seal digest
 cumulus_pallet_parachain_system::register_validate_block!(
 	Runtime,
 	pallet_author_inherent::BlockExecutor<Runtime, Executive>


### PR DESCRIPTION
This PR updates a comment that was present in all four runtimes, but was still phrased in terms of an earlier phase of development.

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
