### PR TITLE
[DO NOT MERGE] Fixes prediction candidate list order

### DIFF
--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -357,9 +357,11 @@ macro_rules! impl_runtime_apis_plus_common {
 							return false
 						};
 						// predict eligibility post-selection by computing selection results now
+						let mut top_candidates = parachain_staking::Pallet::<Self>::compute_top_candidates();
+						top_candidates.sort();
 						let (eligible, _) =
 							pallet_author_slot_filter::compute_pseudo_random_subset::<Self>(
-								parachain_staking::Pallet::<Self>::compute_top_candidates(),
+								top_candidates,
 								&slot
 							);
 						eligible.contains(&author_account_id)


### PR DESCRIPTION
This is to show how to quickly fix the candidate list.
However I believe this is not the right way as any change in the pallet staking logic will lead to a broken prediction again