### PR TITLE
Make precompile utils slightly more useful

### DIFF
--- a/precompiles/crowdloan-rewards/src/mock.rs
+++ b/precompiles/crowdloan-rewards/src/mock.rs
@@ -293,7 +293,7 @@ impl ExtBuilder {
 			funded_amount: self.crowdloan_pot,
 		}
 		.assimilate_storage(&mut t)
-		.expect("Pallet balances storage can be assimilated");
+		.expect("Crowdloan Rewards storage can be assimilated");
 
 		let mut ext = sp_io::TestExternalities::new(t);
 		ext.execute_with(|| System::set_block_number(1));

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -195,7 +195,12 @@ where
 			used_weight.unwrap_or(dispatch_info.weight),
 		))
 	}
+}
 
+impl<Runtime> RuntimeHelper<Runtime>
+where
+	Runtime: pallet_evm::Config,
+{
 	/// Cost of a Substrate DB write in gas.
 	pub fn db_write_gas_cost() -> u64 {
 		<Runtime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(


### PR DESCRIPTION
This PR makes two minor improvements to precopmiles:

1. The `RuntimeHelper` for the utils is split into two `impl` blocks. This makes it still possible to fetch the storage costs when you aren't planning to dispatch any calls.

2. It fixes an incorrect expect message in the crowdloan reward precompiles.