### PR TITLE
Remove `ensure_candidate` check in author-mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5672,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-author-mapping"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/pallets/author-mapping/Cargo.toml
+++ b/pallets/author-mapping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-author-mapping"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["PureStake"]
 edition = "2018"
 description = "Maps AuthorIds to AccountIds Useful for associating consensus authors with in-runtime accounts"

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -67,10 +67,6 @@ pub mod pallet {
 		type DepositCurrency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
 		/// The amount that should be taken as a security deposit when registering an AuthorId.
 		type DepositAmount: Get<<Self::DepositCurrency as Currency<Self::AccountId>>::Balance>;
-
-		/// A rough preliminary check to determine whether an account can make a new registration.
-		/// If you don't wish to do any such check, just return `true`.
-		fn can_register(account: &Self::AccountId) -> bool;
 	}
 
 	/// An error that can occur while executing the mapping pallet's logic.
@@ -80,8 +76,6 @@ pub mod pallet {
 		AssociationNotFound,
 		/// The association can't be cleared because it belongs to another account.
 		NotYourAssociation,
-		/// This account cannot set an author because it fails the preliminary check
-		CannotSetAuthor,
 		/// This account cannot set an author because it cannon afford the security deposit
 		CannotAffordSecurityDeposit,
 		/// The AuthorId in question is already associated and cannot be overwritten
@@ -112,8 +106,6 @@ pub mod pallet {
 		pub fn add_association(origin: OriginFor<T>, author_id: T::AuthorId) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;
 
-			ensure!(T::can_register(&account_id), Error::<T>::CannotSetAuthor);
-
 			ensure!(
 				MappingWithDeposit::<T>::get(&author_id).is_none(),
 				Error::<T>::AlreadyAssociated
@@ -137,8 +129,6 @@ pub mod pallet {
 			new_author_id: T::AuthorId,
 		) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;
-
-			ensure!(T::can_register(&account_id), Error::<T>::CannotSetAuthor);
 
 			let stored_info = MappingWithDeposit::<T>::try_get(&old_author_id)
 				.map_err(|_| Error::<T>::AssociationNotFound)?;

--- a/pallets/author-mapping/src/mock.rs
+++ b/pallets/author-mapping/src/mock.rs
@@ -111,11 +111,6 @@ impl pallet_author_mapping::Config for Test {
 	type AuthorId = TestAuthor;
 	type DepositCurrency = Balances;
 	type DepositAmount = DepositAmount;
-
-	// For this mock runtime, we'll only allow even accounts to register.
-	fn can_register(account: &AccountId) -> bool {
-		account % 2 == 0
-	}
 }
 
 /// Externality builder for pallet author mapping's mock runtime

--- a/pallets/author-mapping/src/tests.rs
+++ b/pallets/author-mapping/src/tests.rs
@@ -60,22 +60,6 @@ fn eligible_account_can_register() {
 }
 
 #[test]
-fn ineligible_account_cannot_register() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 1000)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				AuthorMapping::add_association(Origin::signed(1), TestAuthor::Alice),
-				Error::<Test>::CannotSetAuthor
-			);
-
-			assert_eq!(Balances::free_balance(&1), 1000);
-			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Alice), None);
-		})
-}
-
-#[test]
 fn cannot_register_without_deposit() {
 	ExtBuilder::default()
 		.with_balances(vec![(2, 10)])
@@ -244,31 +228,6 @@ fn registered_author_cannot_be_rotated_by_non_owner() {
 				),
 				Error::<Test>::NotYourAssociation
 			);
-		})
-}
-
-// The notion of eligible accounts may change as runtimes are upgraded. If an account previously
-// registered when it was eligible and has ince become ineleigible, we don't want them to rotate
-// anymore as this takes compute that is not useful. This mechanism interacts well with the narc
-// extrinsic if we ever bring it back.
-#[test]
-fn no_longer_eligible_account_cannot_rotate() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 1000)])
-		.with_mappings(vec![(TestAuthor::Alice, 1)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				AuthorMapping::update_association(
-					Origin::signed(1),
-					TestAuthor::Alice,
-					TestAuthor::Bob
-				),
-				Error::<Test>::CannotSetAuthor
-			);
-
-			assert_eq!(Balances::free_balance(&1), 900);
-			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Alice), Some(1));
 		})
 }
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -649,9 +649,6 @@ impl pallet_author_mapping::Config for Runtime {
 	type AuthorId = NimbusId;
 	type DepositCurrency = Balances;
 	type DepositAmount = DepositAmount;
-	fn can_register(account: &AccountId) -> bool {
-		ParachainStaking::is_candidate(account)
-	}
 }
 
 parameter_types! {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -653,9 +653,6 @@ impl pallet_author_mapping::Config for Runtime {
 	type AuthorId = NimbusId;
 	type DepositCurrency = Balances;
 	type DepositAmount = DepositAmount;
-	fn can_register(account: &AccountId) -> bool {
-		ParachainStaking::is_candidate(account)
-	}
 }
 
 parameter_types! {

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -665,9 +665,6 @@ impl pallet_author_mapping::Config for Runtime {
 	type AuthorId = NimbusId;
 	type DepositCurrency = Balances;
 	type DepositAmount = DepositAmount;
-	fn can_register(account: &AccountId) -> bool {
-		ParachainStaking::is_candidate(account)
-	}
 }
 
 parameter_types! {

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -652,9 +652,6 @@ impl pallet_author_mapping::Config for Runtime {
 	type AuthorId = NimbusId;
 	type DepositCurrency = Balances;
 	type DepositAmount = DepositAmount;
-	fn can_register(account: &AccountId) -> bool {
-		ParachainStaking::is_candidate(account)
-	}
 }
 
 parameter_types! {


### PR DESCRIPTION
Remove the `ensure_candidate` check in author-mapping. The security deposit + tx fees (from #597 ) is sufficient disincentive to abuse key registration.

This simplifies benchmarking in #597 

- [x] bumped the pallet crate patch version
