### PR TITLE
Runtime 600

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "assert_cmd",
  "futures 0.3.15",
@@ -4977,7 +4977,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam-cli"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-service",
@@ -5005,7 +5005,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam-cli-opt"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "account",
  "libsecp256k1 0.3.5",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "moonbeam-service"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "ansi_term 0.12.1",
  "assert_cmd",

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Docker images are published for every tagged release. Learn more with `moonbeam 
 
 ```bash
 # Join the public testnet
-docker run --network="host" purestake/moonbeam:v0.11.2 --chain alphanet
+docker run --network="host" purestake/moonbeam:v0.11.3 --chain alphanet
 ```
 
 You can find more detailed instructions to [run a full node in our TestNet](https://docs.moonbeam.network/node-operators/networks/full-node/)
@@ -27,7 +27,7 @@ service.
 
 ```bash
 # Run a dev service node.
-docker run --network="host" purestake/moonbeam:v0.11.2 --dev
+docker run --network="host" purestake/moonbeam:v0.11.3 --dev
 ```
 
 For more information, see our detailed instructions to [run a development node](https://docs.moonbeam.network/getting-started/local-node/setting-up-a-node/)
@@ -38,10 +38,10 @@ The command above will start the node in instant seal mode. It creates a block w
 
 ```bash
 # Author a block every 6 seconds.
-docker run --network="host" purestake/moonbeam:v0.11.2 --dev --sealing 6000
+docker run --network="host" purestake/moonbeam:v0.11.3 --dev --sealing 6000
 
 # Manually control the block authorship and finality
-docker run --network="host" purestake/moonbeam:v0.11.2 --dev --sealing manual
+docker run --network="host" purestake/moonbeam:v0.11.3 --dev --sealing manual
 ```
 
 ### Prefunded Development Addresses

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -3,7 +3,7 @@ name = 'moonbeam'
 description = 'Moonbeam Collator'
 homepage = 'https://moonbeam.network'
 license = 'GPL-3.0-only'
-version = '0.11.2'
+version = '0.11.3'
 authors = ["PureStake"]
 edition = '2018'
 

--- a/node/cli-opt/Cargo.toml
+++ b/node/cli-opt/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'moonbeam-cli-opt'
 homepage = 'https://moonbeam.network'
 license = 'GPL-3.0-only'
-version = '0.11.2'
+version = '0.11.3'
 authors = ["PureStake"]
 edition = '2018'
 

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moonbeam-cli"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["PureStake"]
 edition = "2018"
 

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'moonbeam-service'
 homepage = 'https://moonbeam.network'
 license = 'GPL-3.0-only'
-version = '0.11.2'
+version = '0.11.3'
 authors = ["PureStake"]
 edition = '2018'
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -133,7 +133,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase"),
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 3,
-	spec_version: 0400,
+	spec_version: 0500,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -133,7 +133,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbase"),
 	impl_name: create_runtime_str!("moonbase"),
 	authoring_version: 3,
-	spec_version: 0500,
+	spec_version: 0600,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -134,7 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 0500,
+	spec_version: 0600,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -134,7 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonbeam"),
 	impl_name: create_runtime_str!("moonbeam"),
 	authoring_version: 3,
-	spec_version: 0400,
+	spec_version: 0500,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -133,7 +133,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 0500,
+	spec_version: 0600,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -133,7 +133,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("moonriver"),
 	impl_name: create_runtime_str!("moonriver"),
 	authoring_version: 3,
-	spec_version: 0400,
+	spec_version: 0500,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
This client version is require for tracing the new runtime
Runtime appears to jump from 400 to 600, because the 500 wasn't merged into master. I cherry picked it for reference