### PR TITLE
Trigger CI by PR instead of push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,8 @@ name: Build
 # This is only allowing pushes on the moonbeam repo for pull requests.
 ####### DO NOT CHANGE THIS !! #######
 on:
-  push:
+  pull_request:
+    types: [opened, edited, unassigned, synchronize]
   workflow_dispatch:
     inputs:
       pull_request:


### PR DESCRIPTION
### What does it do?

### What important points reviewers should know?

We trigger at `unassigned` in order to have a way to re-trigger the CI without changing the PR.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
