### PR TITLE
Adds check in the build CI for build version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,10 +136,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
-      # - uses: actions/cache@v2
-      #   with:
-      #     path: ${{ runner.tool_cache }}/cargo-sccache
-      #     key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}-v1
 
       # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
       # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
@@ -152,10 +148,6 @@ jobs:
           fi
           ls -la ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
           ps aux | grep sccache
-          # if [[ ! -z `pgrep sccache` ]]; then
-          #   chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
-          #   ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --stop-server
-          # fi
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
             ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,11 +147,9 @@ jobs:
         run: rustup show
       - name: SCCache
         run: |
-          # Must use purestake version to support SUBSTRATE_ env (for binary version matching git hash)
-          # if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
-          #   cargo install sccache --git https://github.com/purestake/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
-          # fi
-          cargo install sccache --git https://github.com/paritytech/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+            cargo install sccache --git https://github.com/paritytech/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+          fi
           ls -la ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,9 +147,10 @@ jobs:
         run: rustup show
       - name: SCCache
         run: |
-          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
-            cargo install sccache --git https://github.com/paritytech/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
-          fi
+          # if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+          #   cargo install sccache --git https://github.com/paritytech/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+          # fi
+          cargo install sccache --git https://github.com/paritytech/sccache.git --rev f199fa6d3ed156138555a9733de8000ca8a84e31 --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
           ls -la ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,17 +143,20 @@ jobs:
         run: rustup show
       - name: SCCache
         run: |
-          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
-            cargo install sccache --git https://github.com/paritytech/sccache.git --rev f199fa6d3ed156138555a9733de8000ca8a84e31 --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+          # We altered the path to avoid old actions to overwrite it
+          SCCACHE_PATH=${{ runner.tool_cache }}/cargo-sccache2
+          SCCACHE_BIN=${SCCACHE_PATH}/bin/sccache
+          if [ ! -f $SCCACHE_BIN ]; then
+            cargo install sccache --git https://github.com/PureStake/sccache.git --force --no-default-features --features=dist-client --root $SCCACHE_PATH
           fi
-          ls -la ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
+          ls -la $SCCACHE_BIN
           ps aux | grep sccache
           if [[ -z `pgrep sccache` ]]; then
-            chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
-            ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
+            chmod +x $SCCACHE_BIN
+            $SCCACHE_BIN --start-server
           fi
-          ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
-          echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
+          $SCCACHE_BIN -s
+          echo "RUSTC_WRAPPER=$SCCACHE_BIN" >> $GITHUB_ENV
       - id: get-rust-versions
         run: |
           echo "::set-output name=rustc::$(rustc --version)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,11 +147,15 @@ jobs:
         run: rustup show
       - name: SCCache
         run: |
-          # if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
-          #   cargo install sccache --git https://github.com/paritytech/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
-          # fi
-          cargo install sccache --git https://github.com/paritytech/sccache.git --rev f199fa6d3ed156138555a9733de8000ca8a84e31 --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+            cargo install sccache --git https://github.com/paritytech/sccache.git --rev f199fa6d3ed156138555a9733de8000ca8a84e31 --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+          fi
           ls -la ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
+          ps aux | grep sccache
+          if [[ ! -z `pgrep sccache` ]]; then
+            chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
+            ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --stop-server
+          fi
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
             ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,9 +148,10 @@ jobs:
       - name: SCCache
         run: |
           # Must use purestake version to support SUBSTRATE_ env (for binary version matching git hash)
-          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
-            cargo install sccache --git https://github.com/purestake/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
-          fi
+          # if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
+          #   cargo install sccache --git https://github.com/purestake/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+          # fi
+          cargo install sccache --git https://github.com/paritytech/sccache.git --force --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
           ls -la ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
     runs-on: self-hosted
     needs: ["set-tags"]
     env:
-      CARGO_SCCACHE_VERSION: 0.2.14-alpha.0-parity
+      CARGO_SCCACHE_COMMIT: 49ab6cb5f216a6529f7273de4322e0a9194e6951
       RUSTFLAGS: "-C opt-level=3"
       # MOONBEAM_LOG: info
       # DEBUG: "test*"
@@ -141,13 +141,17 @@ jobs:
       # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
       - name: Setup Rust toolchain
         run: rustup show
+      - uses: actions/cache@v2
+        with:
+          path: ${{ runner.tool_cache }}/cargo-sccache-${CARGO_SCCACHE_COMMIT}
+          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_COMMIT }}-v1
       - name: SCCache
         run: |
           # We altered the path to avoid old actions to overwrite it
-          SCCACHE_PATH=${{ runner.tool_cache }}/cargo-sccache2
+          SCCACHE_PATH=${{ runner.tool_cache }}/cargo-sccache-${CARGO_SCCACHE_COMMIT}
           SCCACHE_BIN=${SCCACHE_PATH}/bin/sccache
           if [ ! -f $SCCACHE_BIN ]; then
-            cargo install sccache --git https://github.com/PureStake/sccache.git --force --no-default-features --features=dist-client --root $SCCACHE_PATH
+            cargo install sccache --git https://github.com/paritytech/sccache.git --rev $CARGO_SCCACHE_COMMIT --force --no-default-features --features=dist-client --root $SCCACHE_PATH
           fi
           ls -la $SCCACHE_BIN
           ps aux | grep sccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,10 +152,10 @@ jobs:
           fi
           ls -la ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
           ps aux | grep sccache
-          if [[ ! -z `pgrep sccache` ]]; then
-            chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
-            ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --stop-server
-          fi
+          # if [[ ! -z `pgrep sccache` ]]; then
+          #   chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
+          #   ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --stop-server
+          # fi
           if [[ -z `pgrep sccache` ]]; then
             chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
             ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,8 +167,10 @@ jobs:
           cargo build --release --all
       - name: Verify node version
         run: |
-          git log -1 --format="%H"
-          ./target/release/moonbeam --version
+          GIT_COMMIT=`git log -1 --format="%H" | cut -c1-7`
+          MB_VERSION=`./target/release/moonbeam --version`
+          echo "Checking $MB_VERSION contains $GIT_COMMIT"
+          echo "$MB_VERSION" | grep $GIT_COMMIT
       - name: Unit tests
         run: cargo test --release --all
       - name: Format code with rustfmt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,10 +136,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
-      - uses: actions/cache@v2
-        with:
-          path: ${{ runner.tool_cache }}/cargo-sccache
-          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}-v1
+      # - uses: actions/cache@v2
+      #   with:
+      #     path: ${{ runner.tool_cache }}/cargo-sccache
+      #     key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}-v1
 
       # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
       # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,15 +136,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
+      - uses: actions/cache@v2
+        with:
+          path: ${{ runner.tool_cache }}/cargo-sccache-${CARGO_SCCACHE_COMMIT}
+          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_COMMIT }}-v1
 
       # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
       # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
       - name: Setup Rust toolchain
         run: rustup show
-      - uses: actions/cache@v2
-        with:
-          path: ${{ runner.tool_cache }}/cargo-sccache-${CARGO_SCCACHE_COMMIT}
-          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_COMMIT }}-v1
       - name: SCCache
         run: |
           # We altered the path to avoid old actions to overwrite it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,20 @@ jobs:
         run: rustup show
       - name: SCCache
         run: |
-          if [ ! -f ${{ runner.tool_cache }}/cargo-sccache/bin/sccache ]; then
-            cargo install sccache --git https://github.com/paritytech/sccache.git --no-default-features --features=dist-client --root ${{ runner.tool_cache }}/cargo-sccache
+          # We altered the path to avoid old actions to overwrite it
+          SCCACHE_PATH=${{ runner.tool_cache }}/cargo-sccache2
+          SCCACHE_BIN=${SCCACHE_PATH}/bin/sccache
+          if [ ! -f $SCCACHE_BIN ]; then
+            cargo install sccache --git https://github.com/PureStake/sccache.git --force --no-default-features --features=dist-client --root $SCCACHE_PATH
           fi
+          ls -la $SCCACHE_BIN
+          ps aux | grep sccache
           if [[ -z `pgrep sccache` ]]; then
-            chmod +x ${{ runner.tool_cache }}/cargo-sccache/bin/sccache
-            ${{ runner.tool_cache }}/cargo-sccache/bin/sccache --start-server
+            chmod +x $SCCACHE_BIN
+            $SCCACHE_BIN --start-server
           fi
-          ${{ runner.tool_cache }}/cargo-sccache/bin/sccache -s
-          echo "RUSTC_WRAPPER=${{ runner.tool_cache }}/cargo-sccache/bin/sccache" >> $GITHUB_ENV
+          $SCCACHE_BIN -s
+          echo "RUSTC_WRAPPER=$SCCACHE_BIN" >> $GITHUB_ENV
       - id: get-rust-versions
         run: |
           echo "::set-output name=rustc::$(rustc --version)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.tag }}
-      - uses: actions/cache@v2
-        with:
-          path: ${{ runner.tool_cache }}/cargo-sccache
-          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_VERSION }}-v1
 
       # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
       # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: self-hosted
     env:
-      CARGO_SCCACHE_VERSION: 0.2.14-alpha.0-parity
+      CARGO_SCCACHE_COMMIT: 49ab6cb5f216a6529f7273de4322e0a9194e6951
       RUSTFLAGS: "-C opt-level=3"
     outputs:
       RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
@@ -28,13 +28,17 @@ jobs:
       # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
       - name: Setup Rust toolchain
         run: rustup show
+      - uses: actions/cache@v2
+        with:
+          path: ${{ runner.tool_cache }}/cargo-sccache-${CARGO_SCCACHE_COMMIT}
+          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_COMMIT }}-v1
       - name: SCCache
         run: |
           # We altered the path to avoid old actions to overwrite it
-          SCCACHE_PATH=${{ runner.tool_cache }}/cargo-sccache2
+          SCCACHE_PATH=${{ runner.tool_cache }}/cargo-sccache-${CARGO_SCCACHE_COMMIT}
           SCCACHE_BIN=${SCCACHE_PATH}/bin/sccache
           if [ ! -f $SCCACHE_BIN ]; then
-            cargo install sccache --git https://github.com/PureStake/sccache.git --force --no-default-features --features=dist-client --root $SCCACHE_PATH
+            cargo install sccache --git https://github.com/paritytech/sccache.git --rev $CARGO_SCCACHE_COMMIT --force --no-default-features --features=dist-client --root $SCCACHE_PATH
           fi
           ls -la $SCCACHE_BIN
           ps aux | grep sccache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,15 +23,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.tag }}
+      - uses: actions/cache@v2
+        with:
+          path: ${{ runner.tool_cache }}/cargo-sccache-${CARGO_SCCACHE_COMMIT}
+          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_COMMIT }}-v1
 
       # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
       # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
       - name: Setup Rust toolchain
         run: rustup show
-      - uses: actions/cache@v2
-        with:
-          path: ${{ runner.tool_cache }}/cargo-sccache-${CARGO_SCCACHE_COMMIT}
-          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_COMMIT }}-v1
       - name: SCCache
         run: |
           # We altered the path to avoid old actions to overwrite it


### PR DESCRIPTION
With the new SCCache version, it is now supporting rustc env variable and should now enforce new build when the git commit is different (slower but ensure the right version of the binary)
