### PR TITLE
feat(precompile-utils): impl EvmData for all primitive uint

### DIFF
--- a/precompiles/utils/src/data.rs
+++ b/precompiles/utils/src/data.rs
@@ -263,6 +263,7 @@ macro_rules! impl_evmdata_for_uints {
 }
 impl_evmdata_for_uints!(u16, u32, u64, u128,);
 
+// The implementation for u8 is specific, for performance reasons.
 impl EvmData for u8 {
 	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
 		let range = reader.move_cursor(32)?;

--- a/precompiles/utils/src/data.rs
+++ b/precompiles/utils/src/data.rs
@@ -243,7 +243,9 @@ macro_rules! impl_evmdata_for_uints {
 					let data = reader
 						.input
 						.get(range)
-						.ok_or_else(|| error(alloc::format!("tried to parse {} out of bounds", core::any::type_name::<Self>())))?;
+						.ok_or_else(|| error(alloc::format!(
+							"tried to parse {} out of bounds", core::any::type_name::<Self>()
+						)))?;
 
 					let mut buffer = [0u8; core::mem::size_of::<Self>()];
 					buffer.copy_from_slice(&data[..core::mem::size_of::<Self>()]);

--- a/precompiles/utils/src/data.rs
+++ b/precompiles/utils/src/data.rs
@@ -233,6 +233,54 @@ impl EvmData for U256 {
 	}
 }
 
+macro_rules! impl_evmdata_for_uints {
+	($($uint:ty, )*) => {
+		$(
+			impl EvmData for $uint {
+				fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+					let range = reader.move_cursor(32)?;
+
+					let data = reader
+						.input
+						.get(range)
+						.ok_or_else(|| error(alloc::format!("tried to parse {} out of bounds", core::any::type_name::<Self>())))?;
+
+					let mut buffer = [0u8; core::mem::size_of::<Self>()];
+					buffer.copy_from_slice(&data[..core::mem::size_of::<Self>()]);
+					Ok(Self::from_be_bytes(buffer))
+				}
+
+				fn write(writer: &mut EvmDataWriter, value: Self) {
+					let mut buffer = [0u8; 32];
+					buffer[..core::mem::size_of::<Self>()].copy_from_slice(&value.to_be_bytes());
+					writer.data.extend_from_slice(&buffer);
+				}
+			}
+		)*
+	};
+}
+impl_evmdata_for_uints!(u16, u32, u64, u128,);
+
+impl EvmData for u8 {
+	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+		let range = reader.move_cursor(32)?;
+
+		let data = reader
+			.input
+			.get(range)
+			.ok_or_else(|| error("tried to parse u64 out of bounds"))?;
+
+		Ok(data[0])
+	}
+
+	fn write(writer: &mut EvmDataWriter, value: Self) {
+		let mut buffer = [0u8; 32];
+		buffer[0] = value;
+
+		writer.data.extend_from_slice(&buffer);
+	}
+}
+
 impl EvmData for bool {
 	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
 		let h256 = H256::read(reader).map_err(|_| error("tried to parse bool out of bounds"))?;

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -16,6 +16,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 use evm::ExitError;
 use frame_support::{
 	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
@@ -35,7 +37,7 @@ mod tests;
 pub type EvmResult<T = ()> = Result<T, ExitError>;
 
 /// Return an error with provided (static) text.
-pub fn error(text: &'static str) -> ExitError {
+pub fn error<T: Into<alloc::borrow::Cow<'static, str>>>(text: T) -> ExitError {
 	ExitError::Other(text.into())
 }
 

--- a/precompiles/utils/src/tests.rs
+++ b/precompiles/utils/src/tests.rs
@@ -48,6 +48,52 @@ fn read_bool() {
 }
 
 #[test]
+fn write_u64() {
+	let value = 42u64;
+
+	let writer_output = EvmDataWriter::new().write(value).build();
+
+	let mut expected_output = [0u8; 32];
+	expected_output[..8].copy_from_slice(&value.to_be_bytes());
+
+	assert_eq!(writer_output, expected_output);
+}
+
+#[test]
+fn read_u64() {
+	let value = 42u64;
+	let writer_output = EvmDataWriter::new().write(value).build();
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let parsed: u64 = reader.read().expect("to correctly parse u64");
+
+	assert_eq!(value, parsed);
+}
+
+#[test]
+fn write_u128() {
+	let value = 42u128;
+
+	let writer_output = EvmDataWriter::new().write(value).build();
+
+	let mut expected_output = [0u8; 32];
+	expected_output[..16].copy_from_slice(&value.to_be_bytes());
+
+	assert_eq!(writer_output, expected_output);
+}
+
+#[test]
+fn read_u128() {
+	let value = 42u128;
+	let writer_output = EvmDataWriter::new().write(value).build();
+
+	let mut reader = EvmDataReader::new(&writer_output);
+	let parsed: u128 = reader.read().expect("to correctly parse u128");
+
+	assert_eq!(value, parsed);
+}
+
+#[test]
 fn write_u256() {
 	let value = U256::from(42);
 
@@ -92,6 +138,12 @@ fn write_h256() {
 	let output = EvmDataWriter::new().write(value).build();
 
 	assert_eq!(&output, &raw);
+}
+
+#[test]
+fn tmp() {
+	let u = U256::from(1_000_000_000);
+	println!("U256={:?}", u.0);
 }
 
 #[test]


### PR DESCRIPTION
### What does it do?

This PR implements the `EvmData` trait for all unsigned integers (`u8` to `u128`) and relax the `error` function to support strings built at runtime.

### What important points reviewers should know?

The implementation directly transforms the integer into a bigendian representation, without passing through an intermediate `U256`, for performance reasons.
The implementation for `u8` is specific, for performance reasons too.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
