### PR TITLE
Add token symbols to specs

### DIFF
--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -76,7 +76,10 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 		vec![],
 		None,
 		None,
-		Some(serde_json::from_str("{\"tokenDecimals\": 18}").expect("Provided valid json map")),
+		Some(
+			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"UNIT\"}")
+				.expect("Provided valid json map"),
+		),
 		Extensions {
 			relay_chain: "dev-service".into(),
 			para_id: Default::default(),
@@ -127,7 +130,10 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		vec![],
 		None,
 		None,
-		Some(serde_json::from_str("{\"tokenDecimals\": 18}").expect("Provided valid json map")),
+		Some(
+			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"UNIT\"}")
+				.expect("Provided valid json map"),
+		),
 		Extensions {
 			relay_chain: "westend_testnet".into(),
 			para_id: para_id.into(),

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -75,7 +75,10 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 		vec![],
 		None,
 		None,
-		Some(serde_json::from_str("{\"tokenDecimals\": 18}").expect("Provided valid json map")),
+		Some(
+			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"GLMR\"}")
+				.expect("Provided valid json map"),
+		),
 		Extensions {
 			relay_chain: "dev-service".into(),
 			para_id: Default::default(),
@@ -126,7 +129,10 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		vec![],
 		None,
 		None,
-		Some(serde_json::from_str("{\"tokenDecimals\": 18}").expect("Provided valid json map")),
+		Some(
+			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"GLMR\"}")
+				.expect("Provided valid json map"),
+		),
 		Extensions {
 			relay_chain: "polkadot-local".into(),
 			para_id: para_id.into(),

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -75,7 +75,10 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 		vec![],
 		None,
 		None,
-		Some(serde_json::from_str("{\"tokenDecimals\": 18}").expect("Provided valid json map")),
+		Some(
+			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"MOVR\"}")
+				.expect("Provided valid json map"),
+		),
 		Extensions {
 			relay_chain: "dev-service".into(),
 			para_id: Default::default(),
@@ -126,7 +129,10 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		vec![],
 		None,
 		None,
-		Some(serde_json::from_str("{\"tokenDecimals\": 18}").expect("Provided valid json map")),
+		Some(
+			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"MOVR\"}")
+				.expect("Provided valid json map"),
+		),
 		Extensions {
 			relay_chain: "kusama-local".into(),
 			para_id: para_id.into(),

--- a/node/service/src/chain_spec/moonshadow.rs
+++ b/node/service/src/chain_spec/moonshadow.rs
@@ -75,7 +75,10 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 		vec![],
 		None,
 		None,
-		Some(serde_json::from_str("{\"tokenDecimals\": 18}").expect("Provided valid json map")),
+		Some(
+			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"MSHD\"}")
+				.expect("Provided valid json map"),
+		),
 		Extensions {
 			relay_chain: "dev-service".into(),
 			para_id: Default::default(),
@@ -126,7 +129,10 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		vec![],
 		None,
 		None,
-		Some(serde_json::from_str("{\"tokenDecimals\": 18}").expect("Provided valid json map")),
+		Some(
+			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"MSHD\"}")
+				.expect("Provided valid json map"),
+		),
 		Extensions {
 			relay_chain: "westend-local".into(),
 			para_id: para_id.into(),

--- a/specs/alphanet/parachain-embedded-specs-v8.json
+++ b/specs/alphanet/parachain-embedded-specs-v8.json
@@ -11,7 +11,8 @@
   ],
   "protocolId": null,
   "properties": {
-    "tokenDecimals": 18
+    "tokenDecimals": 18,
+    "tokenSymbol": "UNIT"
   },
   "relayChain": "westend_moonbase_relay_testnet",
   "paraId": 1000,

--- a/specs/alphanet/parachain-specs-template.json
+++ b/specs/alphanet/parachain-specs-template.json
@@ -8,7 +8,8 @@
   ],
   "protocolId": null,
   "properties": {
-    "tokenDecimals": 18
+    "tokenDecimals": 18,
+    "tokenSymbol": "UNIT"
   },
   "relayChain": "moonbase_alpha_relay",
   "paraId": 1000,

--- a/specs/moonriver/parachain-embedded-specs.json
+++ b/specs/moonriver/parachain-embedded-specs.json
@@ -13,7 +13,8 @@
   ],
   "protocolId": null,
   "properties": {
-    "tokenDecimals": 18
+    "tokenDecimals": 18,
+    "tokenSymbol": "MOVR"
   },
   "relayChain": "kusama",
   "paraId": 2023,

--- a/specs/moonshadow/parachain-embedded-specs.json
+++ b/specs/moonshadow/parachain-embedded-specs.json
@@ -11,7 +11,8 @@
   ],
   "protocolId": null,
   "properties": {
-    "tokenDecimals": 18
+    "tokenDecimals": 18,
+    "tokenSymbol": "MSHD"
   },
   "relayChain": "westend",
   "paraId": 2002,

--- a/tests/tests/test-author-mapping.ts
+++ b/tests/tests/test-author-mapping.ts
@@ -29,13 +29,13 @@ async function getMappingInfo(
 describeDevMoonbeam("Author Mapping - simple association", (context) => {
   it("should match genesis state", async function () {
     expect((await getMappingInfo(context, aliceAuthorId)).account).to.eq(ALITH);
-    expect((await getMappingInfo(context, aliceAuthorId)).deposit).to.eq("100.0000 Unit");
+    expect((await getMappingInfo(context, aliceAuthorId)).deposit).to.eq("100.0000 UNIT");
     expect(await getMappingInfo(context, bobAuthorId)).to.eq(null);
     expect((await context.polkadotApi.query.system.account(ALITH)).data.free.toHuman()).to.eq(
-      "1.2078 MUnit"
+      "1.2078 MUNIT"
     );
     expect((await context.polkadotApi.query.system.account(ALITH)).data.reserved.toHuman()).to.eq(
-      "1.1000 kUnit"
+      "1.1000 kUNIT"
     );
   });
   it("should succeed in adding an association", async function () {
@@ -47,10 +47,10 @@ describeDevMoonbeam("Author Mapping - simple association", (context) => {
     await context.createBlock();
     expect((await getMappingInfo(context, bobAuthorId)).account).to.eq(ALITH);
     expect((await context.polkadotApi.query.system.account(ALITH)).data.free.toHuman()).to.eq(
-      "1.2077 MUnit"
+      "1.2077 MUNIT"
     );
     expect((await context.polkadotApi.query.system.account(ALITH)).data.reserved.toHuman()).to.eq(
-      "1.2000 kUnit"
+      "1.2000 kUNIT"
     );
   });
   it("should check events", async function () {
@@ -105,7 +105,7 @@ describeDevMoonbeam("Author Mapping - Fail to reassociate alice", (context) => {
     await context.polkadotApi.tx.authorMapping.addAssociation(aliceAuthorId).signAndSend(baltathar);
     await context.createBlock();
     expect((await context.polkadotApi.query.system.account(BALTATHAR)).data.free.toHuman()).to.eq(
-      "1.2089 MUnit"
+      "1.2089 MUNIT"
     );
     expect(
       (await context.polkadotApi.query.system.account(BALTATHAR)).data.reserved.toHuman()
@@ -223,10 +223,10 @@ describeDevMoonbeam("Author Mapping - double registration", (context) => {
     await context.createBlock();
     expect((await getMappingInfo(context, bobAuthorId)).account).to.eq(ALITH);
     expect((await context.polkadotApi.query.system.account(ALITH)).data.free.toHuman()).to.eq(
-      "1.2077 MUnit"
+      "1.2077 MUNIT"
     );
     expect((await context.polkadotApi.query.system.account(ALITH)).data.reserved.toHuman()).to.eq(
-      "1.2000 kUnit"
+      "1.2000 kUNIT"
     );
   });
   it("should associate with charlie, although already associated with bob", async function () {
@@ -240,10 +240,10 @@ describeDevMoonbeam("Author Mapping - double registration", (context) => {
     expect((await getMappingInfo(context, charlieAuthorId)).account).to.eq(ALITH);
     expect((await getMappingInfo(context, bobAuthorId)).account).to.eq(ALITH);
     expect((await context.polkadotApi.query.system.account(ALITH)).data.free.toHuman()).to.eq(
-      "1.2076 MUnit"
+      "1.2076 MUNIT"
     );
     expect((await context.polkadotApi.query.system.account(ALITH)).data.reserved.toHuman()).to.eq(
-      "1.3000 kUnit"
+      "1.3000 kUNIT"
     );
   });
 });

--- a/tests/tests/test-crowdloan.ts
+++ b/tests/tests/test-crowdloan.ts
@@ -26,7 +26,7 @@ async function calculate_vested_amount(context, totalReward, initialPayment, num
   // In the dev service, where the relay block number is mocked, we get exactly two relay blocks.
   let elapsedRelayBlocks = numberOfBlocks * 2;
   let shouldHaveVested = BigInt(initialPayment) + vestedPerBlock * BigInt(elapsedRelayBlocks);
-  let claimedAsBalance = formatBalance(shouldHaveVested, { withSi: true, withUnit: "Unit" }, 18);
+  let claimedAsBalance = formatBalance(shouldHaveVested, { withSi: true, withUnit: "UNIT" }, 18);
   return claimedAsBalance;
 }
 
@@ -71,7 +71,7 @@ describeDevMoonbeam("Crowdloan", (context) => {
           await context.polkadotApi.query.crowdloanRewards.accountsPayable(GENESIS_ACCOUNT)
         ).toHuman() as any
       ).total_reward
-    ).to.equal("3.0000 MUnit");
+    ).to.equal("3.0000 MUNIT");
     let isInitialized = await context.polkadotApi.query.crowdloanRewards.initialized();
     expect(isInitialized.toHuman()).to.be.true;
   });
@@ -124,7 +124,7 @@ describeDevMoonbeam("Crowdloan", (context) => {
     expect(
       formatBalance(
         BigInt(await context.web3.eth.getBalance(GENESIS_ACCOUNT)) - GENESIS_ACCOUNT_BALANCE,
-        { withSi: true, withUnit: "Unit" },
+        { withSi: true, withUnit: "UNIT" },
         18
       )
     ).to.equal(claimed);
@@ -132,7 +132,7 @@ describeDevMoonbeam("Crowdloan", (context) => {
     expect(
       formatBalance(
         account.data.free.toBigInt() - GENESIS_ACCOUNT_BALANCE,
-        { withSi: true, withUnit: "Unit" },
+        { withSi: true, withUnit: "UNIT" },
         18
       )
     ).to.equal(claimed);
@@ -297,7 +297,7 @@ describeDevMoonbeam("Crowdloan", (context) => {
     expect(
       ((await context.polkadotApi.query.crowdloanRewards.accountsPayable(ALITH)).toHuman() as any)
         .total_reward
-    ).to.equal("3.0000 MUnit");
+    ).to.equal("3.0000 MUNIT");
 
     let rewardInfo = (
       await context.polkadotApi.query.crowdloanRewards.accountsPayable(ALITH)
@@ -358,7 +358,7 @@ describeDevMoonbeam("Crowdloan", (context) => {
               await context.polkadotApi.query.crowdloanRewards.accountsPayable(input[1])
             ).toHuman() as any
           ).total_reward
-        ).to.equal("600.0000 Unit");
+        ).to.equal("600.0000 UNIT");
       })
     );
   });
@@ -429,7 +429,7 @@ describeDevMoonbeam("Crowdloan", (context) => {
               await context.polkadotApi.query.crowdloanRewards.accountsPayable(input[1])
             ).toHuman() as any
           ).total_reward
-        ).to.equal("600.0000 Unit");
+        ).to.equal("600.0000 UNIT");
       })
     );
   });

--- a/tests/tests/test-stake.ts
+++ b/tests/tests/test-stake.ts
@@ -40,9 +40,9 @@ describeDevMoonbeam("Staking - Genesis", (context) => {
     const inflationInfo = await context.polkadotApi.query.parachainStaking.inflationConfig();
     // {
     //   expect: {
-    //     min: '100.0000 kUnit',
-    //     ideal: '200.0000 kUnit',
-    //     max: '500.0000 kUnit'
+    //     min: '100.0000 kUNIT',
+    //     ideal: '200.0000 kUNIT',
+    //     max: '500.0000 kUNIT'
     //   },
     //  annual: {
     //     min: '4.00%',
@@ -51,9 +51,9 @@ describeDevMoonbeam("Staking - Genesis", (context) => {
     // },
     //   round: { min: '0.00%', ideal: '0.00%', max: '0.00%' }
     // }
-    expect(inflationInfo.toHuman()["expect"]["min"]).to.eq("100.0000 kUnit");
-    expect(inflationInfo.toHuman()["expect"]["ideal"]).to.eq("200.0000 kUnit");
-    expect(inflationInfo.toHuman()["expect"]["max"]).to.eq("500.0000 kUnit");
+    expect(inflationInfo.toHuman()["expect"]["min"]).to.eq("100.0000 kUNIT");
+    expect(inflationInfo.toHuman()["expect"]["ideal"]).to.eq("200.0000 kUNIT");
+    expect(inflationInfo.toHuman()["expect"]["max"]).to.eq("500.0000 kUNIT");
     expect(inflationInfo.toHuman()["annual"]["min"]).to.eq("4.00%");
     expect(inflationInfo.toHuman()["annual"]["ideal"]).to.eq("5.00%");
     expect(inflationInfo.toHuman()["annual"]["max"]).to.eq("5.00%");
@@ -84,7 +84,7 @@ describeDevMoonbeam("Staking - Join Candidates", (context) => {
     ).to.equal(true, "new candidate ethan should have been added");
     expect(
       (candidatesAfter.toHuman() as { owner: string; amount: string }[])[1].amount ===
-        "1.0000 kUnit"
+        "1.0000 kUNIT"
     ).to.equal(true, "new candidate ethan should have been added (wrong amount)");
   });
 });
@@ -107,7 +107,7 @@ describeDevMoonbeam("Staking - Candidate bond more", (context) => {
     let candidatesAfter = await context.polkadotApi.query.parachainStaking.candidatePool();
     expect(
       (candidatesAfter.toHuman() as { owner: string; amount: string }[])[1].amount ===
-        "2.0000 kUnit"
+        "2.0000 kUNIT"
     ).to.equal(true, "bond should have increased");
   });
 });
@@ -130,7 +130,7 @@ describeDevMoonbeam("Staking - Candidate bond less", (context) => {
     let candidatesAfter = await context.polkadotApi.query.parachainStaking.candidatePool();
     expect(
       (candidatesAfter.toHuman() as { owner: string; amount: string }[])[1].amount ===
-        "1.0000 kUnit"
+        "1.0000 kUNIT"
     ).to.equal(true, "bond should have decreased");
   });
 });


### PR DESCRIPTION
This PR adds token symbols `GLMR`/`MOVR`/`MSHD`/`UNIT` to all the parachain specs in the repo. This helps offchain tools display the correct units.