### PR TITLE
Tests add vscode tasks to run current ts test file

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,6 +18,24 @@
         "reveal": "always",
         "panel": "new"
       }
+    },
+    {
+      "label": "Run current test file in debug mode",
+      "type": "shell",
+      "command": "cd tests && DEBUG_MODE=true npm run current-test -- '${fileDirname}/${fileBasename}'",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
+    },
+    {
+      "label": "Run current test file",
+      "type": "shell",
+      "command": "cd tests && npm run current-test -- '${fileDirname}/${fileBasename}'",
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      }
     }
   ]
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -36,6 +36,7 @@
     "build": "cargo build --release",
     "non-ci-test": "mocha -r ts-node/register 'non_ci_tests/**/test-*.ts'",
     "test-single": "mocha -r ts-node/register 'tests/test-stake.ts'",
+    "current-test": "mocha -r ts-node/register",
     "lint": "npx prettier --write --ignore-path .gitignore '**/*.(yml|js|ts|json)'"
   },
   "author": "",


### PR DESCRIPTION
### What does it do?

Adds 2 vscode tasks to run the typescrypt end2end test currently open in the IDE (one to use the local node in debug and the other to instantiate a temporary node).
This avoids the need to modify the package.json file to play a particular test, just open the file corresponding to the test you want to play and launch the vscode task that fits.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
