### PR TITLE
Kill the PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,9 +9,3 @@
 ### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?
 
 ### What value does it bring to the blockchain users?
-
-## Checklist
-
-- [ ] Does it require a purge of the network?
-- [ ] You bumped the runtime version if there are breaking changes in the **runtime** ?
-- [ ] Does it require changes in documentation/tutorials ?


### PR DESCRIPTION
This PR removes the checklist portion of the PR description template. It removes all three questions for these reasons:

`Does it require a purge of the network?`:
We now have live production networks and aren't purging anymore. PRs that make these kinds of changes needs migrations now and we have a label for that.

`You bumped the runtime version if there are breaking changes in the **runtime**?`: Our process has changed. We now do a single runtime bump at release time.

`Does it require changes in documentation/tutorials?`: This is still an important question. It's actually more important than jut having a checkbox. PRs that break docs should include details about what changed and mentions of the docs team in the description. I've also added `D10-breaksdocs`. This will allow the docs team to also benefit from the label-scraping tools that we are building.