### PR TITLE
Reduce overhead of EVM tracing outside of block replaying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,8 +2107,7 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 [[package]]
 name = "evm"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f833b0e642bec8286b80f00ad6cc6a95e50210c77949b9cb484637e6a05ed596"
+source = "git+https://github.com/purestake/evm?branch=jeremy-evm27-tracing-performance#b6fed7e830103dcea12c71974c5cbc052d1b97dd"
 dependencies = [
  "environmental",
  "ethereum",
@@ -2126,8 +2125,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908739da31125d17a69533c290a6c818b494176e59a2ce8accbf122f7d76835c"
+source = "git+https://github.com/purestake/evm?branch=jeremy-evm27-tracing-performance#b6fed7e830103dcea12c71974c5cbc052d1b97dd"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -2138,8 +2136,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4118f952ce320c11e1b7b8a575e477d70bc86a3b92ea23e427174d979cf1da26"
+source = "git+https://github.com/purestake/evm?branch=jeremy-evm27-tracing-performance#b6fed7e830103dcea12c71974c5cbc052d1b97dd"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2150,8 +2147,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952296b416c3b334b26933ad1f9cfa9203e251691586fb317e411872886ca31b"
+source = "git+https://github.com/purestake/evm?branch=jeremy-evm27-tracing-performance#b6fed7e830103dcea12c71974c5cbc052d1b97dd"
 dependencies = [
  "environmental",
  "evm-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,7 +2107,7 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 [[package]]
 name = "evm"
 version = "0.27.0"
-source = "git+https://github.com/purestake/evm?branch=jeremy-evm27-tracing-performance#b6fed7e830103dcea12c71974c5cbc052d1b97dd"
+source = "git+https://github.com/purestake/evm?branch=jeremy-evm27-tracing-performance#98606a1943eae6047e8c6ea596765779675b6e86"
 dependencies = [
  "environmental",
  "ethereum",
@@ -2125,7 +2125,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.27.1"
-source = "git+https://github.com/purestake/evm?branch=jeremy-evm27-tracing-performance#b6fed7e830103dcea12c71974c5cbc052d1b97dd"
+source = "git+https://github.com/purestake/evm?branch=jeremy-evm27-tracing-performance#98606a1943eae6047e8c6ea596765779675b6e86"
 dependencies = [
  "funty",
  "parity-scale-codec",
@@ -2136,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.27.0"
-source = "git+https://github.com/purestake/evm?branch=jeremy-evm27-tracing-performance#b6fed7e830103dcea12c71974c5cbc052d1b97dd"
+source = "git+https://github.com/purestake/evm?branch=jeremy-evm27-tracing-performance#98606a1943eae6047e8c6ea596765779675b6e86"
 dependencies = [
  "environmental",
  "evm-core",
@@ -2147,7 +2147,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.27.0"
-source = "git+https://github.com/purestake/evm?branch=jeremy-evm27-tracing-performance#b6fed7e830103dcea12c71974c5cbc052d1b97dd"
+source = "git+https://github.com/purestake/evm?branch=jeremy-evm27-tracing-performance#98606a1943eae6047e8c6ea596765779675b6e86"
 dependencies = [
  "environmental",
  "evm-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,9 @@ exclude = [
 
 [profile.release]
 panic = 'unwind'
+
+# Fix EVM tracing impact in block production pipeline.
+[patch.crates-io]
+evm = { git = "https://github.com/purestake/evm", branch = "jeremy-evm27-tracing-performance"}
+evm-runtime = { git = "https://github.com/purestake/evm", branch = "jeremy-evm27-tracing-performance" }
+evm-gasometer = { git = "https://github.com/purestake/evm", branch = "jeremy-evm27-tracing-performance" }

--- a/runtime/evm_tracer/src/call_list.rs
+++ b/runtime/evm_tracer/src/call_list.rs
@@ -115,6 +115,10 @@ impl CallListTracer {
 	/// Consume the tracer and return it alongside the return value of
 	/// the closure.
 	pub fn trace<R, F: FnOnce() -> R>(self, f: F) {
+		evm::tracing::enable_tracing(true);
+		evm_gasometer::tracing::enable_tracing(true);
+		evm_runtime::tracing::enable_tracing(true);
+
 		let wrapped = Rc::new(RefCell::new(self));
 
 		let mut gasometer = ListenerProxy(Rc::clone(&wrapped));
@@ -128,6 +132,11 @@ impl CallListTracer {
 		let f = || gasometer_using(&mut gasometer, f);
 		let f = || evm_using(&mut evm, f);
 		f();
+
+		
+		evm::tracing::enable_tracing(false);
+		evm_gasometer::tracing::enable_tracing(false);
+		evm_runtime::tracing::enable_tracing(false);
 	}
 
 	/// Each extrinsic represents a Call stack in the host and thus a block - a collection of

--- a/runtime/evm_tracer/src/call_list.rs
+++ b/runtime/evm_tracer/src/call_list.rs
@@ -133,7 +133,6 @@ impl CallListTracer {
 		let f = || evm_using(&mut evm, f);
 		f();
 
-		
 		evm::tracing::enable_tracing(false);
 		evm_gasometer::tracing::enable_tracing(false);
 		evm_runtime::tracing::enable_tracing(false);

--- a/runtime/evm_tracer/src/raw.rs
+++ b/runtime/evm_tracer/src/raw.rs
@@ -96,6 +96,9 @@ impl RawTracer {
 	/// Consume the tracer and return it alongside the return value of
 	/// the closure.
 	pub fn trace<R, F: FnOnce() -> R>(self, f: F) {
+		evm_gasometer::tracing::enable_tracing(true);
+		evm_runtime::tracing::enable_tracing(true);
+
 		let wrapped = Rc::new(RefCell::new(self));
 
 		let mut gasometer = ListenerProxy(Rc::clone(&wrapped));
@@ -107,6 +110,9 @@ impl RawTracer {
 		let f = || runtime_using(&mut runtime, f);
 		let f = || gasometer_using(&mut gasometer, f);
 		f();
+
+		evm_gasometer::tracing::enable_tracing(false);
+		evm_runtime::tracing::enable_tracing(false);
 	}
 }
 


### PR DESCRIPTION
### What does it do?

Since there is only a single runtime blob and we need to be able to listen to EVM events for debug/trace, the `tracing` feature is enabled for 3 of the evm crates, even in the block production pipeline (since it's a compile time feature). However some benchmark have shown this have a huge impact on performance, as near 50% of the time is spent trying to acquire a listener in the environmental.

To reduce the overhead, a "short-circuit" boolean global is completely skip interacting with the environmental unless explicitly activated **at runtime**. I'm still waiting for the detailed benchmark but the results were promising.
The check is performed inside the macro call before the provided expression, meaning that the event data should not be computed if tracing is not enabled.

### What important points reviewers should know?

- This PR uses cargo patches to override the evm crates. Moonbeam is currently using version 0.27, while 0.30 is published on crates. However it introduces breaking changes that are not yet accounted for in upstream frontier. Thus the branch used in the patch is made on top of 0.27, while we'll make a PR to push it upstream on top of the latest evm version.
- The change in the evm crates uses unsafe code. However, it makes the same assumptions as the environmental crate that WASM execution is single threaded. Thus, it implements the unsafe `Sync` trait on a wrapper around a `RefCell<bool>` that is used to store the "short-circuit" switch. This static is not exposed publicly, instead a function to change its value is public. This avoids the risk of holding references which may cause the RefCell to panic. In std mode (native) the static is wrapped with `thread_local!` to avoid data races and ensure independent execution of multiple runtime executions on distinct threads.

### Is there something left for follow-up PRs?

Perform dependency upgrade when PR is merged in upstream evm repo, then included in Substrate.

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

- evm repo PR (on top of latest version) : https://github.com/rust-blockchain/evm/pull/53 

### What value does it bring to the blockchain users?
