### PR TITLE
Allow staking proxies to modify author mapping

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -771,7 +771,10 @@ impl InstanceFilter<Call> for ProxyType {
 					| Call::TechComitteeCollective(..)
 					| Call::Utility(..)
 			),
-			ProxyType::Staking => matches!(c, Call::ParachainStaking(..) | Call::Utility(..)),
+			ProxyType::Staking => matches!(
+				c,
+				Call::ParachainStaking(..) | Call::Utility(..) | Call::AuthorMapping
+			),
 			ProxyType::CancelProxy => {
 				matches!(c, Call::Proxy(pallet_proxy::Call::reject_announcement(..)))
 			}

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -762,6 +762,7 @@ impl InstanceFilter<Call> for ProxyType {
 						| Call::Democracy(..) | Call::CouncilCollective(..)
 						| Call::TechComitteeCollective(..)
 						| Call::Utility(..) | Call::Proxy(..)
+						| Call::AuthorMapping(..)
 				)
 			}
 			ProxyType::Governance => matches!(
@@ -773,7 +774,7 @@ impl InstanceFilter<Call> for ProxyType {
 			),
 			ProxyType::Staking => matches!(
 				c,
-				Call::ParachainStaking(..) | Call::Utility(..) | Call::AuthorMapping
+				Call::ParachainStaking(..) | Call::Utility(..) | Call::AuthorMapping(..)
 			),
 			ProxyType::CancelProxy => {
 				matches!(c, Call::Proxy(pallet_proxy::Call::reject_announcement(..)))

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -755,6 +755,7 @@ impl InstanceFilter<Call> for ProxyType {
 						| Call::Democracy(..) | Call::CouncilCollective(..)
 						| Call::TechComitteeCollective(..)
 						| Call::Utility(..) | Call::Proxy(..)
+						| Call::AuthorMapping(..)
 				)
 			}
 			ProxyType::Governance => matches!(
@@ -766,7 +767,7 @@ impl InstanceFilter<Call> for ProxyType {
 			),
 			ProxyType::Staking => matches!(
 				c,
-				Call::ParachainStaking(..) | Call::Utility(..) | Call::AuthorMapping
+				Call::ParachainStaking(..) | Call::Utility(..) | Call::AuthorMapping(..)
 			),
 			ProxyType::CancelProxy => {
 				matches!(c, Call::Proxy(pallet_proxy::Call::reject_announcement(..)))

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -764,7 +764,10 @@ impl InstanceFilter<Call> for ProxyType {
 					| Call::TechComitteeCollective(..)
 					| Call::Utility(..)
 			),
-			ProxyType::Staking => matches!(c, Call::ParachainStaking(..) | Call::Utility(..)),
+			ProxyType::Staking => matches!(
+				c,
+				Call::ParachainStaking(..) | Call::Utility(..) | Call::AuthorMapping
+			),
 			ProxyType::CancelProxy => {
 				matches!(c, Call::Proxy(pallet_proxy::Call::reject_announcement(..)))
 			}

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -755,7 +755,10 @@ impl InstanceFilter<Call> for ProxyType {
 					| Call::TechComitteeCollective(..)
 					| Call::Utility(..)
 			),
-			ProxyType::Staking => matches!(c, Call::ParachainStaking(..) | Call::Utility(..)),
+			ProxyType::Staking => matches!(
+				c,
+				Call::ParachainStaking(..) | Call::Utility(..) | Call::AuthorMapping
+			),
 			ProxyType::CancelProxy => {
 				matches!(c, Call::Proxy(pallet_proxy::Call::reject_announcement(..)))
 			}

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -746,6 +746,7 @@ impl InstanceFilter<Call> for ProxyType {
 						| Call::Democracy(..) | Call::CouncilCollective(..)
 						| Call::TechComitteeCollective(..)
 						| Call::Utility(..) | Call::Proxy(..)
+						| Call::AuthorMapping(..)
 				)
 			}
 			ProxyType::Governance => matches!(
@@ -757,7 +758,7 @@ impl InstanceFilter<Call> for ProxyType {
 			),
 			ProxyType::Staking => matches!(
 				c,
-				Call::ParachainStaking(..) | Call::Utility(..) | Call::AuthorMapping
+				Call::ParachainStaking(..) | Call::Utility(..) | Call::AuthorMapping(..)
 			),
 			ProxyType::CancelProxy => {
 				matches!(c, Call::Proxy(pallet_proxy::Call::reject_announcement(..)))


### PR DESCRIPTION
### What does it do?

Allows proxy accounts with either the `Staking` or `NonTransfer` proxy type to modify the author mapping.

### What important points reviewers should know?

The author mapping maps collators' session keys to onchain account ids. This is all about staking.

The similar calls are available to staking proxies in Polkadot.

### What value does it bring to the blockchain users?

The ability to fully manage a collator's onchain operations through a `Staking` proxy without needing to bring valuable keys online for normal operations.
