### PR TITLE
Switch from `free_balance` to `reducible_balance`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "fp-storage",
  "kvdb",
@@ -2265,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "fc-consensus",
  "fc-db",
@@ -2283,7 +2283,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core 15.1.0",
@@ -2428,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2442,7 +2442,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "impl-trait-for-tuples 0.1.3",
@@ -2455,7 +2455,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "2.1.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 
 [[package]]
 name = "frame-benchmarking"
@@ -6159,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -6197,7 +6197,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "5.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -6224,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "fp-evm",
@@ -6236,7 +6236,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "fp-evm",
@@ -6250,7 +6250,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "fp-evm",
@@ -6262,7 +6262,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "fp-evm",
@@ -6274,7 +6274,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#6235ebb9afe295e8430ec5a889651f6bd7c17bbb"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "fp-evm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,7 +2224,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "fp-storage",
  "kvdb",
@@ -2265,7 +2265,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "fc-consensus",
  "fc-db",
@@ -2283,7 +2283,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "ethereum-types",
  "jsonrpc-core 15.1.0",
@@ -2428,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2442,7 +2442,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "impl-trait-for-tuples 0.1.3",
@@ -2455,7 +2455,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "2.1.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2471,7 +2471,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 
 [[package]]
 name = "frame-benchmarking"
@@ -6159,7 +6159,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -6197,7 +6197,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "5.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -6224,7 +6224,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "fp-evm",
@@ -6236,7 +6236,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "fp-evm",
@@ -6250,7 +6250,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "fp-evm",
@@ -6262,7 +6262,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "fp-evm",
@@ -6274,7 +6274,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-pre#053352d0555eb47b5777a3df9bec141972a3b024"
+source = "git+https://github.com/purestake/frontier?branch=moonriver-phase-four#053352d0555eb47b5777a3df9bec141972a3b024"
 dependencies = [
  "evm",
  "fp-evm",

--- a/client/rpc-core/txpool/Cargo.toml
+++ b/client/rpc-core/txpool/Cargo.toml
@@ -16,4 +16,4 @@ jsonrpc-derive = "14.0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }

--- a/client/rpc/debug/Cargo.toml
+++ b/client/rpc/debug/Cargo.toml
@@ -25,7 +25,7 @@ sp-utils = { git = "https://github.com/paritytech/substrate", branch = "polkadot
 
 moonbeam-rpc-core-debug = { path = "../../rpc-core/debug" }
 moonbeam-rpc-primitives-debug = { path = "../../../primitives/rpc/debug" }
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre", features = ["rpc_binary_search_estimate"] }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
+fc-db = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four", features = ["rpc_binary_search_estimate"] }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }

--- a/client/rpc/trace/Cargo.toml
+++ b/client/rpc/trace/Cargo.toml
@@ -28,7 +28,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 sp-transaction-pool = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
 moonbeam-rpc-primitives-debug = { path = "../../../primitives/rpc/debug" }
 
 # Client and RPC
@@ -36,7 +36,7 @@ jsonrpc-core = "15.0.0"
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 sc-network = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 sc-transaction-graph = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre", features = ["rpc_binary_search_estimate"] }
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four", features = ["rpc_binary_search_estimate"] }
+fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
 moonbeam-rpc-core-trace = { path = "../../rpc-core/trace" }

--- a/client/rpc/txpool/Cargo.toml
+++ b/client/rpc/txpool/Cargo.toml
@@ -24,4 +24,4 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 serde = { version = "1.0", features = ["derive"] }
 
 moonbeam-rpc-primitives-txpool = { path = "../../../primitives/rpc/txpool" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre", features = ["rpc_binary_search_estimate"] }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four", features = ["rpc_binary_search_estimate"] }

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -81,17 +81,17 @@ sc-consensus-manual-seal = { git = "https://github.com/paritytech/substrate", br
 frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 
-evm = { package = "pallet-evm", git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-ethereum = { package = "pallet-ethereum", git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+evm = { package = "pallet-evm", git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
+ethereum = { package = "pallet-ethereum", git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
 ethereum-primitives = { package = "ethereum", version = "0.7.1", default-features = false, features = ["with-codec"] }
 
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fp-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre", features = ["rpc_binary_search_estimate"] }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fc-mapping-sync = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
+fp-consensus = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four", features = ["rpc_binary_search_estimate"] }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
+fc-db = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
+fc-mapping-sync = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
 
 # Cumulus dependencies
 cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }

--- a/precompiles/crowdloan-rewards/Cargo.toml
+++ b/precompiles/crowdloan-rewards/Cargo.toml
@@ -13,7 +13,7 @@ frame-support = { git = "https://github.com/paritytech/substrate", branch = "pol
 evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
 pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", default-features = false, branch = "main" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 precompile-utils = { path = "../utils", default-features = false }

--- a/precompiles/parachain-staking/Cargo.toml
+++ b/precompiles/parachain-staking/Cargo.toml
@@ -15,7 +15,7 @@ evm = { version = "0.27.0", default-features = false, features = ["with-codec"] 
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
 parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 precompile-utils = { path = "../utils", default-features = false }

--- a/precompiles/utils/Cargo.toml
+++ b/precompiles/utils/Cargo.toml
@@ -16,7 +16,7 @@ codec = { package = "parity-scale-codec", version = "2.0.0", default-features = 
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
 evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
 
 precompile-utils-macro = { path = "macro" }

--- a/runtime/evm_tracer/Cargo.toml
+++ b/runtime/evm_tracer/Cargo.toml
@@ -9,8 +9,8 @@ repository = 'https://github.com/PureStake/moonbeam/'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false }
-fp-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
+fp-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
 evm = { version = "0.27.0", default-features = false, features = ["with-codec", "tracing"] }
 evm-runtime = { version = "0.27.0", default-features = false, features = ["tracing"] }
 evm-gasometer = { version = "0.27.0", default-features = false, features = ["tracing"] }

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -26,11 +26,11 @@ nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "jo
 pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
 evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
 precompile-utils = { path = "../../precompiles/utils", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
-pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
-pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
-pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
+pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
+pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
+pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
+pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
 
 
 # Substrate dependencies
@@ -58,11 +58,11 @@ pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", 
 
 frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
 pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 
-pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
+fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
 
 pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -26,11 +26,11 @@ nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "jo
 pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
 evm = { version="0.27.0", default-features=false, features=["with-codec"] }
 precompile-utils = { path = "../../precompiles/utils", default-features = false }
-pallet-evm-precompile-bn128 = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-pre" }
-pallet-evm-precompile-dispatch = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-pre" }
-pallet-evm-precompile-modexp = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-pre" }
-pallet-evm-precompile-simple = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-pre" }
-pallet-evm-precompile-sha3fips = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-pre" }
+pallet-evm-precompile-bn128 = { git="https://github.com/purestake/frontier", default-features=false, branch="moonriver-phase-four" }
+pallet-evm-precompile-dispatch = { git="https://github.com/purestake/frontier", default-features=false, branch="moonriver-phase-four" }
+pallet-evm-precompile-modexp = { git="https://github.com/purestake/frontier", default-features=false, branch="moonriver-phase-four" }
+pallet-evm-precompile-simple = { git="https://github.com/purestake/frontier", default-features=false, branch="moonriver-phase-four" }
+pallet-evm-precompile-sha3fips = { git="https://github.com/purestake/frontier", default-features=false, branch="moonriver-phase-four" }
 
 # Substrate dependencies
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
@@ -57,11 +57,11 @@ pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", 
 
 frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
 pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 
-pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
+fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
 
 pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -26,11 +26,11 @@ nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "jo
 pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
 evm = { version="0.27.0", default-features=false, features=["with-codec"] }
 precompile-utils = { path = "../../precompiles/utils", default-features = false }
-pallet-evm-precompile-bn128 = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-pre" }
-pallet-evm-precompile-dispatch = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-pre" }
-pallet-evm-precompile-modexp = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-pre" }
-pallet-evm-precompile-simple = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-pre" }
-pallet-evm-precompile-sha3fips = { git="https://github.com/purestake/frontier", default-features=false, branch="moonbeam-polkadot-pre" }
+pallet-evm-precompile-bn128 = { git="https://github.com/purestake/frontier", default-features=false, branch="moonriver-phase-four" }
+pallet-evm-precompile-dispatch = { git="https://github.com/purestake/frontier", default-features=false, branch="moonriver-phase-four" }
+pallet-evm-precompile-modexp = { git="https://github.com/purestake/frontier", default-features=false, branch="moonriver-phase-four" }
+pallet-evm-precompile-simple = { git="https://github.com/purestake/frontier", default-features=false, branch="moonriver-phase-four" }
+pallet-evm-precompile-sha3fips = { git="https://github.com/purestake/frontier", default-features=false, branch="moonriver-phase-four" }
 
 # Substrate dependencies
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
@@ -56,11 +56,11 @@ pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", 
 
 frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
-pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonbeam-polkadot-pre" }
+pallet-evm = { git = "https://github.com/purestake/frontier", default-features = false, branch = "moonriver-phase-four" }
 pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 
-pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
-fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-pre" }
+pallet-ethereum = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
+fp-rpc = { default-features = false, git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
 
 pallet-democracy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }
 pallet-scheduler = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8" }

--- a/tests/tests/test-balance-reducible.ts
+++ b/tests/tests/test-balance-reducible.ts
@@ -1,0 +1,67 @@
+import Keyring from "@polkadot/keyring";
+import { expect } from "chai";
+import {
+  GENESIS_ACCOUNT,
+  GENESIS_ACCOUNT_BALANCE,
+  GENESIS_ACCOUNT_PRIVATE_KEY,
+} from "../util/constants";
+import type { SubmittableExtrinsic } from "@polkadot/api/promise/types";
+import { describeDevMoonbeam } from "../util/setup-dev-tests";
+import { blake2AsHex } from "@polkadot/util-crypto";
+
+describeDevMoonbeam("Reducible Balance", (context) => {
+  const TEST_ACCOUNT = "0x1111111111111111111111111111111111111111";
+  it("should show the reducible balanced when some amount is locked", async function () {
+    const keyring = new Keyring({ type: "ethereum" });
+    const genesisAccount = await keyring.addFromUri(GENESIS_ACCOUNT_PRIVATE_KEY, null, "ethereum");
+
+    // Balance should be untouched
+    expect(await context.web3.eth.getBalance(GENESIS_ACCOUNT)).to.equal(
+      GENESIS_ACCOUNT_BALANCE.toString()
+    );
+
+    // Grab existential deposit
+    let existentialDeposit = (await context.polkadotApi.consts.balances.existentialDeposit) as any;
+
+    // Let's lock some funds by doing a public referendum proposal
+    let lock_amount = (await context.polkadotApi.consts.democracy.minimumDeposit) as any;
+    const proposal = context.polkadotApi.tx.balances.setBalance(TEST_ACCOUNT, 100, 100);
+
+    // We encode the proposal
+    let encodedProposal = (proposal as SubmittableExtrinsic)?.method.toHex() || "";
+    let encodedHash = blake2AsHex(encodedProposal);
+
+    // Submit the pre-image
+    await context.polkadotApi.tx.democracy
+      .notePreimage(encodedProposal)
+      .signAndSend(genesisAccount);
+
+    await context.createBlock();
+
+    // Record balance
+    let beforeBalance = await context.web3.eth.getBalance(GENESIS_ACCOUNT);
+
+    // Fees
+    const fee = (
+      await context.polkadotApi.tx.democracy
+        .propose(encodedHash, lock_amount)
+        .paymentInfo(genesisAccount)
+    ).partialFee as any;
+
+    // Propose
+    await context.polkadotApi.tx.democracy
+      .propose(encodedHash, lock_amount)
+      .signAndSend(genesisAccount);
+
+    await context.createBlock();
+
+    expect(await context.web3.eth.getBalance(GENESIS_ACCOUNT)).to.equal(
+      (
+        BigInt(beforeBalance) -
+        BigInt(lock_amount) +
+        BigInt(existentialDeposit) -
+        BigInt(fee)
+      ).toString()
+    );
+  });
+});


### PR DESCRIPTION
This PR brings the changes from https://github.com/paritytech/frontier/pull/420 into Moonbeam.

The upstream PR has not yet been merged because the upstream Substrate dependency is too old to support it. Moonbeam does not have this limitation.

In Moonbeam, this only changes the Frontier dependency, and the interesting work happened in our Frontier branch where I ran `git cherry-pick tgm-reducible-balance`. This graph shows the relevant git history in Frontier.
![image](https://user-images.githubusercontent.com/2915325/129784253-c1217277-ba18-4084-82a5-9c32334e1f5e.png)


