### PR TITLE
Add a link to apopiak/substrate-migrations repo

### DIFF
--- a/tools/github/print-version-bump-info.ts
+++ b/tools/github/print-version-bump-info.ts
@@ -90,6 +90,13 @@ async function printInfo(octokit: Octokit, previousVersion: string, nextVersion:
       console.log(prInfo);
     }
   }
+
+  console.log(`\n## Review 'substrate-migrations' repo\n`);
+  console.log(`https://github.com/apopiak/substrate-migrations#frame-migrations`);
+  console.log(`\nThis repository contains a list of FRAME-related migrations which might be`);
+  console.log(`relevant to Moonbeam.`);
+
+
 }
 
 async function main() {

--- a/tools/github/print-version-bump-info.ts
+++ b/tools/github/print-version-bump-info.ts
@@ -95,8 +95,6 @@ async function printInfo(octokit: Octokit, previousVersion: string, nextVersion:
   console.log(`https://github.com/apopiak/substrate-migrations#frame-migrations`);
   console.log(`\nThis repository contains a list of FRAME-related migrations which might be`);
   console.log(`relevant to Moonbeam.`);
-
-
 }
 
 async function main() {


### PR DESCRIPTION
### What does it do?

Adds a link to this repository: https://github.com/apopiak/substrate-migrations#frame-migrations

when generating a `version-bump` issue.

This could probably be improved upon (e.g. look through the repo's history).

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
