### PR TITLE
Remove staking delay exits migration

### DIFF
--- a/pallets/parachain-staking/migrations.md
+++ b/pallets/parachain-staking/migrations.md
@@ -1,0 +1,10 @@
+# Migration History
+
+## Delay Nominator Exits
+
+- [Migration PR](https://github.com/PureStake/moonbeam/pull/610)
+- [Migration Removal PR](https://github.com/PureStake/moonbeam/pull/662)
+
+## OLDER MIGRATIONS
+
+- TODO

--- a/pallets/parachain-staking/migrations.md
+++ b/pallets/parachain-staking/migrations.md
@@ -1,10 +1,16 @@
 # Migration History
 
-## Delay Nominator Exits
+## Delay nominator exits by changing NominatorState and ExitQueue
 
-- [Migration PR](https://github.com/PureStake/moonbeam/pull/610)
-- [Migration Removal PR](https://github.com/PureStake/moonbeam/pull/662)
+- [Migration PR `#610`](https://github.com/PureStake/moonbeam/pull/610)
+- [Migration Removal PR `#662`](https://github.com/PureStake/moonbeam/pull/662)
 
-## OLDER MIGRATIONS
+## Patch nomination DOS attack vector by changing CollatorState
 
-- TODO
+- [Migration PR `#505`](https://github.com/PureStake/moonbeam/pull/505)
+- [Migration Removal PR `#553`](https://github.com/PureStake/moonbeam/pull/553)
+
+## Patch underflow bug and correct Total storage item
+
+- [Migration PR `#502`](https://github.com/PureStake/moonbeam/pull/502)
+- [Migration Removal PR `#553`](https://github.com/PureStake/moonbeam/pull/553)

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -461,28 +461,6 @@ pub mod pallet {
 		pub status: NominatorStatus,
 	}
 
-	#[derive(Encode, Decode, RuntimeDebug)]
-	/// DEPRECATED nominator state
-	pub struct Nominator<AccountId, Balance> {
-		pub nominations: OrderedSet<Bond<AccountId, Balance>>,
-		pub total: Balance,
-	}
-
-	impl<AccountId: Ord, Balance: Zero> From<Nominator<AccountId, Balance>>
-		for Nominator2<AccountId, Balance>
-	{
-		fn from(other: Nominator<AccountId, Balance>) -> Nominator2<AccountId, Balance> {
-			Nominator2 {
-				nominations: other.nominations,
-				revocations: OrderedSet::new(),
-				total: other.total,
-				scheduled_revocations_count: 0u32,
-				scheduled_revocations_total: Zero::zero(),
-				status: NominatorStatus::Active,
-			}
-		}
-	}
-
 	impl<
 			AccountId: Ord + Clone,
 			Balance: Copy
@@ -860,51 +838,10 @@ pub mod pallet {
 			Perbill,
 			Perbill,
 		),
-		/// Migrated NominatorState -> NominatorState2, ExitQueue -> ExitQueue2
-		DelayNominationExitsMigrationExecuted,
-	}
-
-	/// Storage migration for delaying nomination exits and revocations
-	fn delay_nomination_exits_migration_execution<T: Config>() -> (u64, u64) {
-		if !<DelayNominationExitsMigration<T>>::get() {
-			// migrate from Nominator -> Nominator2
-			let (mut reads, mut writes) = (0u64, 0u64);
-			for (acc, nominator_state) in NominatorState::<T>::drain() {
-				let state: Nominator2<T::AccountId, BalanceOf<T>> = nominator_state.into();
-				<NominatorState2<T>>::insert(acc, state);
-				reads += 1u64;
-				writes += 1u64;
-			}
-			// migrate from ExitQueue -> ExitQueue2
-			let just_collators_exit_queue = <ExitQueue<T>>::take();
-			let mut candidates: Vec<T::AccountId> = Vec::new();
-			for (acc, _) in just_collators_exit_queue.clone().into_iter() {
-				candidates.push(acc);
-			}
-			reads += 1u64;
-			writes += 1u64;
-			<ExitQueue2<T>>::put(ExitQ {
-				candidates: candidates.into(),
-				nominators_leaving: OrderedSet::new(),
-				candidate_schedule: just_collators_exit_queue,
-				nominator_schedule: Vec::new(),
-			});
-			<DelayNominationExitsMigration<T>>::put(true);
-			Pallet::<T>::deposit_event(Event::DelayNominationExitsMigrationExecuted);
-			(reads, writes)
-		} else {
-			(1u64, 0u64)
-		}
 	}
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
-		fn on_runtime_upgrade() -> Weight {
-			let (reads, writes) = delay_nomination_exits_migration_execution::<T>();
-			<T as frame_system::Config>::DbWeight::get().reads(reads)
-				+ <T as frame_system::Config>::DbWeight::get().writes(writes)
-				+ 5_000_000_000 // 1% of the max block weight, to account for computation
-		}
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			let mut round = <Round<T>>::get();
 			if round.should_update(n) {
@@ -963,18 +900,6 @@ pub mod pallet {
 	type Round<T: Config> = StorageValue<_, RoundInfo<T::BlockNumber>, ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn nominator_state)]
-	/// DEPRECATED AFTER `DelayNominationExitsMigration` migration is executed
-	/// Get nominator state associated with an account if account is nominating else None
-	type NominatorState<T: Config> = StorageMap<
-		_,
-		Twox64Concat,
-		T::AccountId,
-		Nominator<T::AccountId, BalanceOf<T>>,
-		OptionQuery,
-	>;
-
-	#[pallet::storage]
 	#[pallet::getter(fn nominator_state2)]
 	/// Get nominator state associated with an account if account is nominating else None
 	type NominatorState2<T: Config> = StorageMap<
@@ -1011,12 +936,6 @@ pub mod pallet {
 	/// The pool of collator candidates, each with their total backing stake
 	type CandidatePool<T: Config> =
 		StorageValue<_, OrderedSet<Bond<T::AccountId, BalanceOf<T>>>, ValueQuery>;
-
-	#[pallet::storage]
-	#[pallet::getter(fn exit_queue)]
-	/// DEPRECATED
-	/// A queue of collators awaiting exit
-	type ExitQueue<T: Config> = StorageValue<_, Vec<(T::AccountId, RoundIndex)>, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn exit_queue2)]

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -874,11 +874,6 @@ pub mod pallet {
 	}
 
 	#[pallet::storage]
-	#[pallet::getter(fn delay_nomination_exits_migration)]
-	/// True if executed, false by default
-	type DelayNominationExitsMigration<T: Config> = StorageValue<_, bool, ValueQuery>;
-
-	#[pallet::storage]
 	#[pallet::getter(fn collator_commission)]
 	/// Commission percent taken off of rewards for all collators
 	type CollatorCommission<T: Config> = StorageValue<_, Perbill, ValueQuery>;

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -842,6 +842,10 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_runtime_upgrade() -> Weight {
+			<DelayNominationExitsMigration<T>>::kill();
+			0
+		}
 		fn on_initialize(n: T::BlockNumber) -> Weight {
 			let mut round = <Round<T>>::get();
 			if round.should_update(n) {
@@ -872,6 +876,11 @@ pub mod pallet {
 			}
 		}
 	}
+
+	#[pallet::storage]
+	#[pallet::getter(fn delay_nomination_exits_migration)]
+	/// DEPRECATED
+	type DelayNominationExitsMigration<T: Config> = StorageValue<_, bool, ValueQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn collator_commission)]


### PR DESCRIPTION
Also adds `migrations.md` to root of `parachain-staking` pallet, which will link to migration creation/removal PRs to track migrations. Networks can use these PRs to write custom migrations when they need to jump versions i.e. `Nominator1 -> Nominator3`.
