### PR TITLE
Draft: Kill pallet ethereum chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ npm test
 The Ethereum specification described a numeric Chain Id. The Moonbeam mainnet Chain Id will be 1284
 because it takes 1284 milliseconds for a moonbeam to reach Earth.
 
-Moonbeam nodes support multiple public chains and testnets, with the following Chain Ids.
+The moonbeam software supports multiple runtimes, each.... but what if we launch multiple networks with the same runtime. Like moonrive rand moonsama.
 
 | Network Description                | Chain ID    |
 | ---------------------------------- | ----------- |
@@ -151,6 +151,7 @@ Moonbeam nodes support multiple public chains and testnets, with the following C
 | Reserved for other TestNets        | 1282 - 1283 |
 | Moonbeam (Polkadot)                | 1284        |
 | Moonriver (Kusama)                 | 1285        |
+| Moonshadow (Westend)               | TODO        |
 | Moonrock (Rococo)                  | 1286        |
 | Moonbase Alpha TestNet             | 1287        |
 | Reserved for other public networks | 1288 - 1289 |

--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -72,7 +72,6 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 				accounts.clone(),
 				3_000_000 * UNIT,
 				Default::default(), // para_id
-				1281,               //ChainId
 			)
 		},
 		vec![],
@@ -134,7 +133,6 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 				],
 				3_000_000 * UNIT,
 				para_id,
-				1280, //ChainId
 			)
 		},
 		vec![],
@@ -182,7 +180,6 @@ pub fn testnet_genesis(
 	endowed_accounts: Vec<AccountId>,
 	crowdloan_fund_pot: Balance,
 	para_id: ParaId,
-	chain_id: u64,
 ) -> GenesisConfig {
 	// This is supposed the be the simplest bytecode to revert without returning any data.
 	// We will pre-deploy it under all of our precompiles to ensure they can be called from
@@ -211,7 +208,6 @@ pub fn testnet_genesis(
 		parachain_info: ParachainInfoConfig {
 			parachain_id: para_id,
 		},
-		ethereum_chain_id: EthereumChainIdConfig { chain_id },
 		evm: EVMConfig {
 			// We need _some_ code inserted at the precompile address so that
 			// the evm will actually call the address.

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -69,7 +69,6 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 				accounts.clone(),
 				3_000_000 * MOVR,
 				Default::default(), // para_id
-				1281,               //ChainId
 			)
 		},
 		vec![],
@@ -125,7 +124,6 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 				],
 				3_000_000 * MOVR,
 				para_id,
-				1280, //ChainId
 			)
 		},
 		vec![],
@@ -172,7 +170,6 @@ pub fn testnet_genesis(
 	endowed_accounts: Vec<AccountId>,
 	crowdloan_fund_pot: Balance,
 	para_id: ParaId,
-	chain_id: u64,
 ) -> GenesisConfig {
 	// This is supposed the be the simplest bytecode to revert without returning any data.
 	// We will pre-deploy it under all of our precompiles to ensure they can be called from
@@ -201,7 +198,6 @@ pub fn testnet_genesis(
 		parachain_info: ParachainInfoConfig {
 			parachain_id: para_id,
 		},
-		ethereum_chain_id: EthereumChainIdConfig { chain_id },
 		evm: EVMConfig {
 			// We need _some_ code inserted at the precompile address so that
 			// the evm will actually call the address.

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -31,7 +31,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 use fp_rpc::TransactionStatus;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Get, Imbalance, InstanceFilter, OnUnbalanced},
+	traits::{Imbalance, InstanceFilter, OnUnbalanced},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_PER_SECOND},
 		IdentityFee, Weight,
@@ -270,8 +270,6 @@ impl pallet_sudo::Config for Runtime {
 	type Event = Event;
 }
 
-impl pallet_ethereum_chain_id::Config for Runtime {}
-
 impl pallet_randomness_collective_flip::Config for Runtime {}
 
 /// Current approximation of the gas/s consumption considering
@@ -298,6 +296,7 @@ impl pallet_evm::GasWeightMapping for MoonbeamGasWeightMapping {
 parameter_types! {
 	pub BlockGasLimit: U256
 		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT / WEIGHT_PER_GAS);
+	pub const EthereumChainId: u64 = 1281;
 }
 
 pub struct FixedGasPrice;
@@ -738,31 +737,31 @@ construct_runtime! {
 		NodeBlock = opaque::Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
-		Utility: pallet_utility::{Pallet, Call, Event},
-		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
-		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
-		Sudo: pallet_sudo::{Pallet, Call, Config<T>, Storage, Event<T>},
-		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Call, Storage},
-		ParachainSystem: cumulus_pallet_parachain_system::{Pallet, Call, Storage, Inherent, Event<T>},
-		TransactionPayment: pallet_transaction_payment::{Pallet, Storage},
-		ParachainInfo: parachain_info::{Pallet, Storage, Config},
-		EthereumChainId: pallet_ethereum_chain_id::{Pallet, Storage, Config},
-		EVM: pallet_evm::{Pallet, Config, Call, Storage, Event<T>},
-		Ethereum: pallet_ethereum::{Pallet, Call, Storage, Event, Config, ValidateUnsigned},
-		ParachainStaking: parachain_staking::{Pallet, Call, Storage, Event<T>, Config<T>},
-		Scheduler: pallet_scheduler::{Pallet, Storage, Config, Event<T>, Call},
-		Democracy: pallet_democracy::{Pallet, Storage, Config<T>, Event<T>, Call},
+		System: frame_system::{Pallet, Call, Storage, Config, Event<T>} = 0,
+		Utility: pallet_utility::{Pallet, Call, Event} = 1,
+		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent} = 2,
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>} = 3,
+		Sudo: pallet_sudo::{Pallet, Call, Config<T>, Storage, Event<T>} = 4,
+		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Call, Storage} = 5,
+		ParachainSystem: cumulus_pallet_parachain_system::{Pallet, Call, Storage, Inherent, Event<T>} = 6,
+		TransactionPayment: pallet_transaction_payment::{Pallet, Storage} = 7,
+		ParachainInfo: parachain_info::{Pallet, Storage, Config} = 8,
+		// Pallet Ethereum Chain ID was previously 9
+		EVM: pallet_evm::{Pallet, Config, Call, Storage, Event<T>} = 10,
+		Ethereum: pallet_ethereum::{Pallet, Call, Storage, Event, Config, ValidateUnsigned} = 11,
+		ParachainStaking: parachain_staking::{Pallet, Call, Storage, Event<T>, Config<T>} = 12,
+		Scheduler: pallet_scheduler::{Pallet, Storage, Config, Event<T>, Call} = 13,
+		Democracy: pallet_democracy::{Pallet, Storage, Config<T>, Event<T>, Call} = 14,
 		CouncilCollective:
-			pallet_collective::<Instance1>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>},
+			pallet_collective::<Instance1>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>} = 15,
 		TechComitteeCollective:
-			pallet_collective::<Instance2>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>},
-		Treasury: pallet_treasury::{Pallet, Storage, Config, Event<T>, Call},
-		AuthorInherent: pallet_author_inherent::{Pallet, Call, Storage, Inherent},
-		AuthorFilter: pallet_author_slot_filter::{Pallet, Call, Storage, Event, Config},
-		CrowdloanRewards: pallet_crowdloan_rewards::{Pallet, Call, Config<T>, Storage, Event<T>},
-		AuthorMapping: pallet_author_mapping::{Pallet, Call, Config<T>, Storage, Event<T>},
-		Proxy: pallet_proxy::{Pallet, Call, Storage, Event<T>},
+			pallet_collective::<Instance2>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>} = 16,
+		Treasury: pallet_treasury::{Pallet, Storage, Config, Event<T>, Call} = 17,
+		AuthorInherent: pallet_author_inherent::{Pallet, Call, Storage, Inherent} = 18,
+		AuthorFilter: pallet_author_slot_filter::{Pallet, Call, Storage, Event, Config} = 19,
+		CrowdloanRewards: pallet_crowdloan_rewards::{Pallet, Call, Config<T>, Storage, Event<T>} = 20,
+		AuthorMapping: pallet_author_mapping::{Pallet, Call, Config<T>, Storage, Event<T>} = 21,
+		Proxy: pallet_proxy::{Pallet, Call, Storage, Event<T>}= 22,
 	}
 }
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -296,7 +296,7 @@ impl pallet_evm::GasWeightMapping for MoonbeamGasWeightMapping {
 parameter_types! {
 	pub BlockGasLimit: U256
 		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT / WEIGHT_PER_GAS);
-	pub const EthereumChainId: u64 = 1281;
+	pub const EthereumChainId: u64 = 1287;
 }
 
 pub struct FixedGasPrice;

--- a/runtime/moonbase/tests/common/mod.rs
+++ b/runtime/moonbase/tests/common/mod.rs
@@ -197,7 +197,7 @@ impl ExtBuilder {
 	}
 }
 
-pub const CHAIN_ID: u64 = 1281;
+pub const CHAIN_ID: u64 = 1287;
 pub const ALICE: [u8; 20] = [4u8; 20];
 pub const ALICE_NIMBUS: [u8; 32] = [4u8; 32];
 pub const BOB: [u8; 20] = [5u8; 20];

--- a/runtime/moonbase/tests/common/mod.rs
+++ b/runtime/moonbase/tests/common/mod.rs
@@ -73,8 +73,6 @@ pub struct ExtBuilder {
 	mappings: Vec<(NimbusId, AccountId)>,
 	// Crowdloan fund
 	crowdloan_fund: Balance,
-	// Chain id
-	chain_id: u64,
 	// EVM genesis accounts
 	evm_accounts: BTreeMap<H160, GenesisAccount>,
 }
@@ -106,7 +104,6 @@ impl Default for ExtBuilder {
 			},
 			mappings: vec![],
 			crowdloan_fund: 0,
-			chain_id: CHAIN_ID,
 			evm_accounts: BTreeMap::new(),
 		}
 	}
@@ -178,14 +175,6 @@ impl ExtBuilder {
 			mappings: self.mappings,
 		}
 		.assimilate_storage(&mut t)
-		.unwrap();
-
-		<pallet_ethereum_chain_id::GenesisConfig as GenesisBuild<Runtime>>::assimilate_storage(
-			&pallet_ethereum_chain_id::GenesisConfig {
-				chain_id: self.chain_id,
-			},
-			&mut t,
-		)
 		.unwrap();
 
 		<pallet_evm::GenesisConfig as GenesisBuild<Runtime>>::assimilate_storage(

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -62,7 +62,6 @@ fn verify_pallet_prefixes() {
 	is_pallet_prefix::<moonbase_runtime::ParachainSystem>("ParachainSystem");
 	is_pallet_prefix::<moonbase_runtime::TransactionPayment>("TransactionPayment");
 	is_pallet_prefix::<moonbase_runtime::ParachainInfo>("ParachainInfo");
-	is_pallet_prefix::<moonbase_runtime::EthereumChainId>("EthereumChainId");
 	is_pallet_prefix::<moonbase_runtime::EVM>("EVM");
 	is_pallet_prefix::<moonbase_runtime::Ethereum>("Ethereum");
 	is_pallet_prefix::<moonbase_runtime::ParachainStaking>("ParachainStaking");
@@ -168,7 +167,7 @@ fn verify_pallet_indices() {
 	is_pallet_index::<moonbase_runtime::ParachainSystem>(6);
 	is_pallet_index::<moonbase_runtime::TransactionPayment>(7);
 	is_pallet_index::<moonbase_runtime::ParachainInfo>(8);
-	is_pallet_index::<moonbase_runtime::EthereumChainId>(9);
+	// Pallet ethereum chain id was previously 9
 	is_pallet_index::<moonbase_runtime::EVM>(10);
 	is_pallet_index::<moonbase_runtime::Ethereum>(11);
 	is_pallet_index::<moonbase_runtime::ParachainStaking>(12);

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -287,8 +287,6 @@ impl pallet_sudo::Config for Runtime {
 	type Event = Event;
 }
 
-impl pallet_ethereum_chain_id::Config for Runtime {}
-
 impl pallet_randomness_collective_flip::Config for Runtime {}
 
 /// Current approximation of the gas/s consumption considering
@@ -315,6 +313,7 @@ impl pallet_evm::GasWeightMapping for MoonbeamGasWeightMapping {
 parameter_types! {
 	pub BlockGasLimit: U256
 		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT / WEIGHT_PER_GAS);
+		pub const EthereumChainId: u64 = 1285;
 }
 
 pub struct FixedGasPrice;
@@ -779,7 +778,6 @@ construct_runtime! {
 		Sudo: pallet_sudo::{Pallet, Call, Config<T>, Storage, Event<T>} = 40,
 
 		// Ethereum compatibility
-		EthereumChainId: pallet_ethereum_chain_id::{Pallet, Storage, Config} = 50,
 		EVM: pallet_evm::{Pallet, Config, Call, Storage, Event<T>} = 51,
 		Ethereum: pallet_ethereum::{Pallet, Call, Storage, Event, Config, ValidateUnsigned} = 52,
 

--- a/runtime/moonriver/tests/common/mod.rs
+++ b/runtime/moonriver/tests/common/mod.rs
@@ -62,8 +62,6 @@ pub struct ExtBuilder {
 	mappings: Vec<(NimbusId, AccountId)>,
 	// Crowdloan fund
 	crowdloan_fund: Balance,
-	// Chain id
-	chain_id: u64,
 	// EVM genesis accounts
 	evm_accounts: BTreeMap<H160, GenesisAccount>,
 }
@@ -95,7 +93,6 @@ impl Default for ExtBuilder {
 			},
 			mappings: vec![],
 			crowdloan_fund: 0,
-			chain_id: CHAIN_ID,
 			evm_accounts: BTreeMap::new(),
 		}
 	}
@@ -169,14 +166,6 @@ impl ExtBuilder {
 		.assimilate_storage(&mut t)
 		.unwrap();
 
-		<pallet_ethereum_chain_id::GenesisConfig as GenesisBuild<Runtime>>::assimilate_storage(
-			&pallet_ethereum_chain_id::GenesisConfig {
-				chain_id: self.chain_id,
-			},
-			&mut t,
-		)
-		.unwrap();
-
 		<pallet_evm::GenesisConfig as GenesisBuild<Runtime>>::assimilate_storage(
 			&pallet_evm::GenesisConfig {
 				accounts: self.evm_accounts,
@@ -197,7 +186,7 @@ impl ExtBuilder {
 	}
 }
 
-pub const CHAIN_ID: u64 = 1281;
+pub const CHAIN_ID: u64 = 1285;
 pub const ALICE: [u8; 20] = [4u8; 20];
 pub const ALICE_NIMBUS: [u8; 32] = [4u8; 32];
 pub const BOB: [u8; 20] = [5u8; 20];

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -61,7 +61,6 @@ fn verify_pallet_prefixes() {
 	is_pallet_prefix::<moonriver_runtime::ParachainSystem>("ParachainSystem");
 	is_pallet_prefix::<moonriver_runtime::TransactionPayment>("TransactionPayment");
 	is_pallet_prefix::<moonriver_runtime::ParachainInfo>("ParachainInfo");
-	is_pallet_prefix::<moonriver_runtime::EthereumChainId>("EthereumChainId");
 	is_pallet_prefix::<moonriver_runtime::EVM>("EVM");
 	is_pallet_prefix::<moonriver_runtime::Ethereum>("Ethereum");
 	is_pallet_prefix::<moonriver_runtime::ParachainStaking>("ParachainStaking");
@@ -178,7 +177,6 @@ fn verify_pallet_indices() {
 	// Sudo
 	is_pallet_index::<moonriver_runtime::Sudo>(40);
 	// Ethereum compatibility
-	is_pallet_index::<moonriver_runtime::EthereumChainId>(50);
 	is_pallet_index::<moonriver_runtime::EVM>(51);
 	is_pallet_index::<moonriver_runtime::Ethereum>(52);
 	// Governance


### PR DESCRIPTION
In this PR, I started removing pallet ethereum chain id. It is a simple pallet that just stores a single number (the etheruem chain id). This pallet was first introduced because we wanted different chain ids for different networks, and we didn't want the overhead of maintaining multiple runtimes.

Since then we had more and more reasons to have multiple runtimes, and now we do maintain four of them. So I figured we could remove this pallet and gain a small bit of performance by hard-coding the chain id in each runtime.

However there may still be a good reason to keep this pallet. Here is the design question to be made:

**Do we want to support different chains with different chain ids but using the same runtime code**. For example {moonbase alpha / moonbase stage} and {moonriver / moonsama / moonsilver}.