### PR TITLE
Add monetary governance origin to staking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6436,7 +6436,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-staking"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parachain-staking"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["PureStake"]
 edition = "2018"
 description = "parachain staking pallet for collator selection and reward distribution"

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -86,7 +86,7 @@ fn create_funded_collator<T: Config>(
 const USER_SEED: u32 = 999666;
 
 benchmarks! {
-	// ROOT DISPATCHABLES
+	// MONETARY ORIGIN DISPATCHABLES
 
 	set_staking_expectations {
 		let stake_range: Range<BalanceOf<T>> = Range {
@@ -123,6 +123,8 @@ benchmarks! {
 	verify {
 		assert_eq!(Pallet::<T>::parachain_bond_info().percent, Percent::from_percent(33));
 	}
+
+	// ROOT DISPATCHABLES
 
 	set_total_selected {}: _(RawOrigin::Root, 100u32)
 	verify {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -607,6 +607,8 @@ pub mod pallet {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		/// The currency type
 		type Currency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
+		/// The origin for monetary governance
+		type MonetaryGovernanceOrigin: EnsureOrigin<Self::Origin>;
 		/// Minimum number of blocks per round
 		type MinBlocksPerRound: Get<u32>;
 		/// Default number of blocks per round at genesis
@@ -985,7 +987,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			expectations: Range<BalanceOf<T>>,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			T::MonetaryGovernanceOrigin::ensure_origin(origin)?;
 			ensure!(expectations.is_valid(), Error::<T>::InvalidSchedule);
 			let mut config = <InflationConfig<T>>::get();
 			ensure!(
@@ -1007,7 +1009,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			schedule: Range<Perbill>,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			T::MonetaryGovernanceOrigin::ensure_origin(origin)?;
 			ensure!(schedule.is_valid(), Error::<T>::InvalidSchedule);
 			let mut config = <InflationConfig<T>>::get();
 			ensure!(config.annual != schedule, Error::<T>::NoWritingSameValue);
@@ -1030,7 +1032,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			new: T::AccountId,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			T::MonetaryGovernanceOrigin::ensure_origin(origin)?;
 			let ParachainBondConfig {
 				account: old,
 				percent,
@@ -1049,7 +1051,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			new: Percent,
 		) -> DispatchResultWithPostInfo {
-			frame_system::ensure_root(origin)?;
+			T::MonetaryGovernanceOrigin::ensure_origin(origin)?;
 			let ParachainBondConfig {
 				account,
 				percent: old,

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -112,6 +112,7 @@ parameter_types! {
 impl Config for Test {
 	type Event = Event;
 	type Currency = Balances;
+	type MonetaryGovernanceOrigin = frame_system::EnsureRoot<AccountId>;
 	type MinBlocksPerRound = MinBlocksPerRound;
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type BondDuration = BondDuration;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -551,6 +551,7 @@ parameter_types! {
 impl parachain_staking::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
+	type MonetaryGovernanceOrigin = EnsureRoot<AccountId>;
 	type MinBlocksPerRound = MinBlocksPerRound;
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type BondDuration = BondDuration;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -567,6 +567,7 @@ parameter_types! {
 impl parachain_staking::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
+	type MonetaryGovernanceOrigin = EnsureRoot<AccountId>;
 	type MinBlocksPerRound = MinBlocksPerRound;
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type BondDuration = BondDuration;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -568,6 +568,7 @@ parameter_types! {
 impl parachain_staking::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
+	type MonetaryGovernanceOrigin = EnsureRoot<AccountId>;
 	type MinBlocksPerRound = MinBlocksPerRound;
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type BondDuration = BondDuration;

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -566,6 +566,7 @@ parameter_types! {
 impl parachain_staking::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
+	type MonetaryGovernanceOrigin = EnsureRoot<AccountId>;
 	type MinBlocksPerRound = MinBlocksPerRound;
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type BondDuration = BondDuration;


### PR DESCRIPTION
This change was promised in the first milestone of the w3f parachain-staking grant as the 3rd task: https://github.com/w3f/Open-Grants-Program/blob/master/applications/parachain-staking.md

### What does it do?

This adds an explicit origin for monetary policy governance such that this origin replaces `ensure_root` checks for the following dispatchables:
```
fn set_staking_expectations
fn set_inflation
fn set_parachain_bond_account
fn set_parachain_bond_reserve_percent
```

In practice, the new origin is set to `EnsureRoot<AccountId>` in all runtimes so these dispatchables still require root origin.

- [x] bumped pallet crate minor version for potential (configurable) runtime interface permissions change