### PR TITLE
Reset crowdloan rewards storage in Moonbase runtime only.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6086,7 +6086,7 @@ dependencies = [
 [[package]]
 name = "pallet-crowdloan-rewards"
 version = "0.6.0"
-source = "git+https://github.com/purestake/crowdloan-rewards?branch=main#7d1e7e87e8adfd7470b9bc31af10e5ee33e25c90"
+source = "git+https://github.com/purestake/crowdloan-rewards?branch=main#8c404ee11e52587f571c1f0389168c3a992d81d3"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",

--- a/moonbeam-types-bundle/index.ts
+++ b/moonbeam-types-bundle/index.ts
@@ -713,6 +713,7 @@ export const moonbeamDefinitions = {
         RewardInfo: {
           total_reward: "Balance",
           claimed_reward: "Balance",
+          contributed_relay_addresses: "Vec<RelayChainAccountId>",
         },
         RegistrationInfo: {
           account: "AccountId",

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -663,7 +663,6 @@ impl frame_support::traits::OnRuntimeUpgrade for NukeRewardsStorage {
 
 
 parameter_types! {
-	// TODO to be revisited
 	pub const VestingPeriod: BlockNumber = 4 * WEEKS;
 	pub const MinimumReward: Balance = 0;
 	pub const Initialized: bool = false;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -673,12 +673,26 @@ impl frame_support::traits::OnRuntimeUpgrade for NukeRewardsStorage {
 		// 	pallet_crowdloan_rewards::AccountsPayable::drain().next().is_none(),
 		// 	"AccountPayable map was not reset"
 		// );
-		ensure!(!CrowdloanRewards::initialized(), "Initialized storage item is set to true");
-		ensure!(CrowdloanRewards::init_relay_block() == 0, "Init relay block is not 0");
-		ensure!(CrowdloanRewards::end_relay_block() == 0, "End relay block is not 0");
-		ensure!(CrowdloanRewards::init_reward_amount() == 0, "Init reward amount is not 0");
-		ensure!(CrowdloanRewards::total_contributors() == 0, "Total contributors is not 0");
-
+		ensure!(
+			!CrowdloanRewards::initialized(),
+			"Initialized storage item is set to true"
+		);
+		ensure!(
+			CrowdloanRewards::init_relay_block() == 0,
+			"Init relay block is not 0"
+		);
+		ensure!(
+			CrowdloanRewards::end_relay_block() == 0,
+			"End relay block is not 0"
+		);
+		ensure!(
+			CrowdloanRewards::init_reward_amount() == 0,
+			"Init reward amount is not 0"
+		);
+		ensure!(
+			CrowdloanRewards::total_contributors() == 0,
+			"Total contributors is not 0"
+		);
 
 		// Ensure that the pot balance is correct
 		ensure!(

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -634,6 +634,27 @@ impl pallet_author_slot_filter::Config for Runtime {
 	type PotentialAuthors = ParachainStaking;
 }
 
+/// Migration that destroys all of pallet crowdloan rewards' stored data.
+///
+/// This is included in moonbase only so that we can re-test rewards intialization with the new
+/// version of the pallet. This migration makes no attempt to recouperate already-claimed tokens
+/// and it also mints tokens for the nwe pot.
+///
+/// NOT FOR USE IN VALUE-BEARING NETWORKS!
+pub struct NukeRewardsStorage;
+
+impl frame_support::traits::OnRuntimeUpgrade for NukeRewardsStorage {
+	fn on_runtime_upgrade() -> Weight {
+		//TODO Delete all crowdlaon rewards storage
+
+		//TODO Reset the pot's funds
+
+		//TODO Return a reasonable weight
+		10_000
+	}
+}
+
+
 parameter_types! {
 	// TODO to be revisited
 	pub const VestingPeriod: BlockNumber = 4 * WEEKS;
@@ -828,6 +849,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPallets,
+	NukeRewardsStorage,
 >;
 
 // All of our runtimes share most of their Runtime API implementations.

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -653,7 +653,6 @@ impl frame_support::traits::OnRuntimeUpgrade for NukeRewardsStorage {
 		// Reset the pot's funds
 		<Balances as frame_support::traits::Currency<AccountId>>::make_free_balance_be(
 			&CrowdloanRewards::account_id(),
-			//TODO is this the right amount to initialize to?
 			3_000_000 * currency::UNIT,
 		);
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -662,6 +662,32 @@ impl frame_support::traits::OnRuntimeUpgrade for NukeRewardsStorage {
 		// * One for updating the total issuance
 		3 * <Runtime as frame_system::Config>::DbWeight::get().write
 	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		use frame_support::ensure;
+
+		// Ensure that the storage is killed
+		// TODO how to ensure that the maps are empty?
+		// ensure!(
+		// 	pallet_crowdloan_rewards::AccountsPayable::drain().next().is_none(),
+		// 	"AccountPayable map was not reset"
+		// );
+		ensure!(!CrowdloanRewards::initialized(), "Initialized storage item is set to true");
+		ensure!(CrowdloanRewards::init_relay_block() == 0, "Init relay block is not 0");
+		ensure!(CrowdloanRewards::end_relay_block() == 0, "End relay block is not 0");
+		ensure!(CrowdloanRewards::init_reward_amount() == 0, "Init reward amount is not 0");
+		ensure!(CrowdloanRewards::total_contributors() == 0, "Total contributors is not 0");
+
+
+		// Ensure that the pot balance is correct
+		ensure!(
+			Balances::free_balance(&CrowdloanRewards::account_id()) == 3_000_000 * currency::UNIT,
+			"Pot balance was not set correctly during migration"
+		);
+
+		Ok(())
+	}
 }
 
 parameter_types! {

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -651,7 +651,11 @@ impl frame_support::traits::OnRuntimeUpgrade for NukeRewardsStorage {
 		frame_support::storage::migration::remove_storage_prefix(b"CrowdloanRewards", &[], &[]);
 
 		// Reset the pot's funds
-		<Balances as frame_support::traits::Currency<AccountId>>::make_free_balance_be(&CrowdloanRewards::account_id(), 3_000_000 * currency::UNIT);
+		<Balances as frame_support::traits::Currency<AccountId>>::make_free_balance_be(
+			&CrowdloanRewards::account_id(),
+			//TODO is this the right amount to initialize to?
+			3_000_000 * currency::UNIT,
+		);
 
 		// Return weight of three DB writes (I'm not really that confident this is right)
 		// * One for the prefix removal
@@ -660,7 +664,6 @@ impl frame_support::traits::OnRuntimeUpgrade for NukeRewardsStorage {
 		3 * <Runtime as frame_system::Config>::DbWeight::get().write
 	}
 }
-
 
 parameter_types! {
 	pub const VestingPeriod: BlockNumber = 4 * WEEKS;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -650,7 +650,8 @@ impl frame_support::traits::OnRuntimeUpgrade for NukeRewardsStorage {
 		// This will cause the entire pallet's storage to be deleted
 		frame_support::storage::migration::remove_storage_prefix(b"CrowdloanRewards", &[], &[]);
 
-		//TODO Reset the pot's funds
+		// Reset the pot's funds
+		<Balances as frame_support::traits::Currency<AccountId>>::make_free_balance_be(&CrowdloanRewards::account_id(), 3_000_000 * currency::UNIT);
 
 		//TODO Return a reasonable weight
 		10_000

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -638,14 +638,17 @@ impl pallet_author_slot_filter::Config for Runtime {
 ///
 /// This is included in moonbase only so that we can re-test rewards intialization with the new
 /// version of the pallet. This migration makes no attempt to recouperate already-claimed tokens
-/// and it also mints tokens for the nwe pot.
+/// and it also mints tokens for the new pot.
 ///
 /// NOT FOR USE IN VALUE-BEARING NETWORKS!
 pub struct NukeRewardsStorage;
 
 impl frame_support::traits::OnRuntimeUpgrade for NukeRewardsStorage {
 	fn on_runtime_upgrade() -> Weight {
-		//TODO Delete all crowdlaon rewards storage
+		// Delete all crowdlaon rewards storage
+		// Supply only the pallet name, no storage item name or map key
+		// This will cause the entire pallet's storage to be deleted
+		frame_support::storage::migration::remove_storage_prefix(b"CrowdloanRewards", &[], &[]);
 
 		//TODO Reset the pot's funds
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -653,8 +653,11 @@ impl frame_support::traits::OnRuntimeUpgrade for NukeRewardsStorage {
 		// Reset the pot's funds
 		<Balances as frame_support::traits::Currency<AccountId>>::make_free_balance_be(&CrowdloanRewards::account_id(), 3_000_000 * currency::UNIT);
 
-		//TODO Return a reasonable weight
-		10_000
+		// Return weight of three DB writes (I'm not really that confident this is right)
+		// * One for the prefix removal
+		// * One for setting the balance
+		// * One for updating the total issuance
+		3 * <Runtime as frame_system::Config>::DbWeight::get().write
 	}
 }
 

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -531,7 +531,6 @@ fn initialize_crowdloan_addresses_with_batch_and_pay() {
 		});
 }
 
-#[ignore]
 #[test]
 fn claim_via_precompile() {
 	ExtBuilder::default()
@@ -831,7 +830,6 @@ fn reward_info_via_precompile() {
 		})
 }
 
-#[ignore]
 #[test]
 fn update_reward_address_via_precompile() {
 	ExtBuilder::default()


### PR DESCRIPTION
This PR adds a runtime migration to the moonbase runtime that will delete all of pallet crowdloan rewards' storage so it can be re-initialized.