### PR TITLE
Add selectors to StakingPrecompile.sol function comments

### DIFF
--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -9,16 +9,19 @@ interface ParachainStaking {
     // First some simple accessors
 
     /// @dev Check whether the specified address is currently a staking nominator
+    /// Selector: 8e5080e7
     /// @param nominator the address that we want to confirm is a nominator
     /// @return A boolean confirming whether the address is a nominator
     function is_nominator(address nominator) external view returns (bool);
 
     /// @dev Check whether the specified address is currently a collator candidate
+    /// Selector: 8545c833
     /// @param collator the address that we want to confirm is a collator andidate
     /// @return A boolean confirming whether the address is a collator candidate
     function is_candidate(address collator) external view returns (bool);
 
     /// @dev Check whether the specifies address is currently a part of the active set
+    /// Selector: 8f6d27c7
     /// @param collator the address that we want to confirm is a part of the active set
     /// @return A boolean confirming whether the address is a part of the active set
     function is_selected_candidate(address collator)
@@ -27,19 +30,23 @@ interface ParachainStaking {
         returns (bool);
 
     /// @dev Total points awarded to all collators in a particular round
+    /// Selector: 9799b4e7
     /// @param round the round for which we are querying the points total
     /// @return The total points awarded to all collators in the round
     function points(uint256 round) external view returns (uint256);
 
     /// @dev Get the minimum nomination amount
+    /// Selector: c9f593b2
     /// @return The minimum nomination amount
     function min_nomination() external view returns (uint256);
 
     /// @dev Get the CandidateCount weight hint
+    /// Selector: 4b1c4c29
     /// @return The CandidateCount weight hint
     function candidate_count() external view returns (uint256);
 
     /// @dev Get the CollatorNominationCount weight hint
+    /// Selector: 0ad6a7be
     /// @param collator The address for which we are querying the nomination count
     /// @return The number of nominations backing the collator
     function collator_nomination_count(address collator)
@@ -48,6 +55,7 @@ interface ParachainStaking {
         returns (uint256);
 
     /// @dev Get the NominatorNominationCount weight hint
+    /// Selector: dae5659b
     /// @param nominator The address for which we are querying the nomination count
     /// @return The number of nominations made by the nominator
     function nominator_nomination_count(address nominator)
@@ -58,29 +66,36 @@ interface ParachainStaking {
     // Now the dispatchables
 
     /// @dev Join the set of collator candidates
+    /// Selector: 0a1bff60
     /// @param amount The amount self-bonded by the caller to become a collator candidate
     /// @param candidateCount The number of candidates in the CandidatePool
     function join_candidates(uint256 amount, uint256 candidateCount) external;
 
     /// @dev Leave the set of collator candidates
+    /// Selector: 72b02a31
     /// @param candidateCount The number of candidates in the CandidatePool
     function leave_candidates(uint256 amount, uint256 candidateCount) external;
 
     /// @dev Temporarily leave the set of collator candidates without unbonding
+    /// Selector: 767e0450
     function go_offline() external;
 
     /// @dev Rejoin the set of collator candidates if previously had called `go_offline`
+    /// Selector: d2f73ceb
     function go_online() external;
 
     /// @dev Bond more for collator candidates
+    /// Selector: c57bd3a8
     /// @param more The additional amount self-bonded
     function candidate_bond_more(uint256 more) external;
 
     /// @dev Bond less for collator candidates
+    /// Selector: 289b6ba7
     /// @param less The amount to be subtracted from self-bond and unreserved
     function candidate_bond_less(uint256 less) external;
 
     /// @dev Make a nomination in support of a collator candidate
+    /// Selector: 49df6eb3
     /// @param collator The address of the supported collator candidate
     /// @param amount The amount bonded in support of the collator candidate
     /// @param collatorNominationCount The number of nominations in support of the candidate
@@ -93,19 +108,23 @@ interface ParachainStaking {
     ) external;
 
     /// @dev Leave the set of nominators and, by implication, revoke all ongoing nominations
+    /// Selector: b71d2153
     /// @param nominatorNominationCount The number of existing nominations to be revoked by caller
     function leave_nominators(uint256 nominatorNominationCount) external;
 
     /// @dev Revoke an existing nomination
+    /// Selector: 4b65c34b
     /// @param collator The address of the collator candidate which will no longer be supported
     function revoke_nomination(address collator) external;
 
     /// @dev Bond more for nominators with respect to a specific collator candidate
+    /// Selector: 971d44c8
     /// @param candidate The address of the collator candidate for which nomination is increased
     /// @param more The amount by which the nomination is increased
     function nominator_bond_more(address candidate, uint256 more) external;
 
     /// @dev Bond less for nominators with respect to a specific collator candidate
+    /// Selector: f6a52569
     /// @param candidate The address of the collator candidate for which nomination is decreased
     /// @param less The amount by which the nomination is decreased
     function nominator_bond_less(address candidate, uint256 less) external;


### PR DESCRIPTION
Requested by @albertov19 

They were previously removed in #685 because I thought we didn't need them anymore because of the proc macro for function selectors. We don't need them in the code, but they are still useful in the comments for debugging. 

I moved them out of the table (below) and into the function comments. This follows how this was done in #625 .

```
// Function selectors for staking precompile functions
// See instructions to generate: https://ethereum.stackexchange.com/a/73405/9963
// {
// 	"8e5080e7": "is_nominator(address)",
// 	"8545c833": "is_candidate(address)",
// 	"8f6d27c7": "is_selected_candidate(address)",
// 	"9799b4e7": "points(uint256)",
// 	"c9f593b2": "min_nomination()",
//      "4b1c4c29": "candidate_count()",
//      "dae5659b": "nominator_nomination_count(address)",
//      "0ad6a7be": "collator_nomination_count(address)",
// 	"0a1bff60": "join_candidates(uint256,uint256)",
// 	"72b02a31": "leave_candidates(uint256)",
// 	"767e0450": "go_offline()",
// 	"d2f73ceb": "go_online()",
// 	"c57bd3a8": "candidate_bond_more(uint256)",
// 	"289b6ba7": "candidate_bond_less(uint256)",
// 	"49df6eb3": "nominate(address,uint256,uint256,uint256)",
// 	"b71d2153": "leave_nominators(uint256)",
// 	"4b65c34b": "revoke_nomination(address)",
// 	"971d44c8": "nominator_bond_more(address,uint256)",
// 	"f6a52569": "nominator_bond_less(address,uint256)",
// }
```