### PR TITLE
Runtime Api versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "sc-cli",
  "sc-service",
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1378,7 +1378,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "derive_more",
  "futures 0.3.15",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.15",
@@ -1425,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -1453,7 +1453,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
  "cumulus-primitives-core",
@@ -1481,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.1",
@@ -1510,7 +1510,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -5372,7 +5372,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5401,7 +5401,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -5655,7 +5655,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5691,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -6451,7 +6451,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#067fc6e079d4d20503c01ecf81707c8a3e4aff6d"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "sc-cli",
  "sc-service",
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1378,7 +1378,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "derive_more",
  "futures 0.3.15",
@@ -1402,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.15",
@@ -1425,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -1453,7 +1453,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
  "cumulus-primitives-core",
@@ -1481,7 +1481,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -1492,7 +1492,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.1",
@@ -1510,7 +1510,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -5372,7 +5372,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5401,7 +5401,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -5655,7 +5655,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5691,7 +5691,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -6451,7 +6451,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#a53c10640a24bb921ba937e5e71690d8338c12cf"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#23d06b72f57dc1a335886cc7d519fa8a24ab1dfb"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",

--- a/primitives/rpc/debug/src/lib.rs
+++ b/primitives/rpc/debug/src/lib.rs
@@ -25,7 +25,21 @@ use sp_std::vec::Vec;
 use serde::Serialize;
 
 sp_api::decl_runtime_apis! {
+	#[api_version(2)]
 	pub trait DebugRuntimeApi {
+
+		#[changed_in(2)]
+		fn trace_transaction(
+			extrinsics: Vec<Block::Extrinsic>,
+			transaction: &Transaction,
+			trace_type: single::TraceType,
+		) -> Result<(), sp_runtime::DispatchError>;
+
+		#[changed_in(2)]
+		fn trace_block(
+			extrinsics: Vec<Block::Extrinsic>,
+		) -> Result<(), sp_runtime::DispatchError>;
+
 		fn trace_transaction(
 			header: &Block::Header,
 			extrinsics: Vec<Block::Extrinsic>,


### PR DESCRIPTION
cc @nanocryk so we take this into account for the future.

### What does it do?

Recently we changed the the `DebugRuntimeApi` signature. We want support older implementations, so when we call the runtime api for older `BlockId` (prior to the upgrade) does not panic.

### What important points reviewers should know?

https://github.com/paritytech/substrate/blob/master/primitives/api/src/lib.rs#L148

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

Changes for `nimbus_primitives::AuthorFilterAPI.` [here](https://github.com/PureStake/cumulus/commit/a53c10640a24bb921ba937e5e71690d8338c12cf).

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
