### PR TITLE
Reduce transaction byte fees to 10 micro per byte

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase"),
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 3,
-	spec_version: 0158,
+	spec_version: 0159,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -88,10 +88,11 @@ pub mod currency {
 	pub const MICROUNIT: Balance = MILLIUNIT / 1_000;
 	pub const NANOUNIT: Balance = MICROUNIT / 1_000;
 
-	pub const BYTE_FEE: Balance = 100 * MICROUNIT;
+	pub const TRANSACTION_BYTE_FEE: Balance = 10 * MICROUNIT;
+	pub const STORAGE_BYTE_FEE: Balance = 100 * MICROUNIT;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 1 * UNIT + (bytes as Balance) * BYTE_FEE
+		items as Balance * 1 * UNIT + (bytes as Balance) * STORAGE_BYTE_FEE
 	}
 }
 
@@ -256,7 +257,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = currency::BYTE_FEE;
+	pub const TransactionByteFee: Balance = currency::TRANSACTION_BYTE_FEE;
 }
 
 impl pallet_transaction_payment::Config for Runtime {
@@ -417,7 +418,7 @@ parameter_types! {
 	pub const MinimumDeposit: Balance = 4 * currency::UNIT;
 	pub const MaxVotes: u32 = 100;
 	pub const MaxProposals: u32 = 100;
-	pub const PreimageByteDeposit: Balance = currency::BYTE_FEE;
+	pub const PreimageByteDeposit: Balance = currency::STORAGE_BYTE_FEE;
 	pub const InstantAllowed: bool = true;
 }
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -88,10 +88,11 @@ pub mod currency {
 	pub const MICROGLMR: Balance = MILLIGLMR / 1_000;
 	pub const NANOGLMR: Balance = MICROGLMR / 1_000;
 
-	pub const BYTE_FEE: Balance = 100 * MICROGLMR;
+	pub const TRANSACTION_BYTE_FEE: Balance = 10 * MICROGLMR;
+	pub const STORAGE_BYTE_FEE: Balance = 100 * MICROGLMR;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 1 * GLMR + (bytes as Balance) * BYTE_FEE
+		items as Balance * 1 * GLMR + (bytes as Balance) * STORAGE_BYTE_FEE
 	}
 }
 
@@ -271,7 +272,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = currency::BYTE_FEE;
+	pub const TransactionByteFee: Balance = currency::TRANSACTION_BYTE_FEE;
 }
 
 impl pallet_transaction_payment::Config for Runtime {
@@ -432,7 +433,7 @@ parameter_types! {
 	pub const MinimumDeposit: Balance = 4 * currency::GLMR;
 	pub const MaxVotes: u32 = 100;
 	pub const MaxProposals: u32 = 100;
-	pub const PreimageByteDeposit: Balance = currency::BYTE_FEE;
+	pub const PreimageByteDeposit: Balance = currency::STORAGE_BYTE_FEE;
 	pub const InstantAllowed: bool = false;
 }
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -131,7 +131,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 0158,
+	spec_version: 0159,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -133,7 +133,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 0158,
+	spec_version: 0159,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -91,10 +91,11 @@ pub mod currency {
 	pub const MOVR: Balance = 1_000_000_000_000_000_000;
 	pub const KILOMOVR: Balance = 1_000_000_000_000_000_000_000;
 
-	pub const BYTE_FEE: Balance = 100 * MICROMOVR;
+	pub const TRANSACTION_BYTE_FEE: Balance = 10 * MICROMOVR;
+	pub const STORAGE_BYTE_FEE: Balance = 100 * MICROMOVR;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 1 * MOVR + (bytes as Balance) * BYTE_FEE
+		items as Balance * 1 * MOVR + (bytes as Balance) * STORAGE_BYTE_FEE
 	}
 }
 
@@ -273,7 +274,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = currency::BYTE_FEE;
+	pub const TransactionByteFee: Balance = currency::TRANSACTION_BYTE_FEE;
 }
 
 impl pallet_transaction_payment::Config for Runtime {
@@ -434,7 +435,7 @@ parameter_types! {
 	pub const MinimumDeposit: Balance = 4 * currency::MOVR;
 	pub const MaxVotes: u32 = 100;
 	pub const MaxProposals: u32 = 100;
-	pub const PreimageByteDeposit: Balance = currency::BYTE_FEE;
+	pub const PreimageByteDeposit: Balance = currency::STORAGE_BYTE_FEE;
 	pub const InstantAllowed: bool = true;
 }
 

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonshadow"),
 	impl_name: create_runtime_str!("moonshadow"),
 	authoring_version: 3,
-	spec_version: 0158,
+	spec_version: 0159,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonshadow/src/lib.rs
+++ b/runtime/moonshadow/src/lib.rs
@@ -88,10 +88,11 @@ pub mod currency {
 	pub const MICROMSHD: Balance = MILLIMSHD / 1_000;
 	pub const NANOMSHD: Balance = MICROMSHD / 1_000;
 
-	pub const BYTE_FEE: Balance = 100 * MICROMSHD;
+	pub const TRANSACTION_BYTE_FEE: Balance = 10 * MICROMSHD;
+	pub const STORAGE_BYTE_FEE: Balance = 100 * MICROMSHD;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		items as Balance * 1 * MSHD + (bytes as Balance) * BYTE_FEE
+		items as Balance * 1 * MSHD + (bytes as Balance) * STORAGE_BYTE_FEE
 	}
 }
 
@@ -270,7 +271,7 @@ where
 }
 
 parameter_types! {
-	pub const TransactionByteFee: Balance = currency::BYTE_FEE;
+	pub const TransactionByteFee: Balance = currency::TRANSACTION_BYTE_FEE;
 }
 
 impl pallet_transaction_payment::Config for Runtime {
@@ -431,7 +432,7 @@ parameter_types! {
 	pub const MinimumDeposit: Balance = 4 * currency::MSHD;
 	pub const MaxVotes: u32 = 100;
 	pub const MaxProposals: u32 = 100;
-	pub const PreimageByteDeposit: Balance = currency::BYTE_FEE;
+	pub const PreimageByteDeposit: Balance = currency::STORAGE_BYTE_FEE;
 	pub const InstantAllowed: bool = false;
 }
 


### PR DESCRIPTION
Currently the transaction byte fee is set to the same as the storage byte fee, which is too high.
The storage byte fee is to pay for long term, while the transaction byte fee is for the cost of handling the transaction.

This will heavily impact the price of doing a runtime upgrade, changing from ~200 units to ~20 units