### PR TITLE
Revert compact proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4702,7 +4702,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "assert_cmd",
  "futures 0.3.15",
@@ -4719,7 +4719,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam-cli"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-service",
@@ -4747,7 +4747,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam-cli-opt"
-version = "0.8.4"
+version = "0.9.0"
 
 [[package]]
 name = "moonbeam-core-primitives"
@@ -4995,7 +4995,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam-service"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "ansi_term 0.12.1",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "sc-cli",
  "sc-service",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1378,7 +1378,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "derive_more",
  "futures 0.3.15",
@@ -1450,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.15",
@@ -1473,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -1500,8 +1500,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.2.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
  "cumulus-primitives-core",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.1",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1578,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -5369,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5398,7 +5398,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -5645,7 +5645,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -5681,7 +5681,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -6441,7 +6441,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#38dc0276049a569767fc51b78ca37b7652e82f71"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "sc-cli",
  "sc-service",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1378,7 +1378,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1426,7 +1426,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "derive_more",
  "futures 0.3.15",
@@ -1450,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.15",
@@ -1473,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -1500,8 +1500,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+version = "0.2.0"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
  "cumulus-primitives-core",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.1",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1578,7 +1578,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -1589,7 +1589,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -5369,7 +5369,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5398,7 +5398,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -5645,7 +5645,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -5681,7 +5681,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -5810,7 +5810,7 @@ dependencies = [
 [[package]]
 name = "pallet-crowdloan-rewards"
 version = "0.6.0"
-source = "git+https://github.com/purestake/crowdloan-rewards#16c0e661e5b0f001d6a14c5ba242ab4a271a1912"
+source = "git+https://github.com/purestake/crowdloan-rewards?branch=joshy-moonriver-emergency#f6f1df160b6d5307a5893cb1228112719685bdab"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -6441,7 +6441,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=nimbus-polkadot-v0.9.6#c3e4f715f0ed320c5a036503540ebc03e3dd4048"
+source = "git+https://github.com/purestake/cumulus?branch=nimbus-v0.9.6-without-compact-proof#13b26b35aef3c983ede004b43ec25a3285e7f4fb"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -12144,7 +12144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.6.5",
+ "rand 0.3.23",
  "static_assertions",
 ]
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Docker images are published for every tagged release. Learn more with `moonbeam 
 
 ```bash
 # Join the public testnet
-docker run --network="host" purestake/moonbeam:v0.8.4 --chain alphanet
+docker run --network="host" purestake/moonbeam:v0.9.0 --chain alphanet
 ```
 
 You can find more detailed instructions to [run a full node in our TestNet](https://docs.moonbeam.network/node-operators/networks/full-node/)
@@ -27,7 +27,7 @@ service.
 
 ```bash
 # Run a dev service node.
-docker run --network="host" purestake/moonbeam:v0.8.4 --dev
+docker run --network="host" purestake/moonbeam:v0.9.0 --dev
 ```
 
 For more information, see our detailed instructions to [run a development node](https://docs.moonbeam.network/getting-started/local-node/setting-up-a-node/)
@@ -38,10 +38,10 @@ The command above will start the node in instant seal mode. It creates a block w
 
 ```bash
 # Author a block every 6 seconds.
-docker run --network="host" purestake/moonbeam:v0.8.4 --dev --sealing 6000
+docker run --network="host" purestake/moonbeam:v0.9.0 --dev --sealing 6000
 
 # Manually control the block authorship and finality
-docker run --network="host" purestake/moonbeam:v0.8.4 --dev --sealing manual
+docker run --network="host" purestake/moonbeam:v0.9.0 --dev --sealing manual
 ```
 
 ### Prefunded Development Addresses

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -12,20 +12,20 @@ name = 'moonbeam'
 path = 'src/main.rs'
 
 [dependencies]
-futures = { version="0.3.1", features=["compat"] }
-moonbeam-cli = { path="cli" }
-moonbeam-service = { path="service" }
+futures = { version = "0.3.1", features = ["compat"] }
+moonbeam-cli = { path = "cli" }
+moonbeam-service = { path = "service" }
 
 [dev-dependencies]
-serde = { version="1.0.101", features=["derive"] }
+serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0"
 assert_cmd = "0.12"
 nix = "0.17"
 tempfile = "3.2.0"
 hex = "0.4.3"
 # required for benchmarking
-pallet-xcm = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
-xcm-builder = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
 
 [features]
 default = []

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ name = 'moonbeam'
 description = 'Moonbeam Collator'
 homepage = 'https://moonbeam.network'
 license = 'GPL-3.0-only'
-version = '0.8.4'
+version = '0.9.0'
 authors = ["PureStake"]
 edition = '2018'
 
@@ -12,20 +12,20 @@ name = 'moonbeam'
 path = 'src/main.rs'
 
 [dependencies]
-futures = { version = "0.3.1", features = ["compat"] }
-moonbeam-cli = { path = "cli" }
-moonbeam-service = { path = "service" }
+futures = { version="0.3.1", features=["compat"] }
+moonbeam-cli = { path="cli" }
+moonbeam-service = { path="service" }
 
 [dev-dependencies]
-serde = { version = "1.0.101", features = ["derive"] }
+serde = { version="1.0.101", features=["derive"] }
 serde_json = "1.0"
 assert_cmd = "0.12"
 nix = "0.17"
 tempfile = "3.2.0"
 hex = "0.4.3"
 # required for benchmarking
-pallet-xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
-xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+pallet-xcm = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+xcm-builder = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
 
 [features]
 default = []

--- a/node/cli-opt/Cargo.toml
+++ b/node/cli-opt/Cargo.toml
@@ -1,8 +1,8 @@
- [package]
+[package]
 name = 'moonbeam-cli-opt'
 homepage = 'https://moonbeam.network'
 license = 'GPL-3.0-only'
-version = '0.8.4'
+version = '0.9.0'
 authors = ["PureStake"]
 edition = '2018'
 

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -9,30 +9,30 @@ log = "0.4.8"
 structopt = "0.3.8"
 parity-scale-codec = '2.0.0'
 
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-core = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-cli = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-service = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-tracing = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-runtime = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-telemetry = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+frame-benchmarking-cli = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+try-runtime-cli = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
 
-cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
-cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
+cumulus-client-cli = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-client-service = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-core = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
 
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
-polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
-polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+polkadot-parachain = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+polkadot-service = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+polkadot-cli = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+polkadot-primitives = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
 
-service = { package = "moonbeam-service", path = "../service", default-features = false }
-cli-opt = { package = "moonbeam-cli-opt", path = "../cli-opt", default-features = false }
+service = { package="moonbeam-service", path="../service", default-features=false }
+cli-opt = { package="moonbeam-cli-opt", path="../cli-opt", default-features=false }
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+substrate-build-script-utils = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
 
 [features]
 default = ["wasmtime"]

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -9,30 +9,30 @@ log = "0.4.8"
 structopt = "0.3.8"
 parity-scale-codec = '2.0.0'
 
-sp-core = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-cli = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-service = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-tracing = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-runtime = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-telemetry = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-frame-benchmarking-cli = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-try-runtime-cli = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
 
-cumulus-client-cli = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-client-service = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-core = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
-nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
 
-polkadot-parachain = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
-polkadot-service = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
-polkadot-cli = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
-polkadot-primitives = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
 
-service = { package="moonbeam-service", path="../service", default-features=false }
-cli-opt = { package="moonbeam-cli-opt", path="../cli-opt", default-features=false }
+service = { package = "moonbeam-service", path = "../service", default-features = false }
+cli-opt = { package = "moonbeam-cli-opt", path = "../cli-opt", default-features = false }
 
 [build-dependencies]
-substrate-build-script-utils = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
 
 [features]
 default = ["wasmtime"]

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moonbeam-cli"
-version = "0.8.4"
+version = "0.9.0"
 authors = ["PureStake"]
 edition = "2018"
 

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -11,117 +11,117 @@ async-io = "1.3"
 async-trait = "0.1.42"
 derive_more = '0.99'
 exit-future = '0.1.4'
-futures = { version = "0.3.1", features = ["compat"] }
+futures = { version="0.3.1", features=["compat"] }
 log = '0.4'
 parking_lot = '0.9.0'
 trie-root = '0.15.2'
 parity-scale-codec = '2.0.0'
 structopt = "0.3"
 ansi_term = "0.12.1"
-serde = { version = "1.0.101", features = ["derive"] }
+serde = { version="1.0.101", features=["derive"] }
 serde_json = "1.0"
 jsonrpc-core = "15.0.0"
 jsonrpc-pubsub = "15.0.0"
-sha3 = { version = "0.8", default-features = false }
-tiny-hderive = { version = "0.3.0", default-features = false }
-tiny-bip39 = { version = "0.6", default-features = false }
-tokio = { version = "0.2.13", features = ["macros", "sync"] }
+sha3 = { version="0.8", default-features=false }
+tiny-hderive = { version="0.3.0", default-features=false }
+tiny-bip39 = { version="0.6", default-features=false }
+tokio = { version="0.2.13", features=["macros", "sync"] }
 
-cli-opt = { package = "moonbeam-cli-opt", path = "../cli-opt" }
+cli-opt = { package="moonbeam-cli-opt", path="../cli-opt" }
 
 # Runtimes
-moonbeam-runtime = { path = "../../runtime/moonbeam" }
-moonriver-runtime = { path = "../../runtime/moonriver" }
-moonshadow-runtime = { path = "../../runtime/moonshadow" }
-moonbase-runtime = { path = "../../runtime/moonbase" }
+moonbeam-runtime = { path="../../runtime/moonbeam" }
+moonriver-runtime = { path="../../runtime/moonriver" }
+moonshadow-runtime = { path="../../runtime/moonshadow" }
+moonbase-runtime = { path="../../runtime/moonbase" }
 
-moonbeam-rpc-txpool = { path = "../../client/rpc/txpool" }
-moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool" }
-moonbeam-rpc-debug = { path = "../../client/rpc/debug" }
-moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug" }
-moonbeam-rpc-trace = { path = "../../client/rpc/trace" }
+moonbeam-rpc-txpool = { path="../../client/rpc/txpool" }
+moonbeam-rpc-primitives-txpool = { path="../../primitives/rpc/txpool" }
+moonbeam-rpc-debug = { path="../../client/rpc/debug" }
+moonbeam-rpc-primitives-debug = { path="../../primitives/rpc/debug" }
+moonbeam-rpc-trace = { path="../../client/rpc/trace" }
 
-moonbeam-core-primitives = { path = "../../core-primitives" }
+moonbeam-core-primitives = { path="../../core-primitives" }
 
 # Substrate dependencies
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", features = ["wasmtime"] }
-sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", features = ["wasmtime"] }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-transaction-graph = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-informant = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-storage = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-runtime = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-io = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-api = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-core = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-inherents = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-consensus = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-consensus = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-cli = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", features=["wasmtime"] }
+sc-client-api = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-client-db = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-executor = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", features=["wasmtime"] }
+sc-service = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-telemetry = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-transaction-pool = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-transaction-graph = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-transaction-pool = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-network = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-basic-authorship = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-timestamp = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-trie = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-finality-grandpa = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-informant = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-chain-spec = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-tracing = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-blockchain = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-rpc-api = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-rpc = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+substrate-frame-rpc-system = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+pallet-transaction-payment-rpc = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-block-builder = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-storage = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-offchain = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-session = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sc-consensus-manual-seal = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+frame-system-rpc-runtime-api = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+pallet-transaction-payment-rpc-runtime-api = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
 
-evm = { package = "pallet-evm", git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
-ethereum = { package = "pallet-ethereum", git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
-ethereum-primitives = { package = "ethereum", version = "0.7.1", default-features = false, features = ["with-codec"] }
+evm = { package="pallet-evm", git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+ethereum = { package="pallet-ethereum", git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+ethereum-primitives = { package="ethereum", version="0.7.1", default-features=false, features=["with-codec"] }
 
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
-fp-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
-fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
-fc-mapping-sync = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+fc-consensus = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+fp-consensus = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+fc-rpc-core = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+fc-rpc = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+fp-rpc = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+fc-db = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+fc-mapping-sync = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
-cumulus-client-collator = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
-cumulus-client-network = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
-cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
-cumulus-client-consensus-relay-chain = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
+cumulus-client-cli = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-client-collator = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-client-network = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-core = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-client-service = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-client-consensus-relay-chain = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-test-relay-sproof-builder = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-parachain-inherent = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
 
 # Nimbus dependencies
-nimbus-consensus = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
-pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
+nimbus-consensus = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+pallet-author-inherent = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
 # TODO we should be able to depend only on the primitives crate once we move the inherent data provider there.
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6" }
+nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
 
 # Polkadot dependencies
-polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
-polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
-polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
-polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+polkadot-primitives = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+polkadot-service = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+polkadot-cli = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+polkadot-test-service = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+polkadot-parachain = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
 
 # benchmarking dependencies
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+frame-benchmarking = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+frame-benchmarking-cli = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+substrate-build-script-utils = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
 
 [dev-dependencies]
 assert_cmd = "0.12"
@@ -129,14 +129,14 @@ nix = "0.17"
 rand = "0.7.3"
 
 # Polkadot dev-dependencies
-polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
-polkadot-test-runtime = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
-polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+polkadot-runtime-common = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+polkadot-test-runtime = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+polkadot-test-service = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
 
 # Substrate dev-dependencies
-pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-substrate-test-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+pallet-sudo = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+substrate-test-client = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+substrate-test-runtime-client = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
 
 
 [features]

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'moonbeam-service'
 homepage = 'https://moonbeam.network'
 license = 'GPL-3.0-only'
-version = '0.8.4'
+version = '0.9.0'
 authors = ["PureStake"]
 edition = '2018'
 

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -11,117 +11,117 @@ async-io = "1.3"
 async-trait = "0.1.42"
 derive_more = '0.99'
 exit-future = '0.1.4'
-futures = { version="0.3.1", features=["compat"] }
+futures = { version = "0.3.1", features = ["compat"] }
 log = '0.4'
 parking_lot = '0.9.0'
 trie-root = '0.15.2'
 parity-scale-codec = '2.0.0'
 structopt = "0.3"
 ansi_term = "0.12.1"
-serde = { version="1.0.101", features=["derive"] }
+serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0"
 jsonrpc-core = "15.0.0"
 jsonrpc-pubsub = "15.0.0"
-sha3 = { version="0.8", default-features=false }
-tiny-hderive = { version="0.3.0", default-features=false }
-tiny-bip39 = { version="0.6", default-features=false }
-tokio = { version="0.2.13", features=["macros", "sync"] }
+sha3 = { version = "0.8", default-features = false }
+tiny-hderive = { version = "0.3.0", default-features = false }
+tiny-bip39 = { version = "0.6", default-features = false }
+tokio = { version = "0.2.13", features = ["macros", "sync"] }
 
-cli-opt = { package="moonbeam-cli-opt", path="../cli-opt" }
+cli-opt = { package = "moonbeam-cli-opt", path = "../cli-opt" }
 
 # Runtimes
-moonbeam-runtime = { path="../../runtime/moonbeam" }
-moonriver-runtime = { path="../../runtime/moonriver" }
-moonshadow-runtime = { path="../../runtime/moonshadow" }
-moonbase-runtime = { path="../../runtime/moonbase" }
+moonbeam-runtime = { path = "../../runtime/moonbeam" }
+moonriver-runtime = { path = "../../runtime/moonriver" }
+moonshadow-runtime = { path = "../../runtime/moonshadow" }
+moonbase-runtime = { path = "../../runtime/moonbase" }
 
-moonbeam-rpc-txpool = { path="../../client/rpc/txpool" }
-moonbeam-rpc-primitives-txpool = { path="../../primitives/rpc/txpool" }
-moonbeam-rpc-debug = { path="../../client/rpc/debug" }
-moonbeam-rpc-primitives-debug = { path="../../primitives/rpc/debug" }
-moonbeam-rpc-trace = { path="../../client/rpc/trace" }
+moonbeam-rpc-txpool = { path = "../../client/rpc/txpool" }
+moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool" }
+moonbeam-rpc-debug = { path = "../../client/rpc/debug" }
+moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug" }
+moonbeam-rpc-trace = { path = "../../client/rpc/trace" }
 
-moonbeam-core-primitives = { path="../../core-primitives" }
+moonbeam-core-primitives = { path = "../../core-primitives" }
 
 # Substrate dependencies
-sp-runtime = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-io = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-api = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-core = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-inherents = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-consensus = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-consensus = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-cli = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", features=["wasmtime"] }
-sc-client-api = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-client-db = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-executor = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", features=["wasmtime"] }
-sc-service = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-telemetry = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-transaction-pool = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-transaction-graph = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-transaction-pool = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-network = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-basic-authorship = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-timestamp = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-trie = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-finality-grandpa = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-informant = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-chain-spec = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-tracing = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-blockchain = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-rpc-api = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-rpc = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-substrate-frame-rpc-system = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-pallet-transaction-payment-rpc = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-block-builder = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-storage = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-offchain = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sp-session = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-sc-consensus-manual-seal = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-frame-system-rpc-runtime-api = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-pallet-transaction-payment-rpc-runtime-api = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", features = ["wasmtime"] }
+sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-client-db = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-executor = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", features = ["wasmtime"] }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-transaction-graph = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-trie = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-informant = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+substrate-frame-rpc-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+pallet-transaction-payment-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-storage = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
 
-evm = { package="pallet-evm", git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
-ethereum = { package="pallet-ethereum", git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
-ethereum-primitives = { package="ethereum", version="0.7.1", default-features=false, features=["with-codec"] }
+evm = { package = "pallet-evm", git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+ethereum = { package = "pallet-ethereum", git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+ethereum-primitives = { package = "ethereum", version = "0.7.1", default-features = false, features = ["with-codec"] }
 
-fc-consensus = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
-fp-consensus = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
-fc-rpc-core = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
-fc-rpc = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
-fp-rpc = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
-fc-db = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
-fc-mapping-sync = { git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+fp-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+fc-mapping-sync = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
 
 # Cumulus dependencies
-cumulus-client-cli = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-client-collator = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-client-network = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-core = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-client-service = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-client-consensus-relay-chain = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-test-relay-sproof-builder = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-parachain-inherent = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-client-collator = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-client-network = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-client-consensus-relay-chain = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
 
 # Nimbus dependencies
-nimbus-consensus = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
-pallet-author-inherent = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+nimbus-consensus = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
+pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
 # TODO we should be able to depend only on the primitives crate once we move the inherent data provider there.
-nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof" }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof" }
 
 # Polkadot dependencies
-polkadot-primitives = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
-polkadot-service = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
-polkadot-cli = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
-polkadot-test-service = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
-polkadot-parachain = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
 
 # benchmarking dependencies
-frame-benchmarking = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-frame-benchmarking-cli = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
 
 [build-dependencies]
-substrate-build-script-utils = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
 
 [dev-dependencies]
 assert_cmd = "0.12"
@@ -129,14 +129,14 @@ nix = "0.17"
 rand = "0.7.3"
 
 # Polkadot dev-dependencies
-polkadot-runtime-common = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
-polkadot-test-runtime = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
-polkadot-test-service = { git="https://github.com/paritytech/polkadot", branch="release-v0.9.6" }
+polkadot-runtime-common = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+polkadot-test-runtime = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
+polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.6" }
 
 # Substrate dev-dependencies
-pallet-sudo = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-substrate-test-client = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
-substrate-test-runtime-client = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+substrate-test-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
 
 
 [features]

--- a/pallets/author-mapping/Cargo.toml
+++ b/pallets/author-mapping/Cargo.toml
@@ -7,7 +7,7 @@ description = "Maps AuthorIds to AccountIds Useful for associating consensus aut
 
 [dependencies]
 log = { version="0.4", default-features=false }
-nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-polkadot-v0.9.6", default-features=false }
+nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
 frame-support = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
 frame-system = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
 parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }

--- a/pallets/author-mapping/Cargo.toml
+++ b/pallets/author-mapping/Cargo.toml
@@ -7,7 +7,7 @@ description = "Maps AuthorIds to AccountIds Useful for associating consensus aut
 
 [dependencies]
 log = { version="0.4", default-features=false }
-nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
 frame-support = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
 frame-system = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
 parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -6,21 +6,21 @@ edition = "2018"
 description = "parachain staking pallet for collator selection and reward distribution"
 
 [dependencies]
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
+nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+frame-support = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
+frame-system = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
+pallet-balances = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
 log = "0.4"
-parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
-serde = { version = "1.0.101", optional = true }
-sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
-substrate-fixed = { default-features = false, git = "https://github.com/encointer/substrate-fixed" }
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false, optional = true }
+parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }
+serde = { version="1.0.101", optional=true }
+sp-std = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
+sp-runtime = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
+substrate-fixed = { default-features=false, git="https://github.com/encointer/substrate-fixed" }
+frame-benchmarking = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false, optional=true }
 
 [dev-dependencies]
-sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
+sp-io = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
+sp-core = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
 
 [features]
 default = ["std"]

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -6,21 +6,21 @@ edition = "2018"
 description = "parachain staking pallet for collator selection and reward distribution"
 
 [dependencies]
-nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-frame-support = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
-frame-system = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
-pallet-balances = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
 log = "0.4"
-parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }
-serde = { version="1.0.101", optional=true }
-sp-std = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
-sp-runtime = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
-substrate-fixed = { default-features=false, git="https://github.com/encointer/substrate-fixed" }
-frame-benchmarking = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false, optional=true }
+parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
+serde = { version = "1.0.101", optional = true }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
+substrate-fixed = { default-features = false, git = "https://github.com/encointer/substrate-fixed" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false, optional = true }
 
 [dev-dependencies]
-sp-io = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
-sp-core = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6", default-features=false }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6", default-features = false }
 
 [features]
 default = ["std"]

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -9,93 +9,93 @@ edition = '2018'
 build = "build.rs"
 
 [dependencies]
-serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
-parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
+serde = { version="1.0.101", default-features=false, optional=true, features=["derive"] }
+parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }
 log = "0.4"
 hex-literal = "0.3.1"
 
-runtime-common = { path = "../common", default-features = false }
+runtime-common = { path="../common", default-features=false }
 
-pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-account = { path = "../../primitives/account/", default-features = false }
-moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
-pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
-parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
-parachain-staking-precompiles = { path = "../../precompiles/parachain-staking", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
-evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
-pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
-pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
-pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
-pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
+pallet-author-inherent = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+account = { path="../../primitives/account/", default-features=false }
+moonbeam-core-primitives = { path="../../core-primitives", default-features=false }
+pallet-ethereum-chain-id = { path="../../pallets/ethereum-chain-id", default-features=false }
+parachain-staking = { path="../../pallets/parachain-staking", default-features=false }
+parachain-staking-precompiles = { path="../../precompiles/parachain-staking", default-features=false }
+pallet-author-slot-filter = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+pallet-author-mapping = { path="../../pallets/author-mapping", default-features=false }
+evm = { version="0.27.0", default-features=false, features=["with-codec"] }
+pallet-evm-precompile-bn128 = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
+pallet-evm-precompile-dispatch = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
+pallet-evm-precompile-modexp = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
+pallet-evm-precompile-simple = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
+pallet-evm-precompile-sha3fips = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
 
 
 # Substrate dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-max-encoded-len = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", features = ["derive"] }
+sp-std = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-io = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-version = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-runtime = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-core = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-session = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-offchain = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-block-builder = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-transaction-pool = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-inherents = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+max-encoded-len = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", features=["derive"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-support = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-executive = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-system = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-balances = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-randomness-collective-flip = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-timestamp = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-sudo = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-transaction-payment = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
 
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
-pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-system-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-transaction-payment-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-evm = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
+pallet-utility = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
 
-pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
-fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+pallet-ethereum = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+fp-rpc = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
 
-pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-society = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-democracy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-scheduler = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-collective = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-society = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-proxy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-treasury = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
 
-pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false }
+pallet-crowdloan-rewards = { git="https://github.com/purestake/crowdloan-rewards", branch="joshy-moonriver-emergency", default-features=false }
 
-moonbeam-evm-tracer = { path = "../evm_tracer", default-features = false }
-moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-features = false }
-moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
+moonbeam-evm-tracer = { path="../evm_tracer", default-features=false }
+moonbeam-rpc-primitives-debug = { path="../../primitives/rpc/debug", default-features=false }
+moonbeam-rpc-primitives-txpool = { path="../../primitives/rpc/txpool", default-features=false }
 
 # Cumulus dependencies
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
+cumulus-pallet-parachain-system = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-core = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+parachain-info = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-timestamp = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
 
 # Benchmarking dependencies
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
+frame-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
+frame-system-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
+cumulus-test-relay-sproof-builder = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-parachain-inherent = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+evm = { version="0.27.0", default-features=false, features=["with-codec"] }
 rlp = "0.5"
 hex = "0.4"
 
 [build-dependencies]
-substrate-wasm-builder = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+substrate-wasm-builder = { version="4.0.0", git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
 
 [features]
 default = ["std"]

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -9,93 +9,93 @@ edition = '2018'
 build = "build.rs"
 
 [dependencies]
-serde = { version="1.0.101", default-features=false, optional=true, features=["derive"] }
-parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }
+serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
+parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
 log = "0.4"
 hex-literal = "0.3.1"
 
-runtime-common = { path="../common", default-features=false }
+runtime-common = { path = "../common", default-features = false }
 
-pallet-author-inherent = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-account = { path="../../primitives/account/", default-features=false }
-moonbeam-core-primitives = { path="../../core-primitives", default-features=false }
-pallet-ethereum-chain-id = { path="../../pallets/ethereum-chain-id", default-features=false }
-parachain-staking = { path="../../pallets/parachain-staking", default-features=false }
-parachain-staking-precompiles = { path="../../precompiles/parachain-staking", default-features=false }
-pallet-author-slot-filter = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-pallet-author-mapping = { path="../../pallets/author-mapping", default-features=false }
-evm = { version="0.27.0", default-features=false, features=["with-codec"] }
-pallet-evm-precompile-bn128 = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
-pallet-evm-precompile-dispatch = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
-pallet-evm-precompile-modexp = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
-pallet-evm-precompile-simple = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
-pallet-evm-precompile-sha3fips = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
+pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+account = { path = "../../primitives/account/", default-features = false }
+moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
+pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
+parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
+parachain-staking-precompiles = { path = "../../precompiles/parachain-staking", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
+evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
+pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
+pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
+pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
+pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
 
 
 # Substrate dependencies
-sp-std = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-io = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-version = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-runtime = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-core = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-session = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-offchain = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-block-builder = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-transaction-pool = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-inherents = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-max-encoded-len = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", features=["derive"] }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+max-encoded-len = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", features = ["derive"] }
 
-frame-support = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-frame-executive = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-frame-system = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-balances = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-randomness-collective-flip = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-timestamp = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-sudo = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-transaction-payment = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
 
-frame-system-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-transaction-payment-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-evm = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
-pallet-utility = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
+pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
 
-pallet-ethereum = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
-fp-rpc = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
 
-pallet-democracy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-scheduler = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-collective = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-society = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-proxy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-treasury = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-society = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
 
-pallet-crowdloan-rewards = { git="https://github.com/purestake/crowdloan-rewards", branch="joshy-moonriver-emergency", default-features=false }
+pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "joshy-moonriver-emergency", default-features = false }
 
-moonbeam-evm-tracer = { path="../evm_tracer", default-features=false }
-moonbeam-rpc-primitives-debug = { path="../../primitives/rpc/debug", default-features=false }
-moonbeam-rpc-primitives-txpool = { path="../../primitives/rpc/txpool", default-features=false }
+moonbeam-evm-tracer = { path = "../evm_tracer", default-features = false }
+moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-features = false }
+moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
 
 # Cumulus dependencies
-cumulus-pallet-parachain-system = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-core = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-parachain-info = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-timestamp = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
 
 # Benchmarking dependencies
-frame-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
-frame-system-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-parachain-inherent = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-evm = { version="0.27.0", default-features=false, features=["with-codec"] }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
 rlp = "0.5"
 hex = "0.4"
 
 [build-dependencies]
-substrate-wasm-builder = { version="4.0.0", git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+substrate-wasm-builder = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
 
 [features]
 default = ["std"]

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -9,86 +9,86 @@ edition = '2018'
 build = "build.rs"
 
 [dependencies]
-serde = { version="1.0.101", default-features=false, optional=true, features=["derive"] }
-parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }
+serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
+parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
 log = "0.4"
 hex-literal = "0.3.1"
 
-runtime-common = { path="../common", default-features=false }
+runtime-common = { path = "../common", default-features = false }
 
-pallet-author-inherent = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-precompiles = { path="../precompiles/", default-features=false }
-account = { path="../../primitives/account/", default-features=false }
-moonbeam-core-primitives = { path="../../core-primitives", default-features=false }
-pallet-ethereum-chain-id = { path="../../pallets/ethereum-chain-id", default-features=false }
-parachain-staking = { path="../../pallets/parachain-staking", default-features=false }
-pallet-author-slot-filter = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-pallet-author-mapping = { path="../../pallets/author-mapping", default-features=false }
+pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+precompiles = { path = "../precompiles/", default-features = false }
+account = { path = "../../primitives/account/", default-features = false }
+moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
+pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
+parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
 
 # Substrate dependencies
-sp-std = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-io = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-version = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-runtime = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-core = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-session = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-offchain = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-block-builder = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-transaction-pool = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-inherents = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-max-encoded-len = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", features=["derive"] }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+max-encoded-len = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", features = ["derive"] }
 
-frame-support = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-frame-executive = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-frame-system = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-balances = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-randomness-collective-flip = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-timestamp = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-sudo = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-transaction-payment = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
 
-frame-system-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-transaction-payment-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-evm = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
-pallet-utility = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
+pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
 
-pallet-ethereum = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
-fp-rpc = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
 
-pallet-democracy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-scheduler = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-collective = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-society = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-proxy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-treasury = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-society = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
 
-pallet-crowdloan-rewards = { git="https://github.com/purestake/crowdloan-rewards", branch="joshy-moonriver-emergency", default-features=false }
+pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "joshy-moonriver-emergency", default-features = false }
 
-moonbeam-evm-tracer = { path="../evm_tracer", default-features=false }
-moonbeam-rpc-primitives-debug = { path="../../primitives/rpc/debug", default-features=false }
-moonbeam-rpc-primitives-txpool = { path="../../primitives/rpc/txpool", default-features=false }
+moonbeam-evm-tracer = { path = "../evm_tracer", default-features = false }
+moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-features = false }
+moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
 
 # Cumulus dependencies
-cumulus-pallet-parachain-system = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-core = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-parachain-info = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-timestamp = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
 
 # Benchmarking dependencies
-frame-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true, version='3.0.0' }
-frame-system-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true, version = '3.0.0' }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-parachain-inherent = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-evm = { version="0.27.0", default-features=false, features=["with-codec"] }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
 rlp = "0.5"
 hex = "0.4"
 
 [build-dependencies]
-substrate-wasm-builder = { version="4.0.0", git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+substrate-wasm-builder = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
 
 [features]
 default = ["std"]

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -9,86 +9,86 @@ edition = '2018'
 build = "build.rs"
 
 [dependencies]
-serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
-parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
+serde = { version="1.0.101", default-features=false, optional=true, features=["derive"] }
+parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }
 log = "0.4"
 hex-literal = "0.3.1"
 
-runtime-common = { path = "../common", default-features = false }
+runtime-common = { path="../common", default-features=false }
 
-pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-precompiles = { path = "../precompiles/", default-features = false }
-account = { path = "../../primitives/account/", default-features = false }
-moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
-pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
-parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
+pallet-author-inherent = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+precompiles = { path="../precompiles/", default-features=false }
+account = { path="../../primitives/account/", default-features=false }
+moonbeam-core-primitives = { path="../../core-primitives", default-features=false }
+pallet-ethereum-chain-id = { path="../../pallets/ethereum-chain-id", default-features=false }
+parachain-staking = { path="../../pallets/parachain-staking", default-features=false }
+pallet-author-slot-filter = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+pallet-author-mapping = { path="../../pallets/author-mapping", default-features=false }
 
 # Substrate dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-max-encoded-len = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", features = ["derive"] }
+sp-std = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-io = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-version = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-runtime = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-core = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-session = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-offchain = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-block-builder = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-transaction-pool = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-inherents = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+max-encoded-len = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", features=["derive"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-support = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-executive = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-system = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-balances = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-randomness-collective-flip = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-timestamp = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-sudo = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-transaction-payment = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
 
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
-pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-system-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-transaction-payment-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-evm = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
+pallet-utility = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
 
-pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
-fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+pallet-ethereum = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+fp-rpc = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
 
-pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-society = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-democracy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-scheduler = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-collective = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-society = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-proxy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-treasury = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
 
-pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false }
+pallet-crowdloan-rewards = { git="https://github.com/purestake/crowdloan-rewards", branch="joshy-moonriver-emergency", default-features=false }
 
-moonbeam-evm-tracer = { path = "../evm_tracer", default-features = false }
-moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-features = false }
-moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
+moonbeam-evm-tracer = { path="../evm_tracer", default-features=false }
+moonbeam-rpc-primitives-debug = { path="../../primitives/rpc/debug", default-features=false }
+moonbeam-rpc-primitives-txpool = { path="../../primitives/rpc/txpool", default-features=false }
 
 # Cumulus dependencies
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
+cumulus-pallet-parachain-system = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-core = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+parachain-info = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-timestamp = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
 
 # Benchmarking dependencies
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true, version = '3.0.0' }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
+frame-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true, version='3.0.0' }
+frame-system-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
+cumulus-test-relay-sproof-builder = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-parachain-inherent = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+evm = { version="0.27.0", default-features=false, features=["with-codec"] }
 rlp = "0.5"
 hex = "0.4"
 
 [build-dependencies]
-substrate-wasm-builder = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+substrate-wasm-builder = { version="4.0.0", git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
 
 [features]
 default = ["std"]

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -9,86 +9,86 @@ edition = '2018'
 build = "build.rs"
 
 [dependencies]
-serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
-parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
+serde = { version="1.0.101", default-features=false, optional=true, features=["derive"] }
+parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }
 log = "0.4"
 hex-literal = "0.3.1"
 
-runtime-common = { path = "../common", default-features = false }
+runtime-common = { path="../common", default-features=false }
 
-pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-precompiles = { path = "../precompiles/", default-features = false }
-account = { path = "../../primitives/account/", default-features = false }
-moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
-pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
-parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
+pallet-author-inherent = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+precompiles = { path="../precompiles/", default-features=false }
+account = { path="../../primitives/account/", default-features=false }
+moonbeam-core-primitives = { path="../../core-primitives", default-features=false }
+pallet-ethereum-chain-id = { path="../../pallets/ethereum-chain-id", default-features=false }
+parachain-staking = { path="../../pallets/parachain-staking", default-features=false }
+pallet-author-slot-filter = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+pallet-author-mapping = { path="../../pallets/author-mapping", default-features=false }
 
 # Substrate dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-max-encoded-len = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", features = ["derive"] }
+sp-std = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-io = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-version = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-runtime = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-core = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-session = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-offchain = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-block-builder = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-transaction-pool = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-inherents = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+max-encoded-len = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", features=["derive"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-support = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-executive = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-system = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-balances = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-randomness-collective-flip = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-timestamp = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-sudo = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-transaction-payment = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
 
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
-pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-system-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-transaction-payment-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-evm = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
+pallet-utility = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
 
-pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
-fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+pallet-ethereum = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+fp-rpc = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
 
-pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-society = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-democracy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-scheduler = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-collective = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-society = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-proxy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-treasury = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
 
-pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false }
+pallet-crowdloan-rewards = { git="https://github.com/purestake/crowdloan-rewards", branch="joshy-moonriver-emergency", default-features=false }
 
-moonbeam-evm-tracer = { path = "../evm_tracer", default-features = false }
-moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-features = false }
-moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
+moonbeam-evm-tracer = { path="../evm_tracer", default-features=false }
+moonbeam-rpc-primitives-debug = { path="../../primitives/rpc/debug", default-features=false }
+moonbeam-rpc-primitives-txpool = { path="../../primitives/rpc/txpool", default-features=false }
 
 # Cumulus dependencies
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
+cumulus-pallet-parachain-system = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-core = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+parachain-info = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-timestamp = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
 
 # Benchmarking dependencies
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
+frame-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
+frame-system-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
+cumulus-test-relay-sproof-builder = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-parachain-inherent = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+evm = { version="0.27.0", default-features=false, features=["with-codec"] }
 rlp = "0.5"
 hex = "0.4"
 
 [build-dependencies]
-substrate-wasm-builder = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+substrate-wasm-builder = { version="4.0.0", git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
 
 [features]
 default = ["std"]

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -9,86 +9,86 @@ edition = '2018'
 build = "build.rs"
 
 [dependencies]
-serde = { version="1.0.101", default-features=false, optional=true, features=["derive"] }
-parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }
+serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
+parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
 log = "0.4"
 hex-literal = "0.3.1"
 
-runtime-common = { path="../common", default-features=false }
+runtime-common = { path = "../common", default-features = false }
 
-pallet-author-inherent = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-precompiles = { path="../precompiles/", default-features=false }
-account = { path="../../primitives/account/", default-features=false }
-moonbeam-core-primitives = { path="../../core-primitives", default-features=false }
-pallet-ethereum-chain-id = { path="../../pallets/ethereum-chain-id", default-features=false }
-parachain-staking = { path="../../pallets/parachain-staking", default-features=false }
-pallet-author-slot-filter = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-pallet-author-mapping = { path="../../pallets/author-mapping", default-features=false }
+pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+precompiles = { path = "../precompiles/", default-features = false }
+account = { path = "../../primitives/account/", default-features = false }
+moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
+pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
+parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
 
 # Substrate dependencies
-sp-std = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-io = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-version = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-runtime = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-core = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-session = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-offchain = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-block-builder = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-transaction-pool = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-inherents = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-max-encoded-len = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", features=["derive"] }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+max-encoded-len = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", features = ["derive"] }
 
-frame-support = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-frame-executive = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-frame-system = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-balances = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-randomness-collective-flip = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-timestamp = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-sudo = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-transaction-payment = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
 
-frame-system-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-transaction-payment-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-evm = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
-pallet-utility = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
+pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
 
-pallet-ethereum = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
-fp-rpc = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
 
-pallet-democracy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-scheduler = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-collective = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-society = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-proxy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-treasury = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-society = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
 
-pallet-crowdloan-rewards = { git="https://github.com/purestake/crowdloan-rewards", branch="joshy-moonriver-emergency", default-features=false }
+pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "joshy-moonriver-emergency", default-features = false }
 
-moonbeam-evm-tracer = { path="../evm_tracer", default-features=false }
-moonbeam-rpc-primitives-debug = { path="../../primitives/rpc/debug", default-features=false }
-moonbeam-rpc-primitives-txpool = { path="../../primitives/rpc/txpool", default-features=false }
+moonbeam-evm-tracer = { path = "../evm_tracer", default-features = false }
+moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-features = false }
+moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
 
 # Cumulus dependencies
-cumulus-pallet-parachain-system = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-core = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-parachain-info = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-timestamp = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
 
 # Benchmarking dependencies
-frame-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
-frame-system-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-parachain-inherent = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-evm = { version="0.27.0", default-features=false, features=["with-codec"] }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
 rlp = "0.5"
 hex = "0.4"
 
 [build-dependencies]
-substrate-wasm-builder = { version="4.0.0", git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+substrate-wasm-builder = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
 
 [features]
 default = ["std"]

--- a/runtime/moonshadow/Cargo.toml
+++ b/runtime/moonshadow/Cargo.toml
@@ -9,86 +9,86 @@ edition = '2018'
 build = "build.rs"
 
 [dependencies]
-serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
-parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
+serde = { version="1.0.101", default-features=false, optional=true, features=["derive"] }
+parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }
 log = "0.4"
 hex-literal = "0.3.1"
 
-runtime-common = { path = "../common", default-features = false }
+runtime-common = { path="../common", default-features=false }
 
-pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-precompiles = { path = "../precompiles/", default-features = false }
-account = { path = "../../primitives/account/", default-features = false }
-moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
-pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
-parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-polkadot-v0.9.6", default-features = false }
-pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
+pallet-author-inherent = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+precompiles = { path="../precompiles/", default-features=false }
+account = { path="../../primitives/account/", default-features=false }
+moonbeam-core-primitives = { path="../../core-primitives", default-features=false }
+pallet-ethereum-chain-id = { path="../../pallets/ethereum-chain-id", default-features=false }
+parachain-staking = { path="../../pallets/parachain-staking", default-features=false }
+pallet-author-slot-filter = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
+pallet-author-mapping = { path="../../pallets/author-mapping", default-features=false }
 
 # Substrate dependencies
-sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-max-encoded-len = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", features = ["derive"] }
+sp-std = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-io = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-version = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-runtime = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-core = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-session = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-offchain = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-block-builder = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-transaction-pool = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+sp-inherents = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+max-encoded-len = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", features=["derive"] }
 
-frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-support = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-executive = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-system = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-balances = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-randomness-collective-flip = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-timestamp = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-sudo = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-transaction-payment = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
 
-frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
-pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-system-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-transaction-payment-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-evm = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
+pallet-utility = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
 
-pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
-fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+pallet-ethereum = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+fp-rpc = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
 
-pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-society = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
-pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-democracy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-scheduler = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-collective = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-society = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-proxy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-treasury = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
 
-pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false }
+pallet-crowdloan-rewards = { git="https://github.com/purestake/crowdloan-rewards", branch="joshy-moonriver-emergency", default-features=false }
 
-moonbeam-evm-tracer = { path = "../evm_tracer", default-features = false }
-moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-features = false }
-moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
+moonbeam-evm-tracer = { path="../evm_tracer", default-features=false }
+moonbeam-rpc-primitives-debug = { path="../../primitives/rpc/debug", default-features=false }
+moonbeam-rpc-primitives-txpool = { path="../../primitives/rpc/txpool", default-features=false }
 
 # Cumulus dependencies
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
+cumulus-pallet-parachain-system = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-core = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+parachain-info = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-timestamp = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
 
 # Benchmarking dependencies
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
-frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
+frame-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
+frame-system-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-polkadot-v0.9.6" }
-evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
+cumulus-test-relay-sproof-builder = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-parachain-inherent = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+evm = { version="0.27.0", default-features=false, features=["with-codec"] }
 rlp = "0.5"
 hex = "0.4"
 
 [build-dependencies]
-substrate-wasm-builder = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
+substrate-wasm-builder = { version="4.0.0", git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
 
 [features]
 default = ["std"]

--- a/runtime/moonshadow/Cargo.toml
+++ b/runtime/moonshadow/Cargo.toml
@@ -9,86 +9,86 @@ edition = '2018'
 build = "build.rs"
 
 [dependencies]
-serde = { version="1.0.101", default-features=false, optional=true, features=["derive"] }
-parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }
+serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
+parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
 log = "0.4"
 hex-literal = "0.3.1"
 
-runtime-common = { path="../common", default-features=false }
+runtime-common = { path = "../common", default-features = false }
 
-pallet-author-inherent = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-precompiles = { path="../precompiles/", default-features=false }
-account = { path="../../primitives/account/", default-features=false }
-moonbeam-core-primitives = { path="../../core-primitives", default-features=false }
-pallet-ethereum-chain-id = { path="../../pallets/ethereum-chain-id", default-features=false }
-parachain-staking = { path="../../pallets/parachain-staking", default-features=false }
-pallet-author-slot-filter = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="nimbus-v0.9.6-without-compact-proof", default-features=false }
-pallet-author-mapping = { path="../../pallets/author-mapping", default-features=false }
+pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+precompiles = { path = "../precompiles/", default-features = false }
+account = { path = "../../primitives/account/", default-features = false }
+moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
+pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
+parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "nimbus-v0.9.6-without-compact-proof", default-features = false }
+pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
 
 # Substrate dependencies
-sp-std = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-io = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-version = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-runtime = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-core = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-session = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-offchain = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-block-builder = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-transaction-pool = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-sp-inherents = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-max-encoded-len = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", features=["derive"] }
+sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-version = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-session = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-transaction-pool = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+max-encoded-len = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", features = ["derive"] }
 
-frame-support = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-frame-executive = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-frame-system = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-balances = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-randomness-collective-flip = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-timestamp = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-sudo = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-transaction-payment = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
 
-frame-system-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-transaction-payment-rpc-runtime-api = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-evm = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-v0.9.6" }
-pallet-utility = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-v0.9.6" }
+pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
 
-pallet-ethereum = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
-fp-rpc = { default-features=false, git="https://github.com/purestake/frontier", branch="moonbeam-polkadot-v0.9.6" }
+pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
+fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.6" }
 
-pallet-democracy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-scheduler = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-collective = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-society = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-proxy = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
-pallet-treasury = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6" }
+pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-collective = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-society = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
+pallet-treasury = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6" }
 
-pallet-crowdloan-rewards = { git="https://github.com/purestake/crowdloan-rewards", branch="joshy-moonriver-emergency", default-features=false }
+pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "joshy-moonriver-emergency", default-features = false }
 
-moonbeam-evm-tracer = { path="../evm_tracer", default-features=false }
-moonbeam-rpc-primitives-debug = { path="../../primitives/rpc/debug", default-features=false }
-moonbeam-rpc-primitives-txpool = { path="../../primitives/rpc/txpool", default-features=false }
+moonbeam-evm-tracer = { path = "../evm_tracer", default-features = false }
+moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-features = false }
+moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
 
 # Cumulus dependencies
-cumulus-pallet-parachain-system = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-core = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-parachain-info = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-timestamp = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
 
 # Benchmarking dependencies
-frame-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
-frame-system-benchmarking = { git="https://github.com/paritytech/substrate", default-features=false, branch="polkadot-v0.9.6", optional=true }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
+frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.6", optional = true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-cumulus-primitives-parachain-inherent = { git="https://github.com/purestake/cumulus", default-features=false, branch="nimbus-v0.9.6-without-compact-proof" }
-evm = { version="0.27.0", default-features=false, features=["with-codec"] }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "nimbus-v0.9.6-without-compact-proof" }
+evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
 rlp = "0.5"
 hex = "0.4"
 
 [build-dependencies]
-substrate-wasm-builder = { version="4.0.0", git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.6" }
+substrate-wasm-builder = { version = "4.0.0", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.6" }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
This PR cherry picks Basti's commit "Revert Compact Proof" https://github.com/paritytech/cumulus/commit/e2850ce7d53cc6c6eb927195539098610ce8edac

This was needed to get moonriver moving again after the 13k RMRKs.

It's not yet clear whether this is a good idea for a runtime that is already expecting the compact proof (after polkadot v0.9.4), but now the branch exists to try it out.

This also bumps the crate versions in preparation for a release should we choose to make one.