### PR TITLE
Adds publish CI actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,11 @@ jobs:
       - name: Check git ref
         id: check-git-ref
         run: |
-          if [[ -z "${{ github.event.inputs.pull_request }}" ]]; then
+          if [[ -n "${{ github.event.inputs.pull_request }}" ]]; then
             echo ::set-output name=git_ref::pull/${{ github.event.inputs.pull_request }}/head
             echo "git_ref: pull/${{ github.event.inputs.pull_request }}/head"
           fi
+
   check-copyright:
     runs-on: ubuntu-latest
     needs: ["set-tags"]
@@ -47,6 +48,7 @@ jobs:
           else
             false
           fi
+
   check-links:
     runs-on: ubuntu-latest
     needs: ["set-tags"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,372 @@
+name: Build
+
+# Using a single file workflow is the preferred solution for our CI over workflow_runs.
+# 1. It generates only 1 action item in the list making it more readable
+# 2. It includes the PR/Commit text in the action item
+# 3. Artifacts are not available between workflows.
+
+# This is only allowing pushes on the moonbeam repo for pull requests.
+####### DO NOT CHANGE THIS !! #######
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: set to pull_request number to execute on external pr
+        required: false
+
+jobs:
+  ####### Check files and formatting #######
+
+  set-tags:
+    runs-on: ubuntu-latest
+    outputs:
+      git_ref: ${{ steps.check-input.git-ref.git_ref }}
+    steps:
+      - name: Check git ref
+        id: check-git-ref
+        run: |
+          if [[ -z ${{ github.event.inputs.pull_request }} ]]; then
+            echo ::set-output name=git_ref::pull/${{ github.event.inputs.pull_request }}/head
+            echo "git_ref: pull/${{ github.event.inputs.pull_request }}/head"
+          fi
+
+  check-copyright:
+    runs-on: ubuntu-latest
+    needs: ["set-tags"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
+      - name: Find un-copyrighted files
+        run: |
+          find . -name '*.rs' -exec grep  -H -E -o -c Copyright {} \; | grep ':0' || true
+          FILECOUNT=$(find . -name '*.rs' -exec grep  -H -E -o -c  'Copyright'  {} \; | grep -c ':0' || true)
+          if [[ $FILECOUNT -eq 0 ]]; then
+            true
+          else
+            false
+          fi
+
+  check-links:
+    runs-on: ubuntu-latest
+    needs: ["set-tags"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: "yes"
+
+  check-editorconfig:
+    name: "Check editorconfig"
+    runs-on: ubuntu-latest
+    needs: ["set-tags"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
+      - name: Setup editorconfig checker
+        run: |
+          ls /tmp/bin/ec-linux-amd64 || \
+          cd /tmp && \
+          wget https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.1.0/ec-linux-amd64.tar.gz && \
+          tar xvf ec-linux-amd64.tar.gz && \
+          chmod +x bin/ec-linux-amd64
+      - name: Check files
+        run: /tmp/bin/ec-linux-amd64
+
+  check-prettier:
+    name: "Check with Prettier"
+    runs-on: ubuntu-latest
+    needs: ["set-tags"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Check with Prettier
+        run: npx prettier --check --ignore-path .gitignore '**/*.(yml|js|ts|json)'
+
+  ####### Building and Testing binaries #######
+
+  build:
+    runs-on: self-hosted
+    needs: ["set-tags"]
+    env:
+      CARGO_SCCACHE_VERSION: 0.2.14-alpha.0-parity
+      RUSTFLAGS: "-C opt-level=3"
+      # MOONBEAM_LOG: info
+      # DEBUG: "test*"
+    outputs:
+      RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
+      - uses: actions/cache@v2
+        with:
+          path: ${{ runner.tool_cache }}/cargo-sccache
+          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}-v1
+
+      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
+      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
+      - name: Setup Rust toolchain
+        run: rustup show
+      - name: SCCache
+        run: |
+          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+            cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+          fi
+          if [[ -z `pgrep sccache` ]]; then
+            chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
+            ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
+          fi
+          ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
+          echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
+      - id: get-rust-versions
+        run: |
+          echo "::set-output name=rustc::$(rustc --version)"
+      - name: Build Node
+        run: cargo build --release --all
+      - name: Unit tests
+        run: cargo test --release --all
+      - name: Format code with rustfmt
+        run: cargo fmt -- --check
+
+      # We determine whether there are unmodified Cargo.lock files by:
+      # 1. Asking git for a list of all modified files
+      # 2. Using grep to reduce the list to only Cargo.lock files
+      # 3. Counting the number of lines of output
+      - name: Check Cargo Toml
+        run: |
+          # Make sure git is working, and if not abort early. When git is not working it looks like:
+          # $ git diff-index --name-only HEAD
+          # fatal: not a git repository (or any of the parent directories): .git
+          DIFF_INDEX=$(git diff-index --name-only HEAD)
+          if [[ ${DIFF_INDEX:0:5} == "fatal" ]]; then
+            echo "There was an error with the git checkout. Can't check Cargo.lock file."
+            false
+          fi
+
+          FILECOUNT=$(echo $DIFF_INDEX | grep Cargo.lock | wc -l)
+          if [[ $FILECOUNT -eq 0 ]]; then
+            echo "All lock files are valid"
+          else
+            echo "The following Cargo.lock files have uncommitted changes"
+            echo $DIFF_INDEX | grep Cargo.lock
+            false
+          fi
+      - name: Check with Clippy
+        run: cargo clippy --release --workspace
+      - name: Ensure benchmarking compiles
+        run: cargo check --release --features=runtime-benchmarks
+      - name: Save parachain binary
+        run: |
+          mkdir -p build
+          cp target/release/moonbeam build/moonbeam;
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: moonbeam
+          path: build
+
+  typescript-tests:
+    runs-on: self-hosted
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: moonbeam
+          path: build
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Typescript integration tests (against dev service)
+        env:
+          BINARY_PATH: ../build/moonbeam
+        run: |
+          chmod uog+x build/moonbeam
+          cd moonbeam-types-bundle
+          npm install
+          cd ../tests
+          npm install
+          node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tests/**/test-*.ts'
+
+  ####### Prepare and Deploy Docker images #######
+
+  generate-parachain-specs:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    needs: ["build", "typescript-tests"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: moonbeam
+          path: build
+      - name: Make moonbeam executable
+        run: |
+          chmod uog+x build/moonbeam
+      - name: Generate specs
+        run: |
+          MOONBEAM_BINARY=build/moonbeam scripts/generate-parachain-specs.sh
+      - name: Generate runtimes
+        run: |
+          MOONBEAM_BINARY=build/moonbeam scripts/generate-runtimes.sh
+      - name: Upload parachain specs
+        uses: actions/upload-artifact@v2
+        with:
+          name: moonbeam
+          path: build
+
+  docker-parachain:
+    runs-on: ubuntu-latest
+    needs: ["build", "generate-parachain-specs"]
+    if: github.event_name == 'push'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: moonbeam
+          path: build
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=purestake/moonbase-parachain
+          VERSION=noop
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            VERSION=nightly
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+              VERSION=edge
+            fi
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          driver-opts: |
+            image=moby/buildkit:master
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push parachain
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/moonbase-parachain.Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+
+  docker-moonbeam:
+    runs-on: ubuntu-latest
+    needs: ["build", "generate-parachain-specs"]
+    if: github.event_name == 'push'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: moonbeam
+          path: build
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=purestake/moonbeam
+          VERSION=noop
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            VERSION=nightly
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+              VERSION=edge
+            fi
+          elif [[ $GITHUB_REF == refs/pull/* ]]; then
+            VERSION=pr-${{ github.event.number }}
+          fi
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          driver-opts: |
+            image=moby/buildkit:master
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push moonbeam
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/moonbeam.Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
   set-tags:
     runs-on: ubuntu-latest
     outputs:
-      git_ref: ${{ steps.check-input.git-ref.git_ref }}
+      git_ref: ${{ steps.check-git-ref.outputs.git_ref }}
     steps:
       - name: Check git ref
         id: check-git-ref

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ name: Build
 # This is only allowing pushes on the moonbeam repo for pull requests.
 ####### DO NOT CHANGE THIS !! #######
 on:
+  push:
   workflow_dispatch:
     inputs:
       pull_request:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ name: Build
 # This is only allowing pushes on the moonbeam repo for pull requests.
 ####### DO NOT CHANGE THIS !! #######
 on:
-  push:
   workflow_dispatch:
     inputs:
       pull_request:
@@ -26,11 +25,10 @@ jobs:
       - name: Check git ref
         id: check-git-ref
         run: |
-          if [[ -z ${{ github.event.inputs.pull_request }} ]]; then
+          if [[ -z "${{ github.event.inputs.pull_request }}" ]]; then
             echo ::set-output name=git_ref::pull/${{ github.event.inputs.pull_request }}/head
             echo "git_ref: pull/${{ github.event.inputs.pull_request }}/head"
           fi
-
   check-copyright:
     runs-on: ubuntu-latest
     needs: ["set-tags"]
@@ -48,7 +46,6 @@ jobs:
           else
             false
           fi
-
   check-links:
     runs-on: ubuntu-latest
     needs: ["set-tags"]
@@ -157,7 +154,6 @@ jobs:
             echo "There was an error with the git checkout. Can't check Cargo.lock file."
             false
           fi
-
           FILECOUNT=$(echo $DIFF_INDEX | grep Cargo.lock | wc -l)
           if [[ $FILECOUNT -eq 0 ]]; then
             echo "All lock files are valid"
@@ -206,9 +202,7 @@ jobs:
           cd ../tests
           npm install
           node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tests/**/test-*.ts'
-
   ####### Prepare and Deploy Docker images #######
-
   generate-parachain-specs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
         id: check-git-ref
         run: |
           if [[ -n "${{ github.event.inputs.pull_request }}" ]]; then
-            echo ::set-output name=git_ref::pull/${{ github.event.inputs.pull_request }}/head
-            echo "git_ref: pull/${{ github.event.inputs.pull_request }}/head"
+            echo ::set-output name=git_ref::refs/pull/${{ github.event.inputs.pull_request }}/head
+            echo "git_ref: refs/pull/${{ github.event.inputs.pull_request }}/head"
           fi
 
   check-copyright:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -27,6 +27,7 @@ jobs:
           SHA=sha-${COMMIT::8}
           TAGS="${DOCKER_IMAGE}:${VERSION}"
 
+          docker pull "${DOCKER_IMAGE}:${SHA}"
           docker image tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${VERSION}"
           docker push "${DOCKER_IMAGE}:${VERSION}"
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -23,7 +23,7 @@ jobs:
       - run: |
           DOCKER_IMAGE=purestake/moonbeam
           VERSION=${{ github.event.inputs.tag }}
-          COMMIT=`git rev-list -n 1 '${{ github.event.inputs.tag }} '`
+          COMMIT=`git rev-list -n 1 '${{ github.event.inputs.tag }}'`
           SHA=sha-${COMMIT::8}
           TAGS="${DOCKER_IMAGE}:${VERSION}"
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -11,6 +11,10 @@ jobs:
   tag-docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,38 @@
+name: Publish Docker
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: tag (ex. v0.8.3) to publish on docker
+        required: true
+
+jobs:
+  tag-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - run: |
+          DOCKER_IMAGE=purestake/moonbeam
+          VERSION=${{ github.event.inputs.tag }}
+          COMMIT=`git rev-list -n 1 '${{ github.event.inputs.tag }} '`
+          SHA=sha-${COMMIT::8}
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+
+          docker image tag "${DOCKER_IMAGE}:${SHA}"" "${DOCKER_IMAGE}:${VERSION}"
+          docker push "${DOCKER_IMAGE}:${VERSION}"
+
+          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            docker image tag "${DOCKER_IMAGE}:${SHA}"" "${DOCKER_IMAGE}:${MINOR}"
+            docker push "${DOCKER_IMAGE}:${MINOR}"
+
+            docker image tag "${DOCKER_IMAGE}:${SHA}"" "${DOCKER_IMAGE}:${MAJOR}"
+            docker push "${DOCKER_IMAGE}:${MAJOR}"
+
+            docker image tag "${DOCKER_IMAGE}:${SHA}"" "${DOCKER_IMAGE}:latest"
+            docker push "${DOCKER_IMAGE}:latest"
+          fi

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -27,16 +27,16 @@ jobs:
           SHA=sha-${COMMIT::8}
           TAGS="${DOCKER_IMAGE}:${VERSION}"
 
-          docker image tag "${DOCKER_IMAGE}:${SHA}"" "${DOCKER_IMAGE}:${VERSION}"
+          docker image tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${VERSION}"
           docker push "${DOCKER_IMAGE}:${VERSION}"
 
           if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            docker image tag "${DOCKER_IMAGE}:${SHA}"" "${DOCKER_IMAGE}:${MINOR}"
+            docker image tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${MINOR}"
             docker push "${DOCKER_IMAGE}:${MINOR}"
 
-            docker image tag "${DOCKER_IMAGE}:${SHA}"" "${DOCKER_IMAGE}:${MAJOR}"
+            docker image tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${MAJOR}"
             docker push "${DOCKER_IMAGE}:${MAJOR}"
 
-            docker image tag "${DOCKER_IMAGE}:${SHA}"" "${DOCKER_IMAGE}:latest"
+            docker image tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:latest"
             docker push "${DOCKER_IMAGE}:latest"
           fi

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -22,22 +22,29 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: |
           DOCKER_IMAGE=purestake/moonbeam
-          VERSION=${{ github.event.inputs.tag }}
+          VERSION="${{ github.event.inputs.tag }}"
           COMMIT=`git rev-list -n 1 '${{ github.event.inputs.tag }}'`
           SHA=sha-${COMMIT::8}
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
 
+          echo using "${DOCKER_IMAGE}:${SHA}"
           docker pull "${DOCKER_IMAGE}:${SHA}"
-          docker image tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${VERSION}"
+
+          echo tagging "${DOCKER_IMAGE}:${VERSION}"
+          docker tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${VERSION}"
           docker push "${DOCKER_IMAGE}:${VERSION}"
 
           if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            docker image tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${MINOR}"
+            MINOR=${VERSION%.*}
+            echo tagging "${DOCKER_IMAGE}:${MINOR}"
+            docker tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${MINOR}"
             docker push "${DOCKER_IMAGE}:${MINOR}"
 
-            docker image tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${MAJOR}"
+            MAJOR=${MINOR%.*}
+            echo tagging "${DOCKER_IMAGE}:${MAJOR}"
+            docker tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:${MAJOR}"
             docker push "${DOCKER_IMAGE}:${MAJOR}"
 
-            docker image tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:latest"
+            echo tagging "${DOCKER_IMAGE}:latest"
+            docker tag "${DOCKER_IMAGE}:${SHA}" "${DOCKER_IMAGE}:latest"
             docker push "${DOCKER_IMAGE}:latest"
           fi

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,255 @@
+name: Publish Release Draft
+
+# The code (like generate-release-body) will be taken from the tag version, not master
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: tag (ex. v0.8.3) to generate release note and srtool runtimes from
+        required: true
+
+jobs:
+  ####### Building binaries #######
+
+  build-binary:
+    runs-on: self-hosted
+    env:
+      CARGO_SCCACHE_VERSION: 0.2.14-alpha.0-parity
+      RUSTFLAGS: "-C opt-level=3"
+    outputs:
+      RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.tag }}
+      - uses: actions/cache@v2
+        with:
+          path: ${{ runner.tool_cache }}/cargo-sccache
+          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}-v1
+
+      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
+      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
+      - name: Setup Rust toolchain
+        run: rustup show
+      - name: SCCache
+        run: |
+          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+            cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+          fi
+          if [[ -z `pgrep sccache` ]]; then
+            chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
+            ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
+          fi
+          ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
+          echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
+      - id: get-rust-versions
+        run: |
+          echo "::set-output name=rustc::$(rustc --version)"
+      - name: Build Node
+        run: cargo build --release --all
+      - name: Save parachain binary
+        run: |
+          mkdir -p build
+          cp target/release/moonbeam build/moonbeam;
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: moonbeam
+          path: build
+
+  ####### Build runtimes with srtool #######
+
+  build-srtool-runtimes:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chain: ["moonbase", "moonshadow", "moonriver", "moonbeam"]
+    steps:
+      - name: Get Timestamp
+        run: echo "TMSP=$(date '+%Y%m%d_%H%M%S')" >> $GITHUB_ENV
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.tag }}
+      - name: Srtool build
+        id: srtool_build
+        uses: chevdor/srtool-actions@v0.1.0
+        with:
+          chain: ${{ matrix.chain }}
+          tag: 1.53.0-rc2
+      - name: Summary
+        run: |
+          echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain }}-srtool-digest.json
+          cat ${{ matrix.chain }}-srtool-digest.json
+          cp ${{ steps.srtool_build.outputs.wasm }} ${{ matrix.chain }}-runtime.compact.wasm
+      - name: Archive Artifacts for ${{ matrix.chain }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.chain }}-runtime
+          path: |
+            ${{ matrix.chain }}-runtime.compact.wasm
+            ${{ matrix.chain }}-srtool-digest.json
+
+  ####### Prepare the release draft #######
+
+  publish-draft-release:
+    runs-on: ubuntu-latest
+    needs: ["build-binary", "build-srtool-runtimes"]
+    outputs:
+      release_url: ${{ steps.create-release.outputs.html_url }}
+      asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.tag }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@v2
+        with:
+          name: moonbeam
+          path: build
+      - name: Download moonbase runtime
+        uses: actions/download-artifact@v2
+        with:
+          name: moonbase-runtime
+          path: build
+      - name: Download moonshadow runtime
+        uses: actions/download-artifact@v2
+        with:
+          name: moonshadow-runtime
+          path: build
+      - name: Download moonriver runtime
+        uses: actions/download-artifact@v2
+        with:
+          name: moonriver-runtime
+          path: build
+      - name: Download moonbeam runtime
+        uses: actions/download-artifact@v2
+        with:
+          name: moonbeam-runtime
+          path: build
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Generate release body
+        id: generate-release-body
+        run: |
+          cd tools
+          yarn
+          yarn -s run ts-node github/generate-release-body.ts --srtool-report-folder '../build/' > ../body.md
+      - name: Get runtime version
+        id: get-runtime-ver
+        run: |
+          runtime_moonbase_ver="$(cat ./runtime/moonbase/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
+
+          echo "::set-output name=runtime_moonbase_ver::$runtime_moonbase_ver"
+          mv build/moonbase-runtime.compact.wasm moonbase-runtime-${runtime_moonbase_ver}.wasm
+          mv build/moonbase-srtool-digest.json moonbase-runtime-${runtime_moonbase_ver}-srtool-digest.json
+          runtime_moonshadow_ver="$(cat ./runtime/moonshadow/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
+
+          echo "::set-output name=runtime_moonshadow_ver::$runtime_moonshadow_ver"
+          mv build/moonshadow-runtime.compact.wasm moonshadow-runtime-${runtime_moonshadow_ver}.wasm
+          mv build/moonshadow-srtool-digest.json moonshadow-runtime-${runtime_moonshadow_ver}-srtool-digest.json
+          runtime_moonriver_ver="$(cat ./runtime/moonriver/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
+
+          echo "::set-output name=runtime_moonriver_ver::$runtime_moonriver_ver"
+          mv build/moonriver-runtime.compact.wasm moonriver-runtime-${runtime_moonriver_ver}.wasm
+          mv build/moonriver-srtool-digest.json moonriver-runtime-${runtime_moonriver_ver}-srtool-digest.json
+          runtime_moonbeam_ver="$(cat ./runtime/moonbeam/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
+
+          echo "::set-output name=runtime_moonbeam_ver::$runtime_moonbeam_ver"
+          mv build/moonbeam-runtime.compact.wasm moonbeam-runtime-${runtime_moonbeam_ver}.wasm
+          mv build/moonbeam-srtool-digest.json moonbeam-runtime-${runtime_moonbeam_ver}-srtool-digest.json
+
+      - name: Create draft release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.tag }}
+          release_name: Moonbase ${{ github.event.inputs.tag }}
+          body_path: body.md
+          draft: true
+      - name: Upload moonbase wasm
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: moonbase-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbase_ver }}.wasm
+          asset_name: moonbase-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbase_ver }}.wasm
+          asset_content_type: application/octet-stream
+      - name: Upload moonbase srtool digest
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: moonbase-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbase_ver }}-srtool-digest.json
+          asset_name: moonbase-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbase_ver }}.srtool-digest.json
+          asset_content_type: application/json
+      - name: Upload moonshadow wasm
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: moonshadow-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonshadow_ver }}.wasm
+          asset_name: moonshadow-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonshadow_ver }}.wasm
+          asset_content_type: application/octet-stream
+      - name: Upload moonshadow srtool digest
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: moonshadow-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonshadow_ver }}-srtool-digest.json
+          asset_name: moonshadow-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonshadow_ver }}.srtool-digest.json
+          asset_content_type: application/json
+      - name: Upload moonriver wasm
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: moonriver-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonriver_ver }}.wasm
+          asset_name: moonriver-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonriver_ver }}.wasm
+          asset_content_type: application/octet-stream
+      - name: Upload moonriver srtool digest
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: moonriver-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonriver_ver }}-srtool-digest.json
+          asset_name: moonriver-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonriver_ver }}.srtool-digest.json
+          asset_content_type: application/json
+      - name: Upload moonbeam wasm
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: moonbeam-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbeam_ver }}.wasm
+          asset_name: moonbeam-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbeam_ver }}.wasm
+          asset_content_type: application/octet-stream
+      - name: Upload moonbeam srtool digest
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: moonbeam-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbeam_ver }}-srtool-digest.json
+          asset_name: moonbeam-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbeam_ver }}.srtool-digest.json
+          asset_content_type: application/json
+      - name: Upload moonbeam
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: build/moonbeam
+          asset_name: moonbeam
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,11 +222,11 @@ jobs:
         with:
           node-version: 14.x
       - name: Generate release body
-        id: generate-release-body will be taken from the tag version, not master
+        id: generate-release-body
         run: |
           cd tools
           yarn
-          yarn -s run ts-node github/generate-release-body.ts --srtool-report-folder '../build/' > ../body.md will be taken from the tag version, not master
+          yarn -s run ts-node github/generate-release-body.ts --srtool-report-folder '../build/' > ../body.md
       - name: Get runtime version
         id: get-runtime-ver
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,11 +222,11 @@ jobs:
         with:
           node-version: 14.x
       - name: Generate release body
-        id: generate-release-bodybody will be taken from the tag version, not master
+        id: generate-release-body will be taken from the tag version, not master
         run: |
           cd tools
           yarn
-          yarn -s run ts-node github/generate-release-bodybody.ts --srtool-report-folder '../build/' > ../body.md will be taken from the tag version, not master
+          yarn -s run ts-node github/generate-release-body.ts --srtool-report-folder '../build/' > ../body.md will be taken from the tag version, not master
       - name: Get runtime version
         id: get-runtime-ver
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,94 +8,27 @@ name: Release
 # This is only allowing pushes on the moonbeam repo for pull requests.
 ####### DO NOT CHANGE THIS !! #######
 on:
-  push:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: tag (ex. v0.8.3) to generate release note and srtool runtime images from
+        required: true
 
 jobs:
-  ####### Check files and formatting #######
-
-  check-copyright:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Find un-copyrighted files
-        run: |
-          find . -name '*.rs' -exec grep  -H -E -o -c Copyright {} \; | grep ':0' || true
-          FILECOUNT=$(find . -name '*.rs' -exec grep  -H -E -o -c  'Copyright'  {} \; | grep -c ':0' || true)
-          if [[ $FILECOUNT -eq 0 ]]; then
-            true
-          else
-            false
-          fi
-
-  set-tags:
-    runs-on: ubuntu-latest
-    outputs:
-      is_release: ${{ steps.check-tag.outputs.is_release }}
-    steps:
-      # Determine whether this is a release based on the git tags that are applied.
-      # Some other CI tasks check this and only run on releases.
-      - name: Check Tag
-        id: check-tag
-        run: |
-          if [[ ${{ github.event.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo ::set-output name=is_release::true
-            echo "is_release: true"
-          fi
-
-  check-links:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          use-quiet-mode: "yes"
-
-  check-editorconfig:
-    name: "Check editorconfig"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup editorconfig checker
-        run: |
-          ls /tmp/bin/ec-linux-amd64 || \
-          cd /tmp && \
-          wget https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.1.0/ec-linux-amd64.tar.gz && \
-          tar xvf ec-linux-amd64.tar.gz && \
-          chmod +x bin/ec-linux-amd64
-      - name: Check files
-        run: /tmp/bin/ec-linux-amd64
-
-  check-prettier:
-    name: "Check with Prettier"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-      - name: Check with Prettier
-        run: npx prettier --check --ignore-path .gitignore '**/*.(yml|js|ts|json)'
-
-  ####### Building and Testing binaries #######
+  ####### Building binaries #######
 
   build:
     runs-on: self-hosted
     env:
       CARGO_SCCACHE_VERSION: 0.2.14-alpha.0-parity
       RUSTFLAGS: "-C opt-level=3"
-      # MOONBEAM_LOG: info
-      # DEBUG: "test*"
     outputs:
       RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.tag }}
       - uses: actions/cache@v2
         with:
           path: ${{ runner.tool_cache }}/cargo-sccache
@@ -121,38 +54,6 @@ jobs:
           echo "::set-output name=rustc::$(rustc --version)"
       - name: Build Node
         run: cargo build --release --all
-      - name: Unit tests
-        run: cargo test --release --all
-      - name: Format code with rustfmt
-        run: cargo fmt -- --check
-
-      # We determine whether there are unmodified Cargo.lock files by:
-      # 1. Asking git for a list of all modified files
-      # 2. Using grep to reduce the list to only Cargo.lock files
-      # 3. Counting the number of lines of output
-      - name: Check Cargo Toml
-        run: |
-          # Make sure git is working, and if not abort early. When git is not working it looks like:
-          # $ git diff-index --name-only HEAD
-          # fatal: not a git repository (or any of the parent directories): .git
-          DIFF_INDEX=$(git diff-index --name-only HEAD)
-          if [[ ${DIFF_INDEX:0:5} == "fatal" ]]; then
-            echo "There was an error with the git checkout. Can't check Cargo.lock file."
-            false
-          fi
-
-          FILECOUNT=$(echo $DIFF_INDEX | grep Cargo.lock | wc -l)
-          if [[ $FILECOUNT -eq 0 ]]; then
-            echo "All lock files are valid"
-          else
-            echo "The following Cargo.lock files have uncommitted changes"
-            echo $DIFF_INDEX | grep Cargo.lock
-            false
-          fi
-      - name: Check with Clippy
-        run: cargo clippy --release --workspace
-      - name: Ensure benchmarking compiles
-        run: cargo check --release --features=runtime-benchmarks
       - name: Save parachain binary
         run: |
           mkdir -p build
@@ -163,31 +64,6 @@ jobs:
           name: moonbeam
           path: build
 
-  typescript-tests:
-    runs-on: self-hosted
-    needs: build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: moonbeam
-          path: build
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14.x
-      - name: Typescript integration tests (against dev service)
-        env:
-          BINARY_PATH: ../build/moonbeam
-        run: |
-          chmod uog+x build/moonbeam
-          cd moonbeam-types-bundle
-          npm install
-          cd ../tests
-          npm install
-          node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tests/**/test-*.ts'
-
   ####### Prepare and Deploy Docker images #######
 
   generate-parachain-specs:
@@ -197,6 +73,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.tag }}
       - uses: actions/download-artifact@v2
         with:
           name: moonbeam
@@ -216,77 +94,6 @@ jobs:
           name: moonbeam
           path: build
 
-  docker-parachain:
-    runs-on: ubuntu-latest
-    needs: ["build", "generate-parachain-specs"]
-    if: github.event_name == 'push'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
-        with:
-          name: moonbeam
-          path: build
-      - name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=purestake/moonbase-parachain
-          VERSION=noop
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            VERSION=nightly
-          elif [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=edge
-            fi
-          elif [[ $GITHUB_REF == refs/pull/* ]]; then
-            VERSION=pr-${{ github.event.number }}
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            MINOR=${VERSION%.*}
-            MAJOR=${MINOR%.*}
-            TAGS="$TAGS,${DOCKER_IMAGE}:${MINOR},${DOCKER_IMAGE}:${MAJOR},${DOCKER_IMAGE}:latest"
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
-          fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-        with:
-          version: latest
-          driver-opts: |
-            image=moby/buildkit:master
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push parachain
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./docker/moonbase-parachain.Dockerfile
-          platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.prep.outputs.tags }}
-          labels: |
-            org.opencontainers.image.title=${{ github.event.repository.name }}
-            org.opencontainers.image.description=${{ github.event.repository.description }}
-            org.opencontainers.image.url=${{ github.event.repository.html_url }}
-            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
-            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
-
   docker-moonbeam:
     runs-on: ubuntu-latest
     needs: ["build", "generate-parachain-specs"]
@@ -294,6 +101,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.tag }}
       - uses: actions/download-artifact@v2
         with:
           name: moonbeam
@@ -302,19 +111,7 @@ jobs:
         id: prep
         run: |
           DOCKER_IMAGE=purestake/moonbeam
-          VERSION=noop
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            VERSION=nightly
-          elif [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=edge
-            fi
-          elif [[ $GITHUB_REF == refs/pull/* ]]; then
-            VERSION=pr-${{ github.event.number }}
-          fi
+          VERSION=${{ github.event.inputs.tag }}
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             MINOR=${VERSION%.*}
@@ -358,101 +155,75 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
 
-  ####### Prepare the release draft #######
+  ####### Build runtimes with srtool #######
 
   build-srtool-runtimes:
     runs-on: self-hosted
-    needs: ["set-tags"]
-    if: needs.set-tags.outputs.is_release == 'true'
     strategy:
       matrix:
-        runtime: ["moonbase", "moonshadow", "moonriver", "moonbeam"]
-    container:
-      image: paritytech/srtool:nightly-2021-03-15
-      volumes:
-        - ${{ github.workspace }}:/build
-      env:
-        PACKAGE: ${{ matrix.runtime }}-runtime
+        chain: ["moonbase", "moonshadow", "moonriver", "moonbeam"]
     steps:
+      - name: Get Timestamp
+        run: echo "TMSP=$(date '+%Y%m%d_%H%M%S')" >> $GITHUB_ENV
       - uses: actions/checkout@v2
-      - name: Cache target dir
-        uses: actions/cache@v2
         with:
-          path: "${{ github.workspace }}/runtime/${{ matrix.runtime }}/target"
-          key: srtool-target-${{ matrix.runtime }}-${{ github.sha }}
-          restore-keys: |
-            srtool-target-${{ matrix.runtime }}-
-            srtool-target-
-      - name: Build ${{ matrix.runtime }} runtime
-        id: build-runtime
-        shell: bash
-        env:
-          srtool_output_filename: ${{ matrix.runtime }}_srtool_output.json
+          ref: ${{ github.event.inputs.tag }}
+      - name: Srtool build
+        id: srtool_build
+        uses: chevdor/srtool-actions@v0.1.0
+        with:
+          chain: ${{ matrix.chain }}
+          tag: 1.53.0-rc2
+      - name: Summary
         run: |
-          cd /build
-          build --json | tee $srtool_output_filename
-          cat $srtool_output_filename
-          while IFS= read -r line; do
-            echo "::set-output name=$line::$(jq -r ".$line" < $srtool_output_filename)"
-          done <<< "$(jq -r 'keys[]' < $srtool_output_filename)"
-      - name: Upload ${{ matrix.runtime }} srtool json
+          echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.chain }}-srtool-digest.json
+          cat ${{ matrix.chain }}-srtool-digest.json
+          mv ${{ steps.srtool_build.outputs.wasm }} ${{ matrix.chain }}_runtime.compact.wasm
+      - name: Archive Artifacts for ${{ matrix.chain }}
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.runtime }}-srtool-json
-          path: ${{ matrix.runtime }}_srtool_output.json
-      - name: Upload ${{ matrix.runtime }} runtime
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.runtime }}-runtime
-          path: "${{ steps.build-runtime.outputs.wasm }}"
+          name: ${{ matrix.chain }}-runtime
+          path: |
+            ${{ matrix.chain }}_runtime.compact.wasm
+            ${{ matrix.chain }}-srtool-digest.json
+
+  ####### Prepare the release draft #######
 
   publish-draft-release:
     runs-on: ubuntu-latest
-    needs:
-      ["set-tags", "build", "generate-parachain-specs", "build-srtool-runtimes"]
-    if: needs.set-tags.outputs.is_release == 'true'
+    needs: ["build", "generate-parachain-specs", "build-srtool-runtimes"]
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.tag }}
       - uses: actions/download-artifact@v2
         with:
           name: moonbeam
           path: build
-      - name: Download moonbase srtool json output
-        uses: actions/download-artifact@v2
-        with:
-          name: moonbase-srtool-json
       - name: Download moonbase runtime
         uses: actions/download-artifact@v2
         with:
           name: moonbase-runtime
-      - name: Download moonshadow srtool json output
-        uses: actions/download-artifact@v2
-        with:
-          name: moonshadow-srtool-json
+          path: build
       - name: Download moonshadow runtime
         uses: actions/download-artifact@v2
         with:
           name: moonshadow-runtime
-      - name: Download moonriver srtool json output
-        uses: actions/download-artifact@v2
-        with:
-          name: moonriver-srtool-json
+          path: build
       - name: Download moonriver runtime
         uses: actions/download-artifact@v2
         with:
           name: moonriver-runtime
-      - name: Download moonbeam srtool json output
-        uses: actions/download-artifact@v2
-        with:
-          name: moonbeam-srtool-json
+          path: build
       - name: Download moonbeam runtime
         uses: actions/download-artifact@v2
         with:
           name: moonbeam-runtime
+          path: build
       - name: Use Node.js 14.x
         uses: actions/setup-node@v2
         with:
@@ -462,30 +233,39 @@ jobs:
         run: |
           cd tools
           npm install
-          node_modules/.bin/ts-node github/generate-release-body.ts > ../body.md
+          node_modules/.bin/ts-node github/generate-release-body.ts --srtool-report-folder '../build/' > ../body.md
       - name: Get runtime version
         id: get-runtime-ver
         run: |
           runtime_moonbase_ver="$(cat ./runtime/moonbase/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
+
           echo "::set-output name=runtime_moonbase_ver::$runtime_moonbase_ver"
-          mv moonbase_runtime.compact.wasm moonbase-runtime-${runtime_moonbase_ver}.wasm
+          mv build/moonbase_runtime.compact.wasm moonbase-runtime-${runtime_moonbase_ver}.wasm
+          mv build/moonbase-srtool-digest.json moonbase-runtime-${runtime_moonbase_ver}-srtool-digest.json
           runtime_moonshadow_ver="$(cat ./runtime/moonshadow/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
+
           echo "::set-output name=runtime_moonshadow_ver::$runtime_moonshadow_ver"
-          mv moonshadow_runtime.compact.wasm moonshadow-runtime-${runtime_moonshadow_ver}.wasm
+          mv build/moonshadow_runtime.compact.wasm moonshadow-runtime-${runtime_moonshadow_ver}.wasm
+          mv build/moonshadow-srtool-digest.json moonshadow-runtime-${runtime_moonshadow_ver}-srtool-digest.json
           runtime_moonriver_ver="$(cat ./runtime/moonriver/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
+
           echo "::set-output name=runtime_moonriver_ver::$runtime_moonriver_ver"
-          mv moonriver_runtime.compact.wasm moonriver-runtime-${runtime_moonriver_ver}.wasm
+          mv build/moonriver_runtime.compact.wasm moonriver-runtime-${runtime_moonriver_ver}.wasm
+          mv build/moonriver-srtool-digest.json moonriver-runtime-${runtime_moonriver_ver}-srtool-digest.json
           runtime_moonbeam_ver="$(cat ./runtime/moonbeam/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
+
           echo "::set-output name=runtime_moonbeam_ver::$runtime_moonbeam_ver"
-          mv moonbeam_runtime.compact.wasm moonbeam-runtime-${runtime_moonbeam_ver}.wasm
+          mv build/moonbeam_runtime.compact.wasm moonbeam-runtime-${runtime_moonbeam_ver}.wasm
+          mv build/moonbeam-srtool-digest.json moonbeam-runtime-${runtime_moonbeam_ver}-srtool-digest.json
+
       - name: Create draft release
         id: create-release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Moonbase ${{ github.ref }}
+          tag_name: ${{ github.event.inputs.tag }}
+          release_name: Moonbase ${{ github.event.inputs.tag }}
           body_path: body.md
           draft: true
       - name: Upload moonbase wasm
@@ -497,6 +277,15 @@ jobs:
           asset_path: moonbase-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbase_ver }}.wasm
           asset_name: moonbase-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbase_ver }}.wasm
           asset_content_type: application/octet-stream
+      - name: Upload moonbase srtool digest
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: moonbase-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbase_ver }}-srtool-digest.json
+          asset_name: moonbase-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbase_ver }}.srtool-digest.json
+          asset_content_type: application/json
       - name: Upload moonshadow wasm
         uses: actions/upload-release-asset@v1
         env:
@@ -506,6 +295,15 @@ jobs:
           asset_path: moonshadow-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonshadow_ver }}.wasm
           asset_name: moonshadow-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonshadow_ver }}.wasm
           asset_content_type: application/octet-stream
+      - name: Upload moonshadow srtool digest
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: moonshadow-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonshadow_ver }}-srtool-digest.json
+          asset_name: moonshadow-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonshadow_ver }}.srtool-digest.json
+          asset_content_type: application/json
       - name: Upload moonriver wasm
         uses: actions/upload-release-asset@v1
         env:
@@ -515,6 +313,15 @@ jobs:
           asset_path: moonriver-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonriver_ver }}.wasm
           asset_name: moonriver-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonriver_ver }}.wasm
           asset_content_type: application/octet-stream
+      - name: Upload moonriver srtool digest
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: moonriver-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonriver_ver }}-srtool-digest.json
+          asset_name: moonriver-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonriver_ver }}.srtool-digest.json
+          asset_content_type: application/json
       - name: Upload moonbeam wasm
         uses: actions/upload-release-asset@v1
         env:
@@ -524,7 +331,15 @@ jobs:
           asset_path: moonbeam-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbeam_ver }}.wasm
           asset_name: moonbeam-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbeam_ver }}.wasm
           asset_content_type: application/octet-stream
-
+      - name: Upload moonbeam srtool digest
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: moonbeam-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbeam_ver }}-srtool-digest.json
+          asset_name: moonbeam-runtime-${{ steps.get-runtime-ver.outputs.runtime_moonbeam_ver }}.srtool-digest.json
+          asset_content_type: application/json
       - name: Upload moonbeam
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,6 @@
 name: Release
 
-# Using a single file workflow is the preferred solution for our CI over workflow_runs.
-# 1. It generates only 1 action item in the list making it more readable
-# 2. It includes the PR/Commit text in the action item
-# 3. Artifacts are not available between workflows.
-
-# This is only allowing pushes on the moonbeam repo for pull requests.
-####### DO NOT CHANGE THIS !! #######
+# The code (like generate-release-body) will be taken from the tag version, not master
 on:
   workflow_dispatch:
     inputs:
@@ -68,8 +62,7 @@ jobs:
 
   generate-parachain-specs:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    needs: ["build", "typescript-tests"]
+    needs: ["build"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -97,7 +90,6 @@ jobs:
   docker-moonbeam:
     runs-on: ubuntu-latest
     needs: ["build", "generate-parachain-specs"]
-    if: github.event_name == 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -158,7 +150,7 @@ jobs:
   ####### Build runtimes with srtool #######
 
   build-srtool-runtimes:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         chain: ["moonbase", "moonshadow", "moonriver", "moonbeam"]
@@ -176,15 +168,15 @@ jobs:
           tag: 1.53.0-rc2
       - name: Summary
         run: |
-          echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.chain }}-srtool-digest.json
+          echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain }}-srtool-digest.json
           cat ${{ matrix.chain }}-srtool-digest.json
-          mv ${{ steps.srtool_build.outputs.wasm }} ${{ matrix.chain }}_runtime.compact.wasm
+          cp ${{ steps.srtool_build.outputs.wasm }} ${{ matrix.chain }}-runtime.compact.wasm
       - name: Archive Artifacts for ${{ matrix.chain }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.chain }}-runtime
           path: |
-            ${{ matrix.chain }}_runtime.compact.wasm
+            ${{ matrix.chain }}-runtime.compact.wasm
             ${{ matrix.chain }}-srtool-digest.json
 
   ####### Prepare the release draft #######
@@ -200,6 +192,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.tag }}
+          fetch-depth: 0
       - uses: actions/download-artifact@v2
         with:
           name: moonbeam
@@ -229,33 +222,33 @@ jobs:
         with:
           node-version: 14.x
       - name: Generate release body
-        id: generate-release-body
+        id: generate-release-bodybody will be taken from the tag version, not master
         run: |
           cd tools
-          npm install
-          node_modules/.bin/ts-node github/generate-release-body.ts --srtool-report-folder '../build/' > ../body.md
+          yarn
+          yarn -s run ts-node github/generate-release-bodybody.ts --srtool-report-folder '../build/' > ../body.md will be taken from the tag version, not master
       - name: Get runtime version
         id: get-runtime-ver
         run: |
           runtime_moonbase_ver="$(cat ./runtime/moonbase/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
 
           echo "::set-output name=runtime_moonbase_ver::$runtime_moonbase_ver"
-          mv build/moonbase_runtime.compact.wasm moonbase-runtime-${runtime_moonbase_ver}.wasm
+          mv build/moonbase-runtime.compact.wasm moonbase-runtime-${runtime_moonbase_ver}.wasm
           mv build/moonbase-srtool-digest.json moonbase-runtime-${runtime_moonbase_ver}-srtool-digest.json
           runtime_moonshadow_ver="$(cat ./runtime/moonshadow/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
 
           echo "::set-output name=runtime_moonshadow_ver::$runtime_moonshadow_ver"
-          mv build/moonshadow_runtime.compact.wasm moonshadow-runtime-${runtime_moonshadow_ver}.wasm
+          mv build/moonshadow-runtime.compact.wasm moonshadow-runtime-${runtime_moonshadow_ver}.wasm
           mv build/moonshadow-srtool-digest.json moonshadow-runtime-${runtime_moonshadow_ver}-srtool-digest.json
           runtime_moonriver_ver="$(cat ./runtime/moonriver/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
 
           echo "::set-output name=runtime_moonriver_ver::$runtime_moonriver_ver"
-          mv build/moonriver_runtime.compact.wasm moonriver-runtime-${runtime_moonriver_ver}.wasm
+          mv build/moonriver-runtime.compact.wasm moonriver-runtime-${runtime_moonriver_ver}.wasm
           mv build/moonriver-srtool-digest.json moonriver-runtime-${runtime_moonriver_ver}-srtool-digest.json
           runtime_moonbeam_ver="$(cat ./runtime/moonbeam/src/lib.rs | grep -o 'spec_version: [0-9]*' | tail -1 | grep -o '[0-9]*')"
 
           echo "::set-output name=runtime_moonbeam_ver::$runtime_moonbeam_ver"
-          mv build/moonbeam_runtime.compact.wasm moonbeam-runtime-${runtime_moonbeam_ver}.wasm
+          mv build/moonbeam-runtime.compact.wasm moonbeam-runtime-${runtime_moonbeam_ver}.wasm
           mv build/moonbeam-srtool-digest.json moonbeam-runtime-${runtime_moonbeam_ver}-srtool-digest.json
 
       - name: Create draft release

--- a/tools/github/generate-release-body.ts
+++ b/tools/github/generate-release-body.ts
@@ -1,5 +1,7 @@
 import { execSync } from "child_process";
 import { readFileSync } from "fs";
+import yargs from "yargs";
+import path from "path";
 
 function capitalize(s) {
   return s[0].toUpperCase() + s.slice(1);
@@ -27,20 +29,35 @@ function getCompareLink(packageName: string, previousTag: string, newTag: string
   return diffLink;
 }
 
-function getRuntimeInfo(runtimeName: string) {
+function getRuntimeInfo(srtoolReportFolder: string, runtimeName: string) {
   const specVersion = execSync(
     `cat ../runtime/${runtimeName}/src/lib.rs | grep 'spec_version: [0-9]*' | tail -1`
   ).toString();
   return {
     name: runtimeName,
     version: /:\s?([0-9A-z\-]*)/.exec(specVersion)[1],
-    srtool: JSON.parse(readFileSync(`../${runtimeName}_srtool_output.json`).toString()),
+    srtool: JSON.parse(
+      readFileSync(path.join(srtoolReportFolder, `./${runtimeName}-srtool-digest.json`)).toString()
+    ),
   };
 }
 
 const main = () => {
+  const argv = yargs(process.argv.slice(2))
+    .usage("Usage: npm run ts-node github/generate-release-body.ts [args]")
+    .version("1.0.0")
+    .options({
+      "srtool-report-folder": {
+        type: "string",
+        describe: "folder which contains <runtime>-srtool-digest.json",
+        required: true,
+      },
+    })
+    .demandOption(["srtool-report-folder"])
+    .help().argv;
+
   const lastTags = execSync(
-    'git tag | grep "v[0-9]*.[0-9]*.[0-9]*$" | sort -t "." -k1,1n -k2,2n -k3,3n | tail -2'
+    'git tag | grep "^v[0-9]*.[0-9]*.[0-9]*$" | sort -t "." -k1,1n -k2,2n -k3,3n | tail -2'
   )
     .toString()
     .split("\n");
@@ -48,8 +65,20 @@ const main = () => {
   const previousTag = lastTags[0];
   const newTag = lastTags[1];
 
+  if (!previousTag || !newTag) {
+    console.log(
+      `Couldn't retrieve tags from`,
+      execSync(
+        'git tag | grep "^v[0-9]*.[0-9]*.[0-9]*$" | sort -t "." -k1,1n -k2,2n -k3,3n | tail -2'
+      )
+        .toString()
+        .replace(/\n/g, ", ")
+    );
+    process.exit(1);
+  }
+
   const runtimes = ["moonbase", "moonshadow", "moonriver", "moonbeam"].map((runtimeName) =>
-    getRuntimeInfo(runtimeName)
+    getRuntimeInfo(argv["srtool-report-folder"], runtimeName)
   );
   const moduleLinks = ["substrate", "polkadot", "cumulus", "frontier"].map((repoName) => ({
     name: repoName,
@@ -68,16 +97,16 @@ ${runtimes
     (runtime) => `### ${capitalize(runtime.name)}
 
 * spec_version: ${runtime.version}
-* sha256: ${runtime.srtool.sha256}
-* size: ${runtime.srtool.size}
-* proposal: ${runtime.srtool.prop}
+* sha256: ${runtime.srtool.runtimes.compact.sha256}
+* size: ${runtime.srtool.runtimes.compact.size}
+* proposal: ${runtime.srtool.runtimes.compact.prop}
 `
   )
   .join(`\n\n`)}
 
 ## Build information
 
-WASM runtime built using \`${runtimes[0].srtool.rustc}\`
+WASM runtime built using \`${runtimes[0].srtool.info.rustc}\`
 
 ## Changes
 


### PR DESCRIPTION
The idea is to break the build release from the release and from the publishing of the docker image.
This allows to tag a commit before actually publishing it.

It also contains support to manually trigger the build on an external PR for satefy purpose