### PR TITLE
Remove unused constant `VestingPeriod` from runtimes

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -636,7 +636,6 @@ impl pallet_author_slot_filter::Config for Runtime {
 
 parameter_types! {
 	// TODO to be revisited
-	pub const VestingPeriod: BlockNumber = 4 * WEEKS;
 	pub const MinimumReward: Balance = 0;
 	pub const Initialized: bool = false;
 	pub const InitializationPayment: Perbill = Perbill::from_percent(30);

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -639,8 +639,6 @@ impl pallet_author_slot_filter::Config for Runtime {
 }
 
 parameter_types! {
-	// TODO to be revisited
-	pub const VestingPeriod: BlockNumber = 4 * WEEKS;
 	pub const MinimumReward: Balance = 0;
 	pub const Initialized: bool = false;
 	pub const InitializationPayment: Perbill = Perbill::from_percent(30);

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -630,7 +630,6 @@ impl pallet_author_slot_filter::Config for Runtime {
 }
 
 parameter_types! {
-	pub const VestingPeriod: BlockNumber = 48 * WEEKS;
 	pub const MinimumReward: Balance = 0;
 	pub const Initialized: bool = false;
 	pub const InitializationPayment: Perbill = Perbill::from_percent(30);


### PR DESCRIPTION
Previous versions of pallet crowdloan rewards had an associated type `VestingPeriod`. Although that type no longer exists, the constant value that we had previously used was still declared in our runtimes. This PR cleans that up.