### PR TITLE
Enable binary search in gas estimation

### DIFF
--- a/client/rpc/debug/Cargo.toml
+++ b/client/rpc/debug/Cargo.toml
@@ -27,5 +27,5 @@ moonbeam-rpc-core-debug = { path = "../../rpc-core/debug" }
 moonbeam-rpc-primitives-debug = { path = "../../../primitives/rpc/debug" }
 fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
 fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre", features = ["rpc_binary_search_estimate"] }
 fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }

--- a/client/rpc/trace/Cargo.toml
+++ b/client/rpc/trace/Cargo.toml
@@ -36,7 +36,7 @@ jsonrpc-core = "15.0.0"
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 sc-transaction-graph = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre", features = ["rpc_binary_search_estimate"] }
 fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
 fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
 moonbeam-rpc-core-trace = { path = "../../rpc-core/trace" }

--- a/client/rpc/txpool/Cargo.toml
+++ b/client/rpc/txpool/Cargo.toml
@@ -24,4 +24,4 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 serde = { version = "1.0", features = ["derive"] }
 
 moonbeam-rpc-primitives-txpool = { path = "../../../primitives/rpc/txpool" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre", features = ["rpc_binary_search_estimate"] }

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -88,7 +88,7 @@ ethereum-primitives = { package = "ethereum", version = "0.7.1", default-feature
 fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
 fp-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
 fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre", features = ["rpc_binary_search_estimate"] }
 fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
 fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
 fc-mapping-sync = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }

--- a/tests/tests/test-gas-estimation.ts
+++ b/tests/tests/test-gas-estimation.ts
@@ -25,31 +25,15 @@ describeDevMoonbeam("Estimate Gas - Multiply", (context) => {
     ).to.equal(21994);
   });
 
+  // Since the binary search has been activated, the gas indicated in the request is not taken into
+  // account by the estimation:
+  // https://github.com/PureStake/frontier/blob/moonbeam-polkadot-v0.9.8-binary-search/client/rpc/
+  // src/eth.rs#L907
   it("should work with gas limit", async function () {
     expect(
       await multContract.methods.multiply(3).estimateGas({
-        gas: 21994,
+        gas: 0,
       })
     ).to.equal(21994);
-  });
-
-  it("should ignore from balance (?)", async function () {
-    expect(
-      await multContract.methods.multiply(3).estimateGas({
-        gas: 21994,
-      })
-    ).to.equal(21994);
-  });
-
-  it("should fail with a lower gas limit", async function () {
-    await multContract.methods
-      .multiply(3)
-      .estimateGas({
-        gas: 21993,
-      })
-      .then(() => {
-        return Promise.reject({ message: "Execution succeeded but should have failed" });
-      })
-      .catch((err) => expect(err.message).to.equal(`Returned error: out of gas`));
   });
 });

--- a/tests/tests/test-gas-estimation.ts
+++ b/tests/tests/test-gas-estimation.ts
@@ -25,14 +25,30 @@ describeDevMoonbeam("Estimate Gas - Multiply", (context) => {
     ).to.equal(21994);
   });
 
-  // Since the binary search has been activated, the gas indicated in the request is not taken into
-  // account by the estimation:
-  // https://github.com/PureStake/frontier/blob/moonbeam-polkadot-v0.9.8-binary-search/client/rpc/
-  // src/eth.rs#L907
   it("should work with gas limit", async function () {
     expect(
       await multContract.methods.multiply(3).estimateGas({
-        gas: 0,
+        gas: 21994,
+      })
+    ).to.equal(21994);
+  });
+
+  it("should ignore from balance (?)", async function () {
+    expect(
+      await multContract.methods.multiply(3).estimateGas({
+        gas: 21994,
+      })
+    ).to.equal(21994);
+  });
+
+  // Since the binary search has been activated, the gas indicated in the request is not taken into
+  // account by the estimation, so any provided gas limit should work:
+  // https://github.com/PureStake/frontier/blob/moonbeam-polkadot-v0.9.8-binary-search/client/rpc/
+  // src/eth.rs#L907
+  it("should work with a lower gas limit", async function () {
+    expect(
+      await multContract.methods.multiply(3).estimateGas({
+        gas: 21993,
       })
     ).to.equal(21994);
   });

--- a/tests/tests/test-gas-estimation2.ts
+++ b/tests/tests/test-gas-estimation2.ts
@@ -1,0 +1,18 @@
+import { expect } from "chai";
+
+import { describeDevMoonbeam } from "../util/setup-dev-tests";
+
+import { createContract } from "../util/transactions";
+
+describeDevMoonbeam("Estimate Gas - infinite loop", (context) => {
+  it("Should be able to estimate gas of infinite loop call", async function () {
+    const { contract, rawTx } = await createContract(context.web3, "InfiniteContract");
+    await context.createBlock({ transactions: [rawTx] });
+
+    expect(
+      await contract.methods.infinite().estimateGas({
+        gas: null,
+      })
+    ).to.equal(15_000_000);
+  });
+});


### PR DESCRIPTION
### What does it do?

Enable binary search in gas estimation (frontier feature).
We already tried to activate this feature 6 months ago (#243), but at that time the binary search algo had a bug, this bug has been fixed in frontier on Feb 25: paritytech/frontier#297

In particular the binary search algo could go into an infinite loop in some cases (reported by @albertov19 ), it is precisely this diff that should normally ensure that the binary search does not go into an infinite loop now: https://github.com/paritytech/frontier/pull/338/files#diff-d5674a04eba0110e1cda44150baf38a6f2fab62561ee2033e2066a537bf97b69R832

###  important points reviewers should know?

Since the binary search has been activated, the gas indicated in the request is not taken into account by the estimation rpc: https://github.com/PureStake/frontier/blob/moonbeam-polkadot-v0.9.8/client/rpc/src/eth.rs#L907

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
