### PR TITLE
Test to show nominator_bond_less decreases the nomination amount for nominator state

### DIFF
--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -25,7 +25,7 @@ use crate::mock::{
 	events, last_event, roll_to, set_author, Balances, Event as MetaEvent, ExtBuilder, Origin,
 	Stake, Test,
 };
-use crate::{Bond, CollatorState2, CollatorStatus, Error, Event, NominatorAdded, Range};
+use crate::{Bond, CollatorStatus, Error, Event, NominatorAdded, Range};
 use frame_support::{assert_noop, assert_ok};
 use sp_runtime::{traits::Zero, DispatchError, Perbill, Percent};
 
@@ -2312,8 +2312,24 @@ fn nominator_bond_less_updates_nominator_state() {
 		.build()
 		.execute_with(|| {
 			assert_eq!(Stake::nominator_state2(2).expect("exists").total, 10);
+			assert_eq!(
+				Stake::nominator_state2(2).expect("exists").nominations.0[0].amount,
+				10
+			);
+			assert_eq!(
+				Stake::nominator_state2(2).expect("exists").nominations.0[0].owner,
+				1
+			);
 			assert_ok!(Stake::nominator_bond_less(Origin::signed(2), 1, 5));
 			assert_eq!(Stake::nominator_state2(2).expect("exists").total, 5);
+			assert_eq!(
+				Stake::nominator_state2(2).expect("exists").nominations.0[0].amount,
+				5
+			);
+			assert_eq!(
+				Stake::nominator_state2(2).expect("exists").nominations.0[0].owner,
+				1
+			);
 		});
 }
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -2083,8 +2083,22 @@ fn nominator_bond_more_updates_nominator_state() {
 		.build()
 		.execute_with(|| {
 			assert_eq!(Stake::nominator_state2(2).expect("exists").total, 10);
+			assert_eq!(
+				Stake::nominator_state2(2).expect("exists").nominations.0[0],
+				Bond {
+					owner: 1,
+					amount: 10
+				}
+			);
 			assert_ok!(Stake::nominator_bond_more(Origin::signed(2), 1, 5));
 			assert_eq!(Stake::nominator_state2(2).expect("exists").total, 15);
+			assert_eq!(
+				Stake::nominator_state2(2).expect("exists").nominations.0[0],
+				Bond {
+					owner: 1,
+					amount: 15
+				}
+			);
 		});
 }
 
@@ -2313,22 +2327,20 @@ fn nominator_bond_less_updates_nominator_state() {
 		.execute_with(|| {
 			assert_eq!(Stake::nominator_state2(2).expect("exists").total, 10);
 			assert_eq!(
-				Stake::nominator_state2(2).expect("exists").nominations.0[0].amount,
-				10
-			);
-			assert_eq!(
-				Stake::nominator_state2(2).expect("exists").nominations.0[0].owner,
-				1
+				Stake::nominator_state2(2).expect("exists").nominations.0[0],
+				Bond {
+					owner: 1,
+					amount: 10
+				}
 			);
 			assert_ok!(Stake::nominator_bond_less(Origin::signed(2), 1, 5));
 			assert_eq!(Stake::nominator_state2(2).expect("exists").total, 5);
 			assert_eq!(
-				Stake::nominator_state2(2).expect("exists").nominations.0[0].amount,
-				5
-			);
-			assert_eq!(
-				Stake::nominator_state2(2).expect("exists").nominations.0[0].owner,
-				1
+				Stake::nominator_state2(2).expect("exists").nominations.0[0],
+				Bond {
+					owner: 1,
+					amount: 5
+				}
 			);
 		});
 }


### PR DESCRIPTION
The edited test demonstrates the correct effect of `nominator_bond_less` on `NominatorState2`. This effect is not yet verified in the TS tests https://github.com/PureStake/moonbeam/pull/790 cc @joelamouche 

Also adds the same check to the `nominator_bond_more` test.