### PR TITLE
Fix wrong commit hash in PRs CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,13 @@ jobs:
     steps:
       - name: Check git ref
         id: check-git-ref
+        # if PR
+        # else if manual PR
+        # else (push)
         run: |
           if [[ -n "${{ github.event.pull_request.head.sha }}" ]]; then
             echo ::set-output name=git_ref::${{ github.event.pull_request.head.sha }}
-          else if [[ -n "${{ github.event.inputs.pull_request }}" ]]; then
+          elif [[ -n "${{ github.event.inputs.pull_request }}" ]]; then
             echo ::set-output name=git_ref::refs/pull/${{ github.event.inputs.pull_request }}/head
           else 
             echo ::set-output name=git_ref::$GITHUB_REF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Check git ref
         id: check-git-ref
         run: |
-          if [[ -n "${{ github.event.inputs.pull_request }}" ]]; then
+          if [[ -n "${{ github.event.pull_request }}" ]]; then
+            echo ::set-output name=git_ref::${{ github.event.pull_request.head.sha }}
+          else if [[ -n "${{ github.event.inputs.pull_request }}" ]]; then
             echo ::set-output name=git_ref::refs/pull/${{ github.event.inputs.pull_request }}/head
           else 
             echo ::set-output name=git_ref::$GITHUB_REF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check git ref
         id: check-git-ref
         run: |
-          if [[ -n "${{ github.event.pull_request }}" ]]; then
+          if [[ -n "${{ github.event.pull_request.head.sha }}" ]]; then
             echo ::set-output name=git_ref::${{ github.event.pull_request.head.sha }}
           else if [[ -n "${{ github.event.inputs.pull_request }}" ]]; then
             echo ::set-output name=git_ref::refs/pull/${{ github.event.inputs.pull_request }}/head


### PR DESCRIPTION
### What does it do?

The CI was doing a checkout of the `refs/pull/${{ github.event.inputs.pull_request }}/head` ref for PR.
This was functional before, as the CI was playing manually for PRs. As it is now automatic, there is no input, so `${{ github.event.inputs.pull_request }}` is empty, so we checkout $GITHUB_REF, which is not worth the desired hash in the case of a PR.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
