### PR TITLE
Fix max nominators per collator upgrade bug

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -140,7 +140,7 @@ pub mod pallet {
 		pub total: Balance,
 	}
 
-	#[derive(Encode, Decode, RuntimeDebug)]
+	#[derive(Clone, Encode, Decode, RuntimeDebug)]
 	/// Collator state with commission fee, bonded stake, and nominations
 	pub struct Collator2<AccountId, Balance> {
 		/// The account of this collator
@@ -939,57 +939,59 @@ pub mod pallet {
 		(reads, writes)
 	}
 
-	// TODO: combine with other migration to optimize read/writes
-	// TODO: if not combined, does order of execution matter? I don't think so
 	pub(crate) fn correct_max_nominations_per_collator_upgrade_mistake<T: Config>() -> (u64, u64) {
 		let (mut reads, mut writes) = (0u64, 0u64);
 		for (account, state) in <CollatorState2<T>>::iter() {
 			reads += 1u64;
-			if state.nominators.0.len() < 10 && state.bottom_nominators.is_empty() {
-				// not effected by the bug
-				continue;
+			// 1. collect all nominator amounts into single vec and order them
+			let mut all_nominators = state.top_nominators.clone();
+			let mut starting_bottom_nominators = state.bottom_nominators.clone();
+			all_nominators.append(&mut starting_bottom_nominators);
+			// sort all nominators from greatest to least
+			all_nominators.sort_unstable_by(|a, b| b.amount.cmp(&a.amount));
+			let top_n = T::MaxNominatorsPerCollator::get() as usize;
+			// 2. split them into top and bottom using the T::MaxNominatorsPerCollator
+			let top_nominators: Vec<Bond<T::AccountId, BalanceOf<T>>> =
+				all_nominators.clone().into_iter().take(top_n).collect();
+			let bottom_nominators = if all_nominators.len() > top_n {
+				let rest = all_nominators.len() - top_n;
+				let bottom: Vec<Bond<T::AccountId, BalanceOf<T>>> = all_nominators
+					.clone()
+					.into_iter()
+					.rev()
+					.take(rest)
+					.collect();
+				bottom
 			} else {
-				// else >= 10 nominators
-				// 1. collect all nominator amounts into single vec and order them
-				let mut all_nominators = state.top_nominators.clone();
-				let mut starting_bottom_nominators = state.bottom_nominators.clone();
-				all_nominators.append(&mut starting_bottom_nominators);
-				// sort all nominators from greatest to least
-				all_nominators.sort_unstable_by(|a, b| b.amount.cmp(&a.amount));
-				let top_n = T::MaxNominatorsPerCollator::get() as usize;
-				// 2. split them into top and bottom using the T::MaxNominatorsPerCollator
-				let top_nominators: Vec<Bond<T::AccountId, BalanceOf<T>>> =
-					all_nominators.clone().into_iter().take(top_n).collect();
-				let mut bottom_nominators = all_nominators;
-				//  sorts bottom nominators least to greatest
-				bottom_nominators.sort_unstable_by(|a, b| a.amount.cmp(&b.amount));
-				let (mut total_counted, mut total_backing): (BalanceOf<T>, BalanceOf<T>) =
-					(1u32.into(), 1u32.into());
-				for Bond { amount, .. } in &top_nominators {
-					total_counted += *amount;
-					total_backing += *amount;
-				}
-				for Bond { amount, .. } in &bottom_nominators {
-					total_backing += *amount;
-				}
-				// update candidate pool with new total counted if it changed
-				if state.total_counted != total_counted && state.is_active() {
-					reads += 1u64;
-					writes += 1u64;
-					<Pallet<T>>::update_active(account.clone(), total_counted);
-				}
-				<CollatorState2<T>>::insert(
-					account,
-					Collator2 {
-						top_nominators,
-						bottom_nominators,
-						total_counted,
-						total_backing,
-						..state
-					},
-				);
-				writes += 1u64;
+				// empty, all nominations are in top
+				Vec::new()
+			};
+			let (mut total_counted, mut total_backing): (BalanceOf<T>, BalanceOf<T>) =
+				(0u32.into(), 0u32.into());
+			for Bond { amount, .. } in &top_nominators {
+				total_counted += *amount;
+				total_backing += *amount;
 			}
+			for Bond { amount, .. } in &bottom_nominators {
+				total_backing += *amount;
+			}
+			// update candidate pool with new total counted if it changed
+			if state.total_counted != total_counted && state.is_active() {
+				reads += 1u64;
+				writes += 1u64;
+				<Pallet<T>>::update_active(account.clone(), total_counted);
+			}
+			<CollatorState2<T>>::insert(
+				account,
+				Collator2 {
+					top_nominators,
+					bottom_nominators,
+					total_counted,
+					total_backing,
+					..state
+				},
+			);
+			writes += 1u64;
 		}
 		(reads, writes)
 	}


### PR DESCRIPTION
When we increased `MaxNominatorsPerCollator` from 10 -> 100 in https://github.com/PureStake/moonbeam/pull/746 , we did not add a migration to push the bottom nominators into the top upon the change. The fix is a migration that fixes the top_nominators and bottom_nominators fields for all CollatorState.

It is naive in its current state and could be optimized by combining it with the other runtime upgrade instead of keeping it separate. I'm writing a unit test to verify correctness now.