### PR TITLE
update types

### DIFF
--- a/moonbeam-types-bundle/index.ts
+++ b/moonbeam-types-bundle/index.ts
@@ -455,7 +455,7 @@ export const moonbeamDefinitions = {
       },
     },
     {
-      minmax: [43, undefined],
+      minmax: [43, 154],
       types: {
         AccountId: "EthereumAccountId",
         AccountId32: "H256",
@@ -580,6 +580,141 @@ export const moonbeamDefinitions = {
         ParachainBondConfig: {
           account: "AccountId",
           percent: "Percent",
+        },
+      },
+    },
+    ,
+    {
+      minmax: [155, undefined],
+      types: {
+        AccountId: "EthereumAccountId",
+        AccountId32: "H256",
+        AccountInfo: "AccountInfoWithTripleRefCount",
+        Address: "AccountId",
+        AuthorId: "AccountId32",
+        Balance: "u128",
+        LookupSource: "AccountId",
+        Account: {
+          nonce: "U256",
+          balance: "u128",
+        },
+        ExtrinsicSignature: "EthereumSignature",
+        RoundIndex: "u32",
+        Candidate: {
+          id: "AccountId",
+          fee: "Perbill",
+          bond: "Balance",
+          nominators: "Vec<Bond>",
+          total: "Balance",
+          state: "CollatorStatus",
+        },
+        Nominator: {
+          nominations: "Vec<Bond>",
+          total: "Balance",
+        },
+        Bond: {
+          owner: "AccountId",
+          amount: "Balance",
+        },
+        CollatorStatus: {
+          _enum: ["Active", "Idle", { Leaving: "RoundIndex" }],
+        },
+        TxPoolResultContent: {
+          pending: "HashMap<H160, HashMap<U256, PoolTransaction>>",
+          queued: "HashMap<H160, HashMap<U256, PoolTransaction>>",
+        },
+        TxPoolResultInspect: {
+          pending: "HashMap<H160, HashMap<U256, Summary>>",
+          queued: "HashMap<H160, HashMap<U256, Summary>>",
+        },
+        TxPoolResultStatus: {
+          pending: "U256",
+          queued: "U256",
+        },
+        Summary: "Bytes",
+        PoolTransaction: {
+          hash: "H256",
+          nonce: "U256",
+          block_hash: "Option<H256>",
+          block_number: "Option<U256>",
+          from: "H160",
+          to: "Option<H160>",
+          value: "U256",
+          gas_price: "U256",
+          gas: "U256",
+          input: "Bytes",
+        },
+        // Staking inflation
+        Range: "RangeBalance",
+        RangeBalance: {
+          min: "Balance",
+          ideal: "Balance",
+          max: "Balance",
+        },
+        RangePerbill: {
+          min: "Perbill",
+          ideal: "Perbill",
+          max: "Perbill",
+        },
+        InflationInfo: {
+          expect: "RangeBalance",
+          annual: "RangePerbill",
+          round: "RangePerbill",
+        },
+        OrderedSet: "Vec<Bond>",
+        Collator: {
+          id: "AccountId",
+          bond: "Balance",
+          nominators: "Vec<Bond>",
+          total: "Balance",
+          state: "CollatorStatus",
+        },
+        Collator2: {
+          id: "AccountId",
+          bond: "Balance",
+          nominators: "Vec<AccountId>",
+          top_nominators: "Vec<Bond>",
+          bottom_nominators: "Vec<Bond>",
+          total_counted: "Balance",
+          total_backing: "Balance",
+          state: "CollatorStatus",
+        },
+        NominatorAdded: {
+          _enum: ["AddedToBottom", { AddedToTop: "Balance" }],
+        },
+        CollatorSnapshot: {
+          bond: "Balance",
+          nominators: "Vec<Bond>",
+          total: "Balance",
+        },
+        SystemInherentData: {
+          validation_data: "PersistedValidationData",
+          relay_chain_state: "StorageProof",
+          downward_messages: "Vec<InboundDownwardMessage>",
+          horizontal_messages: "BTreeMap<ParaId, Vec<InboundHrmpMessage>>",
+        },
+        RelayChainAccountId: "AccountId32",
+        RoundInfo: {
+          current: "RoundIndex",
+          first: "BlockNumber",
+          length: "u32",
+        },
+        RewardInfo: {
+          total_reward: "Balance",
+          claimed_reward: "Balance",
+        },
+        RegistrationInfo: {
+          account: "AccountId",
+          deposit: "Balance",
+        },
+        ParachainBondConfig: {
+          account: "AccountId",
+          percent: "Percent",
+        },
+        EthereumSignature: {
+          r: "H256",
+          s: "H256",
+          v: "U8",
         },
       },
     },

--- a/moonbeam-types-bundle/package-lock.json
+++ b/moonbeam-types-bundle/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moonbeam-types-bundle",
-  "version": "1.1.22",
+  "version": "1.1.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/moonbeam-types-bundle/package.json
+++ b/moonbeam-types-bundle/package.json
@@ -1,12 +1,13 @@
 {
   "name": "moonbeam-types-bundle",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "Bundled types to instantiate the Polkadot JS api with a Moonbeam network",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "prepublish": "tsc",
   "scripts": {
     "build": "tsc",
+    "publish": "tsc && npm publish",
     "lint": "npx prettier --write --ignore-path .gitignore '**/*.(yml|js|ts|json)'"
   },
   "keywords": [

--- a/moonbeam-types-bundle/package.json
+++ b/moonbeam-types-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moonbeam-types-bundle",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "description": "Bundled types to instantiate the Polkadot JS api with a Moonbeam network",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
### What does it do?
Adding type: 

```
"EthereumSignature": {
    "r": "H256",
    "s": "H256",
    "v": "U8"
  }
```
solved the problem. (https://github.com/polkadot-js/apps/issues/5818)

NB: In the api, they added a type:
 
```
export interface EthTransactionSignature extends Struct {
  readonly v: u64;
  readonly r: H256;
  readonly s: H256;
}
```

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
