### PR TITLE
Normalize currency units like moonriver conventions

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -82,12 +82,14 @@ pub type Precompiles = MoonbasePrecompiles<Runtime>;
 pub mod currency {
 	use super::Balance;
 
-	pub const UNIT: Balance = 1_000_000_000_000_000_000;
-	pub const KILOUNIT: Balance = UNIT * 1_000;
-	pub const MILLIUNIT: Balance = UNIT / 1_000;
-	pub const MICROUNIT: Balance = MILLIUNIT / 1_000;
-	pub const NANOUNIT: Balance = MICROUNIT / 1_000;
 	pub const WEI: Balance = 1;
+	pub const KILOWEI: Balance = 1_000;
+	pub const MEGAWEI: Balance = 1_000_000;
+	pub const GIGAWEI: Balance = 1_000_000_000;
+	pub const MICROUNIT: Balance = 1_000_000_000_000;
+	pub const MILLIUNIT: Balance = 1_000_000_000_000_000;
+	pub const UNIT: Balance = 1_000_000_000_000_000_000;
+	pub const KILOUNIT: Balance = 1_000_000_000_000_000_000_000;
 
 	pub const TRANSACTION_BYTE_FEE: Balance = 10 * MICROUNIT;
 	pub const STORAGE_BYTE_FEE: Balance = 100 * MICROUNIT;
@@ -318,7 +320,7 @@ parameter_types! {
 pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
 	fn min_gas_price() -> U256 {
-		(1 * currency::NANOUNIT).into()
+		(1 * currency::GIGAWEI).into()
 	}
 }
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -82,12 +82,14 @@ pub type Precompiles = MoonbeamPrecompiles<Runtime>;
 pub mod currency {
 	use super::Balance;
 
-	pub const GLMR: Balance = 1_000_000_000_000_000_000;
-	pub const KILOGLMR: Balance = GLMR * 1_000;
-	pub const MILLIGLMR: Balance = GLMR / 1_000;
-	pub const MICROGLMR: Balance = MILLIGLMR / 1_000;
-	pub const NANOGLMR: Balance = MICROGLMR / 1_000;
 	pub const WEI: Balance = 1;
+	pub const KILOWEI: Balance = 1_000;
+	pub const MEGAWEI: Balance = 1_000_000;
+	pub const GIGAWEI: Balance = 1_000_000_000;
+	pub const MICROGLMR: Balance = 1_000_000_000_000;
+	pub const MILLIGLMR: Balance = 1_000_000_000_000_000;
+	pub const GLMR: Balance = 1_000_000_000_000_000_000;
+	pub const KILOGLMR: Balance = 1_000_000_000_000_000_000_000;
 
 	pub const TRANSACTION_BYTE_FEE: Balance = 10 * MICROGLMR;
 	pub const STORAGE_BYTE_FEE: Balance = 100 * MICROGLMR;
@@ -333,7 +335,7 @@ parameter_types! {
 pub struct FixedGasPrice;
 impl FeeCalculator for FixedGasPrice {
 	fn min_gas_price() -> U256 {
-		(1 * currency::NANOGLMR).into()
+		(1 * currency::GIGAWEI).into()
 	}
 }
 


### PR DESCRIPTION
### What does it do?

Normalize currency unit constants according to the moonriver conventions for all runtimes.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
