### PR TITLE
Local chains export id dependent state

### DIFF
--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -89,8 +89,8 @@ pub struct ExportGenesisStateCommand {
 	pub output: Option<PathBuf>,
 
 	/// Id of the parachain this state is for.
-	#[structopt(long, default_value = "1000")]
-	pub parachain_id: u32,
+	#[structopt(long)]
+	pub parachain_id: Option<u32>,
 
 	/// Write output in binary. Default is to write in hex.
 	#[structopt(short, long)]

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -319,6 +319,7 @@ pub fn run() -> Result<()> {
 			builder.with_profiling(sc_tracing::TracingReceiver::Log, "");
 			let _ = builder.init();
 
+			// Cumulus approach here, we directly call the generic load_spec func
 			let chain_spec = load_spec(
 				&params.chain.clone().unwrap_or_default(),
 				params.parachain_id.unwrap_or(1000).into(),

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -319,7 +319,11 @@ pub fn run() -> Result<()> {
 			builder.with_profiling(sc_tracing::TracingReceiver::Log, "");
 			let _ = builder.init();
 
-			let chain_spec = cli.load_spec(&params.chain.clone().unwrap_or_default())?;
+			let chain_spec = load_spec(
+				&params.chain.clone().unwrap_or_default(),
+				params.parachain_id.unwrap_or(1000).into(),
+				&cli.run,
+			)?;
 			let output_buf = if chain_spec.is_moonbeam() {
 				let block: service::moonbeam_runtime::Block =
 					generate_genesis_block(&chain_spec).map_err(|e| format!("{:?}", e))?;

--- a/scripts/generate-parachain-specs.sh
+++ b/scripts/generate-parachain-specs.sh
@@ -28,7 +28,7 @@ $MOONBEAM_BINARY export-genesis-wasm \
 echo $ALPHANET_WASM generated
 
 $MOONBEAM_BINARY export-genesis-state \
-  --parachain-id $PARACHAIN_ID \
+  --parachain-id $ALPHANET_PARACHAIN_ID \
   --chain $ALPHANET_PARACHAIN_SPEC_RAW \
   > $ALPHANET_GENESIS;
 echo $ALPHANET_GENESIS generated


### PR DESCRIPTION
### What does it do?
Fixes a small discrepancy with local chains. `export-genesis-state` wasnt giving the same state as the nodes that were running the chain spec if the parachain-id was not the default one. I opted for an approach similar to what cumulus is doing to fix it.
### What important points reviewers should know?
This was preventing our local launch script to register parachains in an parachain Id different than the default one.
### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
