### PR TITLE
rework tracing ci: always run all "classic" ci jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,6 +402,7 @@ jobs:
           BINARY_PATH: ../build/moonbeam-tracing
           ETHAPI_CMD: --ethapi=txpool,debug,trace
         run: |
+          cd tests
           node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tracing-tests/**/test-*.ts'
 
   typescript-para-tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -387,15 +387,21 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
+      - name: Typescript integration tests (against dev service)
+        env:
+          BINARY_PATH: ../build/moonbeam-tracing
+        run: |
+          chmod uog+x build/moonbeam-tracing
+          cd moonbeam-types-bundle
+          npm install
+          cd ../tests
+          npm install
+          node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tests/**/test-*.ts'
       - name: Typescript evm-tracing tests (against dev service)
         env:
           BINARY_PATH: ../build/moonbeam-tracing
           ETHAPI_CMD: --ethapi=txpool,debug,trace
         run: |
-          cd moonbeam-types-bundle
-          npm install
-          cd ../tests
-          npm install
           node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tracing-tests/**/test-*.ts'
 
   typescript-para-tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -373,7 +373,7 @@ jobs:
   typescript-tracing-tests:
     if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
     runs-on: self-hosted
-    needs: build
+    needs: tracing-build
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,11 +215,6 @@ jobs:
         run: |
           env
           cargo build --release --all
-      - name: Build Tracing Node
-        if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
-        run: |
-          env
-          cargo build --release -p moonbeam --features evm-tracing
       - name: Verify node version
         run: |
           GIT_COMMIT=`git log -1 --format="%H" | cut -c1-7`
@@ -255,7 +250,7 @@ jobs:
         run: cargo clippy --release --workspace
       - name: Ensure benchmarking compiles
         run: cargo check --release --features=runtime-benchmarks
-      - name: Save parachain binary
+      - name: Save moonbeam binary
         run: |
           mkdir -p build
           cp target/release/moonbeam build/moonbeam;
@@ -315,10 +310,86 @@ jobs:
             false
           fi
 
+  ####### Building and Testing tracing binaries #######
+
+  tracing-build:
+    if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
+    runs-on: self-hosted
+    needs: ["set-tags"]
+    env:
+      CARGO_SCCACHE_COMMIT: 90e1dc81
+      RUSTFLAGS: "-C opt-level=3"
+      # MOONBEAM_LOG: info
+      # DEBUG: "test*"
+    outputs:
+      RUSTC: ${{ steps.get-rust-versions.outputs.rustc }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
+      - uses: actions/cache@v2
+        with:
+          path: ${{ runner.tool_cache }}/cargo-sccache-${CARGO_SCCACHE_COMMIT}
+          key: ${{ runner.OS }}-sccache-bin-${{ env.CARGO_SCCACHE_COMMIT }}-v1
+
+      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
+      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
+      - name: Setup Rust toolchain
+        run: rustup show
+      - name: SCCache
+        run: |
+          # We altered the path to avoid old actions to overwrite it
+          SCCACHE_PATH=${{ runner.tool_cache }}/cargo-sccache-${CARGO_SCCACHE_COMMIT}
+          SCCACHE_BIN=${SCCACHE_PATH}/bin/sccache
+          if [ ! -f $SCCACHE_BIN ]; then
+            cargo install sccache --git https://github.com/purestake/sccache.git --rev $CARGO_SCCACHE_COMMIT --force --no-default-features --features=dist-client --root $SCCACHE_PATH
+          fi
+          ls -la $SCCACHE_BIN
+          ps aux | grep sccache
+          if [[ -z `pgrep sccache` ]]; then
+            chmod +x $SCCACHE_BIN
+            $SCCACHE_BIN --start-server
+          fi
+          $SCCACHE_BIN -s
+          echo "RUSTC_WRAPPER=$SCCACHE_BIN" >> $GITHUB_ENV
+      - id: get-rust-versions
+        run: |
+          echo "::set-output name=rustc::$(rustc --version)"
+      - name: Build Tracing Node
+        run: |
+          env
+          cargo build --release -p moonbeam --features evm-tracing
+      - name: Save moonbeam tracing binary
+        run: |
+          mkdir -p build
+          cp target/release/moonbeam build/moonbeam-tracing;
+      - name: Upload tracing binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: moonbeam-tracing
+          path: build
+
+  typescript-tracing-tests:
+    if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
+    runs-on: self-hosted
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: moonbeam-tracing
+          path: build
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
       - name: Typescript evm-tracing tests (against dev service)
-        if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
         env:
-          BINARY_PATH: ../build/moonbeam
+          BINARY_PATH: ../build/moonbeam-tracing
           ETHAPI_CMD: --ethapi=txpool,debug,trace
         run: |
           cd moonbeam-types-bundle


### PR DESCRIPTION
### What does it do?

Make sure that non-tracing tests are always played with the non-tracing binary. Tracing related jobs are now separated so as not to interfere with non-tracing jobs.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
