### PR TITLE
Comment out author-mapping twox-to-blake migration

### DIFF
--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -61,6 +61,9 @@ where
 		// TODO: this is a lot of allocation to do upon every get() call. this *should* be avoided
 		// except when pallet_migrations undergoes a runtime upgrade -- but TODO: review
 
-		vec![Box::new(migration_author_mapping_twox_to_blake)]
+		vec![
+			// completed in runtime 800
+			// Box::new(migration_author_mapping_twox_to_blake)
+		]
 	}
 }


### PR DESCRIPTION
### What does it do?

This PR is a chance for us to discuss what to do with migrations that have been performed against all runtimes but also exist in `pallet-migrations`.

This pallet ensures that any migration will be performed only once, so it's not strictly necessary that we do anything. However, there may be value in leaving some comments about when a migration was run or doing some other bookkeeping. Additionally, removing obsolete migrations will have some minor performance benefits as well as help reduce runtime code size.

Feedback encouraged.