### PR TITLE
Define and implement the `TraceResponseBuilder` trait

### DIFF
--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -30,6 +30,7 @@ use ethereum_types::{H128, H256};
 use fc_rpc::{frontier_backend_client, internal_err};
 use fp_rpc::EthereumRuntimeRPCApi;
 use moonbeam_rpc_primitives_debug::{proxy, single, DebugRuntimeApi, V2_RUNTIME_VERSION};
+use proxy::formats::TraceResponseBuilder;
 use sc_client_api::backend::Backend;
 use sp_api::{ApiExt, BlockId, Core, HeaderT, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
@@ -302,7 +303,7 @@ where
 								disable_stack,
 							);
 							proxy.using(f)?;
-							Ok(proxy.into_tx_trace())
+							Ok(proxy::formats::raw::Response::build(proxy).unwrap())
 						} else if api_version == 2 {
 							let mut proxy = proxy::v1::RawProxy::new();
 							proxy.using(f)?;
@@ -324,8 +325,7 @@ where
 						if runtime_version.spec_version >= V2_RUNTIME_VERSION && api_version >= 3 {
 							let mut proxy = proxy::v2::call_list::Listener::default();
 							proxy.using(f)?;
-							proxy
-								.into_tx_trace()
+							proxy::formats::blockscout::Response::build(proxy)
 								.ok_or("Trace result is empty.")
 								.map_err(|e| internal_err(format!("{:?}", e)))
 						} else if api_version == 2 {

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -56,6 +56,7 @@ pub use moonbeam_rpc_core_trace::{
 	FilterRequest, RequestBlockId, RequestBlockTag, Trace as TraceT, TraceServer, TransactionTrace,
 };
 use moonbeam_rpc_primitives_debug::{block, proxy, DebugRuntimeApi, V2_RUNTIME_VERSION};
+use proxy::formats::TraceResponseBuilder;
 
 /// RPC handler. Will communicate with a `CacheTask` through a `CacheRequester`.
 pub struct Trace<B, C> {
@@ -927,7 +928,7 @@ where
 		if runtime_version.spec_version >= V2_RUNTIME_VERSION && api_version >= 3 {
 			let mut proxy = proxy::v2::call_list::Listener::default();
 			proxy.using(f)?;
-			let mut traces: Vec<_> = proxy.into_tx_traces();
+			let mut traces: Vec<_> = proxy::formats::trace_filter::Response::build(proxy).unwrap();
 			// Fill missing data.
 			for trace in traces.iter_mut() {
 				trace.block_hash = eth_block_hash;

--- a/primitives/rpc/debug/src/proxy/formats/blockscout.rs
+++ b/primitives/rpc/debug/src/proxy/formats/blockscout.rs
@@ -14,7 +14,22 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-pub mod formats;
-pub mod types;
-pub mod v1;
-pub mod v2;
+use crate::proxy::v2::call_list::Listener;
+use crate::single::TransactionTrace;
+
+pub struct Response;
+
+#[cfg(feature = "std")]
+impl super::TraceResponseBuilder for Response {
+	type Listener = Listener;
+	type Response = TransactionTrace;
+
+	fn build(listener: Listener) -> Option<TransactionTrace> {
+		if let Some(entry) = listener.entries.last() {
+			return Some(TransactionTrace::CallList(
+				entry.into_iter().map(|(_, value)| value.clone()).collect(),
+			));
+		}
+		None
+	}
+}

--- a/primitives/rpc/debug/src/proxy/formats/mod.rs
+++ b/primitives/rpc/debug/src/proxy/formats/mod.rs
@@ -14,7 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-pub mod formats;
-pub mod types;
-pub mod v1;
-pub mod v2;
+pub mod blockscout;
+pub mod raw;
+pub mod trace_filter;
+
+use crate::proxy::v2::Listener;
+#[cfg(feature = "std")]
+use serde::Serialize;
+
+#[cfg(feature = "std")]
+pub trait TraceResponseBuilder {
+	type Listener: Listener;
+	type Response: Serialize;
+
+	fn build(listener: Self::Listener) -> Option<Self::Response>;
+}

--- a/primitives/rpc/debug/src/proxy/formats/raw.rs
+++ b/primitives/rpc/debug/src/proxy/formats/raw.rs
@@ -14,7 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-pub mod formats;
-pub mod types;
-pub mod v1;
-pub mod v2;
+use crate::proxy::v2::raw::Listener;
+use crate::single::TransactionTrace;
+
+pub struct Response;
+
+#[cfg(feature = "std")]
+impl super::TraceResponseBuilder for Response {
+	type Listener = Listener;
+	type Response = TransactionTrace;
+
+	fn build(listener: Listener) -> Option<TransactionTrace> {
+		Some(TransactionTrace::Raw {
+			step_logs: listener.step_logs,
+			gas: listener.final_gas.into(),
+			return_value: listener.return_value,
+		})
+	}
+}

--- a/primitives/rpc/debug/src/proxy/formats/trace_filter.rs
+++ b/primitives/rpc/debug/src/proxy/formats/trace_filter.rs
@@ -1,0 +1,133 @@
+// Copyright 2019-2021 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::block::{
+	TransactionTrace, TransactionTraceAction, TransactionTraceOutput, TransactionTraceResult,
+};
+use crate::proxy::v2::call_list::Listener;
+use crate::{single::CallInner, CallResult, CreateResult, CreateType};
+
+pub use ethereum_types::{H160, H256, U256};
+
+pub struct Response;
+
+#[cfg(feature = "std")]
+impl super::TraceResponseBuilder for Response {
+	type Listener = Listener;
+	type Response = Vec<TransactionTrace>;
+
+	fn build(listener: Listener) -> Option<Vec<TransactionTrace>> {
+		let mut traces = Vec::new();
+		for (eth_tx_index, entry) in listener.entries.iter().enumerate() {
+			let mut tx_traces: Vec<_> = entry
+				.into_iter()
+				.map(|(_, trace)| match trace.inner.clone() {
+					CallInner::Call {
+						input,
+						to,
+						res,
+						call_type,
+					} => TransactionTrace {
+						action: TransactionTraceAction::Call {
+							call_type,
+							from: trace.from,
+							gas: trace.gas,
+							input,
+							to,
+							value: trace.value,
+						},
+						// Can't be known here, must be inserted upstream.
+						block_hash: H256::default(),
+						// Can't be known here, must be inserted upstream.
+						block_number: 0,
+						output: match res {
+							CallResult::Output(output) => {
+								TransactionTraceOutput::Result(TransactionTraceResult::Call {
+									gas_used: trace.gas_used,
+									output,
+								})
+							}
+							CallResult::Error(error) => TransactionTraceOutput::Error(error),
+						},
+						subtraces: trace.subtraces,
+						trace_address: trace.trace_address.clone(),
+						// Can't be known here, must be inserted upstream.
+						transaction_hash: H256::default(),
+						transaction_position: eth_tx_index as u32,
+					},
+					CallInner::Create { init, res } => {
+						TransactionTrace {
+							action: TransactionTraceAction::Create {
+								creation_method: CreateType::Create,
+								from: trace.from,
+								gas: trace.gas,
+								init,
+								value: trace.value,
+							},
+							// Can't be known here, must be inserted upstream.
+							block_hash: H256::default(),
+							// Can't be known here, must be inserted upstream.
+							block_number: 0,
+							output: match res {
+								CreateResult::Success {
+									created_contract_address_hash,
+									created_contract_code,
+								} => {
+									TransactionTraceOutput::Result(TransactionTraceResult::Create {
+										gas_used: trace.gas_used,
+										code: created_contract_code,
+										address: created_contract_address_hash,
+									})
+								}
+								CreateResult::Error { error } => {
+									TransactionTraceOutput::Error(error)
+								}
+							},
+							subtraces: trace.subtraces,
+							trace_address: trace.trace_address.clone(),
+							// Can't be known here, must be inserted upstream.
+							transaction_hash: H256::default(),
+							transaction_position: eth_tx_index as u32,
+						}
+					}
+					CallInner::SelfDestruct {
+						balance,
+						refund_address,
+					} => TransactionTrace {
+						action: TransactionTraceAction::Suicide {
+							address: trace.from,
+							balance,
+							refund_address,
+						},
+						// Can't be known here, must be inserted upstream.
+						block_hash: H256::default(),
+						// Can't be known here, must be inserted upstream.
+						block_number: 0,
+						output: TransactionTraceOutput::Result(TransactionTraceResult::Suicide),
+						subtraces: trace.subtraces,
+						trace_address: trace.trace_address.clone(),
+						// Can't be known here, must be inserted upstream.
+						transaction_hash: H256::default(),
+						transaction_position: eth_tx_index as u32,
+					},
+				})
+				.collect();
+
+			traces.append(&mut tx_traces);
+		}
+		Some(traces)
+	}
+}

--- a/primitives/rpc/debug/src/proxy/v2/call_list.rs
+++ b/primitives/rpc/debug/src/proxy/v2/call_list.rs
@@ -17,15 +17,11 @@
 extern crate alloc;
 use super::{
 	Capture, ContextType, Event, EvmEvent, ExitError, ExitReason, ExitSucceed, GasometerEvent,
-	Listener as ListenerT, RuntimeEvent, H160, H256, U256,
+	Listener as ListenerT, RuntimeEvent, H160, U256,
 };
 use crate::{
-	block::{
-		TransactionTrace as BlockTrace, TransactionTraceAction, TransactionTraceOutput,
-		TransactionTraceResult,
-	},
-	single::{Call, CallInner, TransactionTrace as SingleTrace},
-	CallResult, CallType, CreateResult, CreateType,
+	single::{Call, CallInner},
+	CallResult, CallType, CreateResult,
 };
 use alloc::{collections::btree_map::BTreeMap, vec, vec::Vec};
 
@@ -34,7 +30,7 @@ pub struct Listener {
 	transaction_cost: u64,
 
 	// Final logs.
-	entries: Vec<BTreeMap<u32, Call>>,
+	pub entries: Vec<BTreeMap<u32, Call>>,
 	// Next index to use.
 	entries_next_index: u32,
 	// Stack of contexts with data to keep between events.
@@ -85,119 +81,6 @@ impl Default for Listener {
 impl Listener {
 	pub fn using<R, F: FnOnce() -> R>(&mut self, f: F) -> R {
 		super::listener::using(self, f)
-	}
-
-	pub fn into_tx_trace(self) -> Option<SingleTrace> {
-		if let Some(entry) = self.entries.last() {
-			return Some(SingleTrace::CallList(
-				entry.into_iter().map(|(_, value)| value.clone()).collect(),
-			));
-		}
-		None
-	}
-
-	/// Format the RPC output for multiple transactions. Each call-stack represents a single
-	/// transaction/EVM execution.
-	pub fn into_tx_traces(self) -> Vec<BlockTrace> {
-		let mut traces = Vec::new();
-		for (eth_tx_index, entry) in self.entries.iter().enumerate() {
-			let mut tx_traces: Vec<_> = entry
-				.into_iter()
-				.map(|(_, trace)| match trace.inner.clone() {
-					CallInner::Call {
-						input,
-						to,
-						res,
-						call_type,
-					} => BlockTrace {
-						action: TransactionTraceAction::Call {
-							call_type,
-							from: trace.from,
-							gas: trace.gas,
-							input,
-							to,
-							value: trace.value,
-						},
-						// Can't be known here, must be inserted upstream.
-						block_hash: H256::default(),
-						// Can't be known here, must be inserted upstream.
-						block_number: 0,
-						output: match res {
-							CallResult::Output(output) => {
-								TransactionTraceOutput::Result(TransactionTraceResult::Call {
-									gas_used: trace.gas_used,
-									output,
-								})
-							}
-							crate::CallResult::Error(error) => TransactionTraceOutput::Error(error),
-						},
-						subtraces: trace.subtraces,
-						trace_address: trace.trace_address.clone(),
-						// Can't be known here, must be inserted upstream.
-						transaction_hash: H256::default(),
-						transaction_position: eth_tx_index as u32,
-					},
-					CallInner::Create { init, res } => {
-						BlockTrace {
-							action: TransactionTraceAction::Create {
-								creation_method: CreateType::Create,
-								from: trace.from,
-								gas: trace.gas,
-								init,
-								value: trace.value,
-							},
-							// Can't be known here, must be inserted upstream.
-							block_hash: H256::default(),
-							// Can't be known here, must be inserted upstream.
-							block_number: 0,
-							output: match res {
-								CreateResult::Success {
-									created_contract_address_hash,
-									created_contract_code,
-								} => {
-									TransactionTraceOutput::Result(TransactionTraceResult::Create {
-										gas_used: trace.gas_used,
-										code: created_contract_code,
-										address: created_contract_address_hash,
-									})
-								}
-								crate::CreateResult::Error { error } => {
-									TransactionTraceOutput::Error(error)
-								}
-							},
-							subtraces: trace.subtraces,
-							trace_address: trace.trace_address.clone(),
-							// Can't be known here, must be inserted upstream.
-							transaction_hash: H256::default(),
-							transaction_position: eth_tx_index as u32,
-						}
-					}
-					CallInner::SelfDestruct {
-						balance,
-						refund_address,
-					} => BlockTrace {
-						action: TransactionTraceAction::Suicide {
-							address: trace.from,
-							balance,
-							refund_address,
-						},
-						// Can't be known here, must be inserted upstream.
-						block_hash: H256::default(),
-						// Can't be known here, must be inserted upstream.
-						block_number: 0,
-						output: TransactionTraceOutput::Result(TransactionTraceResult::Suicide),
-						subtraces: trace.subtraces,
-						trace_address: trace.trace_address.clone(),
-						// Can't be known here, must be inserted upstream.
-						transaction_hash: H256::default(),
-						transaction_position: eth_tx_index as u32,
-					},
-				})
-				.collect();
-
-			traces.append(&mut tx_traces);
-		}
-		traces
 	}
 
 	pub fn gasometer_event(&mut self, event: GasometerEvent) {

--- a/primitives/rpc/debug/src/proxy/v2/raw.rs
+++ b/primitives/rpc/debug/src/proxy/v2/raw.rs
@@ -21,9 +21,9 @@ use super::{
 };
 use alloc::{collections::btree_map::BTreeMap, vec, vec::Vec};
 
-use crate::single::{RawStepLog, TransactionTrace as SingleTrace};
+use crate::single::RawStepLog;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Listener {
 	disable_storage: bool,
 	disable_memory: bool,
@@ -32,12 +32,12 @@ pub struct Listener {
 	new_context: bool,
 	context_stack: Vec<Context>,
 
-	step_logs: Vec<RawStepLog>,
-	return_value: Vec<u8>,
-	final_gas: u64,
+	pub step_logs: Vec<RawStepLog>,
+	pub return_value: Vec<u8>,
+	pub final_gas: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Context {
 	storage_cache: BTreeMap<H256, H256>,
 	address: H160,
@@ -45,7 +45,7 @@ struct Context {
 	global_storage_changes: BTreeMap<H160, BTreeMap<H256, H256>>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct Step {
 	/// Current opcode.
 	opcode: Vec<u8>,
@@ -83,13 +83,13 @@ impl Listener {
 		super::listener::using(self, f)
 	}
 
-	pub fn into_tx_trace(self) -> SingleTrace {
-		SingleTrace::Raw {
-			step_logs: self.step_logs,
-			gas: self.final_gas.into(),
-			return_value: self.return_value,
-		}
-	}
+	// pub fn into_tx_trace(self) -> SingleTrace {
+	// 	SingleTrace::Raw {
+	// 		step_logs: self.step_logs,
+	// 		gas: self.final_gas.into(),
+	// 		return_value: self.return_value,
+	// 	}
+	// }
 
 	pub fn gasometer_event(&mut self, event: GasometerEvent) {
 		match event {

--- a/primitives/rpc/debug/src/proxy/v2/raw.rs
+++ b/primitives/rpc/debug/src/proxy/v2/raw.rs
@@ -83,14 +83,6 @@ impl Listener {
 		super::listener::using(self, f)
 	}
 
-	// pub fn into_tx_trace(self) -> SingleTrace {
-	// 	SingleTrace::Raw {
-	// 		step_logs: self.step_logs,
-	// 		gas: self.final_gas.into(),
-	// 		return_value: self.return_value,
-	// 	}
-	// }
-
 	pub fn gasometer_event(&mut self, event: GasometerEvent) {
 		match event {
 			GasometerEvent::RecordTransaction { .. } => {

--- a/primitives/rpc/debug/src/proxy/v2/raw.rs
+++ b/primitives/rpc/debug/src/proxy/v2/raw.rs
@@ -23,7 +23,7 @@ use alloc::{collections::btree_map::BTreeMap, vec, vec::Vec};
 
 use crate::single::RawStepLog;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Listener {
 	disable_storage: bool,
 	disable_memory: bool,
@@ -37,7 +37,7 @@ pub struct Listener {
 	pub final_gas: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct Context {
 	storage_cache: BTreeMap<H256, H256>,
 	address: H160,
@@ -45,7 +45,7 @@ struct Context {
 	global_storage_changes: BTreeMap<H160, BTreeMap<H256, H256>>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 struct Step {
 	/// Current opcode.
 	opcode: Vec<u8>,


### PR DESCRIPTION
### What does it do?

Decouples the response format from the event `Listener`.

The goal is to have a proper way for supporting multiple formatters without populating the proxy itself: once the trace has finished, we move the `Listener` to a `TraceResponseBuilder` implementor that will process the trace and satisfy the request format.

### Is there something left for follow-up PRs?

This PR prepares the ground for introducing the Etherscan response format, which will be an additional `TraceResponseBuilder` implementor.