### PR TITLE
Client fix for tracing nodes >= v0.9.8

### DIFF
--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -260,7 +260,9 @@ where
 					} else {
 						// For versions < 2 block needs to be manually initialized.
 						api.initialize_block(&parent_block_id, &header)
-							.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
+							.map_err(|e| {
+								internal_err(format!("Runtime api access error: {:?}", e))
+							})?;
 
 						#[allow(deprecated)]
 						api.trace_transaction_before_version_2(
@@ -282,7 +284,8 @@ where
 					single::TraceType::CallList { .. } => {
 						let mut proxy = proxy::CallListProxy::new();
 						proxy.using(f)?;
-						proxy.into_tx_trace()
+						proxy
+							.into_tx_trace()
 							.ok_or("Trace result is empty.")
 							.map_err(|e| internal_err(format!("{:?}", e)))?
 					}

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -283,6 +283,8 @@ where
 						let mut proxy = proxy::CallListProxy::new();
 						proxy.using(f)?;
 						proxy.into_tx_trace()
+							.ok_or("Trace result is empty.")
+							.map_err(|e| internal_err(format!("{:?}", e)))?
 					}
 				});
 			}

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -31,7 +31,7 @@ use fc_rpc::{frontier_backend_client, internal_err};
 use fp_rpc::EthereumRuntimeRPCApi;
 use moonbeam_rpc_primitives_debug::{proxy, single, DebugRuntimeApi};
 use sc_client_api::backend::Backend;
-use sp_api::{ApiExt, BlockId, HeaderT, ProvideRuntimeApi};
+use sp_api::{ApiExt, BlockId, Core, HeaderT, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{
 	Backend as BlockchainBackend, Error as BlockChainError, HeaderBackend, HeaderMetadata,
@@ -258,6 +258,10 @@ where
 						.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?
 						.map_err(|e| internal_err(format!("DispatchError: {:?}", e)))
 					} else {
+						// For versions < 2 block needs to be manually initialized.
+						api.initialize_block(&parent_block_id, &header)
+							.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
+
 						#[allow(deprecated)]
 						api.trace_transaction_before_version_2(
 							&parent_block_id,

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -276,12 +276,12 @@ where
 				return Ok(match trace_type {
 					single::TraceType::Raw { .. } => {
 						let mut proxy = proxy::RawProxy::new();
-						proxy.using(f);
+						proxy.using(f)?;
 						proxy.into_tx_trace()
 					}
 					single::TraceType::CallList { .. } => {
 						let mut proxy = proxy::CallListProxy::new();
-						proxy.using(f);
+						proxy.using(f)?;
 						proxy.into_tx_trace()
 					}
 				});

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -40,7 +40,7 @@ use tracing::{instrument, Instrument};
 
 use jsonrpc_core::Result;
 use sc_client_api::backend::Backend;
-use sp_api::{ApiExt, BlockId, HeaderT, ProvideRuntimeApi};
+use sp_api::{ApiExt, BlockId, Core, HeaderT, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{
 	Backend as BlockchainBackend, Error as BlockChainError, HeaderBackend, HeaderMetadata,
@@ -870,6 +870,10 @@ where
 						))
 					})
 			} else {
+				// For versions < 2 block needs to be manually initialized.
+				api.initialize_block(&substrate_parent_id, &block_header)
+					.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
+
 				#[allow(deprecated)]
 				api.trace_block_before_version_2(&substrate_parent_id, extrinsics)
 					.map_err(|e| {

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -897,7 +897,7 @@ where
 		};
 
 		let mut proxy = proxy::CallListProxy::new();
-		proxy.using(f);
+		proxy.using(f)?;
 		let mut traces: Vec<_> = proxy.into_tx_traces();
 
 		// Fill missing data.

--- a/primitives/rpc/debug/src/proxy.rs
+++ b/primitives/rpc/debug/src/proxy.rs
@@ -134,9 +134,7 @@ impl CallListProxy {
 	pub fn into_tx_trace(self) -> Option<SingleTrace> {
 		if let Some(entry) = self.entries.last() {
 			return Some(SingleTrace::CallList(
-				entry.into_iter()
-					.map(|(_, value)| value.clone())
-					.collect(),
+				entry.into_iter().map(|(_, value)| value.clone()).collect(),
 			));
 		}
 		None

--- a/primitives/rpc/debug/src/proxy.rs
+++ b/primitives/rpc/debug/src/proxy.rs
@@ -131,15 +131,15 @@ impl CallListProxy {
 	}
 
 	/// Format the RPC output of a single call-stack.
-	pub fn into_tx_trace(self) -> SingleTrace {
-		SingleTrace::CallList(
-			self.entries
-				.last()
-				.unwrap()
-				.into_iter()
-				.map(|(_, value)| value.clone())
-				.collect(),
-		)
+	pub fn into_tx_trace(self) -> Option<SingleTrace> {
+		if let Some(entry) = self.entries.last() {
+			return Some(SingleTrace::CallList(
+				entry.into_iter()
+					.map(|(_, value)| value.clone())
+					.collect(),
+			));
+		}
+		None
 	}
 
 	/// Format the RPC output for multiple transactions. Each call-stack represents a single

--- a/primitives/rpc/debug/src/proxy.rs
+++ b/primitives/rpc/debug/src/proxy.rs
@@ -85,8 +85,8 @@ impl RawProxy {
 	///
 	/// With `using`, the Runtime Api is called with thread safe/local access to the mutable
 	/// reference of `self`.
-	pub fn using<R, F: FnOnce() -> R>(&mut self, f: F) {
-		listener::using(self, f);
+	pub fn using<R, F: FnOnce() -> R>(&mut self, f: F) -> R {
+		listener::using(self, f)
 	}
 
 	/// Format the RPC output.
@@ -126,8 +126,8 @@ impl CallListProxy {
 	///
 	/// With `using`, the Runtime Api is called with thread safe/local access to the mutable
 	/// reference of `self`.
-	pub fn using<R, F: FnOnce() -> R>(&mut self, f: F) {
-		listener::using(self, f);
+	pub fn using<R, F: FnOnce() -> R>(&mut self, f: F) -> R {
+		listener::using(self, f)
 	}
 
 	/// Format the RPC output of a single call-stack.


### PR DESCRIPTION
With runtime api versioning in place, some outstanding work on tracing apis:

- Clients using >= v0.9.8 require to call `Core::initialize_block` before interacting with `DebugRuntimeApi` versions < 2.
- Handle runtime instance errors when calling `DebugRuntimeApi` using environmental.
- Handle empty trace entries.