### PR TITLE
Filters out invalid transaction trace entries

### DIFF
--- a/primitives/rpc/debug/src/proxy/formats/trace_filter.rs
+++ b/primitives/rpc/debug/src/proxy/formats/trace_filter.rs
@@ -29,7 +29,10 @@ impl super::TraceResponseBuilder for Response {
 	type Listener = Listener;
 	type Response = Vec<TransactionTrace>;
 
-	fn build(listener: Listener) -> Option<Vec<TransactionTrace>> {
+	fn build(mut listener: Listener) -> Option<Vec<TransactionTrace>> {
+		// Remove empty BTreeMaps pushed to `entries`.
+		// I.e. InvalidNonce or other pallet_evm::runner exits
+		listener.entries.retain(|x| !x.is_empty());
 		let mut traces = Vec::new();
 		for (eth_tx_index, entry) in listener.entries.iter().enumerate() {
 			let mut tx_traces: Vec<_> = entry

--- a/primitives/rpc/debug/src/proxy/v1/mod.rs
+++ b/primitives/rpc/debug/src/proxy/v1/mod.rs
@@ -167,7 +167,10 @@ impl CallListProxy {
 
 	/// Format the RPC output for multiple transactions. Each call-stack represents a single
 	/// transaction/EVM execution.
-	pub fn into_tx_traces(self) -> Vec<BlockTrace> {
+	pub fn into_tx_traces(&mut self) -> Vec<BlockTrace> {
+		// Remove empty BTreeMaps pushed to `entries`.
+		// I.e. InvalidNonce or other pallet_evm::runner exits
+		self.entries.retain(|x| !x.is_empty());
 		let mut traces = Vec::new();
 		for (eth_tx_index, entry) in self.entries.iter().enumerate() {
 			let mut tx_traces: Vec<_> = entry

--- a/primitives/rpc/debug/src/proxy/v2/call_list.rs
+++ b/primitives/rpc/debug/src/proxy/v2/call_list.rs
@@ -80,6 +80,11 @@ pub struct Listener {
 	/// True if only the `GasometerEvent::RecordTransaction` event has been received.
 	/// Allow to correctly handle transactions that cannot pay for the tx data in Legacy mode.
 	record_transaction_event_only: bool,
+
+	/// Boolean storing if the last received event was `Event::CallListNew`.
+	/// Multiple consecutive of those event can occur when an invalid transaction is in a block,
+	/// which can cause issues.
+	last_event_is_call_list_new: bool,
 }
 
 struct Context {
@@ -117,6 +122,7 @@ impl Default for Listener {
 			skip_next_context: false,
 			call_list_first_transaction: true,
 			record_transaction_event_only: false,
+			last_event_is_call_list_new: false,
 		}
 	}
 }
@@ -622,11 +628,19 @@ fn error_message(error: &ExitError) -> Vec<u8> {
 
 impl ListenerT for Listener {
 	fn event(&mut self, event: Event) {
+		if matches!(&event, &Event::CallListNew()) && self.last_event_is_call_list_new {
+			return;
+		}
+
+		self.last_event_is_call_list_new = false;
+
 		match event {
 			Event::Gasometer(gasometer_event) => self.gasometer_event(gasometer_event),
 			Event::Runtime(runtime_event) => self.runtime_event(runtime_event),
 			Event::Evm(evm_event) => self.evm_event(evm_event),
 			Event::CallListNew() => {
+				self.last_event_is_call_list_new = true;
+
 				if !self.call_list_first_transaction {
 					self.finish_transaction();
 					self.skip_next_context = false;


### PR DESCRIPTION
### What does it do?

Empty trace entries can be produced when invalid Ethereum transactions are in the block, which cause issues when building the RPC response. This PR thus filter out empty entries. that can only be produced in this situation.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
