### PR TITLE
Fix off-by-one in active_on_initialize benchmark

### DIFF
--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -524,9 +524,9 @@ benchmarks! {
 		let before_running_round_index = Pallet::<T>::round().current;
 		let round_length: T::BlockNumber = Pallet::<T>::round().length.into();
 		let reward_delay = <<T as Config>::RewardPaymentDelay as Get<u32>>::get() + 2u32;
-		let mut now = <frame_system::Pallet<T>>::block_number();
+		let mut now = <frame_system::Pallet<T>>::block_number() + 1u32.into();
 		let mut counter = 0usize;
-		let end = Pallet::<T>::round().first + (round_length * reward_delay.into()) - 1u32.into();
+		let end = Pallet::<T>::round().first + (round_length * reward_delay.into());
 		// SET collators as authors for blocks from now - end
 		while now < end {
 			let author = collators[counter % collators.len()].clone();

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -526,7 +526,7 @@ benchmarks! {
 		let reward_delay = <<T as Config>::RewardPaymentDelay as Get<u32>>::get() + 2u32;
 		let mut now = <frame_system::Pallet<T>>::block_number();
 		let mut counter = 0usize;
-		let end = Pallet::<T>::round().first + (round_length * reward_delay.into());
+		let end = Pallet::<T>::round().first + (round_length * reward_delay.into()) - 1u32.into();
 		// SET collators as authors for blocks from now - end
 		while now < end {
 			let author = collators[counter % collators.len()].clone();

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -294,7 +294,7 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(9 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
 	}
-	fn active_on_initialize(x: u32, y: u32, ) -> Weight {
+	fn active_on_initialize(x: u32, y: u32) -> Weight {
 		(0 as Weight)
 			// Standard Error: 299_000
 			.saturating_add((208_550_000 as Weight).saturating_mul(x as Weight))

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -176,13 +176,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(9 as Weight))
 			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
-	fn active_on_initialize(x: u32, y: u32) -> Weight {
-		(10_177_000 as Weight)
-			// Standard Error: 0
-			.saturating_add((24_000 as Weight).saturating_mul(x as Weight))
-			// Standard Error: 0
-			.saturating_add((1_000 as Weight).saturating_mul(y as Weight))
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+	fn active_on_initialize(x: u32, y: u32, ) -> Weight {
+		(0 as Weight)
+			// Standard Error: 299_000
+			.saturating_add((208_550_000 as Weight).saturating_mul(x as Weight))
+			// Standard Error: 27_000
+			.saturating_add((15_580_000 as Weight).saturating_mul(y as Weight))
+			.saturating_add(T::DbWeight::get().reads(26 as Weight))
+			.saturating_add(T::DbWeight::get().reads((4 as Weight).saturating_mul(x as Weight)))
+			.saturating_add(T::DbWeight::get().writes(16 as Weight))
+			.saturating_add(T::DbWeight::get().writes((4 as Weight).saturating_mul(x as Weight)))
 	}
 	fn passive_on_initialize() -> Weight {
 		(4_913_000 as Weight).saturating_add(T::DbWeight::get().reads(1 as Weight))
@@ -291,13 +294,16 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(9 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
 	}
-	fn active_on_initialize(x: u32, y: u32) -> Weight {
-		(10_177_000 as Weight)
-			// Standard Error: 0
-			.saturating_add((24_000 as Weight).saturating_mul(x as Weight))
-			// Standard Error: 0
-			.saturating_add((1_000 as Weight).saturating_mul(y as Weight))
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
+	fn active_on_initialize(x: u32, y: u32, ) -> Weight {
+		(0 as Weight)
+			// Standard Error: 299_000
+			.saturating_add((208_550_000 as Weight).saturating_mul(x as Weight))
+			// Standard Error: 27_000
+			.saturating_add((15_580_000 as Weight).saturating_mul(y as Weight))
+			.saturating_add(RocksDbWeight::get().reads(26 as Weight))
+			.saturating_add(RocksDbWeight::get().reads((4 as Weight).saturating_mul(x as Weight)))
+			.saturating_add(RocksDbWeight::get().writes(16 as Weight))
+			.saturating_add(RocksDbWeight::get().writes((4 as Weight).saturating_mul(x as Weight)))
 	}
 	fn passive_on_initialize() -> Weight {
 		(4_913_000 as Weight).saturating_add(RocksDbWeight::get().reads(1 as Weight))

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -176,7 +176,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(9 as Weight))
 			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
-	fn active_on_initialize(x: u32, y: u32, ) -> Weight {
+	fn active_on_initialize(x: u32, y: u32) -> Weight {
 		(0 as Weight)
 			// Standard Error: 299_000
 			.saturating_add((208_550_000 as Weight).saturating_mul(x as Weight))


### PR DESCRIPTION
### What does it do?

Fixes what I think is a off-by-one error in `parachain-staking`'s `active_on_initialize` benchmark.

Resulting benchmark results:

```rust
// before
    fn active_on_initialize(x: u32, _y: u32, ) -> Weight {
        (8_739_000 as Weight)
            // Standard Error: 11_000
            .saturating_add((29_000 as Weight).saturating_mul(x as Weight))
            .saturating_add(T::DbWeight::get().reads(2 as Weight))
    }
```

```rust
// after
	fn active_on_initialize(x: u32, y: u32, ) -> Weight {
		(0 as Weight)
			// Standard Error: 1_191_000
			.saturating_add((182_543_000 as Weight).saturating_mul(x as Weight))
			// Standard Error: 109_000
			.saturating_add((13_710_000 as Weight).saturating_mul(y as Weight))
			.saturating_add(T::DbWeight::get().reads(26 as Weight))
			.saturating_add(T::DbWeight::get().reads((4 as Weight).saturating_mul(x as Weight)))
			.saturating_add(T::DbWeight::get().writes(16 as Weight))
			.saturating_add(T::DbWeight::get().writes((4 as Weight).saturating_mul(x as Weight)))
	}
```