### PR TITLE
Enforce changelog labels for all PR

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -1,0 +1,14 @@
+name: Enforce PR labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: yogevbd/enforce-label-action@2.2.0
+        with:
+          REQUIRED_LABELS_ANY: "B0-silent,B5-clientnoteworthy,B7-runtimenoteworthy"
+          REQUIRED_LABELS_ALL: ""
+          BANNED_LABELS: ""

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -44,3 +44,13 @@ The following is a list of directories of interest in development.
 |scripts/               | Utilities for launching and interacting with a Moonbeam chain (typescript) |
 |specs/                 | Spec files used to generate genesis for well-known Moonbeam networks       |
 |tools/                 | Various tools generally related to development (typescript)                |
+
+### PR labels conventions
+
+Any PR must indicate whether the changes should be part of the runtime changelog or the binary changelog or neither.
+
+If the changes are to be listed in the runtime changelog, associate the label `B7-runtimenoteworthy` with your PR.
+
+If the changes should be listed in the binary changelog, associate the label `B5-clientnoteworthy` with your PR.
+
+If the changes are not to be listed in any changelog, associate the label `B0-silent` with your PR.


### PR DESCRIPTION
### What does it do?

Add a github workflow that makes sure all PRs contain at least 1 of these 3 labels: B0-silent, B5-clientnoteworthy, B7-runtimenoteworthy

And update the doc to indicate the convention for labels.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require changes in documentation/tutorials ?
