### PR TITLE
Make `ExportGenesisWasm` error handling consistent

### DIFF
--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -326,8 +326,7 @@ pub fn run() -> Result<()> {
 				&cli.run,
 			)?;
 			let output_buf = if chain_spec.is_moonbeam() {
-				let block: service::moonbeam_runtime::Block =
-					generate_genesis_block(&chain_spec)?;
+				let block: service::moonbeam_runtime::Block = generate_genesis_block(&chain_spec)?;
 				let raw_header = block.header().encode();
 				let output_buf = if params.raw {
 					raw_header
@@ -336,8 +335,7 @@ pub fn run() -> Result<()> {
 				};
 				output_buf
 			} else if chain_spec.is_moonriver() {
-				let block: service::moonriver_runtime::Block =
-					generate_genesis_block(&chain_spec)?;
+				let block: service::moonriver_runtime::Block = generate_genesis_block(&chain_spec)?;
 				let raw_header = block.header().encode();
 				let output_buf = if params.raw {
 					raw_header
@@ -346,8 +344,7 @@ pub fn run() -> Result<()> {
 				};
 				output_buf
 			} else {
-				let block: service::moonbase_runtime::Block =
-					generate_genesis_block(&chain_spec)?;
+				let block: service::moonbase_runtime::Block = generate_genesis_block(&chain_spec)?;
 				let raw_header = block.header().encode();
 				let output_buf = if params.raw {
 					raw_header


### PR DESCRIPTION
This fixes a minor error handling inconsistency in the `export-genesis-wasm` subcommand. Before this PR Moonbeam errors would be formatted as a string for moonbeam, but returned directly for other runtimes. After this PR errors are formatteed as stings regardless of runtime. This is consistent with the behavior for the (inplicit) `RunCmd`.

Note: this is slightly different than how cumulus handles this, I don't see any real strengths or weaknesses to either approach.
https://github.com/paritytech/cumulus/blob/master/polkadot-parachains/src/command.rs#L340-L363