### PR TITLE
Fix tracing response handling for `DebugRuntimeApi` v1

### DIFF
--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -259,7 +259,7 @@ where
 							.map_err(|e| {
 								internal_err(format!("Runtime api access error: {:?}", e))
 							})?
-							.map_err(|e| internal_err(format!("DispatchError: {:?}", e)));
+							.map_err(|e| internal_err(format!("DispatchError: {:?}", e)))?;
 
 						Ok(proxy::Result::V2(proxy::ResultV2::Single))
 					} else {

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -248,15 +248,20 @@ where
 			if let Some(transaction) = transactions.get(index) {
 				let f = || {
 					if api_version >= 2 {
-						api.trace_transaction(
-							&parent_block_id,
-							&header,
-							ext,
-							&transaction,
-							trace_type,
-						)
-						.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?
-						.map_err(|e| internal_err(format!("DispatchError: {:?}", e)))
+						let _result = api
+							.trace_transaction(
+								&parent_block_id,
+								&header,
+								ext,
+								&transaction,
+								trace_type,
+							)
+							.map_err(|e| {
+								internal_err(format!("Runtime api access error: {:?}", e))
+							})?
+							.map_err(|e| internal_err(format!("DispatchError: {:?}", e)));
+
+						Ok(proxy::Result::V2(proxy::ResultV2::Single))
 					} else {
 						// For versions < 2 block needs to be manually initialized.
 						api.initialize_block(&parent_block_id, &header)
@@ -265,31 +270,57 @@ where
 							})?;
 
 						#[allow(deprecated)]
-						api.trace_transaction_before_version_2(
+						let result = api.trace_transaction_before_version_2(
 							&parent_block_id,
 							ext,
 							&transaction,
 							trace_type,
 						)
 						.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?
-						.map_err(|e| internal_err(format!("DispatchError: {:?}", e)))
+						.map_err(|e| internal_err(format!("DispatchError: {:?}", e)))?;
+
+						Ok(proxy::Result::V1(proxy::ResultV1::Single(result)))
 					}
 				};
-				return Ok(match trace_type {
+				return match trace_type {
 					single::TraceType::Raw { .. } => {
 						let mut proxy = proxy::RawProxy::new();
-						proxy.using(f)?;
-						proxy.into_tx_trace()
+						if api_version >= 2 {
+							proxy.using(f)?;
+							Ok(proxy.into_tx_trace())
+						} else {
+							match proxy.using(f) {
+								Ok(proxy::Result::V1(proxy::ResultV1::Single(result))) => {
+									Ok(result)
+								}
+								Err(e) => Err(e),
+								_ => Err(internal_err(format!(
+									"Bug: Api and result versions must match"
+								))),
+							}
+						}
 					}
 					single::TraceType::CallList { .. } => {
 						let mut proxy = proxy::CallListProxy::new();
-						proxy.using(f)?;
-						proxy
-							.into_tx_trace()
-							.ok_or("Trace result is empty.")
-							.map_err(|e| internal_err(format!("{:?}", e)))?
+						if api_version >= 2 {
+							proxy.using(f)?;
+							proxy
+								.into_tx_trace()
+								.ok_or("Trace result is empty.")
+								.map_err(|e| internal_err(format!("{:?}", e)))
+						} else {
+							match proxy.using(f) {
+								Ok(proxy::Result::V1(proxy::ResultV1::Single(result))) => {
+									Ok(result)
+								}
+								Err(e) => Err(e),
+								_ => Err(internal_err(format!(
+									"Bug: Api and result versions must match"
+								))),
+							}
+						}
 					}
-				});
+				};
 			}
 		}
 		Err(internal_err("Runtime block call failed".to_string()))

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -869,7 +869,7 @@ where
 							"Internal runtime error when replaying block {} : {:?}",
 							height, e
 						))
-					});
+					})?;
 				Ok(proxy::Result::V2(proxy::ResultV2::Block))
 			} else {
 				// For versions < 2 block needs to be manually initialized.

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -851,7 +851,8 @@ where
 		// Trace the block.
 		let f = || {
 			if api_version >= 2 {
-				api.trace_block(&substrate_parent_id, &block_header, extrinsics)
+				let _result = api
+					.trace_block(&substrate_parent_id, &block_header, extrinsics)
 					.map_err(|e| {
 						internal_err(format!(
 							"Blockchain error when replaying block {} : {:?}",
@@ -868,14 +869,15 @@ where
 							"Internal runtime error when replaying block {} : {:?}",
 							height, e
 						))
-					})
+					});
+				Ok(proxy::Result::V2(proxy::ResultV2::Block))
 			} else {
 				// For versions < 2 block needs to be manually initialized.
 				api.initialize_block(&substrate_parent_id, &block_header)
 					.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
 
 				#[allow(deprecated)]
-				api.trace_block_before_version_2(&substrate_parent_id, extrinsics)
+				let result = api.trace_block_before_version_2(&substrate_parent_id, extrinsics)
 					.map_err(|e| {
 						internal_err(format!(
 							"Blockchain error when replaying block {} : {:?}",
@@ -892,41 +894,51 @@ where
 							"Internal runtime error when replaying block {} : {:?}",
 							height, e
 						))
-					})
+					})?;
+				Ok(proxy::Result::V1(proxy::ResultV1::Block(result)))
 			}
 		};
 
 		let mut proxy = proxy::CallListProxy::new();
-		proxy.using(f)?;
-		let mut traces: Vec<_> = proxy.into_tx_traces();
 
-		// Fill missing data.
-		for trace in traces.iter_mut() {
-			trace.block_hash = eth_block_hash;
-			trace.block_number = height;
-			trace.transaction_hash = eth_transactions
-				.get(trace.transaction_position as usize)
-				.ok_or_else(|| {
-					tracing::warn!(
-						"Bug: A transaction has been replayed while it shouldn't (in block {}).",
-						height
-					);
+		if api_version >= 2 {
+			proxy.using(f)?;
+			let mut traces: Vec<_> = proxy.into_tx_traces();
+			// Fill missing data.
+			for trace in traces.iter_mut() {
+				trace.block_hash = eth_block_hash;
+				trace.block_number = height;
+				trace.transaction_hash = eth_transactions
+					.get(trace.transaction_position as usize)
+					.ok_or_else(|| {
+						tracing::warn!(
+							"Bug: A transaction has been replayed while it shouldn't (in block {}).",
+							height
+						);
 
-					internal_err(format!(
-						"Bug: A transaction has been replayed while it shouldn't (in block {}).",
-						height
-					))
-				})?
-				.transaction_hash;
+						internal_err(format!(
+							"Bug: A transaction has been replayed while it shouldn't (in block {}).",
+							height
+						))
+					})?
+					.transaction_hash;
 
-			// Reformat error messages.
-			if let block::TransactionTraceOutput::Error(ref mut error) = trace.output {
-				if error.as_slice() == b"execution reverted" {
-					*error = b"Reverted".to_vec();
+				// Reformat error messages.
+				if let block::TransactionTraceOutput::Error(ref mut error) = trace.output {
+					if error.as_slice() == b"execution reverted" {
+						*error = b"Reverted".to_vec();
+					}
 				}
 			}
+			Ok(traces)
+		} else {
+			match proxy.using(f) {
+				Ok(proxy::Result::V1(proxy::ResultV1::Block(result))) => Ok(result),
+				Err(e) => Err(e),
+				_ => Err(internal_err(format!(
+					"Bug: Api and result versions must match"
+				))),
+			}
 		}
-
-		Ok(traces)
 	}
 }

--- a/primitives/rpc/debug/src/lib.rs
+++ b/primitives/rpc/debug/src/lib.rs
@@ -33,12 +33,12 @@ sp_api::decl_runtime_apis! {
 			extrinsics: Vec<Block::Extrinsic>,
 			transaction: &Transaction,
 			trace_type: single::TraceType,
-		) -> Result<(), sp_runtime::DispatchError>;
+		) -> Result<single::TransactionTrace, sp_runtime::DispatchError>;
 
 		#[changed_in(2)]
 		fn trace_block(
 			extrinsics: Vec<Block::Extrinsic>,
-		) -> Result<(), sp_runtime::DispatchError>;
+		) -> Result<Vec<block::TransactionTrace>, sp_runtime::DispatchError>;
 
 		fn trace_transaction(
 			header: &Block::Header,

--- a/primitives/rpc/debug/src/proxy.rs
+++ b/primitives/rpc/debug/src/proxy.rs
@@ -66,6 +66,29 @@ impl Event {
 	}
 }
 
+/// DebugRuntimeApi V1 result. Trace response is stored in runtime memory and returned as part of
+/// the runtime api call.
+#[derive(Debug)]
+pub enum ResultV1 {
+	Single(SingleTrace),
+	Block(Vec<BlockTrace>),
+}
+
+/// DebugRuntimeApi V2 result. Trace response is stored in client and runtime api call response is
+/// empty.
+#[derive(Debug)]
+pub enum ResultV2 {
+	Single,
+	Block,
+}
+
+/// Runtime api closure result.
+#[derive(Debug)]
+pub enum Result {
+	V1(ResultV1),
+	V2(ResultV2),
+}
+
 #[derive(Debug)]
 pub struct RawProxy {
 	gas: U256,


### PR DESCRIPTION
`DebugRuntimeApi` V1 stored tracing result on memory and returned it as part of the runtime api call. That needs to be taken into account and correctly handled in the client once we introduced V2.

Tested with https://github.com/PureStake/moonbeam/tree/crystalin-debug-tracing

### What important points reviewers should know?

This solves handling multiple Runtime Api version responses, however, **V1 still stores the response in memory** and I'm afraid there isn't any way around that: it will overflow wasm memory in Alphanet if the trace is big. That is what V2 aims to solve anyways. This shouldn't be a problem for versions > V1, so we are covered in our production networks, but still something worth noting.