### PR TITLE
[Moonriver] Remove BaseFilter

### DIFF
--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -32,7 +32,7 @@ use cumulus_pallet_parachain_system::RelaychainBlockNumberProvider;
 use fp_rpc::TransactionStatus;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Filter, Get, Imbalance, InstanceFilter, OnUnbalanced},
+	traits::{Get, Imbalance, InstanceFilter, OnUnbalanced},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_PER_SECOND},
 		IdentityFee, Weight,
@@ -60,7 +60,7 @@ use sp_core::{u32_trait::*, OpaqueMetadata, H160, H256, U256};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{BlakeTwo256, Block as BlockT, IdentityLookup},
-	transaction_validity::{InvalidTransaction, TransactionSource, TransactionValidity},
+	transaction_validity::{TransactionSource, TransactionValidity},
 	AccountId32, ApplyExtrinsicResult, FixedPointNumber, Perbill, Percent, Permill, Perquintill,
 };
 use sp_std::{convert::TryFrom, prelude::*};
@@ -150,20 +150,6 @@ pub fn native_version() -> NativeVersion {
 
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
-/// Returns if calls are allowed through the filter
-pub struct BaseFilter;
-impl Filter<Call> for BaseFilter {
-	fn filter(c: &Call) -> bool {
-		match c {
-			Call::Balances(_) => false,
-			Call::CrowdloanRewards(_) => false,
-			Call::Ethereum(_) => false,
-			Call::EVM(_) => false,
-			_ => true,
-		}
-	}
-}
-
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 256;
 	pub const Version: RuntimeVersion = VERSION;
@@ -211,7 +197,7 @@ impl frame_system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type DbWeight = RocksDbWeight;
-	type BaseCallFilter = BaseFilter;
+	type BaseCallFilter = ();
 	type SystemWeightInfo = ();
 	/// This is used as an identifier of the chain. 42 is the generic substrate prefix.
 	type SS58Prefix = SS58Prefix;
@@ -872,14 +858,7 @@ runtime_common::impl_runtime_apis_plus_common! {
 			tx: <Block as BlockT>::Extrinsic,
 			block_hash: <Block as BlockT>::Hash,
 		) -> TransactionValidity {
-			// Filtered calls should not enter the tx pool as they'll fail if inserted.
-			let allowed = <Runtime as frame_system::Config>::BaseCallFilter::filter(&tx.function);
-
-			if allowed {
-				Executive::validate_transaction(source, tx, block_hash)
-			} else {
-				InvalidTransaction::Call.into()
-			}
+			Executive::validate_transaction(source, tx, block_hash)
 		}
 	}
 }

--- a/runtime/moonriver/tests/runtime_apis.rs
+++ b/runtime/moonriver/tests/runtime_apis.rs
@@ -25,7 +25,6 @@ use sp_core::{Public, H160, H256, U256};
 
 use fp_rpc::runtime_decl_for_EthereumRuntimeRPCApi::EthereumRuntimeRPCApi;
 use fp_rpc::ConvertTransaction;
-use frame_support::assert_noop;
 use moonbeam_rpc_primitives_debug::runtime_decl_for_DebugRuntimeApi::DebugRuntimeApi;
 use moonbeam_rpc_primitives_txpool::runtime_decl_for_TxPoolRuntimeApi::TxPoolRuntimeApi;
 use std::collections::BTreeMap;
@@ -226,14 +225,12 @@ fn ethereum_runtime_rpc_api_current_transaction_statuses() {
 		.execute_with(|| {
 			set_parachain_inherent_data();
 			set_author(NimbusId::from_slice(&ALICE_NIMBUS));
-			// Calls are currently filtered, so the extrinsic will fail to apply.
 			let result = Executive::apply_extrinsic(uxt()).expect("Apply result.");
-			assert_noop!(result, sp_runtime::DispatchError::BadOrigin);
-			// // Future us: uncomment below.
-			// run_to_block(2);
-			// let statuses =
-			// 	Runtime::current_transaction_statuses().expect("Transaction statuses result.");
-			// assert_eq!(statuses.len(), 1);
+			assert_eq!(result, Ok(()));
+			run_to_block(2);
+			let statuses =
+				Runtime::current_transaction_statuses().expect("Transaction statuses result.");
+			assert_eq!(statuses.len(), 1);
 		});
 }
 
@@ -290,13 +287,11 @@ fn ethereum_runtime_rpc_api_current_receipts() {
 		.execute_with(|| {
 			set_parachain_inherent_data();
 			set_author(NimbusId::from_slice(&ALICE_NIMBUS));
-			// Calls are currently filtered, so the extrinsic will fail to apply.
 			let result = Executive::apply_extrinsic(uxt()).expect("Apply result.");
-			assert_noop!(result, sp_runtime::DispatchError::BadOrigin);
-			// // Future us: uncomment below.
-			// run_to_block(2);
-			// let receipts = Runtime::current_receipts().expect("Receipts result.");
-			// assert_eq!(receipts.len(), 1);
+			assert_eq!(result, Ok(()));
+			run_to_block(2);
+			let receipts = Runtime::current_receipts().expect("Receipts result.");
+			assert_eq!(receipts.len(), 1);
 		});
 }
 


### PR DESCRIPTION
### What does it do?

Removes the `BaseFilter` in Moonriver, allowing all calls for Phase 4.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
