### PR TITLE
Prevents the CI to push docker image with wrong version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,6 +232,7 @@ jobs:
           node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tests/**/test-*.ts'
 
   ####### Prepare and Deploy Docker images #######
+
   generate-parachain-specs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,9 +147,9 @@ jobs:
         run: rustup show
       - name: SCCache
         run: |
-          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
-            cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
-          fi
+          # if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+            cargo install sccache --git https://github.com/purestake/sccache.git --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+          # fi
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
             ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
@@ -167,7 +167,7 @@ jobs:
       - name: Build Node
         run: |
           env
-          SCCACHE_RECACHE=1 cargo build --release --all
+          cargo build --release --all
       - name: Verify node version
         run: |
           git log -1 --format="%H"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,7 +261,7 @@ jobs:
   docker-parachain:
     runs-on: ubuntu-latest
     needs: ["set-tags", "build", "generate-parachain-specs"]
-    if: github.event_name == 'push' && ${{ steps.check-check-docker-image.outputs.image_exists }} == false
+    if: github.event_name == 'push' && ${{ needs.set-tags.outputs.image_exists }} == false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -312,7 +312,7 @@ jobs:
   docker-moonbeam:
     runs-on: ubuntu-latest
     needs: ["set-tags", "build", "generate-parachain-specs"]
-    if: github.event_name == 'push' && ${{ steps.check-check-docker-image.outputs.image_exists }} == false
+    if: github.event_name == 'push' && ${{ needs.set-tags.outputs.image_exists }} == false
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,6 +166,7 @@ jobs:
           if [[ -f ../target/release/moonbeam ]]; then ../target/release/moonbeam --version; fi
       - name: Build Node
         run: |
+          env
           SCCACHE_RECACHE=1 cargo build --release --all
       - name: Verify node version
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,12 +45,7 @@ jobs:
       - name: Check existing docker image
         id: check-docker-image
         run: |
-          docker manifest inspect purestake/moonbeam:sha-${{ steps.get-sha.outputs.sha8 }};
-          if [[ $? == 0 ]]; then
-            echo ::set-output name=image_exists::true
-          else
-            echo ::set-output name=image_exists::false
-          fi
+          echo ::set-output name=image_exists::$(docker manifest inspect purestake/moonbeam:v0.9.1 > /dev/null && echo "true" || echo "false")
 
   check-copyright:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,10 +330,6 @@ jobs:
         with:
           name: moonbeam
           path: build
-      - name: Verify
-        run: |
-          chmod uog+x build/moonbeam
-          ./build/moonbeam --version
       - name: Prepare
         id: prep
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,34 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       git_ref: ${{ steps.check-git-ref.outputs.git_ref }}
+      image_exists: ${{ steps.check-check-docker-image.outputs.image_exists }}
+      sha: ${{ steps.get-sha.outputs.sha }}
+      sha8: ${{ steps.get-sha.outputs.sha8 }}
     steps:
       - name: Check git ref
         id: check-git-ref
         run: |
           if [[ -n "${{ github.event.inputs.pull_request }}" ]]; then
             echo ::set-output name=git_ref::refs/pull/${{ github.event.inputs.pull_request }}/head
-            echo "git_ref: refs/pull/${{ github.event.inputs.pull_request }}/head"
+          else 
+            echo ::set-output name=git_ref::$GITHUB_REF
+          fi
+      - name: Get Sha
+        id: get-sha
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.check-git-ref.outputs.git_ref }}
+        run: |
+          echo ::set-output name=sha::$(git log -1 --format="%H")
+          echo ::set-output name=sha8::$(git log -1 --format="%H" | cut -c1-8)
+      - name: Check existing docker image
+        id: check-docker-image
+        run: |
+          docker manifest inspect purestake/moonbeam:sha-${{ steps.get-sha.outputs.sha8 }};
+          if [[ $? == 0 ]]; then
+            echo ::set-output name=image_exists::true
+          else
+            echo ::set-output name=image_exists::false
           fi
 
   check-copyright:
@@ -207,10 +228,11 @@ jobs:
           cd ../tests
           npm install
           node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tests/**/test-*.ts'
+
   ####### Prepare and Deploy Docker images #######
   generate-parachain-specs:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push
     needs: ["build", "typescript-tests"]
     steps:
       - name: Checkout
@@ -238,8 +260,8 @@ jobs:
 
   docker-parachain:
     runs-on: ubuntu-latest
-    needs: ["build", "generate-parachain-specs"]
-    if: github.event_name == 'push'
+    needs: ["set-tags", "build", "generate-parachain-specs"]
+    if: github.event_name == 'push' && ${{ steps.check-check-docker-image.outputs.image_exists }} == false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -253,22 +275,7 @@ jobs:
         id: prep
         run: |
           DOCKER_IMAGE=purestake/moonbase-parachain
-          VERSION=noop
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            VERSION=nightly
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=edge
-            fi
-          elif [[ $GITHUB_REF == refs/pull/* ]]; then
-            VERSION=pr-${{ github.event.number }}
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [ "${{ github.event_name }}" = "push" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
-          fi
-          echo ::set-output name=version::${VERSION}
+          TAGS="${DOCKER_IMAGE}:sha-${{ needs.set-tags.outputs.sha8 }}"
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       - name: Set up QEMU
@@ -298,7 +305,6 @@ jobs:
             org.opencontainers.image.description=${{ github.event.repository.description }}
             org.opencontainers.image.url=${{ github.event.repository.html_url }}
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
@@ -306,7 +312,7 @@ jobs:
   docker-moonbeam:
     runs-on: ubuntu-latest
     needs: ["build", "generate-parachain-specs"]
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && ${{ steps.check-check-docker-image.outputs.image_exists }} == false
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -319,27 +325,12 @@ jobs:
       - name: Verify
         run: |
           chmod uog+x build/moonbeam
-          ./target/release/moonbeam --version
+          ./build/moonbeam --version
       - name: Prepare
         id: prep
         run: |
           DOCKER_IMAGE=purestake/moonbeam
-          VERSION=noop
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            VERSION=nightly
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=edge
-            fi
-          elif [[ $GITHUB_REF == refs/pull/* ]]; then
-            VERSION=pr-${{ github.event.number }}
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [ "${{ github.event_name }}" = "push" ]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:sha-${GITHUB_SHA::8}"
-          fi
-          echo ::set-output name=version::${VERSION}
+          TAGS="${DOCKER_IMAGE}:sha-${{ needs.set-tags.outputs.sha8 }}"
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       - name: Set up QEMU
@@ -369,7 +360,6 @@ jobs:
             org.opencontainers.image.description=${{ github.event.repository.description }}
             org.opencontainers.image.url=${{ github.event.repository.html_url }}
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,9 +148,9 @@ jobs:
       - name: SCCache
         run: |
           # Must use purestake version to support SUBSTRATE_ env (for binary version matching git hash)
-          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+          # if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
             cargo install sccache --git https://github.com/purestake/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
-          fi
+          # fi
           ls -la ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,11 +160,6 @@ jobs:
       - id: get-rust-versions
         run: |
           echo "::set-output name=rustc::$(rustc --version)"
-      - name: Verify node version - prebuild
-        run: |
-          git log -1 --format="%H"
-          git rev-parse --short HEAD
-          if [[ -f ../target/release/moonbeam ]]; then ../target/release/moonbeam --version; fi
       - name: Build Node
         run: |
           env

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,9 +148,9 @@ jobs:
       - name: SCCache
         run: |
           # Must use purestake version to support SUBSTRATE_ env (for binary version matching git hash)
-          # if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
             cargo install sccache --git https://github.com/purestake/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
-          # fi
+          fi
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
             ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,9 +148,9 @@ jobs:
       - name: SCCache
         run: |
           # Must use purestake version to support SUBSTRATE_ env (for binary version matching git hash)
-          # if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
             cargo install sccache --git https://github.com/purestake/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
-          # fi
+          fi
           ls -la ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,7 @@ jobs:
       - id: get-rust-versions
         run: |
           echo "::set-output name=rustc::$(rustc --version)"
-      - name: Verify node version (prebuild)
+      - name: Verify node version - prebuild
         run: |
           git log -1 --format="%H"
           ls -la ./target/release/moonbeam

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,6 +147,7 @@ jobs:
         run: rustup show
       - name: SCCache
         run: |
+          # Must use purestake version to support SUBSTRATE_ env (for binary version matching git hash)
           # if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
             cargo install sccache --git https://github.com/purestake/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
           # fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
             ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
           fi
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
-          echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
+          # echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
       - id: get-rust-versions
         run: |
           echo "::set-output name=rustc::$(rustc --version)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,9 @@ jobs:
         run: |
           echo "::set-output name=rustc::$(rustc --version)"
       - name: Build Node
-        run: cargo build --release --all
+        run: |
+          cargo build --release --all
+          ./target/release/moonbeam --version
       - name: Unit tests
         run: cargo test --release --all
       - name: Format code with rustfmt
@@ -314,6 +316,10 @@ jobs:
         with:
           name: moonbeam
           path: build
+      - name: Verify
+        run: |
+          chmod uog+x build/moonbeam
+          ./target/release/moonbeam --version
       - name: Prepare
         id: prep
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,7 +232,7 @@ jobs:
   ####### Prepare and Deploy Docker images #######
   generate-parachain-specs:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push
+    if: github.event_name == 'push'
     needs: ["build", "typescript-tests"]
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,7 +155,7 @@ jobs:
             ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
           fi
           ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
-          # echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
       - id: get-rust-versions
         run: |
           echo "::set-output name=rustc::$(rustc --version)"
@@ -165,7 +165,8 @@ jobs:
           git rev-parse --short HEAD
           if [[ -f ../target/release/moonbeam ]]; then ../target/release/moonbeam --version; fi
       - name: Build Node
-        run: cargo build --release --all
+        run: |
+          SCCACHE_RECACHE=1 cargo build --release --all
       - name: Verify node version
         run: |
           git log -1 --format="%H"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,9 +148,9 @@ jobs:
       - name: SCCache
         run: |
           # Must use purestake version to support SUBSTRATE_ env (for binary version matching git hash)
-          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+          # if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
             cargo install sccache --git https://github.com/purestake/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
-          fi
+          # fi
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
             ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,8 +160,10 @@ jobs:
         run: |
           echo "::set-output name=rustc::$(rustc --version)"
       - name: Build Node
+        run: cargo build --release --all
+      - name: Verify node version
         run: |
-          cargo build --release --all
+          git log -1 --format="%H"
           ./target/release/moonbeam --version
       - name: Unit tests
         run: cargo test --release --all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,12 @@ jobs:
         id: check-docker-image
         run: |
           echo ::set-output name=image_exists::$(docker manifest inspect purestake/moonbeam:v0.9.1 > /dev/null && echo "true" || echo "false")
+      - name: Display variables
+        run: |
+          echo git_ref: ${{ steps.check-git-ref.outputs.git_ref }}
+          echo sha: ${{ steps.get-sha.outputs.sha }}
+          echo sha8: ${{ steps.get-sha.outputs.sha8 }}
+          echo image_exists: ${{ steps.check-docker-image.outputs.image_exists }}
 
   check-copyright:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,7 @@ jobs:
           if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
             cargo install sccache --git https://github.com/purestake/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
           fi
+          ls -la ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
             ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,11 @@ jobs:
           else 
             echo ::set-output name=git_ref::$GITHUB_REF
           fi
-      - name: Get Sha
-        id: get-sha
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           ref: ${{ steps.check-git-ref.outputs.git_ref }}
+      - name: Get Sha
+        id: get-sha
         run: |
           echo ::set-output name=sha::$(git log -1 --format="%H")
           echo ::set-output name=sha8::$(git log -1 --format="%H" | cut -c1-8)
@@ -311,7 +311,7 @@ jobs:
 
   docker-moonbeam:
     runs-on: ubuntu-latest
-    needs: ["build", "generate-parachain-specs"]
+    needs: ["set-tags", "build", "generate-parachain-specs"]
     if: github.event_name == 'push' && ${{ steps.check-check-docker-image.outputs.image_exists }} == false
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Check existing docker image
         id: check-docker-image
         run: |
-          echo ::set-output name=image_exists::$(docker manifest inspect purestake/moonbeam:v0.9.1 > /dev/null && echo "true" || echo "false")
+          TAG=sha-${{ steps.get-sha.outputs.sha8 }}
+          echo ::set-output name=image_exists::$(docker manifest inspect purestake/moonbeam:$TAG > /dev/null && echo "true" || echo "false")
       - name: Display variables
         run: |
           echo git_ref: ${{ steps.check-git-ref.outputs.git_ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Verify node version - prebuild
         run: |
           git log -1 --format="%H"
-          ls -la ./target/release/moonbeam
+          git rev-parse --short HEAD
           if [[ -f ../target/release/moonbeam ]]; then ../target/release/moonbeam --version; fi
       - name: Build Node
         run: cargo build --release --all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
       - name: SCCache
         run: |
           # if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
-            cargo install sccache --git https://github.com/purestake/sccache.git --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+            cargo install sccache --git https://github.com/purestake/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
           # fi
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,11 @@ jobs:
       - id: get-rust-versions
         run: |
           echo "::set-output name=rustc::$(rustc --version)"
+      - name: Verify node version (prebuild)
+        run: |
+          git log -1 --format="%H"
+          ls -la ./target/release/moonbeam
+          if [[ -f ../target/release/moonbeam ]]; then ../target/release/moonbeam --version; fi
       - name: Build Node
         run: cargo build --release --all
       - name: Verify node version

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,7 +14,6 @@ jobs:
   build-binary:
     runs-on: self-hosted
     env:
-      CARGO_SCCACHE_VERSION: 0.2.14-alpha.0-parity
       RUSTFLAGS: "-C opt-level=3"
     outputs:
       RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
@@ -23,26 +22,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.tag }}
-      - uses: actions/cache@v2
-        with:
-          path: ${{ runner.tool_cache }}/cargo-sccache
-          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}-v1
-
-      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
       - name: Setup Rust toolchain
         run: rustup show
-      - name: SCCache
-        run: |
-          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
-            cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
-          fi
-          if [[ -z `pgrep sccache` ]]; then
-            chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
-            ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
-          fi
-          ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
-          echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
       - id: get-rust-versions
         run: |
           echo "::set-output name=rustc::$(rustc --version)"


### PR DESCRIPTION
`$GITHUB_REF` is referencing the triggering branch and not the checked-out branch, which lead to a difference between the build code and the docker image tag used in some cases.

It removes non sha tags to the docker images
It also adds a check if the docker image sha tag is already on dockerhub and prevents docker to build/push in that case
It also changes SCCache version, to fix the issue with the binary version being different from the git sha.

It also removes the SCCache for Release builds (safety measure)