### PR TITLE
Maintenance mode

### DIFF
--- a/pallets/migrations/src/lib.rs
+++ b/pallets/migrations/src/lib.rs
@@ -126,7 +126,10 @@ pub mod pallet {
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
-		pub completed_migrations: Vec<Vec<u8>>,
+		/// Any migrations that will never be relevant to this chain.
+		/// A new chain may launch from a pre-existing codebase. In this case the new chain should
+		/// include any migrations from the codebase's history before it was launched.
+		pub prehistoric_migrations: Vec<Vec<u8>>,
 		pub dummy: PhantomData<T>, // TODO:
 	}
 
@@ -134,7 +137,7 @@ pub mod pallet {
 	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self {
 			Self {
-				completed_migrations: vec![],
+				prehistoric_migrations: vec![],
 				dummy: PhantomData,
 			}
 		}
@@ -143,11 +146,10 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
-			//TODO Does it make sense to configure migrations at genesis? Would they even be run?
-			for migration_name in &self.completed_migrations {
+			for migration_name in &self.prehistoric_migrations {
 				<MigrationState<T>>::insert(migration_name, Perbill::one());
 			}
-			// When a new chain is launched, it starts im a fully migrated state.
+			// When a new chain is launched, it starts in a fully migrated state.
 			FullyUpgraded::<T>::put(true);
 		}
 	}

--- a/pallets/migrations/src/lib.rs
+++ b/pallets/migrations/src/lib.rs
@@ -143,9 +143,12 @@ pub mod pallet {
 	#[pallet::genesis_build]
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
+			//TODO Does it make sense to configure migrations at genesis? Would they even be run?
 			for migration_name in &self.completed_migrations {
 				<MigrationState<T>>::insert(migration_name, Perbill::one());
 			}
+			// When a new chain is launched, it starts im a fully migrated state.
+			FullyUpgraded::<T>::put(true);
 		}
 	}
 

--- a/pallets/migrations/src/mock.rs
+++ b/pallets/migrations/src/mock.rs
@@ -103,13 +103,13 @@ impl Config for Test {
 
 /// Externality builder for pallet migration's mock runtime
 pub(crate) struct ExtBuilder {
-	completed_migrations: Vec<Vec<u8>>,
+	prehistoric_migrations: Vec<Vec<u8>>,
 }
 
 impl Default for ExtBuilder {
 	fn default() -> ExtBuilder {
 		ExtBuilder {
-			completed_migrations: vec![],
+			prehistoric_migrations: vec![],
 		}
 	}
 }
@@ -121,7 +121,7 @@ impl ExtBuilder {
 			.expect("Frame system builds valid default genesis config");
 
 		pallet_migrations::GenesisConfig::<Test> {
-			completed_migrations: self.completed_migrations,
+			prehistoric_migrations: self.prehistoric_migrations,
 			dummy: Default::default(),
 		}
 		.assimilate_storage(&mut t)

--- a/pallets/migrations/src/mock.rs
+++ b/pallets/migrations/src/mock.rs
@@ -17,6 +17,7 @@
 //! A minimal runtime including the migrations pallet
 use super::*;
 use crate as pallet_migrations;
+use frame_support::traits::Filter;
 use frame_support::{
 	construct_runtime, pallet_prelude::*, parameter_types, traits::GenesisBuild, weights::Weight,
 };
@@ -53,7 +54,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Test {
-	type BaseCallFilter = ();
+	type BaseCallFilter = Migrations;
 	type DbWeight = ();
 	type Origin = Origin;
 	type Index = u64;
@@ -85,9 +86,19 @@ impl Get<Vec<Box<dyn Migration>>> for MockMigrations {
 	}
 }
 
+/// During migrations we will not allow any calls.
+pub struct MigrationCallFilter;
+impl Filter<Call> for MigrationCallFilter {
+	fn filter(_: &Call) -> bool {
+		false
+	}
+}
+
 impl Config for Test {
 	type Event = Event;
 	type MigrationsList = MockMigrations;
+	type NormalCallFilter = ();
+	type MigrationCallFilter = MigrationCallFilter;
 }
 
 /// Externality builder for pallet migration's mock runtime

--- a/pallets/migrations/src/tests.rs
+++ b/pallets/migrations/src/tests.rs
@@ -15,9 +15,9 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Unit testing
-use crate::mock::{events, ExtBuilder, Migrations, System};
+use crate::mock::{events, Call, ExtBuilder, Migrations, Origin, System};
 use crate::Event;
-use frame_support::traits::OnRuntimeUpgrade;
+use frame_support::{assert_ok, dispatch::Dispatchable, traits::OnRuntimeUpgrade};
 
 #[test]
 fn genesis_builder_works() {
@@ -45,3 +45,17 @@ fn on_runtime_upgrade_emits_events() {
 		assert_eq!(events(), expected);
 	});
 }
+
+//TODO test for multi-block migration
+// we would need to make one take more than a block worth of weight for that.
+
+#[test]
+fn can_remark_when_not_migrating() {
+	ExtBuilder::default().build().execute_with(|| {
+		let call: Call = frame_system::Call::remark(vec![]).into();
+		assert_ok!(call.dispatch(Origin::signed(1)));
+	})
+}
+
+// TODO Once we have multiblock migration testing, test that calls are disabled during migrations
+// the flow would be: start a migration, try to dispatch, ensure the dispatch failed.


### PR DESCRIPTION
Sketches out the maintenance mode feature of the migrations pallet. The idea is that we don't want users interacting with the state machine when it is in a martially-migrated state. To achieve that, we make the migrations pallet responsible for setting the base filter. It is automatically set and reset when migrations start and end.

This PR raised some questions about how the genesis config should work.
