### PR TITLE
Adapt CI for conditional tracing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,6 +215,11 @@ jobs:
         run: |
           env
           cargo build --release --all
+      - name: Build Tracing Node
+        if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
+        run: |
+          env
+          cargo build --release -p moonbeam --features evm-tracing
       - name: Verify node version
         run: |
           GIT_COMMIT=`git log -1 --format="%H" | cut -c1-7`
@@ -286,6 +291,16 @@ jobs:
           cd ../tests
           npm install
           node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tests/**/test-*.ts'
+      - name: Typescript evm-tracing tests (against dev service)
+        if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
+        env:
+          BINARY_PATH: ../build/moonbeam
+        run: |
+          cd moonbeam-types-bundle
+          npm install
+          cd ../tests
+          npm install
+          node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tracing-tests/**/test-*.ts'
 
   typescript-para-tests:
     runs-on: self-hosted

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,6 +295,7 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
         env:
           BINARY_PATH: ../build/moonbeam
+          ETHAPI_CMD: --ethapi=txpool,debug,trace
         run: |
           cd moonbeam-types-bundle
           npm install


### PR DESCRIPTION
### What does it do?

*  Condition the compile job to compile with feature tracing if the `A10-evmtracing` label is set.
* Create a new job named typescript-tracing-tests that would only play if the `A10-evmtracing` label is set.



### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
