### PR TITLE
Release note filter labels

### DIFF
--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -64,12 +64,12 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-      - name: Generate runtimes body
-        id: generate-runtimes-body
+      - name: Generate release body
+        id: generate-release-body
         run: |
           cd tools
           yarn
-          yarn -s run ts-node github/generate-release-body.ts --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' > ../body.md
+          yarn -s run ts-node github/generate-release-body.ts --fron "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' > ../body.md
       - name: Create draft release
         id: create-release
         uses: actions/create-release@v1

--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           cd tools
           yarn
-          yarn -s run ts-node github/generate-release-body.ts --fron "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' > ../body.md
+          yarn -s run ts-node github/generate-release-body.ts --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' > ../body.md
       - name: Create draft release
         id: create-release
         uses: actions/create-release@v1

--- a/tools/github/generate-release-body.ts
+++ b/tools/github/generate-release-body.ts
@@ -39,12 +39,19 @@ async function main() {
     link: getCompareLink(repoName, previousTag, newTag),
   }));
 
-  const { prByLabels } = await getCommitAndLabels(octokit, "PureStake", "moonbeam", previousTag, newTag);
+  const { prByLabels } = await getCommitAndLabels(
+    octokit,
+    "PureStake",
+    "moonbeam",
+    previousTag,
+    newTag
+  );
+  const filteredPr = prByLabels[BINARY_CHANGES_LABEL] || [];
 
   const template = `
 ## Changes
 
-${prByLabels[BINARY_CHANGES_LABEL].map((pr) => `* ${pr.title} (#${pr.number})`).join("\n")}
+${filteredPr.map((pr) => `* ${pr.title} (#${pr.number})`).join("\n")}
 
 ## Dependency changes
 
@@ -52,6 +59,6 @@ Moonbeam: https://github.com/PureStake/moonbeam/compare/${previousTag}...${newTa
 ${moduleLinks.map((modules) => `${capitalize(modules.name)}: ${modules.link}`).join("\n")}
 `;
   console.log(template);
-};
+}
 
 main();

--- a/tools/github/generate-runtimes-body.ts
+++ b/tools/github/generate-runtimes-body.ts
@@ -1,8 +1,11 @@
 import { execSync } from "child_process";
+import { Octokit } from "octokit";
 import { readFileSync } from "fs";
 import yargs from "yargs";
 import path from "path";
-import { getCompareLink } from "./github-utils";
+import { getCommitAndLabels, getCompareLink } from "./github-utils";
+
+const RUNTIME_CHANGES_LABEL = "B7-runtimenoteworthy";
 
 function capitalize(s) {
   return s[0].toUpperCase() + s.slice(1);
@@ -21,7 +24,7 @@ function getRuntimeInfo(srtoolReportFolder: string, runtimeName: string) {
   };
 }
 
-const main = () => {
+async function main() {
   const argv = yargs(process.argv.slice(2))
     .usage("Usage: npm run ts-node github/generate-release-body.ts [args]")
     .version("1.0.0")
@@ -45,6 +48,10 @@ const main = () => {
     .demandOption(["srtool-report-folder", "from", "to"])
     .help().argv;
 
+  const octokit = new Octokit({
+    auth: process.env.GITHUB_TOKEN || undefined,
+  });
+
   const previousTag = argv.from;
   const newTag = argv.to;
 
@@ -56,10 +63,15 @@ const main = () => {
     name: repoName,
     link: getCompareLink(repoName, previousTag, newTag),
   }));
-  const commits = execSync(`git log --oneline --pretty=format:"%s" ${previousTag}...${newTag}`)
-    .toString()
-    .split(`\n`)
-    .filter((l) => !!l);
+
+  const { prByLabels } = await getCommitAndLabels(
+    octokit,
+    "crystalin",
+    "moonbeam",
+    previousTag,
+    newTag
+  );
+  const filteredPr = prByLabels[RUNTIME_CHANGES_LABEL] || [];
 
   const template = `${
     runtimes.length > 0
@@ -85,7 +97,7 @@ WASM runtime built using \`${runtimes[0]?.srtool.info.rustc}\`
 
 ## Changes
 
-${commits.map((commit) => `* ${commit}`).join("\n")}
+${filteredPr.map((pr) => `* ${pr.title} (#${pr.number})`).join("\n")}
 
 ## Dependency changes
 
@@ -93,6 +105,6 @@ Moonbeam: https://github.com/PureStake/moonbeam/compare/${previousTag}...${newTa
 ${moduleLinks.map((modules) => `${capitalize(modules.name)}: ${modules.link}`).join("\n")}
 `;
   console.log(template);
-};
+}
 
 main();

--- a/tools/github/github-utils.ts
+++ b/tools/github/github-utils.ts
@@ -33,7 +33,7 @@ export async function getCommitAndLabels(
   repo: string,
   previousTag: string,
   newTag: string
-): Promise<{ prByLabels: any, commits: any[] }> {
+): Promise<{ prByLabels: any; commits: any[] }> {
   let commits: Commits = [];
   let more = true;
   let page = 0;

--- a/tools/github/github-utils.ts
+++ b/tools/github/github-utils.ts
@@ -33,7 +33,7 @@ export async function getCommitAndLabels(
   repo: string,
   previousTag: string,
   newTag: string
-) {
+): Promise<{ prByLabels: any, commits: any[] }> {
   let commits: Commits = [];
   let more = true;
   let page = 0;


### PR DESCRIPTION
### What does it do?

Changes the way note releases are generated so that only PRs that have the label B7-runtimenoteworthy are listed in a runtime release and only PRs that have the label B5-clientnoteworthy in a binary release.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
