### PR TITLE
Change token name + fix doc

### DIFF
--- a/precompiles/balances-erc20/ERC20.sol
+++ b/precompiles/balances-erc20/ERC20.sol
@@ -36,7 +36,7 @@ interface IERC20 {
    * @param owner The address to query the balance of.
    * @return An uint256 representing the amount owned by the passed address.
    */
-  function balanceOf(address who) external view returns (uint256);
+  function balanceOf(address owner) external view returns (uint256);
 
   /**
    * @dev Function to check the amount of tokens that an owner allowed to a spender.

--- a/precompiles/balances-erc20/ERC20.sol
+++ b/precompiles/balances-erc20/ERC20.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.4.24;
  * @title ERC20 interface
  * @dev see https://github.com/ethereum/EIPs/issues/20
  * @dev copied from https://github.com/OpenZeppelin/openzeppelin-contracts
+ * Moonbase address : 0x0000000000000000000000000000000000000802
  */
 interface IERC20 {
   /**

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -199,7 +199,7 @@ pub struct NativeErc20Metadata;
 impl Erc20Metadata for NativeErc20Metadata {
 	/// Returns the name of the token.
 	fn name() -> &'static str {
-		"Mock tokens"
+		"Mock token"
 	}
 
 	/// Returns the symbol of the token.

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -670,7 +670,7 @@ fn get_metadata_name() {
 				Some(Ok(PrecompileOutput {
 					exit_status: ExitSucceed::Returned,
 					output: EvmDataWriter::new()
-						.write::<Bytes>("Mock tokens".into())
+						.write::<Bytes>("Mock token".into())
 						.build(),
 					cost: Default::default(),
 					logs: Default::default(),

--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -39,7 +39,7 @@ pub struct NativeErc20Metadata;
 impl Erc20Metadata for NativeErc20Metadata {
 	/// Returns the name of the token.
 	fn name() -> &'static str {
-		"Moonbase tokens"
+		"DEV token"
 	}
 
 	/// Returns the symbol of the token.


### PR DESCRIPTION
### What does it do?

Change ERC20 precompile token name on Moonbase to "DEV token" instead of "Moonbase tokens".
Also fix typo in .sol documentation.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
