### PR TITLE
Proper solidity comments for StakingInterface.sol

### DIFF
--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -1,54 +1,70 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity >=0.8.0;
 
-/// The interface through which solidity contracts will interact with Parachain Staking
+/// @author The Moonbeam Team
+/// @title The interface through which solidity contracts will interact with Parachain Staking
 /// We follow this same interface including four-byte function selectors, in the precompile that
 /// wraps the pallet
 interface ParachainStaking {
     // First some simple accessors
 
-    /// Check whether the specified address is currently a staking nominator
+    /// @dev Check whether the specified address is currently a staking nominator
+    /// @param nominator the address that we want to confirm is a nominator
+    /// @return A boolean confirming whether the address is a nominator
     function is_nominator(address nominator) external view returns (bool);
 
-    /// Check whether the specified addess is currently a collator candidate
+    /// @dev Check whether the specified address is currently a collator candidate
+    /// @param collator the address that we want to confirm is a collator andidate
+    /// @return A boolean confirming whether the address is a collator candidate
     function is_candidate(address collator) external view returns (bool);
 
-    /// Check whether the specifies address is currently a part of the active set
+    /// @dev Check whether the specifies address is currently a part of the active set
+    /// @param collator the address that we want to confirm is a part of the active set
+    /// @return A boolean confirming whether the address is a part of the active set
     function is_selected_candidate(address collator)
         external
         view
         returns (bool);
 
-    /// Total points awarded to all collators in a particular round.
+    /// @dev Total points awarded to all collators in a particular round
+    /// @param round the round for which we are querying the points total
+    /// @return The total points awarded to all collators in the round
     function points(uint256 round) external view returns (uint256);
 
-    /// Get the minimum nomination amount
+    /// @dev Get the minimum nomination amount
+    /// @return The minimum nomination amount
     function min_nomination() external view returns (uint256);
 
     // Now the dispatchables
 
-    /// Join the set of collator candidates
+    /// @dev Join the set of collator candidates
+    /// @param amount The amount self-bonded by the caller to become a collator candidate
+    /// @param candidateCount The number of candidates in the CandidatePool
     function join_candidates(uint256 amount, uint256 candidateCount) external;
 
-    /// Request to leave the set of candidates. If successful, the account is immediately
-    /// removed from the candidate pool to prevent selection as a collator, but unbonding is
-    /// executed with a delay of `BondDuration` rounds.
+    /// @dev Leave the set of collator candidates
+    /// @param candidateCount The number of candidates in the CandidatePool
     function leave_candidates(uint256 amount, uint256 candidateCount) external;
 
-    /// Temporarily leave the set of collator candidates without unbonding
+    /// @dev Temporarily leave the set of collator candidates without unbonding
     function go_offline() external;
 
-    /// Rejoin the set of collator candidates if previously had called `go_offline`
+    /// @dev Rejoin the set of collator candidates if previously had called `go_offline`
     function go_online() external;
 
-    /// Bond more for collator candidates
+    /// @dev Bond more for collator candidates
+    /// @param more The additional amount self-bonded
     function candidate_bond_more(uint256 more) external;
 
-    /// Bond less for collator candidates
+    /// @dev Bond less for collator candidates
+    /// @param less The amount to be subtracted from self-bond and unreserved
     function candidate_bond_less(uint256 less) external;
 
-    /// If caller is not a nominator, then join the set of nominators
-    /// If caller is a nominator, then makes nomination to change their nomination state
+    /// @dev Make a nomination in support of a collator candidate
+    /// @param collator The address of the supported collator candidate
+    /// @param amount The amount bonded in support of the collator candidate
+    /// @param collatorNominationCount The number of nominations in support of the candidate
+    /// @param nominatorNominationCount The number of existing nominations by the caller
     function nominate(
         address collator,
         uint256 amount,
@@ -56,16 +72,22 @@ interface ParachainStaking {
         uint256 nominatorNominationCount
     ) external;
 
-    /// Leave the set of nominators and, by implication, revoke all ongoing nominations
+    /// @dev Leave the set of nominators and, by implication, revoke all ongoing nominations
+    /// @param nominatorNominationCount The number of existing nominations to be revoked by caller
     function leave_nominators(uint256 nominatorNominationCount) external;
 
-    /// Revoke an existing nomination
+    /// @dev Revoke an existing nomination
+    /// @param collator The address of the collator candidate which will no longer be supported
     function revoke_nomination(address collator) external;
 
-    /// Bond more for nominators with respect to a specific collator candidate
+    /// @dev Bond more for nominators with respect to a specific collator candidate
+    /// @param candidate The address of the collator candidate for which nomination is increased
+    /// @param more The amount by which the nomination is increased
     function nominator_bond_more(address candidate, uint256 more) external;
 
-    /// Bond less for nominators with respect to a specific nominator candidate
+    /// @dev Bond less for nominators with respect to a specific collator candidate
+    /// @param candidate The address of the collator candidate for which nomination is decreased
+    /// @param less The amount by which the nomination is decreased
     function nominator_bond_less(address candidate, uint256 less) external;
 }
 
@@ -88,5 +110,5 @@ interface ParachainStaking {
 // 	"f6a52569": "nominator_bond_less(address,uint256)",
 // 	"971d44c8": "nominator_bond_more(address,uint256)",
 // 	"4b65c34b": "revoke_nomination(address)"
-// 	"9799b4e7": "points(uint256)"
+// 	"9799b4e7": "points(uint256)",
 // }

--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -110,5 +110,5 @@ interface ParachainStaking {
 // 	"f6a52569": "nominator_bond_less(address,uint256)",
 // 	"971d44c8": "nominator_bond_more(address,uint256)",
 // 	"4b65c34b": "revoke_nomination(address)"
-// 	"9799b4e7": "points(uint256)",
+// 	"9799b4e7": "points(uint256)"
 // }


### PR DESCRIPTION
Adds solidity doc comments for `precompiles/parachain-staking/StakingInterface.sol`

This change was originally in #632 which will now be split into follow ups to facilitate review.
