### PR TITLE
Trace known Ethereum transactions only

### DIFF
--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -823,6 +823,10 @@ where
 		};
 
 		let eth_block_hash = eth_block.header.hash();
+		let eth_tx_hashes = eth_transactions
+			.iter()
+			.map(|t| t.transaction_hash)
+			.collect();
 
 		// Get extrinsics (containing Ethereum ones)
 		let extrinsics = backend
@@ -847,7 +851,7 @@ where
 				.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
 
 			let _result = api
-				.trace_block(&substrate_parent_id, extrinsics)
+				.trace_block(&substrate_parent_id, extrinsics, eth_tx_hashes)
 				.map_err(|e| {
 					internal_err(format!(
 						"Blockchain error when replaying block {} : {:?}",

--- a/primitives/rpc/debug/src/lib.rs
+++ b/primitives/rpc/debug/src/lib.rs
@@ -22,6 +22,7 @@ pub mod serialization;
 pub mod api;
 
 use ethereum::TransactionV0 as Transaction;
+use ethereum_types::H256;
 use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {
@@ -33,6 +34,7 @@ sp_api::decl_runtime_apis! {
 
 		fn trace_block(
 			extrinsics: Vec<Block::Extrinsic>,
+			known_transactions: Vec<H256>,
 		) -> Result<(), sp_runtime::DispatchError>;
 	}
 }

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -126,6 +126,7 @@ macro_rules! impl_runtime_apis_plus_common {
 
 				fn trace_block(
 					extrinsics: Vec<<Block as BlockT>::Extrinsic>,
+					known_transactions: Vec<H256>,
 				) -> Result<
 					(),
 					sp_runtime::DispatchError,
@@ -133,6 +134,7 @@ macro_rules! impl_runtime_apis_plus_common {
 					#[cfg(feature = "evm-tracing")]
 					{
 						use moonbeam_evm_tracer::tracer::EvmTracer;
+						use sha3::{Digest, Keccak256};
 
 						let mut config = <Runtime as pallet_evm::Config>::config().clone();
 						config.estimate = true;
@@ -140,10 +142,16 @@ macro_rules! impl_runtime_apis_plus_common {
 						// Apply all extrinsics. Ethereum extrinsics are traced.
 						for ext in extrinsics.into_iter() {
 							match &ext.function {
-								Call::Ethereum(transact(_transaction)) => {
-									// Each extrinsic is a new call stack.
-									EvmTracer::emit_new();
-									EvmTracer::new().trace(|| Executive::apply_extrinsic(ext));
+								Call::Ethereum(transact(transaction)) => {
+									let eth_extrinsic_hash =
+										H256::from_slice(Keccak256::digest(&rlp::encode(transaction)).as_slice());
+									if known_transactions.contains(&eth_extrinsic_hash) {
+										// Each known extrinsic is a new call stack.
+										EvmTracer::emit_new();
+										EvmTracer::new().trace(|| Executive::apply_extrinsic(ext));
+									} else {
+										let _ = Executive::apply_extrinsic(ext);
+									}
 								}
 								_ => {
 									let _ = Executive::apply_extrinsic(ext);

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -12,6 +12,8 @@ build = "build.rs"
 serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
 parity-scale-codec = { version = "2.2", default-features = false, features = ["derive", "max-encoded-len"] }
 log = "0.4"
+rlp = { version = "0.5", default-features = false, optional = true }
+sha3 = { version = "0.8", default-features = false, optional = true }
 
 runtime-common = { path = "../common", default-features = false }
 
@@ -127,7 +129,7 @@ xcm-simulator = { git = "https://github.com/purestake/polkadot", branch = "notle
 substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "crystalin-v0.9.9-block-response-length" }
 
 [features]
-evm-tracing = ["moonbeam-evm-tracer", "evm-tracing-events"]
+evm-tracing = ["moonbeam-evm-tracer", "evm-tracing-events", "sha3", "rlp"]
 default = ["std"]
 std = [
 	"runtime-common/std",

--- a/runtime/moonbase/tests/evm_tracing.rs
+++ b/runtime/moonbase/tests/evm_tracing.rs
@@ -24,7 +24,8 @@ mod tests {
 	use super::common::*;
 
 	use pallet_evm::AddressMapping;
-	use sp_core::H160;
+	use sha3::{Digest, Keccak256};
+	use sp_core::{H160, H256};
 
 	use moonbeam_rpc_primitives_debug::runtime_decl_for_DebugRuntimeApi::DebugRuntimeApi;
 	use std::str::FromStr;
@@ -76,12 +77,13 @@ mod tests {
 						.into(),
 				);
 				let eth_uxt = unchecked_eth_tx(VALID_ETH_TX);
-				assert!(Runtime::trace_block(vec![
-					non_eth_uxt.clone(),
-					eth_uxt.clone(),
-					non_eth_uxt,
-					eth_uxt
-				],)
+				let eth_tx = ethereum_transaction(VALID_ETH_TX);
+				let eth_extrinsic_hash =
+					H256::from_slice(Keccak256::digest(&rlp::encode(&eth_tx)).as_slice());
+				assert!(Runtime::trace_block(
+					vec![non_eth_uxt.clone(), eth_uxt.clone(), non_eth_uxt, eth_uxt],
+					vec![eth_extrinsic_hash, eth_extrinsic_hash]
+				)
 				.is_ok());
 			});
 	}

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -12,6 +12,8 @@ build = "build.rs"
 serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
 parity-scale-codec = { version = "2.2", default-features = false, features = ["derive", "max-encoded-len"] }
 log = "0.4"
+rlp = { version = "0.5", default-features = false, optional = true }
+sha3 = { version = "0.8", default-features = false, optional = true }
 
 runtime-common = { path = "../common", default-features = false }
 
@@ -102,7 +104,7 @@ sha3 = "0.8"
 substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "crystalin-v0.9.9-block-response-length" }
 
 [features]
-evm-tracing = ["moonbeam-evm-tracer", "evm-tracing-events"]
+evm-tracing = ["moonbeam-evm-tracer", "evm-tracing-events", "sha3", "rlp"]
 default = ["std"]
 std = [
 	"runtime-common/std",

--- a/runtime/moonbeam/tests/evm_tracing.rs
+++ b/runtime/moonbeam/tests/evm_tracing.rs
@@ -24,7 +24,8 @@ mod tests {
 	use super::common::*;
 
 	use pallet_evm::AddressMapping;
-	use sp_core::H160;
+	use sha3::{Digest, Keccak256};
+	use sp_core::{H160, H256};
 
 	use moonbeam_rpc_primitives_debug::runtime_decl_for_DebugRuntimeApi::DebugRuntimeApi;
 	use std::str::FromStr;
@@ -76,12 +77,13 @@ mod tests {
 						.into(),
 				);
 				let eth_uxt = unchecked_eth_tx(VALID_ETH_TX);
-				assert!(Runtime::trace_block(vec![
-					non_eth_uxt.clone(),
-					eth_uxt.clone(),
-					non_eth_uxt,
-					eth_uxt
-				],)
+				let eth_tx = ethereum_transaction(VALID_ETH_TX);
+				let eth_extrinsic_hash =
+					H256::from_slice(Keccak256::digest(&rlp::encode(&eth_tx)).as_slice());
+				assert!(Runtime::trace_block(
+					vec![non_eth_uxt.clone(), eth_uxt.clone(), non_eth_uxt, eth_uxt],
+					vec![eth_extrinsic_hash, eth_extrinsic_hash]
+				)
 				.is_ok());
 			});
 	}

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -12,6 +12,8 @@ build = "build.rs"
 serde = { version = "1.0.101", default-features = false, optional = true, features = ["derive"] }
 parity-scale-codec = { version = "2.2", default-features = false, features = ["derive", "max-encoded-len"] }
 log = "0.4"
+rlp = { version = "0.5", default-features = false, optional = true }
+sha3 = { version = "0.8", default-features = false, optional = true }
 
 runtime-common = { path = "../common", default-features = false }
 
@@ -103,7 +105,7 @@ sha3 = "0.8"
 substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "crystalin-v0.9.9-block-response-length" }
 
 [features]
-evm-tracing = ["moonbeam-evm-tracer", "evm-tracing-events"]
+evm-tracing = ["moonbeam-evm-tracer", "evm-tracing-events", "sha3", "rlp"]
 default = ["std"]
 std = [
 	"runtime-common/std",

--- a/runtime/moonriver/tests/evm_tracing.rs
+++ b/runtime/moonriver/tests/evm_tracing.rs
@@ -24,7 +24,8 @@ mod tests {
 	use super::common::*;
 
 	use pallet_evm::AddressMapping;
-	use sp_core::H160;
+	use sha3::{Digest, Keccak256};
+	use sp_core::{H160, H256};
 
 	use moonbeam_rpc_primitives_debug::runtime_decl_for_DebugRuntimeApi::DebugRuntimeApi;
 	use std::str::FromStr;
@@ -76,12 +77,13 @@ mod tests {
 						.into(),
 				);
 				let eth_uxt = unchecked_eth_tx(VALID_ETH_TX);
-				assert!(Runtime::trace_block(vec![
-					non_eth_uxt.clone(),
-					eth_uxt.clone(),
-					non_eth_uxt,
-					eth_uxt
-				],)
+				let eth_tx = ethereum_transaction(VALID_ETH_TX);
+				let eth_extrinsic_hash =
+					H256::from_slice(Keccak256::digest(&rlp::encode(&eth_tx)).as_slice());
+				assert!(Runtime::trace_block(
+					vec![non_eth_uxt.clone(), eth_uxt.clone(), non_eth_uxt, eth_uxt],
+					vec![eth_extrinsic_hash, eth_extrinsic_hash]
+				)
 				.is_ok());
 			});
 	}


### PR DESCRIPTION
Make sure we only trace transactions mapped in the emulated ethereum block.