### PR TITLE
Upgrade runtime to 300 and client to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam"
-version = "0.9.6"
+version = "0.10.0"
 dependencies = [
  "assert_cmd",
  "futures 0.3.15",
@@ -4984,7 +4984,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam-cli"
-version = "0.9.6"
+version = "0.10.0"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-service",
@@ -5012,7 +5012,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam-cli-opt"
-version = "0.9.6"
+version = "0.10.0"
 dependencies = [
  "account",
  "libsecp256k1 0.3.5",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam-service"
-version = "0.9.6"
+version = "0.10.0"
 dependencies = [
  "ansi_term 0.12.1",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Docker images are published for every tagged release. Learn more with `moonbeam 
 
 ```bash
 # Join the public testnet
-docker run --network="host" purestake/moonbeam:v0.9.6 --chain alphanet
+docker run --network="host" purestake/moonbeam:v0.10.0 --chain alphanet
 ```
 
 You can find more detailed instructions to [run a full node in our TestNet](https://docs.moonbeam.network/node-operators/networks/full-node/)
@@ -27,7 +27,7 @@ service.
 
 ```bash
 # Run a dev service node.
-docker run --network="host" purestake/moonbeam:v0.9.6 --dev
+docker run --network="host" purestake/moonbeam:v0.10.0 --dev
 ```
 
 For more information, see our detailed instructions to [run a development node](https://docs.moonbeam.network/getting-started/local-node/setting-up-a-node/)
@@ -38,10 +38,10 @@ The command above will start the node in instant seal mode. It creates a block w
 
 ```bash
 # Author a block every 6 seconds.
-docker run --network="host" purestake/moonbeam:v0.9.6 --dev --sealing 6000
+docker run --network="host" purestake/moonbeam:v0.10.0 --dev --sealing 6000
 
 # Manually control the block authorship and finality
-docker run --network="host" purestake/moonbeam:v0.9.6 --dev --sealing manual
+docker run --network="host" purestake/moonbeam:v0.10.0 --dev --sealing manual
 ```
 
 ### Prefunded Development Addresses

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ name = 'moonbeam'
 description = 'Moonbeam Collator'
 homepage = 'https://moonbeam.network'
 license = 'GPL-3.0-only'
-version = '0.9.6'
+version = '0.10.0'
 authors = ["PureStake"]
 edition = '2018'
 

--- a/node/cli-opt/Cargo.toml
+++ b/node/cli-opt/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'moonbeam-cli-opt'
 homepage = 'https://moonbeam.network'
 license = 'GPL-3.0-only'
-version = '0.9.6'
+version = '0.10.0'
 authors = ["PureStake"]
 edition = '2018'
 

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moonbeam-cli"
-version = "0.9.6"
+version = "0.10.0"
 authors = ["PureStake"]
 edition = "2018"
 

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'moonbeam-service'
 homepage = 'https://moonbeam.network'
 license = 'GPL-3.0-only'
-version = '0.9.6'
+version = '0.10.0'
 authors = ["PureStake"]
 edition = '2018'
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -131,7 +131,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase"),
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 3,
-	spec_version: 0200,
+	spec_version: 0300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -132,7 +132,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 0200,
+	spec_version: 0300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -133,7 +133,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 0200,
+	spec_version: 0300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
This upgrade removes part of this on_runtime_upgrade, meaning it requires a major bump for the runtime.
The client upgrade is also require due to a new runtime API from Frontier (see release note)