### PR TITLE
Geth's `callTracer`

### DIFF
--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -224,7 +224,7 @@ where
 				let tracer = if hash == blockscout_hash {
 					Some(TracerInput::Blockscout)
 				} else if tracer == "callTracer" {
-					Some(TracerInput::GethCallTrace)
+					Some(TracerInput::Etherscan)
 				} else {
 					None
 				};

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -223,7 +223,7 @@ where
 				let blockscout_hash = H128::from_str("0x94d9f08796f91eb13a2e82a6066882f7").unwrap();
 				let tracer = if hash == blockscout_hash {
 					Some(TracerInput::Blockscout)
-				} else if tracer == "callTrace" {
+				} else if tracer == "callTracer" {
 					Some(TracerInput::GethCallTrace)
 				} else {
 					None

--- a/primitives/rpc/debug/src/blockscout.rs
+++ b/primitives/rpc/debug/src/blockscout.rs
@@ -1,0 +1,80 @@
+// Copyright 2019-2021 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Blockscout specific responses.
+
+#[cfg(feature = "std")]
+use crate::serialization::*;
+#[cfg(feature = "std")]
+use serde::Serialize;
+
+use codec::{Decode, Encode};
+use ethereum_types::{H160, U256};
+use sp_std::vec::Vec;
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Serialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+pub struct Call {
+	pub from: H160,
+	/// Indices of parent calls.
+	pub trace_address: Vec<u32>,
+	/// Number of children calls.
+	/// Not needed for Blockscout, but needed for `crate::block`
+	/// types that are build from this type.
+	#[cfg_attr(feature = "std", serde(skip))]
+	pub subtraces: u32,
+	/// Sends funds to the (payable) function
+	pub value: U256,
+	/// Remaining gas in the runtime.
+	pub gas: U256,
+	/// Gas used by this context.
+	pub gas_used: U256,
+	#[cfg_attr(feature = "std", serde(flatten))]
+	pub inner: CallInner,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Serialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase", tag = "type"))]
+pub enum CallInner {
+	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+	Call {
+		/// Type of call.
+		call_type: crate::CallType,
+		to: H160,
+		#[cfg_attr(feature = "std", serde(serialize_with = "bytes_0x_serialize"))]
+		input: Vec<u8>,
+		/// "output" or "error" field
+		#[cfg_attr(feature = "std", serde(flatten))]
+		res: crate::CallResult,
+	},
+
+	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+	Create {
+		#[cfg_attr(feature = "std", serde(serialize_with = "bytes_0x_serialize"))]
+		init: Vec<u8>,
+		#[cfg_attr(feature = "std", serde(flatten))]
+		res: crate::CreateResult,
+	},
+	// Revert,
+	SelfDestruct {
+		#[cfg_attr(feature = "std", serde(skip))]
+		balance: U256,
+		#[cfg_attr(feature = "std", serde(skip))]
+		refund_address: H160,
+	},
+}

--- a/primitives/rpc/debug/src/etherscan.rs
+++ b/primitives/rpc/debug/src/etherscan.rs
@@ -1,0 +1,112 @@
+// Copyright 2019-2021 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Etherscan specific responses.
+
+#[cfg(feature = "std")]
+use crate::serialization::*;
+#[cfg(feature = "std")]
+use serde::Serialize;
+
+use codec::{Decode, Encode};
+use ethereum_types::{H160, U256};
+use sp_std::vec::Vec;
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Serialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+pub struct Call {
+	pub from: H160,
+
+	/// Indices of parent calls. Used to build the Etherscan nested response.
+	#[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none"))]
+	pub trace_address: Option<Vec<u32>>,
+
+	/// Remaining gas in the runtime.
+	pub gas: U256,
+	/// Gas used by this context.
+	pub gas_used: U256,
+
+	#[cfg_attr(feature = "std", serde(flatten))]
+	pub inner: CallInner,
+
+	#[cfg_attr(feature = "std", serde(skip_serializing_if = "Vec::is_empty"))]
+	pub calls: Vec<crate::single::Call>,
+}
+
+#[derive(Clone, Eq, PartialEq, Debug, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Serialize))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase", untagged))]
+pub enum CallInner {
+	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+	Call {
+		#[cfg_attr(
+			feature = "std",
+			serde(rename = "type", serialize_with = "opcode_serialize")
+		)]
+		call_type: Vec<u8>,
+		to: H160,
+		#[cfg_attr(feature = "std", serde(serialize_with = "bytes_0x_serialize"))]
+		input: Vec<u8>,
+		/// "output" or "error" field
+		#[cfg_attr(feature = "std", serde(flatten))]
+		res: crate::CallResult,
+
+		#[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none"))]
+		value: Option<U256>,
+	},
+
+	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+	Create {
+		#[cfg_attr(
+			feature = "std",
+			serde(rename = "type", serialize_with = "opcode_serialize")
+		)]
+		call_type: Vec<u8>,
+		#[cfg_attr(feature = "std", serde(serialize_with = "bytes_0x_serialize"))]
+		input: Vec<u8>,
+		#[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none"))]
+		to: Option<H160>,
+		#[cfg_attr(
+			feature = "std",
+			serde(
+				skip_serializing_if = "Option::is_none",
+				serialize_with = "option_bytes_0x_serialize"
+			)
+		)]
+		output: Option<Vec<u8>>,
+		#[cfg_attr(
+			feature = "std",
+			serde(
+				skip_serializing_if = "Option::is_none",
+				serialize_with = "option_string_serialize"
+			)
+		)]
+		error: Option<Vec<u8>>,
+		value: U256,
+	},
+	// Revert,
+	SelfDestruct {
+		#[cfg_attr(
+			feature = "std",
+			serde(rename = "type", serialize_with = "opcode_serialize")
+		)]
+		call_type: Vec<u8>,
+		#[cfg_attr(feature = "std", serde(skip))]
+		to: H160,
+		value: U256,
+	},
+}

--- a/primitives/rpc/debug/src/lib.rs
+++ b/primitives/rpc/debug/src/lib.rs
@@ -108,3 +108,10 @@ pub enum CallType {
 pub enum CreateType {
 	Create,
 }
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Encode, Decode)]
+pub enum TracerInput {
+	None,
+	Blockscout,
+	GethCallTrace,
+}

--- a/primitives/rpc/debug/src/lib.rs
+++ b/primitives/rpc/debug/src/lib.rs
@@ -61,6 +61,8 @@ pub mod serialization;
 use crate::serialization::*;
 
 pub mod block;
+pub mod blockscout;
+pub mod etherscan;
 pub mod proxy;
 pub mod single;
 
@@ -113,5 +115,5 @@ pub enum CreateType {
 pub enum TracerInput {
 	None,
 	Blockscout,
-	GethCallTrace,
+	Etherscan,
 }

--- a/primitives/rpc/debug/src/proxy.rs
+++ b/primitives/rpc/debug/src/proxy.rs
@@ -219,51 +219,53 @@ impl CallListProxy {
 				// 		[1] -> pop() and added to []
 				// 		[] -> list length == 1, out
 
-				// Sort by `trace_address.len`
-				result.sort_by(|a, b| match (a, b) {
-					(
-						Call::GethCallTrace {
-							trace_address: Some(a),
-							..
-						},
-						Call::GethCallTrace {
-							trace_address: Some(b),
-							..
-						},
-					) => a.len().cmp(&b.len()),
-					_ => unreachable!(),
-				});
-				// Stack pop-and-push.
-				while result.len() > 1 {
-					let mut last = result.pop().unwrap();
-					// Find the parent index.
-					if let Some(index) =
-						result
-							.iter()
-							.position(|current| match (last.clone(), current) {
-								(
-									Call::GethCallTrace {
-										trace_address: Some(a),
-										..
-									},
-									Call::GethCallTrace {
-										trace_address: Some(b),
-										..
-									},
-								) => &b[..] == &a[0..a.len() - 1],
-								_ => unreachable!(),
-							}) {
-						// Remove `trace_address` from result.
-						if let Call::GethCallTrace {
-							ref mut trace_address,
-							..
-						} = last
-						{
-							*trace_address = None;
-						}
-						// Push the children to parent.
-						if let Some(Call::GethCallTrace { calls, .. }) = result.get_mut(index) {
-							calls.push(last);
+				if result.len() > 1 {
+					// Sort by `trace_address.len`
+					result.sort_by(|a, b| match (a, b) {
+						(
+							Call::GethCallTrace {
+								trace_address: Some(a),
+								..
+							},
+							Call::GethCallTrace {
+								trace_address: Some(b),
+								..
+							},
+						) => a.len().cmp(&b.len()),
+						_ => unreachable!(),
+					});
+					// Stack pop-and-push.
+					while result.len() > 1 {
+						let mut last = result.pop().unwrap();
+						// Find the parent index.
+						if let Some(index) =
+							result
+								.iter()
+								.position(|current| match (last.clone(), current) {
+									(
+										Call::GethCallTrace {
+											trace_address: Some(a),
+											..
+										},
+										Call::GethCallTrace {
+											trace_address: Some(b),
+											..
+										},
+									) => &b[..] == &a[0..a.len() - 1],
+									_ => unreachable!(),
+								}) {
+							// Remove `trace_address` from result.
+							if let Call::GethCallTrace {
+								ref mut trace_address,
+								..
+							} = last
+							{
+								*trace_address = None;
+							}
+							// Push the children to parent.
+							if let Some(Call::GethCallTrace { calls, .. }) = result.get_mut(index) {
+								calls.push(last);
+							}
 						}
 					}
 				}

--- a/primitives/rpc/debug/src/proxy.rs
+++ b/primitives/rpc/debug/src/proxy.rs
@@ -196,8 +196,26 @@ impl CallListProxy {
 								res,
 								value: Some(*value),
 							},
-							CallInner::Create { res, .. } => GethCallInner::Create {
-								res,
+							CallInner::Create { init, res } => GethCallInner::Create {
+								input: init,
+								error: match res {
+									CreateResult::Success { .. } => None,
+									crate::CreateResult::Error { ref error } => Some(error.clone()),
+								},
+								to: match res {
+									CreateResult::Success {
+										created_contract_address_hash,
+										..
+									} => Some(created_contract_address_hash),
+									crate::CreateResult::Error { .. } => None,
+								},
+								output: match res {
+									CreateResult::Success {
+										created_contract_code,
+										..
+									} => Some(created_contract_code),
+									crate::CreateResult::Error { .. } => None,
+								},
 								value: *value,
 								call_type: "CREATE".as_bytes().to_vec(),
 							},

--- a/primitives/rpc/debug/src/proxy.rs
+++ b/primitives/rpc/debug/src/proxy.rs
@@ -276,6 +276,7 @@ impl CallListProxy {
 				if result.len() == 1 {
 					return Some(SingleTrace::CallListNested(result.pop().unwrap()));
 				}
+				return None;
 			}
 			return Some(SingleTrace::CallList(result));
 		}

--- a/primitives/rpc/debug/src/proxy.rs
+++ b/primitives/rpc/debug/src/proxy.rs
@@ -177,21 +177,37 @@ impl CallListProxy {
 						gas_used: *gas_used,
 						trace_address: Some(trace_address.clone()),
 						inner: match inner.clone() {
-							CallInner::Call { input, to, res, .. } => GethCallInner::Call {
+							CallInner::Call {
+								input,
+								to,
+								res,
+								call_type,
+							} => GethCallInner::Call {
+								call_type: match call_type {
+									crate::CallType::Call => "CALL".as_bytes().to_vec(),
+									crate::CallType::CallCode => "CALLCODE".as_bytes().to_vec(),
+									crate::CallType::DelegateCall => {
+										"DELEGATECALL".as_bytes().to_vec()
+									}
+									crate::CallType::StaticCall => "STATICCALL".as_bytes().to_vec(),
+								},
 								to,
 								input,
 								res,
 								value: Some(*value),
 							},
-							CallInner::Create { res, .. } => {
-								GethCallInner::Create { res, value: *value }
-							}
+							CallInner::Create { res, .. } => GethCallInner::Create {
+								res,
+								value: *value,
+								call_type: "CREATE".as_bytes().to_vec(),
+							},
 							CallInner::SelfDestruct {
 								balance,
 								refund_address,
 							} => GethCallInner::SelfDestruct {
 								value: balance,
 								to: refund_address,
+								call_type: "SELFDESTRUCT".as_bytes().to_vec(),
 							},
 						},
 						calls: Vec::new(),

--- a/primitives/rpc/debug/src/serialization.rs
+++ b/primitives/rpc/debug/src/serialization.rs
@@ -41,6 +41,19 @@ where
 	serializer.serialize_str(&format!("0x{}", hex::encode(bytes)))
 }
 
+pub fn option_bytes_0x_serialize<S>(
+	bytes: &Option<Vec<u8>>,
+	serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	if let Some(bytes) = bytes.as_ref() {
+		return serializer.serialize_str(&format!("0x{}", hex::encode(&bytes[..])));
+	}
+	Err(S::Error::custom("String serialize error."))
+}
+
 pub fn opcode_serialize<S>(opcode: &[u8], serializer: S) -> Result<S::Ok, S::Error>
 where
 	S: Serializer,
@@ -59,6 +72,19 @@ where
 		.map_err(|_| S::Error::custom("String serialize error."))?
 		.to_string();
 	serializer.serialize_str(&d)
+}
+
+pub fn option_string_serialize<S>(value: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	if let Some(value) = value.as_ref() {
+		let d = std::str::from_utf8(&value[..])
+			.map_err(|_| S::Error::custom("String serialize error."))?
+			.to_string();
+		return serializer.serialize_str(&d);
+	}
+	Err(S::Error::custom("String serialize error."))
 }
 
 pub fn u256_serialize<S>(data: &U256, serializer: S) -> Result<S::Ok, S::Error>

--- a/primitives/rpc/debug/src/single.rs
+++ b/primitives/rpc/debug/src/single.rs
@@ -161,8 +161,26 @@ pub enum GethCallInner {
 			serde(rename = "type", serialize_with = "opcode_serialize")
 		)]
 		call_type: Vec<u8>,
-		#[cfg_attr(feature = "std", serde(flatten))]
-		res: crate::CreateResult,
+		#[cfg_attr(feature = "std", serde(serialize_with = "bytes_0x_serialize"))]
+		input: Vec<u8>,
+		#[cfg_attr(feature = "std", serde(skip_serializing_if = "Option::is_none"))]
+		to: Option<H160>,
+		#[cfg_attr(
+			feature = "std",
+			serde(
+				skip_serializing_if = "Option::is_none",
+				serialize_with = "option_bytes_0x_serialize"
+			)
+		)]
+		output: Option<Vec<u8>>,
+		#[cfg_attr(
+			feature = "std",
+			serde(
+				skip_serializing_if = "Option::is_none",
+				serialize_with = "option_string_serialize"
+			)
+		)]
+		error: Option<Vec<u8>>,
 		value: U256,
 	},
 	// Revert,

--- a/primitives/rpc/debug/src/single.rs
+++ b/primitives/rpc/debug/src/single.rs
@@ -167,6 +167,7 @@ pub enum GethCallInner {
 #[cfg_attr(feature = "std", derive(Serialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase", untagged))]
 pub enum Call {
+	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 	Blockscout {
 		from: H160,
 		/// Indices of parent calls.
@@ -185,6 +186,7 @@ pub enum Call {
 		#[cfg_attr(feature = "std", serde(flatten))]
 		inner: CallInner,
 	},
+	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 	GethCallTrace {
 		from: H160,
 

--- a/primitives/rpc/debug/src/single.rs
+++ b/primitives/rpc/debug/src/single.rs
@@ -134,10 +134,15 @@ pub enum CallInner {
 
 #[derive(Clone, Eq, PartialEq, Debug, Encode, Decode)]
 #[cfg_attr(feature = "std", derive(Serialize))]
-#[cfg_attr(feature = "std", serde(rename_all = "camelCase", tag = "type"))]
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase", untagged))]
 pub enum GethCallInner {
 	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 	Call {
+		#[cfg_attr(
+			feature = "std",
+			serde(rename = "type", serialize_with = "opcode_serialize")
+		)]
+		call_type: Vec<u8>,
 		to: H160,
 		#[cfg_attr(feature = "std", serde(serialize_with = "bytes_0x_serialize"))]
 		input: Vec<u8>,
@@ -151,12 +156,22 @@ pub enum GethCallInner {
 
 	#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 	Create {
+		#[cfg_attr(
+			feature = "std",
+			serde(rename = "type", serialize_with = "opcode_serialize")
+		)]
+		call_type: Vec<u8>,
 		#[cfg_attr(feature = "std", serde(flatten))]
 		res: crate::CreateResult,
 		value: U256,
 	},
 	// Revert,
 	SelfDestruct {
+		#[cfg_attr(
+			feature = "std",
+			serde(rename = "type", serialize_with = "opcode_serialize")
+		)]
+		call_type: Vec<u8>,
 		#[cfg_attr(feature = "std", serde(skip))]
 		to: H160,
 		value: U256,

--- a/runtime/evm_tracer/src/call_list.rs
+++ b/runtime/evm_tracer/src/call_list.rs
@@ -198,7 +198,7 @@ impl RuntimeListener for CallListTracer {
 									ExitReason::Fatal(_) => CallResult::Error(vec![]),
 								};
 
-								Call {
+								Call::Blockscout {
 									from: context.from,
 									trace_address: context.trace_address,
 									subtraces: context.subtraces,
@@ -229,7 +229,7 @@ impl RuntimeListener for CallListTracer {
 									ExitReason::Fatal(_) => CreateResult::Error { error: vec![] },
 								};
 
-								Call {
+								Call::Blockscout {
 									value: context.value,
 									trace_address: context.trace_address,
 									subtraces: context.subtraces,
@@ -335,7 +335,7 @@ impl EvmListener for CallListTracer {
 			} => {
 				moonbeam_primitives_ext::moonbeam_ext::call_list_entry(
 					self.entries_next_index,
-					Call {
+					Call::Blockscout {
 						from: address, // this contract is self destructing
 						trace_address,
 						subtraces: 0,

--- a/runtime/evm_tracer/src/call_list.rs
+++ b/runtime/evm_tracer/src/call_list.rs
@@ -20,7 +20,7 @@ use codec::Encode;
 use ethereum_types::{H160, U256};
 use evm::{Capture, ExitError, ExitReason, ExitSucceed};
 use moonbeam_rpc_primitives_debug::{
-	single::{Call, CallInner},
+	single::{BlockscoutCall, BlockscoutInner, Call},
 	CallResult, CallType, CreateResult,
 };
 
@@ -198,20 +198,20 @@ impl RuntimeListener for CallListTracer {
 									ExitReason::Fatal(_) => CallResult::Error(vec![]),
 								};
 
-								Call::Blockscout {
+								Call::Blockscout(BlockscoutCall {
 									from: context.from,
 									trace_address: context.trace_address,
 									subtraces: context.subtraces,
 									value: context.value,
 									gas: context.gas.into(),
 									gas_used: gas_used.into(),
-									inner: CallInner::Call {
+									inner: BlockscoutInner::Call {
 										call_type,
 										to: context.to,
 										input: context.data,
 										res,
 									},
-								}
+								})
 								.encode()
 							}
 							ContextType::Create => {
@@ -229,18 +229,18 @@ impl RuntimeListener for CallListTracer {
 									ExitReason::Fatal(_) => CreateResult::Error { error: vec![] },
 								};
 
-								Call::Blockscout {
+								Call::Blockscout(BlockscoutCall {
 									value: context.value,
 									trace_address: context.trace_address,
 									subtraces: context.subtraces,
 									gas: context.gas.into(),
 									gas_used: gas_used.into(),
 									from: context.from,
-									inner: CallInner::Create {
+									inner: BlockscoutInner::Create {
 										init: context.data,
 										res,
 									},
-								}
+								})
 								.encode()
 							}
 						},
@@ -335,18 +335,18 @@ impl EvmListener for CallListTracer {
 			} => {
 				moonbeam_primitives_ext::moonbeam_ext::call_list_entry(
 					self.entries_next_index,
-					Call::Blockscout {
+					Call::Blockscout(BlockscoutCall {
 						from: address, // this contract is self destructing
 						trace_address,
 						subtraces: 0,
 						value: 0.into(),
 						gas: 0.into(),
 						gas_used: 0.into(),
-						inner: CallInner::SelfDestruct {
+						inner: BlockscoutInner::SelfDestruct {
 							refund_address: target,
 							balance,
 						},
-					}
+					})
 					.encode(),
 				);
 

--- a/tests/tests/test-trace.ts
+++ b/tests/tests/test-trace.ts
@@ -191,6 +191,28 @@ describeDevMoonbeam(
       expect(resCallee.traceAddress.length).to.be.eq(1);
       expect(resCallee.traceAddress[0]).to.be.eq(0);
     });
+
+    it("should format as request (Geth's callTrace)", async function () {
+      const send = await nested(context);
+      await context.createBlock();
+      let traceTx = await customWeb3Request(context.web3, "debug_traceTransaction", [
+        send.result,
+        { tracer: "callTrace" },
+      ]);
+      let res = traceTx.result;
+      // Fields
+      expect(Object.keys(res)).to.deep.equal(
+        ["calls","from","gas","gasUsed","input","output","to","type","value"]
+      );
+      // Type
+      expect(res.type).to.be.equal("CALL");
+      // Nested calls
+      let calls = res.calls;
+      expect(calls.length).to.be.eq(1);
+      let nested_call = calls[0];
+      expect(res.to).to.be.equal(nested_call.from);
+      expect(nested_call.type).to.be.equal("CALL");
+    });
   },
   true
 );

--- a/tests/tests/test-trace.ts
+++ b/tests/tests/test-trace.ts
@@ -197,7 +197,7 @@ describeDevMoonbeam(
       await context.createBlock();
       let traceTx = await customWeb3Request(context.web3, "debug_traceTransaction", [
         send.result,
-        { tracer: "callTrace" },
+        { tracer: "callTracer" },
       ]);
       let res = traceTx.result;
       // Fields
@@ -237,7 +237,7 @@ describeDevMoonbeam(
       let createTxHash = txResults[0].result;
       let traceTx = await customWeb3Request(context.web3, "debug_traceTransaction", [
         createTxHash,
-        { tracer: "callTrace" },
+        { tracer: "callTracer" },
       ]);
 
       let res = traceTx.result;

--- a/tests/tests/test-trace.ts
+++ b/tests/tests/test-trace.ts
@@ -201,9 +201,17 @@ describeDevMoonbeam(
       ]);
       let res = traceTx.result;
       // Fields
-      expect(Object.keys(res)).to.deep.equal(
-        ["calls","from","gas","gasUsed","input","output","to","type","value"]
-      );
+      expect(Object.keys(res)).to.deep.equal([
+        "calls",
+        "from",
+        "gas",
+        "gasUsed",
+        "input",
+        "output",
+        "to",
+        "type",
+        "value",
+      ]);
       // Type
       expect(res.type).to.be.equal("CALL");
       // Nested calls

--- a/tests/tests/test-trace.ts
+++ b/tests/tests/test-trace.ts
@@ -192,7 +192,7 @@ describeDevMoonbeam(
       expect(resCallee.traceAddress[0]).to.be.eq(0);
     });
 
-    it("should format as request (Geth's callTrace)", async function () {
+    it("should format as request (callTrace Call)", async function () {
       const send = await nested(context);
       await context.createBlock();
       let traceTx = await customWeb3Request(context.web3, "debug_traceTransaction", [
@@ -220,6 +220,40 @@ describeDevMoonbeam(
       let nested_call = calls[0];
       expect(res.to).to.be.equal(nested_call.from);
       expect(nested_call.type).to.be.equal("CALL");
+    });
+
+    it("should format as request (callTrace Create)", async function () {
+      let nonce = await context.web3.eth.getTransactionCount(GENESIS_ACCOUNT);
+      const { contract: callee, rawTx: rawTx1 } = await createContract(
+        context.web3,
+        "Callee",
+        { nonce: nonce++ },
+        []
+      );
+
+      let { txResults } = await context.createBlock({
+        transactions: [rawTx1],
+      });
+      let createTxHash = txResults[0].result;
+      let traceTx = await customWeb3Request(context.web3, "debug_traceTransaction", [
+        createTxHash,
+        { tracer: "callTrace" },
+      ]);
+
+      let res = traceTx.result;
+      // Fields
+      expect(Object.keys(res)).to.deep.equal([
+        "from",
+        "gas",
+        "gasUsed",
+        "input",
+        "output",
+        "to",
+        "type",
+        "value",
+      ]);
+      // Type
+      expect(res.type).to.be.equal("CREATE");
     });
   },
   true


### PR DESCRIPTION
Add support for the [callTrace](https://github.com/ethereum/go-ethereum/blob/d8ff53dfb8a516f47db37dbc7fd7ad18a1e8a125/eth/tracers/internal/tracers/call_tracer.js) tracer. Required by Etherscan.

###  Important points reviewers should know?

This is mostly a client side re-format of the Blockscout trace result.

- Blockscout expects a stack of calls, and each call to include a list of the parent calls' index.
- Etherscan expects a tree of nested `calls`.

### Is there something left for follow-up PRs?

Currently we emit the Blockscout message format in moonbeam's runtime `evm_tracer`.

Although this is sufficient and works for now (because in the client we can build the Etherscan format with it), we need a refactor to emit a generic message that satisfies current - and potentially future - RPC tracer responses.
