### PR TITLE
fix all warnings

### DIFF
--- a/pallets/migrations/src/mock.rs
+++ b/pallets/migrations/src/mock.rs
@@ -121,6 +121,7 @@ impl<'test> MockMigrationManager<'test> {
 		self.pre_upgrade_fn_callbacks.push(Box::new(|| Ok(())));
 		self.post_upgrade_fn_callbacks.push(Box::new(|| Ok(())));
 	}
+	#[cfg(feature = "try-runtime")]
 	pub fn register_callback_with_try_fns<FN, FM, FT1, FT2>(
 		&mut self,
 		name_fn: FN,
@@ -149,10 +150,12 @@ impl<'test> MockMigrationManager<'test> {
 		self.migrate_fn_callbacks[index](available_weight)
 	}
 
+	#[cfg(feature = "try-runtime")]
 	pub(crate) fn invoke_pre_upgrade(&mut self, index: usize) -> Result<(), &'static str> {
 		self.pre_upgrade_fn_callbacks[index]()
 	}
 
+	#[cfg(feature = "try-runtime")]
 	pub(crate) fn invoke_post_upgrade(&mut self, index: usize) -> Result<(), &'static str> {
 		self.post_upgrade_fn_callbacks[index]()
 	}

--- a/precompiles/assets-erc20/src/mock.rs
+++ b/precompiles/assets-erc20/src/mock.rs
@@ -22,7 +22,7 @@ use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{construct_runtime, parameter_types, traits::Everything};
 
 use frame_system::EnsureRoot;
-use pallet_evm::{AddressMapping, EnsureAddressNever, EnsureAddressRoot, PrecompileSet};
+use pallet_evm::{AddressMapping, EnsureAddressNever, EnsureAddressRoot};
 use serde::{Deserialize, Serialize};
 use sp_core::{H160, H256};
 use sp_runtime::{

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -21,7 +21,7 @@ use super::*;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Everything, OnFinalize, OnInitialize},
+	traits::Everything,
 };
 use pallet_evm::{AddressMapping, EnsureAddressNever, EnsureAddressRoot, PrecompileSet};
 use serde::{Deserialize, Serialize};
@@ -256,23 +256,4 @@ impl ExtBuilder {
 		ext.execute_with(|| System::set_block_number(1));
 		ext
 	}
-}
-
-pub(crate) fn roll_to(n: u64) {
-	while System::block_number() < n {
-		Balances::on_finalize(System::block_number());
-		System::on_finalize(System::block_number());
-
-		System::set_block_number(System::block_number() + 1);
-
-		System::on_initialize(System::block_number());
-		Balances::on_initialize(System::block_number());
-	}
-}
-
-pub(crate) fn events() -> Vec<Event> {
-	System::events()
-		.into_iter()
-		.map(|r| r.event)
-		.collect::<Vec<_>>()
 }

--- a/precompiles/pallet-democracy/src/lib.rs
+++ b/precompiles/pallet-democracy/src/lib.rs
@@ -21,7 +21,7 @@
 use evm::{executor::PrecompileOutput, Context, ExitError, ExitSucceed};
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
 use frame_support::traits::Currency;
-use pallet_democracy::{AccountVote, Call as DemocracyCall, ReferendumInfo, Vote};
+use pallet_democracy::{AccountVote, Call as DemocracyCall, Vote};
 use pallet_evm::AddressMapping;
 use pallet_evm::Precompile;
 use precompile_utils::{

--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
 use crowdloan_rewards_precompiles::CrowdloanRewardsWrapper;
 use evm::{executor::PrecompileOutput, Context, ExitError};
 use pallet_democracy_precompiles::DemocracyWrapper;

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -42,7 +42,7 @@ use pallet_evm_precompile_assets_erc20::{
 use xtokens_precompiles::{Action as XtokensAction, MultiLocationWrapper};
 
 use pallet_transaction_payment::Multiplier;
-use parachain_staking::{Bond, NominatorAdded};
+use parachain_staking::Bond;
 use parity_scale_codec::Encode;
 use sha3::{Digest, Keccak256};
 use sp_core::Pair;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -53,7 +53,6 @@ use pallet_evm::{
 	Account as EVMAccount, EnsureAddressNever, EnsureAddressRoot, FeeCalculator, GasWeightMapping,
 	IdentityAddressMapping, Runner,
 };
-use pallet_migrations::{Config, Pallet};
 use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 pub use parachain_staking::{InflationInfo, Range};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};

--- a/runtime/moonbeam/src/precompiles.rs
+++ b/runtime/moonbeam/src/precompiles.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
 use crowdloan_rewards_precompiles::CrowdloanRewardsWrapper;
 use evm::{executor::PrecompileOutput, Context, ExitError};
 use pallet_evm::{AddressMapping, Precompile, PrecompileSet};

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -21,7 +21,7 @@
 mod common;
 use common::*;
 
-use evm::{executor::PrecompileOutput, Context, ExitError, ExitSucceed};
+use evm::{executor::PrecompileOutput, Context, ExitSucceed};
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::Dispatchable,
@@ -36,7 +36,7 @@ use moonbeam_runtime::{
 use nimbus_primitives::NimbusId;
 use pallet_evm::PrecompileSet;
 use pallet_transaction_payment::Multiplier;
-use parachain_staking::{Bond, NominatorAdded};
+use parachain_staking::Bond;
 use parity_scale_codec::Encode;
 use sha3::{Digest, Keccak256};
 use sp_core::Pair;

--- a/runtime/moonbeam/tests/runtime_apis.rs
+++ b/runtime/moonbeam/tests/runtime_apis.rs
@@ -25,7 +25,6 @@ use sp_core::{Public, H160, H256, U256};
 
 use fp_rpc::runtime_decl_for_EthereumRuntimeRPCApi::EthereumRuntimeRPCApi;
 use frame_support::assert_noop;
-use moonbeam_rpc_primitives_debug::runtime_decl_for_DebugRuntimeApi::DebugRuntimeApi;
 use moonbeam_rpc_primitives_txpool::runtime_decl_for_TxPoolRuntimeApi::TxPoolRuntimeApi;
 use std::collections::BTreeMap;
 use std::str::FromStr;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -53,7 +53,6 @@ use pallet_evm::{
 	Account as EVMAccount, EnsureAddressNever, EnsureAddressRoot, FeeCalculator, GasWeightMapping,
 	IdentityAddressMapping, Runner,
 };
-use pallet_migrations::{Config, Pallet};
 use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 pub use parachain_staking::{InflationInfo, Range};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};

--- a/runtime/moonriver/src/precompiles.rs
+++ b/runtime/moonriver/src/precompiles.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
 use crowdloan_rewards_precompiles::CrowdloanRewardsWrapper;
 use evm::{executor::PrecompileOutput, Context, ExitError};
 use pallet_evm::{AddressMapping, Precompile, PrecompileSet};

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -21,7 +21,7 @@
 mod common;
 use common::*;
 
-use evm::{executor::PrecompileOutput, Context, ExitError, ExitSucceed};
+use evm::{executor::PrecompileOutput, Context, ExitSucceed};
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::Dispatchable,
@@ -33,7 +33,7 @@ use moonriver_runtime::{BlockWeights, Precompiles};
 use nimbus_primitives::NimbusId;
 use pallet_evm::PrecompileSet;
 use pallet_transaction_payment::Multiplier;
-use parachain_staking::{Bond, NominatorAdded};
+use parachain_staking::Bond;
 use parity_scale_codec::Encode;
 use sha3::{Digest, Keccak256};
 use sp_core::Pair;

--- a/runtime/moonriver/tests/runtime_apis.rs
+++ b/runtime/moonriver/tests/runtime_apis.rs
@@ -24,7 +24,6 @@ use pallet_evm::{Account as EVMAccount, AddressMapping, FeeCalculator, GenesisAc
 use sp_core::{Public, H160, H256, U256};
 
 use fp_rpc::runtime_decl_for_EthereumRuntimeRPCApi::EthereumRuntimeRPCApi;
-use moonbeam_rpc_primitives_debug::runtime_decl_for_DebugRuntimeApi::DebugRuntimeApi;
 use moonbeam_rpc_primitives_txpool::runtime_decl_for_TxPoolRuntimeApi::TxPoolRuntimeApi;
 use std::collections::BTreeMap;
 use std::str::FromStr;


### PR DESCRIPTION
### What does it do?

Remove all rustc warnings.
It disturbs me to see warnings in the compile output, it gives me the impression that there are errors when there are not, and when there are many warnings it prevents to see the list of compiled crates.
Moreover, in some contexts we don't have the colors (for example in the CI log), and in these cases the warnings pollute the logs and make it more difficult to read when looking for a real error.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
