### PR TITLE
Simplify precompile trait bounds

### DIFF
--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -31,7 +31,6 @@ use pallet_evm::Precompile;
 use precompile_utils::{
 	error, Address, EvmData, EvmDataReader, EvmDataWriter, Gasometer, RuntimeHelper,
 };
-use sp_core::H160;
 use sp_std::convert::TryInto;
 use sp_std::fmt::Debug;
 use sp_std::marker::PhantomData;
@@ -77,7 +76,6 @@ pub struct ParachainStakingWrapper<Runtime>(PhantomData<Runtime>);
 impl<Runtime> Precompile for ParachainStakingWrapper<Runtime>
 where
 	Runtime: parachain_staking::Config + pallet_evm::Config,
-	Runtime::AccountId: From<H160>,
 	BalanceOf<Runtime>: EvmData,
 	Runtime::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
 	<Runtime::Call as Dispatchable>::Origin: From<Option<Runtime::AccountId>>,
@@ -137,7 +135,6 @@ where
 impl<Runtime> ParachainStakingWrapper<Runtime>
 where
 	Runtime: parachain_staking::Config + pallet_evm::Config,
-	Runtime::AccountId: From<H160>,
 	BalanceOf<Runtime>: EvmData,
 	Runtime::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
 	<Runtime::Call as Dispatchable>::Origin: From<Option<Runtime::AccountId>>,
@@ -216,7 +213,7 @@ where
 
 		// Read input.
 		input.expect_arguments(1)?;
-		let address: Runtime::AccountId = input.read::<Address>()?.0.into();
+		let address = Runtime::AddressMapping::into_account_id(input.read::<Address>()?.0);
 
 		// Fetch info.
 		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
@@ -256,7 +253,7 @@ where
 
 		// Read input.
 		input.expect_arguments(1)?;
-		let address: Runtime::AccountId = input.read::<Address>()?.0.into();
+		let address = Runtime::AddressMapping::into_account_id(input.read::<Address>()?.0);
 
 		// Fetch info.
 		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
@@ -299,7 +296,7 @@ where
 
 		// Read input.
 		input.expect_arguments(1)?;
-		let address: Runtime::AccountId = input.read::<Address>()?.0.into();
+		let address = Runtime::AddressMapping::into_account_id(input.read::<Address>()?.0);
 
 		// Fetch info.
 		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
@@ -322,7 +319,7 @@ where
 
 		// Read input.
 		input.expect_arguments(1)?;
-		let address: Runtime::AccountId = input.read::<Address>()?.0.into();
+		let address = Runtime::AddressMapping::into_account_id(input.read::<Address>()?.0);
 
 		// Fetch info.
 		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
@@ -345,7 +342,7 @@ where
 
 		// Read input.
 		input.expect_arguments(1)?;
-		let address: Runtime::AccountId = input.read::<Address>()?.0.into();
+		let address = Runtime::AddressMapping::into_account_id(input.read::<Address>()?.0);
 
 		// Fetch info.
 		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
@@ -498,7 +495,7 @@ where
 	> {
 		// Read input.
 		input.expect_arguments(4)?;
-		let collator: Runtime::AccountId = input.read::<Address>()?.0.into();
+		let collator = Runtime::AddressMapping::into_account_id(input.read::<Address>()?.0);
 		let amount: BalanceOf<Runtime> = input.read()?;
 		let collator_nomination_count = input.read()?;
 		let nominator_nomination_count = input.read()?;
@@ -550,7 +547,7 @@ where
 	> {
 		// Read input.
 		input.expect_arguments(1)?;
-		let collator: Runtime::AccountId = input.read::<Address>()?.0.into();
+		let collator = Runtime::AddressMapping::into_account_id(input.read::<Address>()?.0);
 
 		// Build call with origin.
 		let origin = Runtime::AddressMapping::into_account_id(context.caller);
@@ -572,7 +569,7 @@ where
 	> {
 		// Read input.
 		input.expect_arguments(2)?;
-		let collator: Runtime::AccountId = input.read::<Address>()?.0.into();
+		let collator = Runtime::AddressMapping::into_account_id(input.read::<Address>()?.0);
 		let amount: BalanceOf<Runtime> = input.read()?;
 
 		// Build call with origin.
@@ -595,7 +592,7 @@ where
 	> {
 		// Read input.
 		input.expect_arguments(2)?;
-		let collator: Runtime::AccountId = input.read::<Address>()?.0.into();
+		let collator = Runtime::AddressMapping::into_account_id(input.read::<Address>()?.0);
 		let amount: BalanceOf<Runtime> = input.read()?;
 
 		// Build call with origin.

--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -28,19 +28,8 @@ use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripe
 use parachain_staking_precompiles::ParachainStakingWrapper;
 use parity_scale_codec::Decode;
 use sp_core::H160;
-use sp_std::convert::TryFrom;
 use sp_std::fmt::Debug;
 use sp_std::marker::PhantomData;
-
-use frame_support::traits::Currency;
-type BalanceOf<Runtime> = <<Runtime as parachain_staking::Config>::Currency as Currency<
-	<Runtime as frame_system::Config>::AccountId,
->>::Balance;
-
-type RewardBalanceOf<Runtime> =
-	<<Runtime as pallet_crowdloan_rewards::Config>::RewardCurrency as Currency<
-		<Runtime as frame_system::Config>::AccountId,
-	>>::Balance;
 
 /// The PrecompileSet installed in the Moonbase runtime.
 /// We include the nine Istanbul precompiles
@@ -70,11 +59,10 @@ impl<R> PrecompileSet for MoonbasePrecompiles<R>
 where
 	R::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo + Decode,
 	<R::Call as Dispatchable>::Origin: From<Option<R::AccountId>>,
-	R: parachain_staking::Config + pallet_evm::Config + pallet_crowdloan_rewards::Config,
-	R::AccountId: From<H160>,
-	BalanceOf<R>: Debug + precompile_utils::EvmData,
-	RewardBalanceOf<R>: TryFrom<sp_core::U256> + Debug,
-	R::Call: From<parachain_staking::Call<R>> + From<pallet_crowdloan_rewards::Call<R>>,
+	R: parachain_staking::Config + pallet_evm::Config,
+
+	ParachainStakingWrapper<R>: Precompile,
+	CrowdloanRewardsWrapper<R>: Precompile,
 {
 	fn execute(
 		address: H160,

--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -18,7 +18,7 @@
 
 use crowdloan_rewards_precompiles::CrowdloanRewardsWrapper;
 use evm::{executor::PrecompileOutput, Context, ExitError};
-use pallet_evm::{Precompile, PrecompileSet};
+use pallet_evm::{AddressMapping, Precompile, PrecompileSet};
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_dispatch::Dispatch;
 use pallet_evm_precompile_modexp::Modexp;
@@ -36,16 +36,16 @@ use sp_std::marker::PhantomData;
 #[derive(Debug, Clone, Copy)]
 pub struct MoonbasePrecompiles<R>(PhantomData<R>);
 
-impl<R: frame_system::Config> MoonbasePrecompiles<R>
+impl<R> MoonbasePrecompiles<R>
 where
-	R::AccountId: From<H160>,
+	R: pallet_evm::Config,
 {
 	/// Return all addresses that contain precompiles. This can be used to populate dummy code
 	/// under the precompile.
 	pub fn used_addresses() -> impl Iterator<Item = R::AccountId> {
 		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 1024, 1025, 1026, 2048, 2049]
 			.into_iter()
-			.map(|x| hash(x).into())
+			.map(|x| R::AddressMapping::into_account_id(hash(x)))
 	}
 }
 

--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -18,7 +18,6 @@
 
 use crowdloan_rewards_precompiles::CrowdloanRewardsWrapper;
 use evm::{executor::PrecompileOutput, Context, ExitError};
-use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
 use pallet_evm::{Precompile, PrecompileSet};
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_dispatch::Dispatch;
@@ -26,7 +25,6 @@ use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
 use parachain_staking_precompiles::ParachainStakingWrapper;
-use parity_scale_codec::Decode;
 use sp_core::H160;
 use sp_std::fmt::Debug;
 use sp_std::marker::PhantomData;
@@ -57,10 +55,9 @@ where
 /// 2048-4095 Moonbeam specific precompiles
 impl<R> PrecompileSet for MoonbasePrecompiles<R>
 where
-	R::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo + Decode,
-	<R::Call as Dispatchable>::Origin: From<Option<R::AccountId>>,
-	R: parachain_staking::Config + pallet_evm::Config,
-
+	// TODO remove this first trait bound once https://github.com/paritytech/frontier/pull/472 lands
+	R: pallet_evm::Config,
+	Dispatch<R>: Precompile,
 	ParachainStakingWrapper<R>: Precompile,
 	CrowdloanRewardsWrapper<R>: Precompile,
 {

--- a/runtime/moonbeam/src/precompiles.rs
+++ b/runtime/moonbeam/src/precompiles.rs
@@ -18,7 +18,7 @@
 
 use crowdloan_rewards_precompiles::CrowdloanRewardsWrapper;
 use evm::{executor::PrecompileOutput, Context, ExitError};
-use pallet_evm::{Precompile, PrecompileSet};
+use pallet_evm::{AddressMapping, Precompile, PrecompileSet};
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_dispatch::Dispatch;
 use pallet_evm_precompile_modexp::Modexp;
@@ -36,16 +36,16 @@ use sp_std::marker::PhantomData;
 #[derive(Debug, Clone, Copy)]
 pub struct MoonbeamPrecompiles<R>(PhantomData<R>);
 
-impl<R: frame_system::Config> MoonbeamPrecompiles<R>
+impl<R> MoonbeamPrecompiles<R>
 where
-	R::AccountId: From<H160>,
+	R: pallet_evm::Config,
 {
 	/// Return all addresses that contain precompiles. This can be used to populate dummy code
 	/// under the precompile.
 	pub fn used_addresses() -> impl Iterator<Item = R::AccountId> {
 		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 1024, 1025, 1026, 2048, 2049]
 			.into_iter()
-			.map(|x| hash(x).into())
+			.map(|x| R::AddressMapping::into_account_id(hash(x)))
 	}
 }
 

--- a/runtime/moonbeam/src/precompiles.rs
+++ b/runtime/moonbeam/src/precompiles.rs
@@ -18,7 +18,6 @@
 
 use crowdloan_rewards_precompiles::CrowdloanRewardsWrapper;
 use evm::{executor::PrecompileOutput, Context, ExitError};
-use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
 use pallet_evm::{Precompile, PrecompileSet};
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_dispatch::Dispatch;
@@ -26,21 +25,9 @@ use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
 use parachain_staking_precompiles::ParachainStakingWrapper;
-use parity_scale_codec::Decode;
 use sp_core::H160;
-use sp_std::convert::TryFrom;
 use sp_std::fmt::Debug;
 use sp_std::marker::PhantomData;
-
-use frame_support::traits::Currency;
-type BalanceOf<Runtime> = <<Runtime as parachain_staking::Config>::Currency as Currency<
-	<Runtime as frame_system::Config>::AccountId,
->>::Balance;
-
-type RewardBalanceOf<Runtime> =
-	<<Runtime as pallet_crowdloan_rewards::Config>::RewardCurrency as Currency<
-		<Runtime as frame_system::Config>::AccountId,
-	>>::Balance;
 
 /// The PrecompileSet installed in the Moonbeam runtime.
 /// We include the nine Istanbul precompiles
@@ -68,13 +55,11 @@ where
 /// 2048-4095 Moonbeam specific precompiles
 impl<R> PrecompileSet for MoonbeamPrecompiles<R>
 where
-	R::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo + Decode,
-	<R::Call as Dispatchable>::Origin: From<Option<R::AccountId>>,
-	R: parachain_staking::Config + pallet_evm::Config + pallet_crowdloan_rewards::Config,
-	R::AccountId: From<H160>,
-	BalanceOf<R>: Debug + precompile_utils::EvmData,
-	RewardBalanceOf<R>: TryFrom<sp_core::U256> + Debug,
-	R::Call: From<parachain_staking::Call<R>> + From<pallet_crowdloan_rewards::Call<R>>,
+	// TODO remove this first trait bound once https://github.com/paritytech/frontier/pull/472 lands
+	R: pallet_evm::Config,
+	Dispatch<R>: Precompile,
+	ParachainStakingWrapper<R>: Precompile,
+	CrowdloanRewardsWrapper<R>: Precompile,
 {
 	fn execute(
 		address: H160,

--- a/runtime/moonriver/src/precompiles.rs
+++ b/runtime/moonriver/src/precompiles.rs
@@ -18,7 +18,7 @@
 
 use crowdloan_rewards_precompiles::CrowdloanRewardsWrapper;
 use evm::{executor::PrecompileOutput, Context, ExitError};
-use pallet_evm::{Precompile, PrecompileSet};
+use pallet_evm::{AddressMapping, Precompile, PrecompileSet};
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_dispatch::Dispatch;
 use pallet_evm_precompile_modexp::Modexp;
@@ -35,16 +35,16 @@ use sp_std::marker::PhantomData;
 #[derive(Debug, Clone, Copy)]
 pub struct MoonriverPrecompiles<R>(PhantomData<R>);
 
-impl<R: frame_system::Config> MoonriverPrecompiles<R>
+impl<R> MoonriverPrecompiles<R>
 where
-	R::AccountId: From<H160>,
+	R: pallet_evm::Config,
 {
 	/// Return all addresses that contain precompiles. This can be used to populate dummy code
 	/// under the precompile.
 	pub fn used_addresses() -> impl Iterator<Item = R::AccountId> {
 		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 1024, 1025, 1026, 2048, 2049]
 			.into_iter()
-			.map(|x| hash(x).into())
+			.map(|x| R::AddressMapping::into_account_id(hash(x)))
 	}
 }
 


### PR DESCRIPTION
### What does it do?
This PR simplifies the trait bounds around our precompile sets significantly. Before this PR our `PrecompileSet` was laden with `where` clauses encompasing the union of the `where` clauses on the individual precompiles. This PR removes those clauses, replacing them with a single clause for each precompile.

As a secondary change, this PR removes the `AccountId: From<H160>` bound from throughout the precompiles and prefers `AccountMapping::into_account_id` instead.

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

https://github.com/paritytech/frontier/pull/472 Once this lands, we can remove one more trait bound.