### PR TITLE
Add ca certificates in docker image

### DIFF
--- a/docker/moonbeam.Dockerfile
+++ b/docker/moonbeam.Dockerfile
@@ -2,6 +2,10 @@
 #
 # Requires to run from repository root and to copy the binary in the build folder (part of the release workflow)
 
+FROM docker.io/library/ubuntu:20.04 AS builder
+
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+
 FROM debian:buster-slim
 LABEL maintainer "alan@purestake.com"
 LABEL description="Binary for Moonbeam Collator"
@@ -12,6 +16,8 @@ RUN useradd -m -u 1000 -U -s /bin/sh -d /moonbeam moonbeam && \
 	chown -R moonbeam:moonbeam /data && \
 	ln -s /data /moonbeam/.local/share/moonbeam && \
 	rm -rf /usr/bin /usr/sbin
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 USER moonbeam
 


### PR DESCRIPTION
### What does it do?

### What important points reviewers should know?

Add ca certificates only to the `moonbeam` image, I don't know if it should also be done for the `moonbase-parachain` and `polkadot-relay` images.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
