### PR TITLE
Fix `CallInner::SelfDestruct` serialization

### DIFF
--- a/client/evm-tracing/src/formatters/trace_filter.rs
+++ b/client/evm-tracing/src/formatters/trace_filter.rs
@@ -107,14 +107,11 @@ impl super::ResponseFormatter for Formatter {
 							transaction_position: eth_tx_index as u32,
 						}
 					}
-					CallInner::SelfDestruct {
-						balance,
-						refund_address,
-					} => TransactionTrace {
+					CallInner::SelfDestruct { balance, to } => TransactionTrace {
 						action: TransactionTraceAction::Suicide {
 							address: trace.from,
 							balance,
-							refund_address,
+							refund_address: to,
 						},
 						// Can't be known here, must be inserted upstream.
 						block_hash: H256::default(),

--- a/client/evm-tracing/src/listeners/call_list.rs
+++ b/client/evm-tracing/src/listeners/call_list.rs
@@ -483,7 +483,7 @@ impl Listener {
 						gas: 0.into(),
 						gas_used: 0.into(),
 						inner: CallInner::SelfDestruct {
-							refund_address: target,
+							to: target,
 							balance,
 						},
 					},

--- a/primitives/rpc/debug/src/api/single.rs
+++ b/primitives/rpc/debug/src/api/single.rs
@@ -127,8 +127,7 @@ pub enum CallInner {
 	SelfDestruct {
 		#[cfg_attr(feature = "std", serde(skip))]
 		balance: U256,
-		#[cfg_attr(feature = "std", serde(skip))]
-		refund_address: H160,
+		to: H160,
 	},
 }
 


### PR DESCRIPTION
We need to include the `to` field when serializing the `SelfDestruct` call type.