### PR TITLE
Adds v0.9.4 to launch script + renaming

### DIFF
--- a/tools/launch.ts
+++ b/tools/launch.ts
@@ -43,25 +43,30 @@ const parachains: { [name: string]: ParachainConfig } = {
     chain: "moonriver-local",
     docker: "purestake/moonbeam:sha-153c4c4a",
   },
-  "alphanet-8.2": {
+  "alphanet-0.8.2": {
     relay: "rococo-9004",
     chain: "moonbase-local",
     docker: "purestake/moonbeam:v0.8.2",
   },
-  "alphanet-8.1": {
+  "alphanet-0.8.1": {
     relay: "rococo-9004",
     chain: "moonbase-local",
     docker: "purestake/moonbeam:v0.8.1",
   },
-  "alphanet-8.0": {
+  "alphanet-0.8.0": {
     relay: "rococo-9001",
     chain: "moonbase-local",
     docker: "purestake/moonbeam:v0.8.0",
   },
-  "alphanet-9.2": {
+  "alphanet-0.9.2": {
     relay: "rococo-9004",
     chain: "moonbase-local",
     docker: "purestake/moonbeam:v0.9.2",
+  },
+  "alphanet-0.9.4": {
+    relay: "rococo-9004",
+    chain: "moonbase-local",
+    docker: "purestake/moonbeam:v0.9.4",
   },
   local: {
     relay: "rococo-9004",
@@ -128,16 +133,6 @@ function start() {
       },
       "parachain-chain": {
         type: "string",
-        choices: [
-          "moonbase",
-          "moonshadow",
-          "moonriver",
-          "moonbeam",
-          "moonbase-local",
-          "moonshadow-local",
-          "moonriver-local",
-          "moonbeam-local",
-        ],
         describe: "overrides parachain chain/runtime",
       },
       "parachain-id": { type: "number", default: 1000, describe: "overrides parachain-id" },

--- a/tools/launch.ts
+++ b/tools/launch.ts
@@ -43,27 +43,27 @@ const parachains: { [name: string]: ParachainConfig } = {
     chain: "moonriver-local",
     docker: "purestake/moonbeam:sha-153c4c4a",
   },
-  "alphanet-0.8.2": {
+  "moonbase-0.8.2": {
     relay: "rococo-9004",
     chain: "moonbase-local",
     docker: "purestake/moonbeam:v0.8.2",
   },
-  "alphanet-0.8.1": {
+  "moonbase-0.8.1": {
     relay: "rococo-9004",
     chain: "moonbase-local",
     docker: "purestake/moonbeam:v0.8.1",
   },
-  "alphanet-0.8.0": {
+  "moonbase-0.8.0": {
     relay: "rococo-9001",
     chain: "moonbase-local",
     docker: "purestake/moonbeam:v0.8.0",
   },
-  "alphanet-0.9.2": {
+  "moonbase-0.9.2": {
     relay: "rococo-9004",
     chain: "moonbase-local",
     docker: "purestake/moonbeam:v0.9.2",
   },
-  "alphanet-0.9.4": {
+  "moonbase-0.9.4": {
     relay: "rococo-9004",
     chain: "moonbase-local",
     docker: "purestake/moonbeam:v0.9.4",


### PR DESCRIPTION
### What does it do?
Adds the v0.9.4 moonbase version to the launch script
It also renames the `alphanet` to `moonbase` which is more accurate to the actual runtime being executed