### PR TITLE
Fix empty traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5055,6 +5055,7 @@ dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
  "sp-std",
+ "tracing",
 ]
 
 [[package]]

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -319,9 +319,7 @@ where
 									Ok(result)
 								}
 								Err(e) => Err(e),
-								_ => Err(internal_err(format!(
-									"Bug: Api and result versions must match"
-								))),
+								_ => Err(internal_err("Bug: Api and result versions must match")),
 							}
 						}
 					}
@@ -329,6 +327,7 @@ where
 						if runtime_version.spec_version >= V2_RUNTIME_VERSION && api_version >= 3 {
 							let mut proxy = proxy::v2::call_list::Listener::default();
 							proxy.using(f)?;
+							proxy.finish_transaction();
 							proxy::formats::blockscout::Response::build(proxy)
 								.ok_or("Trace result is empty.")
 								.map_err(|e| internal_err(format!("{:?}", e)))
@@ -346,9 +345,7 @@ where
 									Ok(result)
 								}
 								Err(e) => Err(e),
-								_ => Err(internal_err(format!(
-									"Bug: Api and result versions must match"
-								))),
+								_ => Err(internal_err("Bug: Api and result versions must match")),
 							}
 						}
 					}

--- a/primitives/ext/Cargo.toml
+++ b/primitives/ext/Cargo.toml
@@ -16,7 +16,7 @@ moonbeam-rpc-primitives-debug = { path = "../rpc/debug", default-features = fals
 sp-runtime-interface = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.8", default-features = false }
 sp-externalities = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.8", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.8", default-features = false }
-
+tracing = { version = "0.1.25", optional = true }
 [features]
 default = ["std"]
 std = [
@@ -26,4 +26,5 @@ std = [
 	"sp-runtime-interface/std",
 	"sp-externalities/std",
 	"sp-std/std",
+	"tracing"
 ]

--- a/primitives/ext/src/lib.rs
+++ b/primitives/ext/src/lib.rs
@@ -40,19 +40,22 @@ use moonbeam_rpc_primitives_debug::{
 pub trait MoonbeamExt {
 	// Old format to be deprecated.
 	fn raw_step(&mut self, data: Vec<u8>) {
-		let data: RawStepLog = Decode::decode(&mut &data[..]).unwrap();
-		EventV1::RawStep(data).emit();
+		if let Ok(data) = RawStepLog::decode(&mut &data[..]) {
+			EventV1::RawStep(data).emit();
+		}
 	}
 	fn raw_gas(&mut self, data: Vec<u8>) {
-		let data: U256 = Decode::decode(&mut &data[..]).unwrap();
-		EventV1::RawGas(data).emit();
+		if let Ok(data) = U256::decode(&mut &data[..]) {
+			EventV1::RawGas(data).emit();
+		}
 	}
 	fn raw_return_value(&mut self, data: Vec<u8>) {
 		EventV1::RawReturnValue(data).emit();
 	}
 	fn call_list_entry(&mut self, index: u32, value: Vec<u8>) {
-		let value: Call = Decode::decode(&mut &value[..]).unwrap();
-		EventV1::CallListEntry((index, value)).emit();
+		if let Ok(value) = Call::decode(&mut &value[..]) {
+			EventV1::CallListEntry((index, value)).emit();
+		}
 	}
 	fn call_list_new(&mut self) {
 		EventV1::CallListNew().emit();
@@ -61,20 +64,23 @@ pub trait MoonbeamExt {
 	/// An `Evm` event proxied by the Moonbeam runtime to this host function.
 	/// evm -> moonbeam_runtime -> host.
 	fn evm_event(&mut self, event: Vec<u8>) {
-		let event: EvmEvent = Decode::decode(&mut &event[..]).unwrap();
-		EventV2::Evm(event).emit();
+		if let Ok(event) = EvmEvent::decode(&mut &event[..]) {
+			EventV2::Evm(event).emit();
+		}
 	}
 	/// A `Gasometer` event proxied by the Moonbeam runtime to this host function.
 	/// evm_gasometer -> moonbeam_runtime -> host.
 	fn gasometer_event(&mut self, event: Vec<u8>) {
-		let event: GasometerEvent = Decode::decode(&mut &event[..]).unwrap();
-		EventV2::Gasometer(event).emit();
+		if let Ok(event) = GasometerEvent::decode(&mut &event[..]) {
+			EventV2::Gasometer(event).emit();
+		}
 	}
 	/// A `Runtime` event proxied by the Moonbeam runtime to this host function.
 	/// evm_runtime -> moonbeam_runtime -> host.
 	fn runtime_event(&mut self, event: Vec<u8>) {
-		let event: RuntimeEvent = Decode::decode(&mut &event[..]).unwrap();
-		EventV2::Runtime(event).emit();
+		if let Ok(event) = RuntimeEvent::decode(&mut &event[..]) {
+			EventV2::Runtime(event).emit();
+		}
 	}
 	/// An event to create a new CallList (currently a new transaction when tracing a block).
 	#[version(2)]

--- a/primitives/ext/src/lib.rs
+++ b/primitives/ext/src/lib.rs
@@ -42,11 +42,15 @@ pub trait MoonbeamExt {
 	fn raw_step(&mut self, data: Vec<u8>) {
 		if let Ok(data) = RawStepLog::decode(&mut &data[..]) {
 			EventV1::RawStep(data).emit();
+		} else {
+			tracing::warn!("Failed to decode RawStepLog from bytes : {:?}", data);
 		}
 	}
 	fn raw_gas(&mut self, data: Vec<u8>) {
 		if let Ok(data) = U256::decode(&mut &data[..]) {
 			EventV1::RawGas(data).emit();
+		} else {
+			tracing::warn!("Failed to decode U256 (raw_gas) from bytes : {:?}", data);
 		}
 	}
 	fn raw_return_value(&mut self, data: Vec<u8>) {
@@ -55,17 +59,27 @@ pub trait MoonbeamExt {
 	fn call_list_entry(&mut self, index: u32, value: Vec<u8>) {
 		if let Ok(value) = Call::decode(&mut &value[..]) {
 			EventV1::CallListEntry((index, value)).emit();
+		} else {
+			tracing::warn!(
+				"Failed to decode Call (call_list_entry) with index {} from bytes : {:?}",
+				index,
+				value
+			);
 		}
 	}
+
 	fn call_list_new(&mut self) {
 		EventV1::CallListNew().emit();
 	}
+
 	// New design, proxy events.
 	/// An `Evm` event proxied by the Moonbeam runtime to this host function.
 	/// evm -> moonbeam_runtime -> host.
 	fn evm_event(&mut self, event: Vec<u8>) {
 		if let Ok(event) = EvmEvent::decode(&mut &event[..]) {
 			EventV2::Evm(event).emit();
+		} else {
+			tracing::warn!("Failed to decode EvmEvent from bytes : {:?}", event);
 		}
 	}
 	/// A `Gasometer` event proxied by the Moonbeam runtime to this host function.
@@ -73,6 +87,8 @@ pub trait MoonbeamExt {
 	fn gasometer_event(&mut self, event: Vec<u8>) {
 		if let Ok(event) = GasometerEvent::decode(&mut &event[..]) {
 			EventV2::Gasometer(event).emit();
+		} else {
+			tracing::warn!("Failed to decode GasometerEvent from bytes : {:?}", event);
 		}
 	}
 	/// A `Runtime` event proxied by the Moonbeam runtime to this host function.
@@ -80,6 +96,8 @@ pub trait MoonbeamExt {
 	fn runtime_event(&mut self, event: Vec<u8>) {
 		if let Ok(event) = RuntimeEvent::decode(&mut &event[..]) {
 			EventV2::Runtime(event).emit();
+		} else {
+			tracing::warn!("Failed to decode RuntimeEvent from bytes : {:?}", event);
 		}
 	}
 	/// An event to create a new CallList (currently a new transaction when tracing a block).

--- a/primitives/rpc/debug/src/proxy/v2/call_list.rs
+++ b/primitives/rpc/debug/src/proxy/v2/call_list.rs
@@ -817,6 +817,10 @@ mod tests {
 		listener.evm_event(test_emit_evm_event(TestEvmEvent::Create, false, None));
 	}
 
+	fn do_evm_suicide_event(listener: &mut Listener) {
+		listener.evm_event(test_emit_evm_event(TestEvmEvent::Suicide, false, None));
+	}
+
 	fn do_runtime_step_event(listener: &mut Listener) {
 		listener.runtime_event(test_emit_runtime_event(TestRuntimeEvent::Step));
 	}
@@ -880,6 +884,21 @@ mod tests {
 		listener.finish_transaction();
 		assert_eq!(listener.entries.len(), 1);
 		assert_eq!(listener.entries[0].len(), 1);
+	}
+
+	// Suicide.
+	#[test]
+	fn call_suicide() {
+		let mut listener = Listener::default();
+		do_transact_call_event(&mut listener);
+		do_gasometer_event(&mut listener);
+		do_evm_call_event(&mut listener);
+		do_runtime_step_event(&mut listener);
+		do_evm_suicide_event(&mut listener);
+		do_exit_event(&mut listener);
+		listener.finish_transaction();
+		assert_eq!(listener.entries.len(), 1);
+		assert_eq!(listener.entries[0].len(), 2);
 	}
 
 	// Create context


### PR DESCRIPTION
### What does it do?

While #742 introduced new events in the Runtime to correctly trace some transactions that failed previously, it also failed where the previous tracer succeeded for the previous runtime version.

This PR fixes this bug and seems to produce correct traces for the future and current runtime. Future is tested in the TS tests, while current was tested by syncing a node on Moonriver and tracing various transactions that failed to produce a correct trace on currently deployed nodes.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

The new tracer is client side but is still located in the primitives folder and crate. All client-side code should be refactored out of this crate into the clients folder crates.

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
