### PR TITLE
fix incorrect reported txid in txpool rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5198,13 +5198,13 @@ dependencies = [
 name = "moonbeam-rpc-txpool"
 version = "0.6.0"
 dependencies = [
- "ethereum",
  "ethereum-types",
  "fc-rpc",
  "frame-system",
  "jsonrpc-core 15.1.0",
  "moonbeam-rpc-core-txpool",
  "moonbeam-rpc-primitives-txpool",
+ "rlp",
  "sc-transaction-graph",
  "serde",
  "sha3 0.8.2",

--- a/client/rpc/txpool/Cargo.toml
+++ b/client/rpc/txpool/Cargo.toml
@@ -8,10 +8,10 @@ license = 'GPL-3.0-only'
 repository = 'https://github.com/PureStake/moonbeam/'
 
 [dependencies]
+rlp = "0.5"
 sha3 = "0.8"
 jsonrpc-core = "15.0.0"
 ethereum-types = "0.11.0"
-ethereum = { version = "0.7.1", default-features = false, features = ["with-codec"] }
 moonbeam-rpc-core-txpool = { path = "../../rpc-core/txpool" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }

--- a/client/rpc/txpool/src/lib.rs
+++ b/client/rpc/txpool/src/lib.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use ethereum::TransactionMessage;
 use ethereum_types::{H160, H256, U256};
 use fc_rpc::{internal_err, public_key};
 use jsonrpc_core::Result as RpcResult;
@@ -83,8 +82,7 @@ where
 		// Build the T response.
 		let mut pending = TransactionMap::<T>::new();
 		for txn in ethereum_txns.ready.iter() {
-			let transaction_message = TransactionMessage::from(txn.clone());
-			let hash = transaction_message.hash();
+			let hash = H256::from_slice(Keccak256::digest(&rlp::encode(txn)).as_slice());
 			let from_address = match public_key(txn) {
 				Ok(pk) => H160::from(H256::from_slice(Keccak256::digest(&pk).as_slice())),
 				Err(_e) => H160::default(),
@@ -96,8 +94,7 @@ where
 		}
 		let mut queued = TransactionMap::<T>::new();
 		for txn in ethereum_txns.future.iter() {
-			let transaction_message = TransactionMessage::from(txn.clone());
-			let hash = transaction_message.hash();
+			let hash = H256::from_slice(Keccak256::digest(&rlp::encode(txn)).as_slice());
 			let from_address = match public_key(txn) {
 				Ok(pk) => H160::from(H256::from_slice(Keccak256::digest(&pk).as_slice())),
 				Err(_e) => H160::default(),

--- a/tests/tests/test-txpool-future.ts
+++ b/tests/tests/test-txpool-future.ts
@@ -35,6 +35,7 @@ describeDevMoonbeam("TxPool - Future Ethereum transaction", (context) => {
       from: GENESIS_ACCOUNT.toLowerCase(),
       gas: "0x100000",
       gasPrice: "0x3b9aca00",
+      hash: txHash,
       nonce: context.web3.utils.toHex(1),
       to: "0x0000000000000000000000000000000000000000",
       value: "0x0",

--- a/tests/tests/test-txpool-pending.ts
+++ b/tests/tests/test-txpool-pending.ts
@@ -63,12 +63,14 @@ describeDevMoonbeam("TxPool - Ethereum Contract Call", (context) => {
     testContract = contract;
     await context.createBlock({ transactions: [rawTx] });
 
-    txHash = await customWeb3Request(context.web3, "eth_sendRawTransaction", [
-      await createContractExecution(context.web3, {
-        contract,
-        contractCall: contract.methods.multiply(5),
-      }),
-    ]);
+    txHash = (
+      await customWeb3Request(context.web3, "eth_sendRawTransaction", [
+        await createContractExecution(context.web3, {
+          contract,
+          contractCall: contract.methods.multiply(5),
+        }),
+      ])
+    ).result;
   });
 
   it("should appear in the txpool inspection", async function () {

--- a/tests/tests/test-txpool-pending.ts
+++ b/tests/tests/test-txpool-pending.ts
@@ -45,6 +45,7 @@ describeDevMoonbeam("TxPool - Pending Ethereum transaction", (context) => {
       from: GENESIS_ACCOUNT.toLowerCase(),
       gas: "0x100000",
       gasPrice: "0x3b9aca00",
+      hash: txHash,
       nonce: context.web3.utils.toHex(0),
       to: "0x0000000000000000000000000000000000000000",
       value: "0x0",
@@ -53,7 +54,7 @@ describeDevMoonbeam("TxPool - Pending Ethereum transaction", (context) => {
 });
 
 describeDevMoonbeam("TxPool - Ethereum Contract Call", (context) => {
-  let testContract: Contract;
+  let testContract: Contract, txHash;
 
   before("Setup: Create contract block and add call transaction", async () => {
     const { contract, rawTx } = await createContract(context.web3, "TestContract", {
@@ -62,7 +63,7 @@ describeDevMoonbeam("TxPool - Ethereum Contract Call", (context) => {
     testContract = contract;
     await context.createBlock({ transactions: [rawTx] });
 
-    await customWeb3Request(context.web3, "eth_sendRawTransaction", [
+    txHash = await customWeb3Request(context.web3, "eth_sendRawTransaction", [
       await createContractExecution(context.web3, {
         contract,
         contractCall: contract.methods.multiply(5),
@@ -90,6 +91,7 @@ describeDevMoonbeam("TxPool - Ethereum Contract Call", (context) => {
       from: GENESIS_ACCOUNT.toLowerCase(),
       gas: "0xb71b00",
       gasPrice: "0x3b9aca00",
+      hash: txHash,
       nonce: context.web3.utils.toHex(1),
       to: testContract.options.address.toString().toLowerCase(),
       value: "0x0",


### PR DESCRIPTION
### What does it do?
Fixes a bug where the Rpc Tx Pool reports incorrect transaction ids.  This PR attempts to fix this issue.

### What important points reviewers should know?
Blockscout explorer's pending transactions never align with the actual completed transactions.  These incorrect transaction ids end up stuck as phantom pending transactions, until blockscout deems them as failed.  This can be observed here: https://moonbase-blockscout.testnet.moonbeam.network/pending-transactions

The bug lies in the conversion from an ethereum::Transaction to ethereum::TransactionMessage and using the TransactionMessage's helper function to get the Tx hash.  This helper derives the chain_id from the V field of the signature's RSV.  It follows eip155 V values so the chain_id calculation formula causes a mismatch, which in turn causes the final rlp encoding/Tx hash to differ from the actual transaction in the Tx Pool.

The remedy is to directly rlp::encode the ethereum::Transaction structs returned by the runtime_api.  Converting them to TransactionMessage is an unnecessary step.

### Is there something left for follow-up PRs?
none

### What alternative implementations were considered?
none

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?
none

### What value does it bring to the blockchain users?
Accurate pending/queued transaction Rpc.
