### PR TITLE
Hack 500ms deadline as an experiment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "sc-cli",
  "sc-service",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "derive_more",
  "futures 0.3.15",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.15",
@@ -1582,7 +1582,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -1610,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
  "cumulus-primitives-core",
@@ -1638,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.1",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -5599,7 +5599,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5628,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5939,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#07944252c6a9cf0a2cd5f7d61f04cad1dd3926ef"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "sc-cli",
  "sc-service",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "derive_more",
  "futures 0.3.15",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.15",
@@ -1582,7 +1582,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
@@ -1610,7 +1610,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "cumulus-pallet-parachain-system-proc-macro",
  "cumulus-primitives-core",
@@ -1638,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.1",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -1699,7 +1699,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -5599,7 +5599,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5628,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5939,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,10 +1367,10 @@ dependencies = [
 name = "crowdloan-rewards-precompiles"
 version = "0.6.0"
 dependencies = [
- "cumulus-pallet-parachain-system",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "derive_more",
  "evm",
  "frame-support",
@@ -1453,7 +1453,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "sc-cli",
  "sc-service",
@@ -1463,11 +1463,11 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "futures 0.3.15",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -1511,11 +1511,11 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "futures 0.3.15",
  "parity-scale-codec",
  "parking_lot 0.10.2",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "derive_more",
  "futures 0.3.15",
@@ -1559,9 +1559,9 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "futures 0.3.15",
  "futures-timer 3.0.2",
  "parity-scale-codec",
@@ -1582,12 +1582,12 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-pov-recovery",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "polkadot-overseer",
@@ -1610,11 +1610,39 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
- "cumulus-pallet-parachain-system-proc-macro",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-pallet-parachain-system-proc-macro 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "environmental",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-balances",
+ "parity-scale-codec",
+ "polkadot-parachain",
+ "serde",
+ "sp-core",
+ "sp-externalities",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
+ "sp-version",
+ "xcm",
+]
+
+[[package]]
+name = "cumulus-pallet-parachain-system"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+dependencies = [
+ "cumulus-pallet-parachain-system-proc-macro 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-np098)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-np098)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-np098)",
  "environmental",
  "frame-support",
  "frame-system",
@@ -1638,7 +1666,18 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
+dependencies = [
+ "proc-macro-crate 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cumulus-pallet-parachain-system-proc-macro"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2",
@@ -1649,7 +1688,25 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
+dependencies = [
+ "frame-support",
+ "impl-trait-for-tuples 0.2.1",
+ "parity-scale-codec",
+ "polkadot-core-primitives",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
+ "sp-trie",
+ "xcm",
+]
+
+[[package]]
+name = "cumulus-primitives-core"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples 0.2.1",
@@ -1667,11 +1724,32 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "async-trait",
- "cumulus-primitives-core",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "parity-scale-codec",
+ "polkadot-client",
+ "sc-client-api",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
+ "tracing",
+]
+
+[[package]]
+name = "cumulus-primitives-parachain-inherent"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+dependencies = [
+ "async-trait",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-np098)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-np098)",
  "parity-scale-codec",
  "polkadot-client",
  "sc-client-api",
@@ -1688,9 +1766,9 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "sp-inherents",
  "sp-std",
  "sp-timestamp",
@@ -1699,9 +1777,22 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+]
+
+[[package]]
+name = "cumulus-test-relay-sproof-builder"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
+dependencies = [
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-np098)",
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-runtime",
@@ -4887,11 +4978,11 @@ version = "0.8.4"
 dependencies = [
  "account",
  "crowdloan-rewards-precompiles",
- "cumulus-pallet-parachain-system",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "cumulus-primitives-timestamp",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "evm",
  "fp-rpc",
  "frame-benchmarking",
@@ -4908,7 +4999,7 @@ dependencies = [
  "moonbeam-evm-tracer",
  "moonbeam-rpc-primitives-debug",
  "moonbeam-rpc-primitives-txpool",
- "nimbus-primitives",
+ "nimbus-primitives 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "pallet-author-inherent",
  "pallet-author-mapping",
  "pallet-author-slot-filter",
@@ -4981,12 +5072,12 @@ version = "0.11.0"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-service",
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "frame-benchmarking-cli",
  "log",
  "moonbeam-cli-opt",
  "moonbeam-service",
- "nimbus-primitives",
+ "nimbus-primitives 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "parity-scale-codec",
  "polkadot-cli",
  "polkadot-parachain",
@@ -5217,11 +5308,11 @@ version = "0.8.4"
 dependencies = [
  "account",
  "crowdloan-rewards-precompiles",
- "cumulus-pallet-parachain-system",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "cumulus-primitives-timestamp",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "evm",
  "fp-rpc",
  "frame-benchmarking",
@@ -5237,7 +5328,7 @@ dependencies = [
  "moonbeam-evm-tracer",
  "moonbeam-rpc-primitives-debug",
  "moonbeam-rpc-primitives-txpool",
- "nimbus-primitives",
+ "nimbus-primitives 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "pallet-author-inherent",
  "pallet-author-mapping",
  "pallet-author-slot-filter",
@@ -5300,9 +5391,9 @@ dependencies = [
  "cumulus-client-consensus-relay-chain",
  "cumulus-client-network",
  "cumulus-client-service",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "derive_more",
  "ethereum",
  "exit-future 0.1.4",
@@ -5332,7 +5423,7 @@ dependencies = [
  "moonbeam-runtime",
  "moonriver-runtime",
  "nimbus-consensus",
- "nimbus-primitives",
+ "nimbus-primitives 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "nix",
  "pallet-author-inherent",
  "pallet-ethereum",
@@ -5410,11 +5501,11 @@ version = "0.8.4"
 dependencies = [
  "account",
  "crowdloan-rewards-precompiles",
- "cumulus-pallet-parachain-system",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "cumulus-primitives-timestamp",
- "cumulus-test-relay-sproof-builder",
+ "cumulus-test-relay-sproof-builder 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "evm",
  "fp-rpc",
  "frame-benchmarking",
@@ -5430,7 +5521,7 @@ dependencies = [
  "moonbeam-evm-tracer",
  "moonbeam-rpc-primitives-debug",
  "moonbeam-rpc-primitives-txpool",
- "nimbus-primitives",
+ "nimbus-primitives 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "pallet-author-inherent",
  "pallet-author-mapping",
  "pallet-author-slot-filter",
@@ -5599,15 +5690,15 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "futures 0.3.15",
  "log",
- "nimbus-primitives",
+ "nimbus-primitives 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "parity-scale-codec",
  "parking_lot 0.9.0",
  "polkadot-service",
@@ -5628,7 +5719,23 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
+dependencies = [
+ "async-trait",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "nimbus-primitives"
+version = "0.1.0"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#2c318d4a5a504b85410ab96e0853588c280042cd"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -5903,12 +6010,12 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "nimbus-primitives",
+ "nimbus-primitives 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "parity-scale-codec",
  "sp-api",
  "sp-application-crypto",
@@ -5926,7 +6033,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "nimbus-primitives",
+ "nimbus-primitives 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "pallet-balances",
  "parity-scale-codec",
  "serde",
@@ -5939,13 +6046,13 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
- "cumulus-pallet-parachain-system",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "frame-support",
  "frame-system",
  "log",
- "nimbus-primitives",
+ "nimbus-primitives 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "pallet-author-inherent",
  "parity-scale-codec",
  "serde",
@@ -6091,15 +6198,15 @@ name = "pallet-crowdloan-rewards"
 version = "0.6.0"
 source = "git+https://github.com/purestake/crowdloan-rewards?branch=main#5c96ec664592987d6f577baa3fa4e7b2bdefc055"
 dependencies = [
- "cumulus-pallet-parachain-system",
- "cumulus-primitives-core",
- "cumulus-primitives-parachain-inherent",
+ "cumulus-pallet-parachain-system 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-np098)",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-np098)",
+ "cumulus-primitives-parachain-inherent 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-np098)",
  "ed25519-dalek",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
- "nimbus-primitives",
+ "nimbus-primitives 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-np098)",
  "pallet-balances",
  "pallet-utility",
  "parity-scale-codec",
@@ -6775,9 +6882,9 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=joshy-np098#cb4309f2c7b1367772f2d311362115309c3cd550"
+source = "git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit#cb4309f2c7b1367772f2d311362115309c3cd550"
 dependencies = [
- "cumulus-primitives-core",
+ "cumulus-primitives-core 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
@@ -6792,7 +6899,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "nimbus-primitives",
+ "nimbus-primitives 0.1.0 (git+https://github.com/purestake/cumulus?branch=joshy-hack-500ms-limit)",
  "pallet-balances",
  "parity-scale-codec",
  "serde",

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -18,10 +18,10 @@ sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "polk
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", optional = true }
 
-cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
-cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
+cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
+cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
 
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.8" }
 polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.8" }

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -94,20 +94,20 @@ fc-db = { git = "https://github.com/purestake/frontier", branch = "moonriver-pha
 fc-mapping-sync = { git = "https://github.com/purestake/frontier", branch = "moonriver-phase-four" }
 
 # Cumulus dependencies
-cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
-cumulus-client-collator = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
-cumulus-client-network = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
-cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
-cumulus-client-consensus-relay-chain = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
+cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
+cumulus-client-collator = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
+cumulus-client-network = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
+cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
+cumulus-client-consensus-relay-chain = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
 
 # Nimbus dependencies
-nimbus-consensus = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
-pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
+nimbus-consensus = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
+pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
 # TODO we should be able to depend only on the primitives crate once we move the inherent data provider there.
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098" }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit" }
 
 # Polkadot dependencies
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.8" }

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -506,6 +506,8 @@ where
 		})
 	};
 
+	let skip_prediction = parachain_config.force_authoring;
+
 	sc_service::spawn_tasks(sc_service::SpawnTasksParams {
 		on_demand: None,
 		remote_blockchain: None,
@@ -546,6 +548,7 @@ where
 			relay_chain_backend: relay_chain_full_node.backend.clone(),
 			parachain_client: client.clone(),
 			keystore: params.keystore_container.sync_keystore(),
+			skip_prediction,
 			create_inherent_data_providers: move |_, (relay_parent, validation_data, author_id)| {
 				let parachain_inherent =
 							cumulus_primitives_parachain_inherent::ParachainInherentData::

--- a/pallets/author-mapping/Cargo.toml
+++ b/pallets/author-mapping/Cargo.toml
@@ -7,7 +7,7 @@ description = "Maps AuthorIds to AccountIds Useful for associating consensus aut
 
 [dependencies]
 log = { version="0.4", default-features=false }
-nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="joshy-np098", default-features=false }
+nimbus-primitives = { git="https://github.com/purestake/cumulus", branch="joshy-hack-500ms-limit", default-features=false }
 frame-support = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.8", default-features=false }
 frame-system = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.8", default-features=false }
 parity-scale-codec = { version="2.0.0", default-features=false, features=["derive"] }

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -10,7 +10,7 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch =
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", default-features = false }
 log = "0.4"
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit", default-features = false }
 parity-scale-codec = { version = "2.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0.101", optional = true }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8", default-features = false }

--- a/precompiles/crowdloan-rewards/Cargo.toml
+++ b/precompiles/crowdloan-rewards/Cargo.toml
@@ -30,10 +30,10 @@ pallet-scheduler = { git="https://github.com/paritytech/substrate", branch="polk
 max-encoded-len = { git="https://github.com/paritytech/substrate", branch="polkadot-v0.9.8", features=["derive"] }
 serde = "1.0.100"
 derive_more = "0.99"
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
 
 [features]
 default = ["std"]

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -15,15 +15,15 @@ log = "0.4"
 
 runtime-common = { path = "../common", default-features = false }
 
-pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098", default-features = false }
+pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit", default-features = false }
 account = { path = "../../primitives/account/", default-features = false }
 moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
 pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
 parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
 parachain-staking-precompiles = { path = "../../precompiles/parachain-staking", default-features = false }
 pallet-maintenance-mode = { path = "../../pallets/maintenance-mode", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098", default-features = false }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit", default-features = false }
 pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
 evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
 precompile-utils = { path = "../../precompiles/utils", default-features = false }
@@ -80,10 +80,10 @@ moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-f
 moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
 
 # Cumulus dependencies
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
 
 # Benchmarking dependencies
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8", optional = true }
@@ -92,8 +92,8 @@ frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", d
 frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8", optional = true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
 evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
 rlp = "0.5"
 hex = "0.4"

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -15,14 +15,14 @@ log = "0.4"
 
 runtime-common = { path = "../common", default-features = false }
 
-pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098", default-features = false }
+pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit", default-features = false }
 account = { path = "../../primitives/account/", default-features = false }
 moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
 pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
 parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
 parachain-staking-precompiles = { path = "../../precompiles/parachain-staking", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098", default-features = false }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit", default-features = false }
 pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
 pallet-maintenance-mode = { path = "../../pallets/maintenance-mode", default-features = false }
 evm = { version="0.27.0", default-features=false, features=["with-codec"] }
@@ -79,18 +79,18 @@ moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-f
 moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
 
 # Cumulus dependencies
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
 
 # Benchmarking dependencies
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8", optional = true, version = '3.0.0' }
 frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8", optional = true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
 evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
 rlp = "0.5"
 hex = "0.4"

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -15,14 +15,14 @@ log = "0.4"
 
 runtime-common = { path = "../common", default-features = false }
 
-pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098", default-features = false }
+pallet-author-inherent = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit", default-features = false }
 account = { path = "../../primitives/account/", default-features = false }
 moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
 pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
 parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
 parachain-staking-precompiles = { path = "../../precompiles/parachain-staking", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098", default-features = false }
-nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "joshy-np098", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/cumulus", branch = "joshy-hack-500ms-limit", default-features = false }
 pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
 pallet-maintenance-mode = { path = "../../pallets/maintenance-mode", default-features = false }
 evm = { version="0.27.0", default-features=false, features=["with-codec"] }
@@ -78,18 +78,18 @@ moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-f
 moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
 
 # Cumulus dependencies
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+parachain-info = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
 
 # Benchmarking dependencies
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8", optional = true }
 frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.8", optional = true }
 
 [dev-dependencies]
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-np098" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", default-features = false, branch = "joshy-hack-500ms-limit" }
 evm = { version = "0.27.0", default-features = false, features = ["with-codec"] }
 rlp = "0.5"
 hex = "0.4"


### PR DESCRIPTION
This PR changes our nimbus dependency to one that is hacked to have a 1s deadline rather than the typical 500ms deadline.

This is based on #722 just because of the order of nimbus commits. If we decide we actually want to merge this then we either need #722 first, or I can create a new nimbus branch. But I don't imagine we'll be merging this soon.