### PR TITLE
Test to verify fast tracking state

### DIFF
--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -36,6 +36,11 @@ use sp_core::{Public, H160, U256};
 use sp_runtime::DispatchError;
 
 #[test]
+fn fast_track_unavailable() {
+	assert!(!<moonbase_runtime::Runtime as pallet_democracy::Config>::InstantAllowed::get());
+}
+
+#[test]
 fn verify_pallet_indices() {
 	fn is_pallet_index<P: 'static>(index: usize) {
 		assert_eq!(

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -36,8 +36,8 @@ use sp_core::{Public, H160, U256};
 use sp_runtime::DispatchError;
 
 #[test]
-fn fast_track_unavailable() {
-	assert!(!<moonbase_runtime::Runtime as pallet_democracy::Config>::InstantAllowed::get());
+fn fast_track_available() {
+	assert!(<moonbase_runtime::Runtime as pallet_democracy::Config>::InstantAllowed::get());
 }
 
 #[test]

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -38,6 +38,11 @@ use sp_core::{Public, H160, U256};
 use sp_runtime::DispatchError;
 
 #[test]
+fn fast_track_unavailable() {
+	assert!(!<moonbeam_runtime::Runtime as pallet_democracy::Config>::InstantAllowed::get());
+}
+
+#[test]
 fn verify_pallet_indices() {
 	fn is_pallet_index<P: 'static>(index: usize) {
 		assert_eq!(

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -35,8 +35,8 @@ use sp_core::{Public, H160, U256};
 use sp_runtime::DispatchError;
 
 #[test]
-fn fast_track_unavailable() {
-	assert!(!<moonriver_runtime::Runtime as pallet_democracy::Config>::InstantAllowed::get());
+fn fast_track_available() {
+	assert!(<moonriver_runtime::Runtime as pallet_democracy::Config>::InstantAllowed::get());
 }
 
 #[test]

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -35,6 +35,11 @@ use sp_core::{Public, H160, U256};
 use sp_runtime::DispatchError;
 
 #[test]
+fn fast_track_unavailable() {
+	assert!(!<moonriver_runtime::Runtime as pallet_democracy::Config>::InstantAllowed::get());
+}
+
+#[test]
 fn verify_pallet_indices() {
 	fn is_pallet_index<P: 'static>(index: usize) {
 		assert_eq!(

--- a/runtime/moonshadow/tests/integration_test.rs
+++ b/runtime/moonshadow/tests/integration_test.rs
@@ -35,6 +35,11 @@ use sp_core::{Public, H160, U256};
 use sp_runtime::DispatchError;
 
 #[test]
+fn fast_track_unavailable() {
+	assert!(!<moonshadow_runtime::Runtime as pallet_democracy::Config>::InstantAllowed::get());
+}
+
+#[test]
 fn verify_pallet_indices() {
 	fn is_pallet_index<P: 'static>(index: usize) {
 		assert_eq!(


### PR DESCRIPTION
Test verifying that instant fast tracking is currently disabled in all runtimes. These tests will fail if/when that changes in the future.