### PR TITLE
Plumb `try-runtime`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4904,6 +4904,7 @@ dependencies = [
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex",
  "log",
  "max-encoded-len",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -16,7 +16,7 @@ sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
-try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", optional = true }
 
 cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
 cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
@@ -38,3 +38,7 @@ substrate-build-script-utils = { git = "https://github.com/paritytech/substrate"
 default = ["wasmtime"]
 wasmtime = ["sc-cli/wasmtime"]
 runtime-benchmarks = ["service/runtime-benchmarks"]
+try-runtime = [
+	"try-runtime-cli",
+	"service/try-runtime",
+]

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -61,6 +61,14 @@ pub enum Subcommand {
 	#[structopt(name = "benchmark", about = "Benchmark runtime pallets.")]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 
+	/// Try some command against runtime state.
+	#[cfg(feature = "try-runtime")]
+	TryRuntime(try_runtime_cli::TryRuntimeCmd),
+
+	/// Try some command against runtime state. Note: `try-runtime` feature must be enabled.
+	#[cfg(not(feature = "try-runtime"))]
+	TryRuntime,
+
 	/// Key management cli utilities
 	Key(KeyCmd),
 }

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -414,15 +414,6 @@ pub fn run() -> Result<()> {
 			}
 		}
 		#[cfg(feature = "try-runtime")]
-		/*
-		Some(Subcommand::CheckBlock(cmd)) => {
-			let runner = cli.create_runner(cmd)?;
-			runner.async_run(|mut config| {
-				let (client, _, import_queue, task_manager) = service::new_chain_ops(&mut config)?;
-				Ok((cmd.run(client, import_queue), task_manager))
-			})
-		}
-		*/
 		Some(Subcommand::TryRuntime(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 			runner.async_run(|config| {

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -432,7 +432,7 @@ pub fn run() -> Result<()> {
 		},
 		#[cfg(not(feature = "try-runtime"))]
 		Some(Subcommand::TryRuntime) => Err("TryRuntime wasn't enabled when building the node. \
-				You can enable it with `--features try-runtime`."
+				You can enable it at build time with `--features try-runtime`."
 			.into()),
 		Some(Subcommand::Key(cmd)) => Ok(cmd.run(&cli)?),
 		None => {

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -413,6 +413,36 @@ pub fn run() -> Result<()> {
 					.into())
 			}
 		}
+		#[cfg(feature = "try-runtime")]
+		/*
+		Some(Subcommand::CheckBlock(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|mut config| {
+				let (client, _, import_queue, task_manager) = service::new_chain_ops(&mut config)?;
+				Ok((cmd.run(client, import_queue), task_manager))
+			})
+		}
+		*/
+		Some(Subcommand::TryRuntime(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.async_run(|config| {
+				// we don't need any of the components of new_partial, just a runtime, or a task
+				// manager to do `async_run`.
+				let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
+				let task_manager =
+					sc_service::TaskManager::new(config.task_executor.clone(), registry)
+					.map_err(|e| sc_cli::Error::Service(sc_service::Error::Prometheus(e)))?;
+
+				// TODO: support all runtimes
+				Ok((cmd.run::<service::moonbase_runtime::Block, service::MoonbaseExecutor>(
+					config,
+				), task_manager))
+			})
+		},
+		#[cfg(not(feature = "try-runtime"))]
+		Some(Subcommand::TryRuntime) => Err("TryRuntime wasn't enabled when building the node. \
+				You can enable it with `--features try-runtime`."
+			.into()),
 		Some(Subcommand::Key(cmd)) => Ok(cmd.run(&cli)?),
 		None => {
 			let runner = cli.create_runner(&(*cli.run).normalize())?;

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -422,14 +422,15 @@ pub fn run() -> Result<()> {
 				let registry = config.prometheus_config.as_ref().map(|cfg| &cfg.registry);
 				let task_manager =
 					sc_service::TaskManager::new(config.task_executor.clone(), registry)
-					.map_err(|e| sc_cli::Error::Service(sc_service::Error::Prometheus(e)))?;
+						.map_err(|e| sc_cli::Error::Service(sc_service::Error::Prometheus(e)))?;
 
 				// TODO: support all runtimes
-				Ok((cmd.run::<service::moonbase_runtime::Block, service::MoonbaseExecutor>(
-					config,
-				), task_manager))
+				Ok((
+					cmd.run::<service::moonbase_runtime::Block, service::MoonbaseExecutor>(config),
+					task_manager,
+				))
 			})
-		},
+		}
 		#[cfg(not(feature = "try-runtime"))]
 		Some(Subcommand::TryRuntime) => Err("TryRuntime wasn't enabled when building the node. \
 				You can enable it at build time with `--features try-runtime`."

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -151,3 +151,6 @@ runtime-benchmarks = [
 	"moonbeam-runtime/runtime-benchmarks",
 	"moonbase-runtime/runtime-benchmarks",
 ]
+try-runtime = [
+	"moonbase-runtime/try-runtime",
+]

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -420,6 +420,15 @@ macro_rules! impl_runtime_apis_plus_common {
 					Ok(batches)
 				}
 			}
+
+			#[cfg(feature = "try-runtime")]
+			impl frame_try_runtime::TryRuntime<Block> for Runtime {
+				fn on_runtime_upgrade() -> Result<(Weight, Weight), sp_runtime::RuntimeString> {
+					log::info!("try-runtime::on_runtime_upgrade()");
+					let weight = Executive::try_runtime_upgrade()?;
+					Ok((weight, BlockWeights::get().max_block))
+				}
+			}
 		}
 	};
 }

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -185,5 +185,4 @@ try-runtime = [
 	"frame-executive/try-runtime",
 	"frame-try-runtime",
 	"frame-system/try-runtime",
-	"pallet-migrations/try-runtime",
 ]

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -87,6 +87,8 @@ cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", d
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8", optional = true }
 frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8", optional = true }
 
+frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8", optional = true }
+
 [dev-dependencies]
 cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
 cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
@@ -178,4 +180,10 @@ runtime-benchmarks = [
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-society/runtime-benchmarks",
 	"pallet-author-mapping/runtime-benchmarks",
+]
+try-runtime = [
+	"frame-executive/try-runtime",
+	"frame-try-runtime",
+	"frame-system/try-runtime",
+	"pallet-migrations/try-runtime",
 ]


### PR DESCRIPTION
### What does it do?

This PR plumbs `try-runtime` through our build system. It can be compiled with `--features try-runtime` and then invoked with the CLI sub-option `try-runtime`. 

Briefly, `try-runtime` allows a compiled node+runtime to be executed as though it was performing a runtime-upgrade against an arbitrary block pulled from a live network.

### What important points reviewers should know?

If you intend to develop something with this feature, I would suggest having a local node that is fully-synced with your target network.

### Is there something left for follow-up PRs?

This (so far) just adds the feature. Tests that actually use this feature will need to be written.

Also, something like [bench-bot](https://github.com/paritytech/bench-bot) will make this feature really useful. I've tried a couple times to set it up; it doesn't seem to play well out-of-the-box with Ubuntu, so it may take some effort.

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

Tools to help lower the probability of bricking chains after runtime upgrades!
