### PR TITLE
feat(precompile-util):relax error fn to support strings built at runtime

### DIFF
--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -16,6 +16,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate alloc;
+
 use evm::ExitError;
 use frame_support::{
 	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
@@ -35,7 +37,7 @@ mod tests;
 pub type EvmResult<T = ()> = Result<T, ExitError>;
 
 /// Return an error with provided (static) text.
-pub fn error(text: &'static str) -> ExitError {
+pub fn error<T: Into<alloc::borrow::Cow<'static, str>>>(text: T) -> ExitError {
 	ExitError::Other(text.into())
 }
 


### PR DESCRIPTION
### What does it do?

precompile-util: relax error function to support strings built at runtime

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
