### PR TITLE
Improve tracing ci

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 [alias]
 moonbase = " build --release -p moonbeam --no-default-features --features moonbase-native"
 moonbase-rococo = " build --release -p moonbeam --no-default-features --features moonbase-native,rococo-native"
+moonbase-tracing = " build --release -p moonbeam --features moonbase-native-tracing"
 moonriver = " build --release -p moonbeam --no-default-features --features moonriver-native"
 moonriver-rococo = " build --release -p moonbeam --no-default-features --features moonriver-native,rococo-native"
 moonriver-kusama = " build --release -p moonbeam --no-default-features --features moonriver-native,kusama-native"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,11 +223,6 @@ jobs:
         run: |
           env
           cargo build --release --all
-      - name: Build Tracing Node
-        if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
-        run: |
-          env
-          cargo build moonbase-tracing
       - name: Verify node version
         run: |
           GIT_COMMIT=`git log -1 --format="%H" | cut -c1-7`
@@ -236,9 +231,6 @@ jobs:
           echo "$MB_VERSION" | grep $GIT_COMMIT
       - name: Unit tests
         run: cargo test --release --all
-      - name: Unit tests (tracing)
-        if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
-        run: cargo test --release -p moonbase-runtime -p moonbeam-runtime -p moonriver-runtime --test evm_tracing --features evm-tracing
 
       # We determine whether there are unmodified Cargo.lock files by:
       # 1. Asking git for a list of all modified files
@@ -387,6 +379,8 @@ jobs:
         run: |
           env
           cargo build moonbase-tracing
+      - name: Unit tests (tracing)
+        run: cargo test --release -p moonbase-runtime -p moonbeam-runtime -p moonriver-runtime --test evm_tracing --features evm-tracing
       - name: Save moonbeam tracing binary
         run: |
           mkdir -p build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,7 +378,7 @@ jobs:
       - name: Build Tracing Node
         run: |
           env
-          cargo build moonbase-tracing
+          cargo moonbase-tracing
       - name: Unit tests (tracing)
         run: cargo test --release -p moonbase-runtime -p moonbeam-runtime -p moonriver-runtime --test evm_tracing --features evm-tracing
       - name: Save moonbeam tracing binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -294,17 +294,6 @@ jobs:
           cd ../tests
           npm install
           node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tests/**/test-*.ts'
-      - name: Typescript evm-tracing tests (against dev service)
-        if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
-        env:
-          BINARY_PATH: ../build/moonbeam
-          ETHAPI_CMD: --ethapi=txpool,debug,trace
-        run: |
-          cd moonbeam-types-bundle
-          npm install
-          cd ../tests
-          npm install
-          node_modules/.bin/mocha --parallel -j 7 -r ts-node/register 'tracing-tests/**/test-*.ts'
 
       # We determine whether there are unmodified package-lock.json files by:
       # 1. Asking git for a list of all modified files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,7 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'A10-evmtracing')
         run: |
           env
-          cargo build --release -p moonbeam -p moonbase-runtime --features moonbase-runtime/evm-tracing
+          cargo build moonbase-tracing
       - name: Verify node version
         run: |
           GIT_COMMIT=`git log -1 --format="%H" | cut -c1-7`
@@ -386,7 +386,7 @@ jobs:
       - name: Build Tracing Node
         run: |
           env
-          cargo build --release -p moonbeam -p moonbase-runtime --features moonbase-runtime/evm-tracing
+          cargo build moonbase-tracing
       - name: Save moonbeam tracing binary
         run: |
           mkdir -p build

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -38,6 +38,8 @@ moonbase-native = [ "moonbeam-cli/moonbase-native", "moonbeam-service/moonbase-n
 moonriver-native = [ "moonbeam-cli/moonriver-native", "moonbeam-service/moonriver-native" ]
 moonbeam-native = [ "moonbeam-cli/moonbeam-native", "moonbeam-service/moonbeam-native" ]
 
+moonbase-native-tracing = [ "moonbeam-service/moonbase-native-tracing" ]
+
 test-spec = []
 
 runtime-benchmarks = [

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -45,7 +45,6 @@ moonbeam-native = ["service/moonbeam-native"]
 
 wasmtime = ["sc-cli/wasmtime"]
 runtime-benchmarks = ["service/runtime-benchmarks"]
-evm-tracing = []
 try-runtime = [
 	"try-runtime-cli",
 	"service/try-runtime",

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -155,6 +155,8 @@ moonbase-native = [ "moonbase-runtime", "westend-native" ]
 moonriver-native = [ "moonriver-runtime" ]
 moonbeam-native = [ "moonbeam-runtime" ]
 
+moonbase-native-tracing = [ "moonbase-native", "moonbase-runtime/evm-tracing" ]
+
 test-spec = []
 
 runtime-benchmarks = [


### PR DESCRIPTION
### What does it do?

- Move tracing unit tests in tracing-build job
- Create cargo feature `moonbase-native-tracing` to build moonbase runtime only for typescript-tracing-tests

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
