### PR TITLE
Fix `trace_transaction_before_version_3`

### DIFF
--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -261,12 +261,16 @@ where
 
 						Ok(proxy::v1::Result::V2(proxy::v1::ResultV2::Single))
 					} else if api_version == 2 {
-						let _result = api
-							.trace_transaction(&parent_block_id, &header, ext, &transaction)
-							.map_err(|e| {
-								internal_err(format!("Runtime api access error: {:?}", e))
-							})?
-							.map_err(|e| internal_err(format!("DispatchError: {:?}", e)))?;
+						#[allow(deprecated)]
+						let _result = api.trace_transaction_before_version_3(
+							&parent_block_id,
+							&header,
+							ext,
+							&transaction,
+							trace_type,
+						)
+						.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?
+						.map_err(|e| internal_err(format!("DispatchError: {:?}", e)))?;
 
 						Ok(proxy::v1::Result::V2(proxy::v1::ResultV2::Single))
 					} else {


### PR DESCRIPTION
Currently we are on `DebugRuntimeApi` version `3`, and introduced changes in `trace_transaction` signature. For version `2` runtime access, we need to use the  `trace_transaction_before_version_3`.