### PR TITLE
Bump to newer Rust nightly

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-08-01"
+channel = "nightly-2021-09-01"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
Just bumps the rust nightly toolchain version. This will be necessary to support upcoming frontier changes (https://github.com/paritytech/frontier/pull/485), and will be nice to have done in advance.