### PR TITLE
Skipped transaction should unpool dependent ones

### DIFF
--- a/tests/tests/test-txpool-future.ts
+++ b/tests/tests/test-txpool-future.ts
@@ -1,8 +1,12 @@
 import { expect } from "chai";
 import { Contract } from "web3-eth-contract";
 
-import { GENESIS_ACCOUNT } from "../util/constants";
-import { createContract, createContractExecution } from "../util/transactions";
+import {
+  GENESIS_ACCOUNT,
+  GENESIS_ACCOUNT_PRIVATE_KEY,
+  EXTRINSIC_GAS_LIMIT,
+} from "../util/constants";
+import { createContract, createContractExecution, createTransaction } from "../util/transactions";
 import { describeDevMoonbeam } from "../util/setup-dev-tests";
 import { customWeb3Request } from "../util/providers";
 
@@ -40,5 +44,76 @@ describeDevMoonbeam("TxPool - Future Ethereum transaction", (context) => {
       to: "0x0000000000000000000000000000000000000000",
       value: "0x0",
     });
+  });
+});
+
+describeDevMoonbeam("TxPool - Skipped transaction should unpool dependent ones", (context) => {
+  it("skipped transaction should unpool dependent ones", async function () {
+    const limit = EXTRINSIC_GAS_LIMIT - 30_000; // let's leave a bit of room
+
+    const { rawTx: deployTx, contract } = await createContract(context.web3, "InfiniteContract", {
+      gas: 1048576,
+      nonce: 0,
+      gasPrice: "0x2540BE400",
+    });
+
+    // 1. transaction using some good chunk of block weight
+    const setupTx = await createContractExecution(
+      context.web3,
+      {
+        contract,
+        contractCall: contract.methods.infinite(),
+      },
+      {
+        from: GENESIS_ACCOUNT,
+        privateKey: GENESIS_ACCOUNT_PRIVATE_KEY,
+        value: "0x0",
+        gas: `0x${limit.toString(16)}`,
+        gasPrice: "0x2540BE401",
+        nonce: 1,
+      }
+    );
+
+    // 2. transaction being to big to fit in the same block as previous tx
+    const tooBigTx = await createTransaction(context.web3, {
+      from: GENESIS_ACCOUNT,
+      privateKey: GENESIS_ACCOUNT_PRIVATE_KEY,
+      value: "0x0",
+      gas: `0x${limit.toString(16)}`,
+      gasPrice: "0x2540BE402",
+      to: GENESIS_ACCOUNT,
+      data: `0x0`,
+      nonce: 2,
+    });
+
+    // 3. while this transaction seems valid in regard of nonces, the previous
+    // tx is too big for the block and will be skipped, making this transaction
+    // invalid. This transaction thus must not be included in the Substrate block.
+    const invalidTx = await createTransaction(context.web3, {
+      from: GENESIS_ACCOUNT,
+      privateKey: GENESIS_ACCOUNT_PRIVATE_KEY,
+      value: "0x0",
+      gas: "0x10000", // small enough to go throught
+      gasPrice: "0x2540BE403",
+      to: GENESIS_ACCOUNT,
+      data: `0x0`,
+      nonce: 3,
+    });
+
+    await customWeb3Request(context.web3, "eth_sendRawTransaction", [deployTx]);
+    await customWeb3Request(context.web3, "eth_sendRawTransaction", [setupTx]);
+    await customWeb3Request(context.web3, "eth_sendRawTransaction", [tooBigTx]);
+    await customWeb3Request(context.web3, "eth_sendRawTransaction", [invalidTx]);
+
+    const blockReceipt = await context.createBlock();
+
+    const block = await context.polkadotApi.rpc.chain.getBlock(blockReceipt.block.hash);
+
+    // 3 inherents + contract deployement + heavy call
+    // if there is 6, it means that either transction with nonce 2 or 3 have been included while
+    // they shouldn't !
+    expect(block.block.extrinsics.length).to.be.eq(5);
+
+    console.log(JSON.stringify(block));
   });
 });


### PR DESCRIPTION
### What does it do?

When a transaction is skipped (because it's gas limit would overfill a block), a transaction depending on it (nonce +1) is not
skipped too, making it included in the Substrate block (but no in the Frontier block since it is invalid).

This PR currently just adds the (failing) test for this scenario.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
