### PR TITLE
Add ss58prefix to specs

### DIFF
--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -79,8 +79,10 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 		None,
 		None,
 		Some(
-			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"UNIT\"}")
-				.expect("Provided valid json map"),
+			serde_json::from_str(
+				"{\"tokenDecimals\": 18, \"tokenSymbol\": \"UNIT\", \"SS58Prefix\": 1287}",
+			)
+			.expect("Provided valid json map"),
 		),
 		Extensions {
 			relay_chain: "dev-service".into(),
@@ -139,8 +141,10 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		None,
 		None,
 		Some(
-			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"UNIT\"}")
-				.expect("Provided valid json map"),
+			serde_json::from_str(
+				"{\"tokenDecimals\": 18, \"tokenSymbol\": \"UNIT\", \"SS58Prefix\": 1287}",
+			)
+			.expect("Provided valid json map"),
 		),
 		Extensions {
 			relay_chain: "westend_testnet".into(),

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -76,8 +76,10 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 		None,
 		None,
 		Some(
-			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"GLMR\"}")
-				.expect("Provided valid json map"),
+			serde_json::from_str(
+				"{\"tokenDecimals\": 18, \"tokenSymbol\": \"GLMR\", \"SS58Prefix\": 1284}",
+			)
+			.expect("Provided valid json map"),
 		),
 		Extensions {
 			relay_chain: "dev-service".into(),
@@ -130,8 +132,10 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		None,
 		None,
 		Some(
-			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"GLMR\"}")
-				.expect("Provided valid json map"),
+			serde_json::from_str(
+				"{\"tokenDecimals\": 18, \"tokenSymbol\": \"GLMR\", \"SS58Prefix\": 1284}",
+			)
+			.expect("Provided valid json map"),
 		),
 		Extensions {
 			relay_chain: "polkadot-local".into(),

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -76,8 +76,10 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 		None,
 		None,
 		Some(
-			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"MOVR\"}")
-				.expect("Provided valid json map"),
+			serde_json::from_str(
+				"{\"tokenDecimals\": 18, \"tokenSymbol\": \"MOVR\", \"SS58Prefix\": 1285}",
+			)
+			.expect("Provided valid json map"),
 		),
 		Extensions {
 			relay_chain: "dev-service".into(),
@@ -130,8 +132,10 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		None,
 		None,
 		Some(
-			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"MOVR\"}")
-				.expect("Provided valid json map"),
+			serde_json::from_str(
+				"{\"tokenDecimals\": 18, \"tokenSymbol\": \"MOVR\", , \"SS58Prefix\": 1285}",
+			)
+			.expect("Provided valid json map"),
 		),
 		Extensions {
 			relay_chain: "kusama-local".into(),

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -133,7 +133,7 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		None,
 		Some(
 			serde_json::from_str(
-				"{\"tokenDecimals\": 18, \"tokenSymbol\": \"MOVR\", , \"SS58Prefix\": 1285}",
+				"{\"tokenDecimals\": 18, \"tokenSymbol\": \"MOVR\", \"SS58Prefix\": 1285}",
 			)
 			.expect("Provided valid json map"),
 		),

--- a/node/service/src/chain_spec/moonshadow.rs
+++ b/node/service/src/chain_spec/moonshadow.rs
@@ -76,8 +76,10 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 		None,
 		None,
 		Some(
-			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"MSHD\"}")
-				.expect("Provided valid json map"),
+			serde_json::from_str(
+				"{\"tokenDecimals\": 18, \"tokenSymbol\": \"MSHD\", \"SS58Prefix\": 1288}",
+			)
+			.expect("Provided valid json map"),
 		),
 		Extensions {
 			relay_chain: "dev-service".into(),
@@ -130,8 +132,10 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		None,
 		None,
 		Some(
-			serde_json::from_str("{\"tokenDecimals\": 18, \"tokenSymbol\": \"MSHD\"}")
-				.expect("Provided valid json map"),
+			serde_json::from_str(
+				"{\"tokenDecimals\": 18, \"tokenSymbol\": \"MSHD\", \"SS58Prefix\": 1288}",
+			)
+			.expect("Provided valid json map"),
 		),
 		Extensions {
 			relay_chain: "westend-local".into(),

--- a/specs/alphanet/parachain-embedded-specs-v8.json
+++ b/specs/alphanet/parachain-embedded-specs-v8.json
@@ -12,7 +12,8 @@
   "protocolId": null,
   "properties": {
     "tokenDecimals": 18,
-    "tokenSymbol": "UNIT"
+    "tokenSymbol": "UNIT",
+    "SS58Prefix": 1287
   },
   "relayChain": "westend_moonbase_relay_testnet",
   "paraId": 1000,

--- a/specs/alphanet/parachain-specs-template.json
+++ b/specs/alphanet/parachain-specs-template.json
@@ -9,7 +9,8 @@
   "protocolId": null,
   "properties": {
     "tokenDecimals": 18,
-    "tokenSymbol": "UNIT"
+    "tokenSymbol": "UNIT",
+    "SS58Prefix": 1287
   },
   "relayChain": "moonbase_alpha_relay",
   "paraId": 1000,

--- a/specs/moonriver/parachain-embedded-specs.json
+++ b/specs/moonriver/parachain-embedded-specs.json
@@ -14,7 +14,8 @@
   "protocolId": null,
   "properties": {
     "tokenDecimals": 18,
-    "tokenSymbol": "MOVR"
+    "tokenSymbol": "MOVR",
+    "SS58Prefix": 1285
   },
   "relayChain": "kusama",
   "paraId": 2023,

--- a/specs/moonshadow/parachain-embedded-specs.json
+++ b/specs/moonshadow/parachain-embedded-specs.json
@@ -12,7 +12,8 @@
   "protocolId": null,
   "properties": {
     "tokenDecimals": 18,
-    "tokenSymbol": "MSHD"
+    "tokenSymbol": "MSHD",
+    "SS58Prefix": 1288
   },
   "relayChain": "westend",
   "paraId": 2002,


### PR DESCRIPTION
Update the Rust and JSON specs with the correct SS58 prefix.