### PR TITLE
Tests: set timeout to 10s for all typescript end2end tests

### DIFF
--- a/tests/util/setup-dev-tests.ts
+++ b/tests/util/setup-dev-tests.ts
@@ -48,8 +48,8 @@ interface InternalDevTestContext extends DevTestContext {
 
 export function describeDevMoonbeam(title: string, cb: (context: DevTestContext) => void) {
   describe(title, function () {
-    // Set timeout to 5000 for all tests.
-    this.timeout(5000);
+    // Set timeout to 10 seconds for all tests.
+    this.timeout(10_000);
 
     // The context is initialized empty to allow passing a reference
     // and to be filled once the node information is retrieved


### PR DESCRIPTION
### What does it do?

Set timeout to 10 seconds for all typescript end2end tests.

To run some long scenarios (like democratic processes), we have to go through a lot of steps, so anyway we won't be able to keep all tests within 5 seconds.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require changes in documentation/tutorials ?
