### PR TITLE
[Staking] Extract pub compute top candidates from private select top candidates

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1865,6 +1865,8 @@ pub mod pallet {
 			exit_queue.nominator_schedule = remaining_exits;
 			<ExitQueue2<T>>::put(exit_queue);
 		}
+		/// Compute the top `TotalSelected` candidates in the CandidatePool and return
+		/// a vec of their AccountIds (in the order of selection)
 		pub fn compute_top_candidates() -> Vec<T::AccountId> {
 			let mut candidates = <CandidatePool<T>>::get().0;
 			// order candidates by stake (least to greatest so requires `rev()`)


### PR DESCRIPTION
To expose the compute top candidates logic without exposing storage writes functionality to some runtime config.

Related: https://github.com/PureStake/moonbeam/pull/744#discussion_r696972844
