### PR TITLE
Forces to use commit branch/tag associated with release

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -107,6 +107,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          commitish: ${{ github.event.inputs.to }}
           tag_name: ${{ github.event.inputs.to }}
           release_name: Runtime ${{ github.event.inputs.to }}
           body_path: body.md


### PR DESCRIPTION
Otherwise commit is kind of set to a weird state pointing to master, to a previous commit ???