### PR TITLE
Crowdloan with change reward address origin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6462,7 +6462,7 @@ dependencies = [
 [[package]]
 name = "pallet-crowdloan-rewards"
 version = "0.6.0"
-source = "git+https://github.com/purestake/crowdloan-rewards?branch=moonbeam-polkadot-v0.9.10#8d29ab6be2f1bd5fcee59573753a593d0ed93b59"
+source = "git+https://github.com/purestake/crowdloan-rewards?branch=moonbeam-polkadot-v0.9.10#db39c7878fa5d9a1bd5a88eb64ebfca547d67799"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6462,7 +6462,7 @@ dependencies = [
 [[package]]
 name = "pallet-crowdloan-rewards"
 version = "0.6.0"
-source = "git+https://github.com/purestake/crowdloan-rewards?branch=moonbeam-polkadot-v0.9.10#56f4e9cdb9e27efcd3337a2dcbcde2f4fdd47c2a"
+source = "git+https://github.com/purestake/crowdloan-rewards?branch=moonbeam-polkadot-v0.9.10#8d29ab6be2f1bd5fcee59573753a593d0ed93b59"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",

--- a/precompiles/crowdloan-rewards/src/mock.rs
+++ b/precompiles/crowdloan-rewards/src/mock.rs
@@ -29,7 +29,7 @@ use frame_support::{
 	parameter_types,
 	traits::{Everything, GenesisBuild, OnFinalize, OnInitialize},
 };
-use frame_system::RawOrigin;
+use frame_system::{EnsureSigned, RawOrigin};
 use pallet_evm::{AddressMapping, EnsureAddressNever, EnsureAddressRoot, PrecompileSet};
 use serde::{Deserialize, Serialize};
 use sp_core::H256;
@@ -249,6 +249,7 @@ impl pallet_crowdloan_rewards::Config for Test {
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
 	type RewardAddressRelayVoteThreshold = RelaySignaturesThreshold;
+	type RewardAddressChangeOrigin = EnsureSigned<Self::AccountId>;
 	type VestingBlockNumber = cumulus_primitives_core::relay_chain::BlockNumber;
 	type VestingBlockProvider =
 		cumulus_pallet_parachain_system::RelaychainBlockNumberProvider<Self>;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -58,7 +58,7 @@ use xcm_builder::{
 
 use xcm_executor::traits::JustTry;
 
-use frame_system::{EnsureOneOf, EnsureRoot};
+use frame_system::{EnsureOneOf, EnsureRoot, EnsureSigned};
 pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, AssetId, Balance, BlockNumber, DigestItem, Hash, Header,
 	Index, Signature,
@@ -759,6 +759,7 @@ impl pallet_crowdloan_rewards::Config for Runtime {
 	type MinimumReward = MinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = AccountId32;
+	type RewardAddressChangeOrigin = EnsureSigned<Self::AccountId>;
 	type RewardAddressRelayVoteThreshold = RelaySignaturesThreshold;
 	type VestingBlockNumber = cumulus_primitives_core::relay_chain::BlockNumber;
 	type VestingBlockProvider =

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -610,8 +610,11 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			let public2 = pair2.public();
 
 			// signature is new_account || previous_account
-			let mut message = AccountId::from(DAVE).encode();
+			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES.to_vec();
+			message.append(&mut AccountId::from(DAVE).encode());
 			message.append(&mut AccountId::from(CHARLIE).encode());
+			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES.to_vec());
+
 			let signature1 = pair1.sign(&message);
 			let signature2 = pair2.sign(&message);
 

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -610,10 +610,10 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			let public2 = pair2.public();
 
 			// signature is new_account || previous_account
-			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES.to_vec();
+			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
 			message.append(&mut AccountId::from(DAVE).encode());
 			message.append(&mut AccountId::from(CHARLIE).encode());
-			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES.to_vec());
+			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES_POSTFIX.to_vec());
 
 			let signature1 = pair1.sign(&message);
 			let signature2 = pair2.sign(&message);

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -40,7 +40,7 @@ use frame_support::{
 	},
 	PalletId,
 };
-use frame_system::{EnsureOneOf, EnsureRoot};
+use frame_system::{EnsureOneOf, EnsureRoot, EnsureSigned};
 pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, Balance, BlockNumber, DigestItem, Hash, Header, Index,
 	Signature,
@@ -707,6 +707,7 @@ impl pallet_crowdloan_rewards::Config for Runtime {
 	type MinimumReward = MinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = AccountId32;
+	type RewardAddressChangeOrigin = EnsureSigned<Self::AccountId>;
 	type RewardAddressRelayVoteThreshold = RelaySignaturesThreshold;
 	type VestingBlockNumber = cumulus_primitives_core::relay_chain::BlockNumber;
 	type VestingBlockProvider =

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -610,8 +610,10 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			let public2 = pair2.public();
 
 			// signature is new_account || previous_account
-			let mut message = AccountId::from(DAVE).encode();
+			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES.to_vec();
 			message.append(&mut AccountId::from(CHARLIE).encode());
+			message.append(&mut AccountId::from(CHARLIE).encode());
+			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES.to_vec());
 			let signature1 = pair1.sign(&message);
 			let signature2 = pair2.sign(&message);
 

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -610,10 +610,10 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			let public2 = pair2.public();
 
 			// signature is new_account || previous_account
-			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES.to_vec();
+			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
 			message.append(&mut AccountId::from(CHARLIE).encode());
 			message.append(&mut AccountId::from(CHARLIE).encode());
-			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES.to_vec());
+			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES_POSTFIX.to_vec());
 			let signature1 = pair1.sign(&message);
 			let signature2 = pair2.sign(&message);
 

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -611,7 +611,7 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 
 			// signature is new_account || previous_account
 			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
-			message.append(&mut AccountId::from(CHARLIE).encode());
+			message.append(&mut AccountId::from(DAVE).encode());
 			message.append(&mut AccountId::from(CHARLIE).encode());
 			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES_POSTFIX.to_vec());
 			let signature1 = pair1.sign(&message);

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -40,7 +40,7 @@ use frame_support::{
 	},
 	PalletId,
 };
-use frame_system::{EnsureOneOf, EnsureRoot};
+use frame_system::{EnsureOneOf, EnsureRoot, EnsureSigned};
 pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, Balance, BlockNumber, DigestItem, Hash, Header, Index,
 	Signature,
@@ -698,6 +698,7 @@ impl pallet_crowdloan_rewards::Config for Runtime {
 	type MinimumReward = MinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = AccountId32;
+	type RewardAddressChangeOrigin = EnsureSigned<Self::AccountId>;
 	type RewardAddressRelayVoteThreshold = RelaySignaturesThreshold;
 	type VestingBlockNumber = cumulus_primitives_core::relay_chain::BlockNumber;
 	type VestingBlockProvider =

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -595,8 +595,10 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			let public2 = pair2.public();
 
 			// signature is new_account || previous_account
-			let mut message = AccountId::from(DAVE).encode();
+			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES.to_vec();
 			message.append(&mut AccountId::from(CHARLIE).encode());
+			message.append(&mut AccountId::from(CHARLIE).encode());
+			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES.to_vec());
 			let signature1 = pair1.sign(&message);
 			let signature2 = pair2.sign(&message);
 

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -596,7 +596,7 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 
 			// signature is new_account || previous_account
 			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
-			message.append(&mut AccountId::from(CHARLIE).encode());
+			message.append(&mut AccountId::from(DAVE).encode());
 			message.append(&mut AccountId::from(CHARLIE).encode());
 			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES_POSTFIX.to_vec());
 			let signature1 = pair1.sign(&message);

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -595,10 +595,10 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			let public2 = pair2.public();
 
 			// signature is new_account || previous_account
-			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES.to_vec();
+			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
 			message.append(&mut AccountId::from(CHARLIE).encode());
 			message.append(&mut AccountId::from(CHARLIE).encode());
-			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES.to_vec());
+			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES_POSTFIX.to_vec());
 			let signature1 = pair1.sign(&message);
 			let signature2 = pair2.sign(&message);
 

--- a/tests/tests/test-crowdloan.ts
+++ b/tests/tests/test-crowdloan.ts
@@ -823,7 +823,12 @@ describeDevMoonbeam("Crowdloan", (context) => {
       ).toHuman() as any
     ).to.be.null;
 
-    let message = new Uint8Array([...stringToU8a("<Bytes>"),...toAssociateAccount.addressRaw, ...firstAccount.addressRaw,...stringToU8a("</Bytes>")]);
+    let message = new Uint8Array([
+      ...stringToU8a("<Bytes>"),
+      ...toAssociateAccount.addressRaw,
+      ...firstAccount.addressRaw,
+      ...stringToU8a("</Bytes>"),
+    ]);
 
     // Construct the signatures
     let signature1 = {};

--- a/tests/tests/test-crowdloan.ts
+++ b/tests/tests/test-crowdloan.ts
@@ -3,7 +3,7 @@ import { KeyringPair } from "@polkadot/keyring/types";
 import { expect } from "chai";
 import Web3 from "web3";
 import { Account } from "web3-core";
-import { formatBalance } from "@polkadot/util";
+import { formatBalance, stringToU8a } from "@polkadot/util";
 import type { SubmittableExtrinsic } from "@polkadot/api/promise/types";
 import { blake2AsHex, randomAsHex } from "@polkadot/util-crypto";
 
@@ -823,7 +823,7 @@ describeDevMoonbeam("Crowdloan", (context) => {
       ).toHuman() as any
     ).to.be.null;
 
-    let message = new Uint8Array([...toAssociateAccount.addressRaw, ...firstAccount.addressRaw]);
+    let message = new Uint8Array([...stringToU8a("<Bytes>"),...toAssociateAccount.addressRaw, ...firstAccount.addressRaw,...stringToU8a("</Bytes>")]);
 
     // Construct the signatures
     let signature1 = {};


### PR DESCRIPTION
### What does it do?
Adapts change reward key association to a signature between "<Bytes>...</Bytes>" and configures the new associated type in crowdloan rewards
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
