### PR TITLE
Update ci to check for un-updated package-lock files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,6 +291,30 @@ jobs:
           cd ../tests
           npm install
           node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tests/**/test-*.ts'
+
+      # We determine whether there are unmodified package-lock.json files by:
+      # 1. Asking git for a list of all modified files
+      # 2. Using grep to reduce the list to only package-lock.json files
+      # 3. Counting the number of lines of output
+      - name: Check package-lock.json
+        run: |
+          # Make sure git is working, and if not abort early. When git is not working it looks like:
+          # $ git diff-index --name-only HEAD
+          # fatal: not a git repository (or any of the parent directories): .git
+          DIFF_INDEX=$(git diff-index --name-only HEAD)
+          if [[ ${DIFF_INDEX:0:5} == "fatal" ]]; then
+            echo "There was an error with the git checkout. Can't check package-lock.json file."
+            false
+          fi
+          FILECOUNT=$(echo $DIFF_INDEX | grep package-lock.json | wc -l)
+          if [[ $FILECOUNT -eq 0 ]]; then
+            echo "All package-lock.json files are valid"
+          else
+            echo "The following Cargo.lock files have uncommitted changes"
+            echo $DIFF_INDEX | grep Cargo.lock
+            false
+          fi
+
       - name: Typescript evm-tracing tests (against dev service)
         if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,8 +310,8 @@ jobs:
           if [[ $FILECOUNT -eq 0 ]]; then
             echo "All package-lock.json files are valid"
           else
-            echo "The following Cargo.lock files have uncommitted changes"
-            echo $DIFF_INDEX | grep Cargo.lock
+            echo "The following package-lock.json files have uncommitted changes"
+            echo $DIFF_INDEX | grep package-lock.json
             false
           fi
 

--- a/moonbeam-types-bundle/package-lock.json
+++ b/moonbeam-types-bundle/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "moonbeam-types-bundle",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### What does it do?
- Adds check to the CI for package-lock files that are not updated, with the same mechanism through which we check for cargo.lock, as per suggested by @JoshOrndorff 
- updates package-lock

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
