### PR TITLE
Update rust toolchain: `nightly-2021-02-24` -> `nightly-2021-08-01`

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-02-24"
+channel = "nightly-2021-08-01"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
This PR updates to a newer (by about 6 months) Rust toolchain version.

As suggested in https://github.com/PureStake/moonbeam/pull/658#issuecomment-893462133