### PR TITLE
precompiles utils + crowdloan precompile refactor

### DIFF
--- a/precompiles/crowdloan-rewards/src/lib.rs
+++ b/precompiles/crowdloan-rewards/src/lib.rs
@@ -24,7 +24,9 @@ use frame_support::{
 	traits::Currency,
 };
 use pallet_evm::{AddressMapping, Precompile};
-use precompile_utils::{error, EvmDataReader, EvmDataWriter, EvmResult, Gasometer, RuntimeHelper};
+use precompile_utils::{
+	error, Address, EvmDataReader, EvmDataWriter, EvmResult, Gasometer, RuntimeHelper,
+};
 
 use sp_core::{H160, U256};
 use sp_std::{
@@ -99,7 +101,7 @@ where
 		input.expect_arguments(1)?;
 
 		// parse the address
-		let contributor: H160 = input.read()?;
+		let contributor: H160 = input.read::<Address>()?.into();
 
 		let account: Runtime::AccountId = contributor.into();
 
@@ -134,7 +136,7 @@ where
 		input.expect_arguments(1)?;
 
 		// parse the address
-		let contributor: H160 = input.read()?;
+		let contributor: H160 = input.read::<Address>()?.into();
 
 		let account: Runtime::AccountId = contributor.into();
 
@@ -214,7 +216,7 @@ where
 		input.expect_arguments(1)?;
 
 		// parse the address
-		let new_address: H160 = input.read()?;
+		let new_address: H160 = input.read::<Address>()?.into();
 
 		log::trace!(target: "crowdloan-rewards-precompile", "New account is {:?}", new_address);
 

--- a/precompiles/crowdloan-rewards/src/lib.rs
+++ b/precompiles/crowdloan-rewards/src/lib.rs
@@ -51,7 +51,6 @@ pub struct CrowdloanRewardsWrapper<Runtime>(PhantomData<Runtime>);
 impl<Runtime> Precompile for CrowdloanRewardsWrapper<Runtime>
 where
 	Runtime: pallet_crowdloan_rewards::Config + pallet_evm::Config,
-	Runtime::AccountId: From<H160>,
 	BalanceOf<Runtime>: TryFrom<U256> + Debug,
 	Runtime::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
 	<Runtime::Call as Dispatchable>::Origin: From<Option<Runtime::AccountId>>,
@@ -84,7 +83,6 @@ where
 impl<Runtime> CrowdloanRewardsWrapper<Runtime>
 where
 	Runtime: pallet_crowdloan_rewards::Config + pallet_evm::Config + frame_system::Config,
-	Runtime::AccountId: From<H160>,
 	BalanceOf<Runtime>: TryFrom<U256> + TryInto<u128> + Debug,
 	Runtime::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
 	<Runtime::Call as Dispatchable>::Origin: From<Option<Runtime::AccountId>>,
@@ -104,7 +102,7 @@ where
 		// parse the address
 		let contributor: H160 = input.read::<Address>()?.into();
 
-		let account: Runtime::AccountId = contributor.into();
+		let account = Runtime::AddressMapping::into_account_id(contributor);
 
 		log::trace!(
 			target: "crowdloan-rewards-precompile",
@@ -139,7 +137,7 @@ where
 		// parse the address
 		let contributor: H160 = input.read::<Address>()?.into();
 
-		let account: Runtime::AccountId = contributor.into();
+		let account = Runtime::AddressMapping::into_account_id(contributor);
 
 		log::trace!(
 			target: "crowdloan-rewards-precompile",
@@ -218,11 +216,13 @@ where
 		// parse the address
 		let new_address: H160 = input.read::<Address>()?.into();
 
+		let new_address_account = Runtime::AddressMapping::into_account_id(new_address);
+
 		log::trace!(target: "crowdloan-rewards-precompile", "New account is {:?}", new_address);
 
 		let origin = Runtime::AddressMapping::into_account_id(context.caller);
 		let call =
-			pallet_crowdloan_rewards::Call::<Runtime>::update_reward_address(new_address.into());
+			pallet_crowdloan_rewards::Call::<Runtime>::update_reward_address(new_address_account);
 
 		let used_gas = RuntimeHelper::<Runtime>::try_dispatch(
 			Some(origin).into(),

--- a/precompiles/crowdloan-rewards/src/lib.rs
+++ b/precompiles/crowdloan-rewards/src/lib.rs
@@ -83,8 +83,7 @@ where
 					"Failed to match function selector in crowdloan rewards precompile"
 				);
 				return Err(error(
-					"No crowdloan rewards wrapper method at given selector"
-					,
+					"No crowdloan rewards wrapper method at given selector",
 				));
 			}
 		};
@@ -124,9 +123,7 @@ where
 					"Crowdloan rewards call via evm failed {:?}",
 					e
 				);
-				Err(ExitError::Other(
-					"Crowdloan rewards call via EVM failed".into(),
-				))
+				Err(error("Crowdloan rewards call via EVM failed"))
 			}
 		}
 	}
@@ -221,12 +218,14 @@ where
 		let reward_info = pallet_crowdloan_rewards::Pallet::<Runtime>::accounts_payable(account);
 
 		let (total, claimed): (U256, U256) = if let Some(reward_info) = reward_info {
-			let total_reward: u128 = reward_info.total_reward.try_into().map_err(|_| {
-				ExitError::Other("Amount is too large for provided balance type".into())
-			})?;
-			let claimed_reward: u128 = reward_info.claimed_reward.try_into().map_err(|_| {
-				ExitError::Other("Amount is too large for provided balance type".into())
-			})?;
+			let total_reward: u128 = reward_info
+				.total_reward
+				.try_into()
+				.map_err(|_| error("Amount is too large for provided balance type"))?;
+			let claimed_reward: u128 = reward_info
+				.claimed_reward
+				.try_into()
+				.map_err(|_| error("Amount is too large for provided balance type"))?;
 
 			(total_reward.into(), claimed_reward.into())
 		} else {
@@ -238,13 +237,13 @@ where
 			total, claimed
 		);
 
-		let mut output = EvmDataWriter::new().write_u256(total).build();
-		output.extend(EvmDataWriter::new().write_u256(claimed).build());
-
 		Ok(PrecompileOutput {
 			exit_status: ExitSucceed::Returned,
 			cost: gas_consumed,
-			output: output,
+			output: EvmDataWriter::new()
+				.write_u256(total)
+				.write_u256(claimed)
+				.build(),
 			logs: Default::default(),
 		})
 	}

--- a/precompiles/crowdloan-rewards/src/lib.rs
+++ b/precompiles/crowdloan-rewards/src/lib.rs
@@ -67,7 +67,6 @@ where
 			[0x53, 0x44, 0x0c, 0x90] => Self::is_contributor(input, target_gas),
 			[0x76, 0xf7, 0x02, 0x49] => Self::reward_info(input, target_gas),
 			[0x4e, 0x71, 0xd9, 0x2d] => Self::claim(target_gas, context),
-
 			[0xaa, 0xac, 0x61, 0xd6] => Self::update_reward_address(input, target_gas, context),
 			_ => {
 				log::trace!(
@@ -100,7 +99,7 @@ where
 		input.expect_arguments(1)?;
 
 		// parse the address
-		let contributor = input.read_address()?;
+		let contributor: H160 = input.read()?;
 
 		let account: Runtime::AccountId = contributor.into();
 
@@ -112,7 +111,7 @@ where
 
 		// fetch data from pallet
 		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-		let is_contributor =
+		let is_contributor: bool =
 			pallet_crowdloan_rewards::Pallet::<Runtime>::accounts_payable(account).is_some();
 
 		log::trace!(target: "crowldoan-rewards-precompile", "Result from pallet is {:?}", is_contributor);
@@ -120,7 +119,7 @@ where
 		Ok(PrecompileOutput {
 			exit_status: ExitSucceed::Returned,
 			cost: gasometer.used_gas(),
-			output: EvmDataWriter::new().write_bool(is_contributor).build(),
+			output: EvmDataWriter::new().write(is_contributor).build(),
 			logs: Default::default(),
 		})
 	}
@@ -135,7 +134,7 @@ where
 		input.expect_arguments(1)?;
 
 		// parse the address
-		let contributor = input.read_address()?;
+		let contributor: H160 = input.read()?;
 
 		let account: Runtime::AccountId = contributor.into();
 
@@ -172,10 +171,7 @@ where
 		Ok(PrecompileOutput {
 			exit_status: ExitSucceed::Returned,
 			cost: gasometer.used_gas(),
-			output: EvmDataWriter::new()
-				.write_u256(total)
-				.write_u256(claimed)
-				.build(),
+			output: EvmDataWriter::new().write(total).write(claimed).build(),
 			logs: Default::default(),
 		})
 	}
@@ -218,7 +214,7 @@ where
 		input.expect_arguments(1)?;
 
 		// parse the address
-		let new_address = input.read_address()?;
+		let new_address: H160 = input.read()?;
 
 		log::trace!(target: "crowdloan-rewards-precompile", "New account is {:?}", new_address);
 

--- a/precompiles/crowdloan-rewards/src/lib.rs
+++ b/precompiles/crowdloan-rewards/src/lib.rs
@@ -96,6 +96,7 @@ where
 		target_gas: Option<u64>,
 	) -> EvmResult<PrecompileOutput> {
 		let mut gasometer = Gasometer::new(target_gas);
+		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?; // accounts_payable
 
 		// Bound check
 		input.expect_arguments(1)?;
@@ -112,7 +113,6 @@ where
 		);
 
 		// fetch data from pallet
-		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 		let is_contributor: bool =
 			pallet_crowdloan_rewards::Pallet::<Runtime>::accounts_payable(account).is_some();
 
@@ -131,6 +131,7 @@ where
 		target_gas: Option<u64>,
 	) -> EvmResult<PrecompileOutput> {
 		let mut gasometer = Gasometer::new(target_gas);
+		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?; // accounts_payable
 
 		// Bound check
 		input.expect_arguments(1)?;
@@ -147,7 +148,6 @@ where
 		);
 
 		// fetch data from pallet
-		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 		let reward_info = pallet_crowdloan_rewards::Pallet::<Runtime>::accounts_payable(account);
 
 		let (total, claimed): (U256, U256) = if let Some(reward_info) = reward_info {

--- a/precompiles/crowdloan-rewards/src/mock.rs
+++ b/precompiles/crowdloan-rewards/src/mock.rs
@@ -69,6 +69,7 @@ construct_runtime!(
 	Ord,
 	PartialOrd,
 	Clone,
+	Copy,
 	Encode,
 	Decode,
 	Debug,
@@ -101,20 +102,20 @@ impl AddressMapping<TestAccount> for TestAccount {
 	}
 }
 
-impl TestAccount {
-	pub(crate) fn to_h160(&self) -> H160 {
-		match self {
-			Self::Alice => H160::repeat_byte(0xAA),
-			Self::Bob => H160::repeat_byte(0xBB),
-			Self::Charlie => H160::repeat_byte(0xCC),
-			Self::Bogus => Default::default(),
-		}
-	}
-}
-
 impl From<H160> for TestAccount {
 	fn from(x: H160) -> TestAccount {
 		TestAccount::into_account_id(x)
+	}
+}
+
+impl From<TestAccount> for H160 {
+	fn from(value: TestAccount) -> H160 {
+		match value {
+			TestAccount::Alice => H160::repeat_byte(0xAA),
+			TestAccount::Bob => H160::repeat_byte(0xBB),
+			TestAccount::Charlie => H160::repeat_byte(0xCC),
+			TestAccount::Bogus => Default::default(),
+		}
 	}
 }
 

--- a/precompiles/crowdloan-rewards/src/tests.rs
+++ b/precompiles/crowdloan-rewards/src/tests.rs
@@ -35,9 +35,7 @@ fn selector_less_than_four_bytes() {
 		let bogus_selector = vec![1u8, 2u8, 3u8];
 
 		// Expected result is an error stating there are too few bytes
-		let expected_result = Some(Err(ExitError::Other(
-			"tried to parse selector out of bounds".into(),
-		)));
+		let expected_result = Some(Err(error("tried to parse selector out of bounds")));
 
 		assert_eq!(
 			Precompiles::execute(
@@ -57,9 +55,7 @@ fn no_selector_exists_but_length_is_right() {
 		let bogus_selector = vec![1u8, 2u8, 3u8, 4u8];
 
 		// Expected result is an error stating there are such a selector does not exist
-		let expected_result = Some(Err(ExitError::Other(
-			"No crowdloan rewards wrapper method at given selector".into(),
-		)));
+		let expected_result = Some(Err(error("unknown selector")));
 
 		assert_eq!(
 			Precompiles::execute(

--- a/precompiles/crowdloan-rewards/src/tests.rs
+++ b/precompiles/crowdloan-rewards/src/tests.rs
@@ -24,7 +24,7 @@ use frame_support::{assert_ok, dispatch::Dispatchable};
 use pallet_crowdloan_rewards::{Call as CrowdloanCall, Event as CrowdloanEvent};
 use pallet_evm::Call as EvmCall;
 use pallet_evm::{ExitError, ExitSucceed, PrecompileSet};
-use precompile_utils::OutputBuilder;
+use precompile_utils::EvmDataWriter;
 use sha3::{Digest, Keccak256};
 use sp_core::U256;
 
@@ -89,7 +89,7 @@ fn is_contributor_returns_false() {
 			// Expected result is one
 			let expected_one_result = Some(Ok(PrecompileOutput {
 				exit_status: ExitSucceed::Returned,
-				output: OutputBuilder::new().write_bool(false).build(),
+				output: EvmDataWriter::new().write_bool(false).build(),
 				cost: Default::default(),
 				logs: Default::default(),
 			}));
@@ -134,7 +134,7 @@ fn is_contributor_returns_true() {
 			// Expected result is one
 			let expected_one_result = Some(Ok(PrecompileOutput {
 				exit_status: ExitSucceed::Returned,
-				output: OutputBuilder::new().write_bool(true).build(),
+				output: EvmDataWriter::new().write_bool(true).build(),
 				cost: Default::default(),
 				logs: Default::default(),
 			}));
@@ -228,8 +228,8 @@ fn reward_info_works() {
 			input_data[0..4].copy_from_slice(&selector);
 			input_data[16..36].copy_from_slice(&Alice.to_h160().0);
 
-			let mut output = OutputBuilder::new().write_u256(50u64).build();
-			output.extend(OutputBuilder::new().write_u256(10u64).build()); // Expected result
+			let mut output = EvmDataWriter::new().write_u256(50u64).build();
+			output.extend(EvmDataWriter::new().write_u256(10u64).build()); // Expected result
 			let expected_buffer_result = Some(Ok(PrecompileOutput {
 				exit_status: ExitSucceed::Returned,
 				output: output,

--- a/precompiles/crowdloan-rewards/src/tests.rs
+++ b/precompiles/crowdloan-rewards/src/tests.rs
@@ -22,7 +22,7 @@ use crate::PrecompileOutput;
 use frame_support::{assert_ok, dispatch::Dispatchable};
 use pallet_crowdloan_rewards::{Call as CrowdloanCall, Event as CrowdloanEvent};
 use pallet_evm::{Call as EvmCall, ExitSucceed, PrecompileSet};
-use precompile_utils::{error, EvmDataWriter};
+use precompile_utils::{error, Address, EvmDataWriter};
 use sha3::{Digest, Keccak256};
 use sp_core::{H160, U256};
 
@@ -76,7 +76,7 @@ fn is_contributor_returns_false() {
 			let selector = &Keccak256::digest(b"is_contributor(address)")[0..4];
 			let input = EvmDataWriter::new()
 				.write_raw_bytes(selector)
-				.write(H160::from(Alice))
+				.write(Address(H160::from(Alice)))
 				.build();
 
 			// Expected result is one
@@ -121,7 +121,7 @@ fn is_contributor_returns_true() {
 			let selector = &Keccak256::digest(b"is_contributor(address)")[0..4];
 			let input = EvmDataWriter::new()
 				.write_raw_bytes(selector)
-				.write(H160::from(Alice))
+				.write(Address(H160::from(Alice)))
 				.build();
 
 			// Assert that no props have been opened.
@@ -211,7 +211,7 @@ fn reward_info_works() {
 			let selector = &Keccak256::digest(b"reward_info(address)")[0..4];
 			let input = EvmDataWriter::new()
 				.write_raw_bytes(selector)
-				.write(H160::from(Alice))
+				.write(Address(H160::from(Alice)))
 				.build();
 
 			// Assert that no props have been opened.
@@ -258,7 +258,7 @@ fn update_reward_address_works() {
 			let selector = &Keccak256::digest(b"update_reward_address(address)")[0..4];
 			let input = EvmDataWriter::new()
 				.write_raw_bytes(selector)
-				.write(H160::from(Charlie))
+				.write(Address(H160::from(Charlie)))
 				.build();
 
 			// Make sure the call goes through successfully

--- a/precompiles/utils/src/data.rs
+++ b/precompiles/utils/src/data.rs
@@ -1,0 +1,208 @@
+// Copyright 2019-2021 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::{error, EvmResult};
+use sp_core::{H160, H256, U256};
+use sp_std::{vec, vec::Vec};
+
+/// Wrapper around an EVM input slice, helping to parse it.
+/// Provide functions to parse common types.
+#[derive(Clone, Copy, Debug)]
+pub struct EvmDataReader<'a> {
+	input: &'a [u8],
+	cursor: usize,
+	max_read_position: usize,
+}
+
+impl<'a> EvmDataReader<'a> {
+	/// Create a new input parser.
+	pub fn new(input: &'a [u8]) -> Self {
+		Self {
+			input,
+			cursor: 0,
+			max_read_position: 0,
+		}
+	}
+
+	/// Check the input has the correct amount of arguments before end (32 bytes values).
+	/// This cannot be used if the arguments contains arrays as array parsing is context dependent.
+	/// If at least one argument is an array, parse it first, then call `validate` after parsing
+	/// the entire input.
+	pub fn expect_arguments(&self, args: usize) -> EvmResult {
+		if self.input.len() == self.cursor + args * 32 {
+			Ok(())
+		} else {
+			Err(error("input doesn't match expected length"))
+		}
+	}
+
+	/// Check the input has been completely read.
+	pub fn check_complete(&self) -> EvmResult {
+		if self.max_read_position == self.input.len() {
+			Ok(())
+		} else {
+			Err(error("input doesn't match expected length"))
+		}
+	}
+
+	/// Read data from the input.
+	pub fn read<T: EvmData>(&mut self) -> EvmResult<T> {
+		T::read(self)
+	}
+
+	/// Parse (4 bytes) selector.
+	/// Returns an error if trying to parse out of bounds.
+	pub fn read_selector(&mut self) -> EvmResult<&[u8]> {
+		let range_end = self.cursor + 4;
+
+		let data = self
+			.input
+			.get(self.cursor..range_end)
+			.ok_or_else(|| error("tried to parse selector out of bounds"))?;
+
+		self.cursor += 4;
+		self.update_max_read_position(self.cursor);
+
+		Ok(data)
+	}
+
+	fn update_max_read_position(&mut self, local_max: usize) {
+		if self.max_read_position < local_max {
+			self.max_read_position = local_max;
+		}
+	}
+}
+
+/// Help build an EVM input/output data.
+#[derive(Clone, Debug)]
+pub struct EvmDataWriter {
+	data: Vec<u8>,
+}
+
+impl EvmDataWriter {
+	/// Creates a new empty output builder.
+	pub fn new() -> Self {
+		Self { data: vec![] }
+	}
+
+	/// Return the built data.
+	pub fn build(self) -> Vec<u8> {
+		self.data
+	}
+
+	/// Write arbitrary bytes.
+	pub fn write_raw_bytes(mut self, value: &[u8]) -> Self {
+		self.data.extend_from_slice(value);
+		self
+	}
+
+	/// Write data of requested type.
+	pub fn write<T: EvmData>(mut self, value: T) -> Self {
+		T::write(&mut self, value);
+		self
+	}
+}
+
+impl Default for EvmDataWriter {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+/// Data that can be converted from and to EVM data types.
+pub trait EvmData: Sized {
+	fn read(reader: &mut EvmDataReader) -> EvmResult<Self>;
+	fn write(writer: &mut EvmDataWriter, value: Self);
+}
+
+impl EvmData for H256 {
+	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+		let range_end = reader.cursor + 32;
+
+		let data = reader
+			.input
+			.get(reader.cursor..range_end)
+			.ok_or_else(|| error("tried to parse H256 out of bounds"))?;
+
+		reader.cursor += 32;
+		reader.update_max_read_position(reader.cursor);
+
+		Ok(H256::from_slice(data))
+	}
+
+	fn write(writer: &mut EvmDataWriter, value: Self) {
+		writer.data.extend_from_slice(&value.as_bytes());
+	}
+}
+
+impl EvmData for H160 {
+	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+		let range_end = reader.cursor + 32;
+
+		let data = reader
+			.input
+			.get(reader.cursor..range_end)
+			.ok_or_else(|| error("tried to parse H160 out of bounds"))?;
+
+		reader.cursor += 32;
+		reader.update_max_read_position(reader.cursor);
+
+		Ok(H160::from_slice(&data[12..32]))
+	}
+
+	fn write(writer: &mut EvmDataWriter, value: Self) {
+		H256::write(writer, value.into());
+	}
+}
+
+impl EvmData for U256 {
+	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+		let range_end = reader.cursor + 32;
+
+		let data = reader
+			.input
+			.get(reader.cursor..range_end)
+			.ok_or_else(|| error("tried to parse U256 out of bounds"))?;
+
+		reader.cursor += 32;
+		reader.update_max_read_position(reader.cursor);
+
+		Ok(U256::from_big_endian(data))
+	}
+
+	fn write(writer: &mut EvmDataWriter, value: Self) {
+		let mut buffer = [0u8; 32];
+		value.to_big_endian(&mut buffer);
+		writer.data.extend_from_slice(&buffer);
+	}
+}
+
+impl EvmData for bool {
+	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+		let h256 = H256::read(reader).map_err(|_| error("tried to parse bool out of bounds"))?;
+
+		Ok(!h256.is_zero())
+	}
+
+	fn write(writer: &mut EvmDataWriter, value: Self) {
+		let mut buffer = [0u8; 32];
+		if value {
+			buffer[31] = 1;
+		}
+
+		writer.data.extend_from_slice(&buffer);
+	}
+}

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -233,7 +233,7 @@ impl Gasometer {
 
 	/// Record cost, and return error if it goes out of gas.
 	pub fn record_cost(&mut self, cost: u64) -> EvmResult {
-		self.used_gas.checked_add(cost).ok_or(ExitError::OutOfGas)?;
+		self.used_gas = self.used_gas.checked_add(cost).ok_or(ExitError::OutOfGas)?;
 
 		match self.target_gas {
 			Some(gas_limit) if self.used_gas > gas_limit => Err(ExitError::OutOfGas),

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -26,7 +26,10 @@ use sp_core::{H160, H256};
 use sp_std::{marker::PhantomData, vec, vec::Vec};
 
 mod data;
-pub use data::{EvmData, EvmDataReader, EvmDataWriter};
+pub use data::{Address, EvmData, EvmDataReader, EvmDataWriter};
+
+#[cfg(test)]
+mod tests;
 
 /// Alias for Result returning an EVM precompile error.
 pub type EvmResult<T = ()> = Result<T, ExitError>;

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -22,8 +22,11 @@ use frame_support::{
 	traits::Get,
 };
 use pallet_evm::{GasWeightMapping, Log};
-use sp_core::{H160, H256, U256};
+use sp_core::{H160, H256};
 use sp_std::{marker::PhantomData, vec, vec::Vec};
+
+mod data;
+pub use data::{EvmData, EvmDataReader, EvmDataWriter};
 
 /// Alias for Result returning an EVM precompile error.
 pub type EvmResult<T = ()> = Result<T, ExitError>;
@@ -31,146 +34,6 @@ pub type EvmResult<T = ()> = Result<T, ExitError>;
 /// Return an error with provided (static) text.
 pub fn error(text: &'static str) -> ExitError {
 	ExitError::Other(text.into())
-}
-
-/// Wrapper around an EVM input slice, helping to parse it.
-/// Provide functions to parse common types.
-#[derive(Clone, Copy, Debug)]
-pub struct EvmDataReader<'a> {
-	input: &'a [u8],
-	cursor: usize,
-}
-
-impl<'a> EvmDataReader<'a> {
-	/// Create a new input parser.
-	pub fn new(input: &'a [u8]) -> Self {
-		Self { input, cursor: 0 }
-	}
-
-	/// Check the input has the correct amount of arguments (32 bytes values).
-	pub fn expect_arguments(&self, args: usize) -> EvmResult {
-		if self.input.len() == self.cursor + args * 32 {
-			Ok(())
-		} else {
-			Err(error("input doesn't match expected length"))
-		}
-	}
-
-	/// Parse (4 bytes) selector.
-	/// Returns an error if trying to parse out of bounds.
-	pub fn read_selector(&mut self) -> EvmResult<&[u8]> {
-		let range_end = self.cursor + 4;
-
-		let data = self
-			.input
-			.get(self.cursor..range_end)
-			.ok_or_else(|| error("tried to parse selector out of bounds"))?;
-
-		self.cursor += 4;
-
-		Ok(data)
-	}
-
-	/// Parse a U256 value.
-	/// Returns an error if trying to parse out of bound.
-	pub fn read_u256(&mut self) -> EvmResult<U256> {
-		let range_end = self.cursor + 32;
-
-		let data = self
-			.input
-			.get(self.cursor..range_end)
-			.ok_or_else(|| error("tried to parse u256 out of bounds"))?;
-
-		self.cursor += 32;
-
-		Ok(U256::from_big_endian(data))
-	}
-
-	/// Parse a H256 value.
-	/// Returns an error if trying to parse out of bound.
-	pub fn read_h256(&mut self) -> EvmResult<H256> {
-		let range_end = self.cursor + 32;
-
-		let data = self
-			.input
-			.get(self.cursor..range_end)
-			.ok_or_else(|| error("tried to parse address out of bounds"))?;
-
-		self.cursor += 32;
-
-		Ok(H256::from_slice(data))
-	}
-
-	/// Parse an address value.
-	/// Returns an error if trying to parse out of bound.
-	/// Ignores the 12 higher bytes.
-	pub fn read_address(&mut self) -> EvmResult<H160> {
-		let range_end = self.cursor + 32;
-
-		let data = self
-			.input
-			.get(self.cursor..range_end)
-			.ok_or_else(|| error("tried to parse address out of bounds"))?;
-
-		self.cursor += 32;
-
-		Ok(H160::from_slice(&data[12..32]))
-	}
-}
-
-/// Help build an EVM input/output data.
-#[derive(Clone, Debug)]
-pub struct EvmDataWriter {
-	data: Vec<u8>,
-}
-
-impl EvmDataWriter {
-	/// Creates a new empty output builder.
-	pub fn new() -> Self {
-		Self { data: vec![] }
-	}
-
-	/// Return the built data.
-	pub fn build(self) -> Vec<u8> {
-		self.data
-	}
-
-	/// Write arbitrary bytes.
-	pub fn write_bytes(mut self, value: &[u8]) -> Self {
-		self.data.extend_from_slice(value);
-		self
-	}
-
-	/// Write an H256 (or something that can be converted into it) to the output.
-	pub fn write_h256<T: Into<H256>>(mut self, value: T) -> Self {
-		let value: H256 = value.into();
-		self.data.extend_from_slice(&value.as_bytes());
-		self
-	}
-
-	/// Write an U256 (or something that can be converted into it) to the output.
-	pub fn write_u256<T: Into<U256>>(mut self, value: T) -> Self {
-		let mut buffer = [0u8; 32];
-		value.into().to_big_endian(&mut buffer);
-		self.data.extend_from_slice(&buffer);
-		self
-	}
-
-	/// Write an bool (or something that can be converted into it) to the output.
-	pub fn write_bool<T: Into<bool>>(mut self, value: T) -> Self {
-		let mut buffer = [0u8; 32];
-		if value.into() {
-			buffer[31] = 1;
-		}
-		self.data.extend_from_slice(&buffer);
-		self
-	}
-}
-
-impl Default for EvmDataWriter {
-	fn default() -> Self {
-		Self::new()
-	}
 }
 
 /// Builder for PrecompileOutput.

--- a/precompiles/utils/src/tests.rs
+++ b/precompiles/utils/src/tests.rs
@@ -17,6 +17,12 @@
 use super::*;
 use sp_core::{H256, U256};
 
+fn u256_repeat_byte(byte: u8) -> U256 {
+	let value = H256::repeat_byte(byte);
+
+	U256::from_big_endian(value.as_bytes())
+}
+
 #[test]
 fn write_u256() {
 	let value = U256::from(42);
@@ -145,4 +151,292 @@ fn read_address() {
 	assert_eq!(value, parsed.0);
 }
 
-// TODO : Test arrays
+#[test]
+fn write_h256_array() {
+	let array = vec![
+		H256::repeat_byte(0x11),
+		H256::repeat_byte(0x22),
+		H256::repeat_byte(0x33),
+		H256::repeat_byte(0x44),
+		H256::repeat_byte(0x55),
+	];
+	let writer_output = EvmDataWriter::new().write(array.clone()).build();
+
+	// We can read this "manualy" using simpler functions since arrays are 32-byte aligned.
+	let mut reader = EvmDataReader::new(&writer_output);
+
+	assert_eq!(reader.read::<U256>().expect("read offset"), 32.into());
+	assert_eq!(reader.read::<U256>().expect("read size"), 5.into());
+	assert_eq!(reader.read::<H256>().expect("read 1st"), array[0]);
+	assert_eq!(reader.read::<H256>().expect("read 2nd"), array[1]);
+	assert_eq!(reader.read::<H256>().expect("read 3rd"), array[2]);
+	assert_eq!(reader.read::<H256>().expect("read 4th"), array[3]);
+	assert_eq!(reader.read::<H256>().expect("read 5th"), array[4]);
+	reader.check_complete().expect("complete");
+}
+
+#[test]
+fn read_h256_array() {
+	let array = vec![
+		H256::repeat_byte(0x11),
+		H256::repeat_byte(0x22),
+		H256::repeat_byte(0x33),
+		H256::repeat_byte(0x44),
+		H256::repeat_byte(0x55),
+	];
+	let writer_output = EvmDataWriter::new().write(array.clone()).build();
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let parsed: Vec<H256> = reader.read().expect("to correctly parse Vec<H256>");
+	reader.check_complete().expect("complete");
+
+	assert_eq!(array, parsed);
+}
+
+#[test]
+fn write_u256_array() {
+	let array = vec![
+		u256_repeat_byte(0x11),
+		u256_repeat_byte(0x22),
+		u256_repeat_byte(0x33),
+		u256_repeat_byte(0x44),
+		u256_repeat_byte(0x55),
+	];
+	let writer_output = EvmDataWriter::new().write(array.clone()).build();
+
+	// We can read this "manualy" using simpler functions since arrays are 32-byte aligned.
+	let mut reader = EvmDataReader::new(&writer_output);
+
+	assert_eq!(reader.read::<U256>().expect("read offset"), 32.into());
+	assert_eq!(reader.read::<U256>().expect("read size"), 5.into());
+	assert_eq!(reader.read::<U256>().expect("read 1st"), array[0]);
+	assert_eq!(reader.read::<U256>().expect("read 2nd"), array[1]);
+	assert_eq!(reader.read::<U256>().expect("read 3rd"), array[2]);
+	assert_eq!(reader.read::<U256>().expect("read 4th"), array[3]);
+	assert_eq!(reader.read::<U256>().expect("read 5th"), array[4]);
+	reader.check_complete().expect("complete");
+}
+
+#[test]
+fn read_u256_array() {
+	let array = vec![
+		u256_repeat_byte(0x11),
+		u256_repeat_byte(0x22),
+		u256_repeat_byte(0x33),
+		u256_repeat_byte(0x44),
+		u256_repeat_byte(0x55),
+	];
+	let writer_output = EvmDataWriter::new().write(array.clone()).build();
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let parsed: Vec<U256> = reader.read().expect("to correctly parse Vec<H256>");
+	reader.check_complete().expect("complete");
+
+	assert_eq!(array, parsed);
+}
+
+#[test]
+fn write_address_array() {
+	let array = vec![
+		Address(H160::repeat_byte(0x11)),
+		Address(H160::repeat_byte(0x22)),
+		Address(H160::repeat_byte(0x33)),
+		Address(H160::repeat_byte(0x44)),
+		Address(H160::repeat_byte(0x55)),
+	];
+	let writer_output = EvmDataWriter::new().write(array.clone()).build();
+
+	// We can read this "manualy" using simpler functions since arrays are 32-byte aligned.
+	let mut reader = EvmDataReader::new(&writer_output);
+
+	assert_eq!(reader.read::<U256>().expect("read offset"), 32.into());
+	assert_eq!(reader.read::<U256>().expect("read size"), 5.into());
+	assert_eq!(reader.read::<Address>().expect("read 1st"), array[0]);
+	assert_eq!(reader.read::<Address>().expect("read 2nd"), array[1]);
+	assert_eq!(reader.read::<Address>().expect("read 3rd"), array[2]);
+	assert_eq!(reader.read::<Address>().expect("read 4th"), array[3]);
+	assert_eq!(reader.read::<Address>().expect("read 5th"), array[4]);
+	reader.check_complete().expect("complete");
+}
+
+#[test]
+fn read_address_array() {
+	let array = vec![
+		Address(H160::repeat_byte(0x11)),
+		Address(H160::repeat_byte(0x22)),
+		Address(H160::repeat_byte(0x33)),
+		Address(H160::repeat_byte(0x44)),
+		Address(H160::repeat_byte(0x55)),
+	];
+	let writer_output = EvmDataWriter::new().write(array.clone()).build();
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let parsed: Vec<Address> = reader.read().expect("to correctly parse Vec<H256>");
+	reader.check_complete().expect("complete");
+
+	assert_eq!(array, parsed);
+}
+
+#[test]
+#[should_panic(expected = "complete")]
+fn read_address_array_size_too_small() {
+	let array = vec![
+		Address(H160::repeat_byte(0x11)),
+		Address(H160::repeat_byte(0x22)),
+		Address(H160::repeat_byte(0x33)),
+		Address(H160::repeat_byte(0x44)),
+		Address(H160::repeat_byte(0x55)),
+	];
+	let mut writer_output = EvmDataWriter::new().write(array.clone()).build();
+
+	U256::from(4).to_big_endian(&mut writer_output[0x20..0x40]);
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let _: Vec<Address> = reader.read().expect("to correctly parse Vec<H256>");
+	reader.check_complete().expect("complete");
+}
+
+#[test]
+fn read_address_array_size_too_big() {
+	let array = vec![
+		Address(H160::repeat_byte(0x11)),
+		Address(H160::repeat_byte(0x22)),
+		Address(H160::repeat_byte(0x33)),
+		Address(H160::repeat_byte(0x44)),
+		Address(H160::repeat_byte(0x55)),
+	];
+	let mut writer_output = EvmDataWriter::new().write(array.clone()).build();
+
+	U256::from(6).to_big_endian(&mut writer_output[0x20..0x40]);
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	match reader.read::<Vec<Address>>() {
+		Ok(_) => panic!("should not parse correctly"),
+		Err(ExitError::Other(err)) => assert_eq!(err, "tried to parse H160 out of bounds"),
+		Err(_) => panic!("unexpected error"),
+	}
+}
+
+#[test]
+fn write_address_nested_array() {
+	let array = vec![
+		vec![
+			Address(H160::repeat_byte(0x11)),
+			Address(H160::repeat_byte(0x22)),
+			Address(H160::repeat_byte(0x33)),
+		],
+		vec![
+			Address(H160::repeat_byte(0x44)),
+			Address(H160::repeat_byte(0x55)),
+		],
+	];
+	let writer_output = EvmDataWriter::new().write(array.clone()).build();
+
+	writer_output
+		.chunks_exact(32)
+		.map(|chunk| H256::from_slice(chunk))
+		.for_each(|hash| println!("{:?}", hash));
+
+	// We can read this "manualy" using simpler functions since arrays are 32-byte aligned.
+	let mut reader = EvmDataReader::new(&writer_output);
+
+	assert_eq!(reader.read::<U256>().expect("read offset"), 0x20.into()); // 0x00
+	assert_eq!(reader.read::<U256>().expect("read size"), 2.into()); // 0x20
+	assert_eq!(reader.read::<U256>().expect("read 1st offset"), 0x80.into()); // 0x40
+	assert_eq!(
+		reader.read::<U256>().expect("read 2st offset"),
+		0x100.into()
+	); // 0x60
+	assert_eq!(reader.read::<U256>().expect("read 1st size"), 3.into()); // 0x80
+	assert_eq!(reader.read::<Address>().expect("read 1-1"), array[0][0]); // 0xA0
+	assert_eq!(reader.read::<Address>().expect("read 1-2"), array[0][1]); // 0xC0
+	assert_eq!(reader.read::<Address>().expect("read 1-3"), array[0][2]); // 0xE0
+	assert_eq!(reader.read::<U256>().expect("read 2nd size"), 2.into()); // 0x100
+	assert_eq!(reader.read::<Address>().expect("read 2-1"), array[1][0]); // 0x120
+	assert_eq!(reader.read::<Address>().expect("read 2-2"), array[1][1]); // 0x140
+	reader.check_complete().expect("complete");
+}
+
+#[test]
+fn read_address_nested_array() {
+	let array = vec![
+		vec![
+			Address(H160::repeat_byte(0x11)),
+			Address(H160::repeat_byte(0x22)),
+			Address(H160::repeat_byte(0x33)),
+		],
+		vec![
+			Address(H160::repeat_byte(0x44)),
+			Address(H160::repeat_byte(0x55)),
+		],
+	];
+	let writer_output = EvmDataWriter::new().write(array.clone()).build();
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let parsed: Vec<Vec<Address>> = reader.read().expect("to correctly parse Vec<Vec<Address>>");
+	reader.check_complete().expect("complete");
+
+	assert_eq!(array, parsed);
+}
+
+#[test]
+
+fn write_multiple_arrays() {
+	let array1 = vec![
+		Address(H160::repeat_byte(0x11)),
+		Address(H160::repeat_byte(0x22)),
+		Address(H160::repeat_byte(0x33)),
+	];
+
+	let array2 = vec![H256::repeat_byte(0x44), H256::repeat_byte(0x55)];
+
+	let writer_output = EvmDataWriter::new()
+		.write(array1.clone())
+		.write(array2.clone())
+		.build();
+
+	writer_output
+		.chunks_exact(32)
+		.map(|chunk| H256::from_slice(chunk))
+		.for_each(|hash| println!("{:?}", hash));
+
+	// We can read this "manualy" using simpler functions since arrays are 32-byte aligned.
+	let mut reader = EvmDataReader::new(&writer_output);
+
+	assert_eq!(reader.read::<U256>().expect("read 1st offset"), 0x40.into()); // 0x00
+	assert_eq!(reader.read::<U256>().expect("read 2nd offset"), 0xc0.into()); // 0x20
+	assert_eq!(reader.read::<U256>().expect("read 1st size"), 3.into()); // 0x40
+	assert_eq!(reader.read::<Address>().expect("read 1-1"), array1[0]); // 0x60
+	assert_eq!(reader.read::<Address>().expect("read 1-2"), array1[1]); // 0x80
+	assert_eq!(reader.read::<Address>().expect("read 1-3"), array1[2]); // 0xA0
+	assert_eq!(reader.read::<U256>().expect("read 2nd size"), 2.into()); // 0xC0
+	assert_eq!(reader.read::<H256>().expect("read 2-1"), array2[0]); // 0xE0
+	assert_eq!(reader.read::<H256>().expect("read 2-2"), array2[1]); // 0x100
+	reader.check_complete().expect("complete");
+}
+
+#[test]
+fn read_multiple_arrays() {
+	let array1 = vec![
+		Address(H160::repeat_byte(0x11)),
+		Address(H160::repeat_byte(0x22)),
+		Address(H160::repeat_byte(0x33)),
+	];
+
+	let array2 = vec![H256::repeat_byte(0x44), H256::repeat_byte(0x55)];
+
+	let writer_output = EvmDataWriter::new()
+		.write(array1.clone())
+		.write(array2.clone())
+		.build();
+
+	let mut reader = EvmDataReader::new(&writer_output);
+
+	let parsed: Vec<Address> = reader.read().expect("to correctly parse Vec<Address>");
+	assert_eq!(array1, parsed);
+
+	let parsed: Vec<H256> = reader.read().expect("to correctly parse Vec<H256>");
+	assert_eq!(array2, parsed);
+
+	reader.check_complete().expect("complete");
+}

--- a/precompiles/utils/src/tests.rs
+++ b/precompiles/utils/src/tests.rs
@@ -1,0 +1,148 @@
+// Copyright 2019-2021 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+use sp_core::{H256, U256};
+
+#[test]
+fn write_u256() {
+	let value = U256::from(42);
+
+	let output = EvmDataWriter::new().write(value).build();
+
+	let mut expected_output = [0u8; 32];
+	value.to_big_endian(&mut expected_output);
+
+	assert_eq!(output, expected_output);
+}
+
+#[test]
+fn read_u256() {
+	let value = U256::from(42);
+	let writer_output = EvmDataWriter::new().write(value).build();
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let parsed: U256 = reader.read().expect("to correctly parse U256");
+	reader.check_complete().expect("complete");
+
+	assert_eq!(value, parsed);
+}
+
+#[test]
+#[should_panic(expected = "to correctly parse U256")]
+fn read_u256_too_short() {
+	let value = U256::from(42);
+	let writer_output = EvmDataWriter::new().write(value).build();
+
+	let mut reader = EvmDataReader::new(&writer_output[0..31]);
+	let _: U256 = reader.read().expect("to correctly parse U256");
+}
+
+#[test]
+#[should_panic(expected = "complete")]
+fn read_u256_too_long() {
+	let value = U256::from(42);
+	let mut writer_output = EvmDataWriter::new().write(value).build();
+	writer_output.push(0);
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let _: U256 = reader.read().expect("to correctly parse U256");
+	reader.check_complete().expect("complete");
+}
+
+#[test]
+fn write_h256() {
+	let mut raw = [0u8; 32];
+	raw[0] = 42;
+	raw[12] = 43;
+	raw[31] = 44;
+
+	let value = H256::from(raw);
+
+	let output = EvmDataWriter::new().write(value).build();
+
+	assert_eq!(&output, &raw);
+}
+
+#[test]
+fn read_h256() {
+	let mut raw = [0u8; 32];
+	raw[0] = 42;
+	raw[12] = 43;
+	raw[31] = 44;
+	let value = H256::from(raw);
+	let writer_output = EvmDataWriter::new().write(value).build();
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let parsed: H256 = reader.read().expect("to correctly parse H256");
+	reader.check_complete().expect("complete");
+
+	assert_eq!(value, parsed);
+}
+
+#[test]
+#[should_panic(expected = "to correctly parse H256")]
+fn read_h256_too_short() {
+	let mut raw = [0u8; 32];
+	raw[0] = 42;
+	raw[12] = 43;
+	raw[31] = 44;
+	let value = H256::from(raw);
+	let writer_output = EvmDataWriter::new().write(value).build();
+
+	let mut reader = EvmDataReader::new(&writer_output[0..31]);
+	let _: H256 = reader.read().expect("to correctly parse H256");
+}
+
+#[test]
+#[should_panic(expected = "complete")]
+fn read_h256_too_long() {
+	let mut raw = [0u8; 32];
+	raw[0] = 42;
+	raw[12] = 43;
+	raw[31] = 44;
+	let value = H256::from(raw);
+	let mut writer_output = EvmDataWriter::new().write(value).build();
+
+	writer_output.push(0);
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let _: H256 = reader.read().expect("to correctly parse H256");
+	reader.check_complete().expect("complete");
+}
+
+#[test]
+fn write_address() {
+	let value = H160::repeat_byte(0xAA);
+
+	let output = EvmDataWriter::new().write(Address(value)).build();
+
+	assert_eq!(&output[12..32], value.as_bytes());
+}
+
+#[test]
+fn read_address() {
+	let value = H160::repeat_byte(0xAA);
+	let writer_output = EvmDataWriter::new().write(Address(value)).build();
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let parsed: Address = reader.read().expect("to correctly parse Address");
+	reader.check_complete().expect("complete");
+
+	assert_eq!(value, parsed.0);
+}
+
+// TODO : Test arrays

--- a/precompiles/utils/src/tests.rs
+++ b/precompiles/utils/src/tests.rs
@@ -24,15 +24,39 @@ fn u256_repeat_byte(byte: u8) -> U256 {
 }
 
 #[test]
+fn write_bool() {
+	let value = true;
+
+	let writer_output = EvmDataWriter::new().write(value).build();
+
+	let mut expected_output = [0u8; 32];
+	expected_output[31] = 1;
+
+	assert_eq!(writer_output, expected_output);
+}
+
+#[test]
+fn read_bool() {
+	let value = true;
+
+	let writer_output = EvmDataWriter::new().write(value).build();
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let parsed: bool = reader.read().expect("to correctly parse bool");
+
+	assert_eq!(value, parsed);
+}
+
+#[test]
 fn write_u256() {
 	let value = U256::from(42);
 
-	let output = EvmDataWriter::new().write(value).build();
+	let writer_output = EvmDataWriter::new().write(value).build();
 
 	let mut expected_output = [0u8; 32];
 	value.to_big_endian(&mut expected_output);
 
-	assert_eq!(output, expected_output);
+	assert_eq!(writer_output, expected_output);
 }
 
 #[test]


### PR DESCRIPTION
### What does it do?

Refactor a bit the precompile util crate to improve its usage in precompiles and their Rust tests.
Also refactor the crowdloan precompile to use new precompile utils.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

Doesn't yet support fixed-length `bytesXX` of Solidity, which are left-padded.
Note that `bytes20` is left-padded, while `address` is right-padded. This is the reason why I used a wrapper `Address` type
around `H160` instead of implementing `EvmData` on `H160`, which would be error-prone. When implementing these bytes types they should thus be distinct from Rust types `HXXX`. (This doesn't apply to `H256` since it has no padding)

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

## Checklist

- [ ] Does it require a purge of the network?
- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
- [ ] Does it require changes in documentation/tutorials ?
