### PR TITLE
Revert "Erc20 metadata for native tokens (DEV)"

### DIFF
--- a/precompiles/balances-erc20/ERC20.sol
+++ b/precompiles/balances-erc20/ERC20.sol
@@ -7,24 +7,6 @@ pragma solidity ^0.4.24;
  */
 interface IERC20 {
   /**
-   * @dev Returns the name of the token.
-   * Selector: 06fdde03
-   */
-  function name() external view returns (string memory);
-
-  /**
-   * @dev Returns the symbol of the token.
-   * Selector: 95d89b41
-   */
-  function symbol() external view returns (string memory);
-
-  /**
-   * @dev Returns the decimals places of the token.
-   * Selector: 313ce567
-   */
-  function decimals() external view returns (uint8);
-
-  /**
    * @dev Total number of tokens in existence
    * Selector: 18160ddd
    */

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -123,34 +123,17 @@ pub enum Action {
 	Transfer = "transfer(address,uint256)",
 	Approve = "approve(address,uint256)",
 	TransferFrom = "transferFrom(address,address,uint256)",
-	Name = "name()",
-	Symbol = "symbol()",
-	Decimals = "decimals()",
-}
-
-/// Metadata of an ERC20 token.
-pub trait Erc20Metadata {
-	/// Returns the name of the token.
-	fn name() -> &'static str;
-
-	/// Returns the symbol of the token.
-	fn symbol() -> &'static str;
-
-	/// Returns the decimals places of the token.
-	fn decimals() -> u8;
 }
 
 /// Precompile exposing a pallet_balance as an ERC20.
 /// Multiple precompiles can support instances of pallet_balance.
 /// The precompile uses an additional storage to store approvals.
-pub struct Erc20BalancesPrecompile<Runtime, Metadata: Erc20Metadata, Instance: 'static = ()>(
-	PhantomData<(Runtime, Metadata, Instance)>,
+pub struct Erc20BalancesPrecompile<Runtime, Instance: 'static = ()>(
+	PhantomData<(Runtime, Instance)>,
 );
 
-impl<Runtime, Metadata, Instance> Precompile
-	for Erc20BalancesPrecompile<Runtime, Metadata, Instance>
+impl<Runtime, Instance> Precompile for Erc20BalancesPrecompile<Runtime, Instance>
 where
-	Metadata: Erc20Metadata,
 	Instance: InstanceToPrefix + 'static,
 	Runtime: pallet_balances::Config<Instance> + pallet_evm::Config,
 	Runtime::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
@@ -172,16 +155,12 @@ where
 			Action::Approve => Self::approve(input, target_gas, context),
 			Action::Transfer => Self::transfer(input, target_gas, context),
 			Action::TransferFrom => Self::transfer_from(input, target_gas, context),
-			Action::Name => Self::name(input, target_gas, context),
-			Action::Symbol => Self::symbol(input, target_gas, context),
-			Action::Decimals => Self::decimals(input, target_gas, context),
 		}
 	}
 }
 
-impl<Runtime, Metadata, Instance> Erc20BalancesPrecompile<Runtime, Metadata, Instance>
+impl<Runtime, Instance> Erc20BalancesPrecompile<Runtime, Instance>
 where
-	Metadata: Erc20Metadata,
 	Instance: InstanceToPrefix + 'static,
 	Runtime: pallet_balances::Config<Instance> + pallet_evm::Config,
 	Runtime::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
@@ -420,40 +399,6 @@ where
 					EvmDataWriter::new().write(amount).build(),
 				)
 				.build(),
-		})
-	}
-
-	fn name(_: EvmDataReader, _: Option<u64>, _: &Context) -> EvmResult<PrecompileOutput> {
-		// Build output.
-		Ok(PrecompileOutput {
-			exit_status: ExitSucceed::Returned,
-			cost: 0,
-			output: EvmDataWriter::new()
-				.write_raw_bytes(Metadata::name().as_bytes())
-				.build(),
-			logs: Default::default(),
-		})
-	}
-
-	fn symbol(_: EvmDataReader, _: Option<u64>, _: &Context) -> EvmResult<PrecompileOutput> {
-		// Build output.
-		Ok(PrecompileOutput {
-			exit_status: ExitSucceed::Returned,
-			cost: 0,
-			output: EvmDataWriter::new()
-				.write_raw_bytes(Metadata::symbol().as_bytes())
-				.build(),
-			logs: Default::default(),
-		})
-	}
-
-	fn decimals(_: EvmDataReader, _: Option<u64>, _: &Context) -> EvmResult<PrecompileOutput> {
-		// Build output.
-		Ok(PrecompileOutput {
-			exit_status: ExitSucceed::Returned,
-			cost: 0,
-			output: EvmDataWriter::new().write(Metadata::decimals()).build(),
-			logs: Default::default(),
 		})
 	}
 

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -193,26 +193,6 @@ construct_runtime!(
 	}
 );
 
-/// ERC20 metadata for the native token.
-pub struct NativeErc20Metadata;
-
-impl Erc20Metadata for NativeErc20Metadata {
-	/// Returns the name of the token.
-	fn name() -> &'static str {
-		"Mock tokens"
-	}
-
-	/// Returns the symbol of the token.
-	fn symbol() -> &'static str {
-		"MOCK"
-	}
-
-	/// Returns the decimals places of the token.
-	fn decimals() -> u8 {
-		18
-	}
-}
-
 pub struct Precompiles<R>(PhantomData<R>);
 
 impl<R> PrecompileSet for Precompiles<R>
@@ -232,10 +212,9 @@ where
 		context: &Context,
 	) -> Option<Result<PrecompileOutput, ExitError>> {
 		match address {
-			a if a == hash(PRECOMPILE_ADDRESS) => Some(Erc20BalancesPrecompile::<
-				R,
-				NativeErc20Metadata,
-			>::execute(input, target_gas, context)),
+			a if a == hash(PRECOMPILE_ADDRESS) => Some(Erc20BalancesPrecompile::<R>::execute(
+				input, target_gas, context,
+			)),
 			_ => None,
 		}
 	}

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -74,9 +74,6 @@ fn selectors() {
 	assert_eq!(Action::Allowance as u32, 0xdd62ed3e);
 	assert_eq!(Action::Transfer as u32, 0xa9059cbb);
 	assert_eq!(Action::TransferFrom as u32, 0x23b872dd);
-	assert_eq!(Action::Name as u32, 0x06fdde03);
-	assert_eq!(Action::Symbol as u32, 0x95d89b41);
-	assert_eq!(Action::Decimals as u32, 0x313ce567);
 
 	assert_eq!(
 		crate::SELECTOR_LOG_TRANSFER,
@@ -643,93 +640,6 @@ fn transfer_from_self() {
 				Some(Ok(PrecompileOutput {
 					exit_status: ExitSucceed::Returned,
 					output: EvmDataWriter::new().write(U256::from(400)).build(),
-					cost: Default::default(),
-					logs: Default::default(),
-				}))
-			);
-		});
-}
-
-#[test]
-fn get_metadata_name() {
-	ExtBuilder::default()
-		.with_balances(vec![(Account::Alice, 1000), (Account::Bob, 2500)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(
-				Precompiles::<Runtime>::execute(
-					Account::Precompile.into(),
-					&EvmDataWriter::new().write_selector(Action::Name).build(),
-					None,
-					&evm::Context {
-						address: Account::Precompile.into(),
-						caller: Account::Alice.into(),
-						apparent_value: From::from(0),
-					},
-				),
-				Some(Ok(PrecompileOutput {
-					exit_status: ExitSucceed::Returned,
-					output: EvmDataWriter::new()
-						.write_raw_bytes("Mock tokens".as_bytes())
-						.build(),
-					cost: Default::default(),
-					logs: Default::default(),
-				}))
-			);
-		});
-}
-
-#[test]
-fn get_metadata_symbol() {
-	ExtBuilder::default()
-		.with_balances(vec![(Account::Alice, 1000), (Account::Bob, 2500)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(
-				Precompiles::<Runtime>::execute(
-					Account::Precompile.into(),
-					&EvmDataWriter::new().write_selector(Action::Symbol).build(),
-					None,
-					&evm::Context {
-						address: Account::Precompile.into(),
-						caller: Account::Alice.into(),
-						apparent_value: From::from(0),
-					},
-				),
-				Some(Ok(PrecompileOutput {
-					exit_status: ExitSucceed::Returned,
-					output: EvmDataWriter::new()
-						.write_raw_bytes("MOCK".as_bytes())
-						.build(),
-					cost: Default::default(),
-					logs: Default::default(),
-				}))
-			);
-		});
-}
-
-#[test]
-fn get_metadata_decimals() {
-	ExtBuilder::default()
-		.with_balances(vec![(Account::Alice, 1000), (Account::Bob, 2500)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(
-				Precompiles::<Runtime>::execute(
-					Account::Precompile.into(),
-					&EvmDataWriter::new()
-						.write_selector(Action::Decimals)
-						.build(),
-					None,
-					&evm::Context {
-						address: Account::Precompile.into(),
-						caller: Account::Alice.into(),
-						apparent_value: From::from(0),
-					},
-				),
-				Some(Ok(PrecompileOutput {
-					exit_status: ExitSucceed::Returned,
-					output: EvmDataWriter::new().write(18u8).build(),
 					cost: Default::default(),
 					logs: Default::default(),
 				}))

--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -20,7 +20,7 @@ use crowdloan_rewards_precompiles::CrowdloanRewardsWrapper;
 use evm::{executor::PrecompileOutput, Context, ExitError};
 use pallet_democracy_precompiles::DemocracyWrapper;
 use pallet_evm::{AddressMapping, Precompile, PrecompileSet};
-use pallet_evm_precompile_balances_erc20::{Erc20BalancesPrecompile, Erc20Metadata};
+use pallet_evm_precompile_balances_erc20::Erc20BalancesPrecompile;
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_dispatch::Dispatch;
 use pallet_evm_precompile_modexp::Modexp;
@@ -30,26 +30,6 @@ use parachain_staking_precompiles::ParachainStakingWrapper;
 use sp_core::H160;
 use sp_std::fmt::Debug;
 use sp_std::marker::PhantomData;
-
-/// ERC20 metadata for the native token.
-pub struct NativeErc20Metadata;
-
-impl Erc20Metadata for NativeErc20Metadata {
-	/// Returns the name of the token.
-	fn name() -> &'static str {
-		"Moonbase tokens"
-	}
-
-	/// Returns the symbol of the token.
-	fn symbol() -> &'static str {
-		"DEV"
-	}
-
-	/// Returns the decimals places of the token.
-	fn decimals() -> u8 {
-		18
-	}
-}
 
 /// The PrecompileSet installed in the Moonbase runtime.
 /// We include the nine Istanbul precompiles
@@ -82,7 +62,7 @@ where
 	Dispatch<R>: Precompile,
 	ParachainStakingWrapper<R>: Precompile,
 	CrowdloanRewardsWrapper<R>: Precompile,
-	Erc20BalancesPrecompile<R, NativeErc20Metadata>: Precompile,
+	Erc20BalancesPrecompile<R>: Precompile,
 	DemocracyWrapper<R>: Precompile,
 {
 	fn execute(
@@ -112,11 +92,9 @@ where
 			a if a == hash(2049) => Some(CrowdloanRewardsWrapper::<R>::execute(
 				input, target_gas, context,
 			)),
-			a if a == hash(2050) => {
-				Some(Erc20BalancesPrecompile::<R, NativeErc20Metadata>::execute(
-					input, target_gas, context,
-				))
-			}
+			a if a == hash(2050) => Some(Erc20BalancesPrecompile::<R>::execute(
+				input, target_gas, context,
+			)),
 			a if a == hash(2051) => {
 				Some(DemocracyWrapper::<R>::execute(input, target_gas, context))
 			}


### PR DESCRIPTION
This is not how strings are encoded in Solidity :c
I'll work on fixing an issue with how generic arrays and byte arrays are encoded.