### PR TITLE
Make --force-authoring skip slot prediction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "sc-cli",
  "sc-service",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "derive_more",
  "futures 0.3.15",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.15",
@@ -1582,7 +1582,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -1610,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
  "cumulus-primitives-core",
@@ -1638,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.1",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -5599,7 +5599,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5628,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5939,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -506,6 +506,8 @@ where
 		})
 	};
 
+	let skip_prediction = parachain_config.force_authoring;
+
 	sc_service::spawn_tasks(sc_service::SpawnTasksParams {
 		on_demand: None,
 		remote_blockchain: None,
@@ -546,6 +548,7 @@ where
 			relay_chain_backend: relay_chain_full_node.backend.clone(),
 			parachain_client: client.clone(),
 			keystore: params.keystore_container.sync_keystore(),
+			skip_prediction,
 			create_inherent_data_providers: move |_, (relay_parent, validation_data, author_id)| {
 				let parachain_inherent =
 							cumulus_primitives_parachain_inherent::ParachainInherentData::


### PR DESCRIPTION
This PR uses sc-cli's `--force-authoring` flag to force the nimbus authorship task to skip the slot prediction step and author with the first nimbus key it finds. This flag was not previously used for anything.

This is not meant for use in normal operation. This is simply a tool to help work around stability issues in live networks while diagnosing and solving the underlying problem. On two occasions in moonbeam's history, this would have been useful.
1. When runtime APIs were no longer initialized automatically https://github.com/paritytech/substrate/pull/8953
2. When we discovered that prediction doesn't work on the first block in a new round. https://github.com/PureStake/moonbeam/pull/704

One minor limitation is that if there are multiple nimbus keys in the keystore, only the first is used is `--force-authoring` mode. It is not possible to author with each of them (without significant reworking) because cumulus's `ParachainConsensus` trait only allows returning a single candidate. Since this feature is only for fixing already distressed networks, I don't imagine this limitation will manifest itself much.

NOTE to reviewers: Most of the interesting changes happened in nimbus in https://github.com/PureStake/cumulus/commit/c0ae4a1f4e821f2fb4619dbc44084861d65fbf77