### PR TITLE
Always author in first slot of new round

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9121,6 +9121,9 @@ dependencies = [
 [[package]]
 name = "runtime-common"
 version = "0.8.0-dev"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -7,5 +7,8 @@ version = '0.8.0-dev'
 authors = ["PureStake"]
 edition = '2018'
 
+[dependencies]
+log = "0.4"
+
 [features]
 std = []

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -372,8 +372,18 @@ macro_rules! impl_runtime_apis_plus_common {
 					// work around it by always authoring the first slot in a new round. A longer-
 					// term solution will be to calculate the staking election result in the last
 					// block of the ending round.
-					parachain_staking::Pallet::<Self>::round().should_update(block_number)
-					|| AuthorInherent::can_author(&author, &slot)
+					if parachain_staking::Pallet::<Self>::round().should_update(block_number) {
+						log::info!(target: "nimbus-staking-workaround", "A new round is starting.\
+						Moonbeam will author during this slot without predicting eligibility first.\
+						You may see a `CannotBeAuthor` error soon. This is expected and harmless.\
+						It will be resolved soon.");
+
+						true
+					}
+					else {
+						AuthorInherent::can_author(&author, &slot)
+
+					}
 				}
 			}
 

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -351,20 +351,29 @@ macro_rules! impl_runtime_apis_plus_common {
 					slot: u32,
 					parent_header: &<Block as BlockT>::Header
 				) -> bool {
+					let block_number = parent_header.number + 1;
+
 					// The Moonbeam runtimes use an entropy source that needs to do some accounting
 					// work during block initialization. Therefore we initialize it here to match
 					// the state it will be in when the next block is being executed.
 					use frame_support::traits::OnInitialize;
 					System::initialize(
-						&(parent_header.number + 1),
+						&block_number,
 						&parent_header.hash(),
 						&parent_header.digest,
 						frame_system::InitKind::Inspection
 					);
-					RandomnessCollectiveFlip::on_initialize(System::block_number());
+					RandomnessCollectiveFlip::on_initialize(block_number);
 
-					// And now the actual prediction call
-					AuthorInherent::can_author(&author, &slot)
+					// Because the staking solution calculates the next staking set at the beginning
+					// of the first block in the next round, the only way to accurately predict the
+					// authors would be to run the staking election while predicting. However this
+					// election is heavy and will take too long during prediction. So instead we
+					// work around it by always authoring the first slot in a new round. A longer
+					// term solution will be to calculate the staking election result in the last
+					// block of the previous round.
+					parachain_staking::Pallet::<Self>::round().should_update(block_number)
+					|| AuthorInherent::can_author(&author, &slot)
 				}
 			}
 

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -366,12 +366,12 @@ macro_rules! impl_runtime_apis_plus_common {
 					RandomnessCollectiveFlip::on_initialize(block_number);
 
 					// Because the staking solution calculates the next staking set at the beginning
-					// of the first block in the next round, the only way to accurately predict the
+					// of the first block in the new round, the only way to accurately predict the
 					// authors would be to run the staking election while predicting. However this
 					// election is heavy and will take too long during prediction. So instead we
-					// work around it by always authoring the first slot in a new round. A longer
+					// work around it by always authoring the first slot in a new round. A longer-
 					// term solution will be to calculate the staking election result in the last
-					// block of the previous round.
+					// block of the ending round.
 					parachain_staking::Pallet::<Self>::round().should_update(block_number)
 					|| AuthorInherent::can_author(&author, &slot)
 				}


### PR DESCRIPTION
This PR introduces a temporary work-around to ensure that block production remains reliable even across round transitions.

Quoting from the body of the PR:
```rust
// Because the staking solution calculates the next staking set at the beginning
// of the first block in the new round, the only way to accurately predict the
// authors would be to run the staking election while predicting. However this
// election is heavy and will take too long during prediction. So instead we
// work around it by always authoring the first slot in a new round. A longer-
// term solution will be to calculate the staking election result in the last
// block of the ending round.
```

**Downside**
Because all collator nodes will author the first block in the new round while this code in effect, many of them will find that they are not in fact eligible. This will result in most collators displaying the following error a few times at the beginning of each round (every 300 blocks on moonriver).
```
2021-07-22 06:18:18 [🌗] Bad mandatory: Module { index: 18, error: 2, message: Some("CannotBeAuthor") }
2021-07-22 06:18:18 [🌗] ❌️ Mandatory inherent extrinsic returned error. Block cannot be produced.
2021-07-22 06:18:18 [🌗] Proposing failed. 
```
To make it more clear to collator node operators that this error is expected, harmless, and temporary, we've added an additional log at the beginning of each round that will tell the collator that the `CannotBeAuthor` error will come soon and is not a problem.

**testing**
I really have no idea how to test this...