### PR TITLE
Add democracy precompile address to used list

### DIFF
--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -45,7 +45,7 @@ where
 	/// Return all addresses that contain precompiles. This can be used to populate dummy code
 	/// under the precompile.
 	pub fn used_addresses() -> impl Iterator<Item = R::AccountId> {
-		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 1024, 1025, 1026, 2048, 2049, 2050]
+		sp_std::vec![1, 2, 3, 4, 5, 6, 7, 8, 1024, 1025, 1026, 2048, 2049, 2050, 2051]
 			.into_iter()
 			.map(|x| R::AddressMapping::into_account_id(hash(x)))
 	}


### PR DESCRIPTION
This PR is a cleanup from #518 . It adds the democracy precompile address to the list of used precompile addresses so that the appropriate bogus bytecode is deployed beneath it.