### PR TITLE
Deny warnings on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
     needs: ["set-tags"]
     env:
       CARGO_SCCACHE_COMMIT: 90e1dc81
-      RUSTFLAGS: "-C opt-level=3"
+      RUSTFLAGS: "-C opt-level=3 -D warnings"
       # MOONBEAM_LOG: info
       # DEBUG: "test*"
     outputs:
@@ -328,7 +328,7 @@ jobs:
     needs: ["set-tags"]
     env:
       CARGO_SCCACHE_COMMIT: 90e1dc81
-      RUSTFLAGS: "-C opt-level=3"
+      RUSTFLAGS: "-C opt-level=3 -D warnings"
       # MOONBEAM_LOG: info
       # DEBUG: "test*"
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,6 +255,8 @@ jobs:
             false
           fi
       - name: Check with Clippy
+        env:
+          RUSTFLAGS: "" # override RUSTFLAGS to disable option -D warnings
         run: cargo clippy --release --workspace
       - name: Ensure benchmarking compiles
         run: cargo check --release --features=runtime-benchmarks

--- a/node/perf-test/src/command.rs
+++ b/node/perf-test/src/command.rs
@@ -40,7 +40,7 @@ use futures::{
 	SinkExt, Stream,
 };
 
-use cli_table::{format::Justify, print_stdout, Cell, Style, Table, WithTitle};
+use cli_table::{print_stdout, WithTitle};
 use serde::Serialize;
 use service::{chain_spec, rpc, Block, RuntimeApiCollection, TransactionConverters};
 use sha3::{Digest, Keccak256};
@@ -74,7 +74,7 @@ where
 		RuntimeApiCollection<StateBackend = sc_client_api::StateBackendFor<FullBackend, Block>>,
 	Executor: NativeExecutionDispatch + 'static,
 {
-	pub fn from_cmd(config: Configuration, cmd: &PerfCmd) -> CliResult<Self> {
+	pub fn from_cmd(config: Configuration, _cmd: &PerfCmd) -> CliResult<Self> {
 		println!("perf-test from_cmd");
 		let sc_service::PartialComponents {
 			client,
@@ -116,7 +116,7 @@ where
 			telemetry.as_ref().map(|x| x.handle()),
 		);
 
-		let mut command_sink = None;
+		let command_sink;
 		let command_stream: Box<dyn Stream<Item = EngineCommand<H256>> + Send + Sync + Unpin> = {
 			let (sink, stream) = mpsc::channel(1000);
 			command_sink = Some(sink);
@@ -360,7 +360,7 @@ where
 			unchecked_extrinsic,
 		);
 
-		futures::executor::block_on(future);
+		let _ = futures::executor::block_on(future);
 
 		Ok(transaction_hash)
 	}
@@ -385,7 +385,7 @@ where
 				parent_hash: Some(hash),
 				sender: Some(sender),
 			};
-			sink.send(command).await;
+			let _ = sink.send(command).await;
 			receiver.await
 		};
 

--- a/node/perf-test/src/lib.rs
+++ b/node/perf-test/src/lib.rs
@@ -20,7 +20,6 @@ pub mod sysinfo;
 mod tests;
 mod txn_signer;
 
-use sc_cli::{ExecutionStrategy, WasmExecutionMethod};
 use std::path::PathBuf;
 use structopt::StructOpt;
 

--- a/node/perf-test/src/sysinfo.rs
+++ b/node/perf-test/src/sysinfo.rs
@@ -133,7 +133,7 @@ pub fn query_system_info() -> Result<SystemInfo, String> {
 /// query the partition info corresponding to the given path. the path doesn't need to be an
 /// explicit mountpoint; it can be a subdirectory of a mountpoint.
 pub fn query_partition_info(path: &std::path::PathBuf) -> Result<PartitionInfo, String> {
-	use std::{collections::HashMap, path::Path};
+	use std::collections::HashMap;
 
 	let canon_path = std::fs::canonicalize(path).expect("Could not deduce canonical path");
 
@@ -156,6 +156,7 @@ pub fn query_partition_info(path: &std::path::PathBuf) -> Result<PartitionInfo, 
 	let partition = ancestors
 		.find_map(|dir| {
 			let dir_str = dir.to_str().expect("path should be valid UTF-8");
+			#[allow(irrefutable_let_patterns)]
 			if let partition = partitions_map.get(dir_str) {
 				partition
 			} else {

--- a/node/perf-test/src/tests/block_creation.rs
+++ b/node/perf-test/src/tests/block_creation.rs
@@ -56,7 +56,7 @@ where
 		const NUM_EMPTY_BLOCKS: u64 = 2048;
 		println!("Creating {} empty blocks...", NUM_EMPTY_BLOCKS);
 		let now = Instant::now();
-		for i in 1..NUM_EMPTY_BLOCKS {
+		for _i in 1..NUM_EMPTY_BLOCKS {
 			context.create_block(true);
 		}
 		results.push(TestResults::new(

--- a/node/perf-test/src/tests/fibonacci.rs
+++ b/node/perf-test/src/tests/fibonacci.rs
@@ -81,7 +81,7 @@ where
 		// do a create() call (which doesn't persist) to see what our expected contract address
 		// will be. afterward we create a txn and produce a block so it will persist.
 		// TODO: better way to calculate new contract address
-		let now = Instant::now();
+		let _now = Instant::now();
 		let create_info = context
 			.evm_create(
 				alice.address,
@@ -112,7 +112,7 @@ where
 			)
 			.expect("EVM create failed while trying to deploy Fibonacci contract");
 
-		let now = Instant::now();
+		let _now = Instant::now();
 		context.create_block(true);
 
 		// TODO: verify txn results

--- a/node/perf-test/src/tests/mod.rs
+++ b/node/perf-test/src/tests/mod.rs
@@ -14,15 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::time::Duration;
-
 use crate::command::{FullBackend, FullClient, TestContext};
 
 use sc_service::NativeExecutionDispatch;
 use service::{Block, RuntimeApiCollection};
 use sp_api::ConstructRuntimeApi;
 
-use cli_table::{format::Justify, print_stdout, Cell, Style, Table};
+use cli_table::{format::Justify, Table};
 use serde::Serialize;
 
 mod block_creation;

--- a/node/perf-test/src/tests/storage.rs
+++ b/node/perf-test/src/tests/storage.rs
@@ -157,7 +157,7 @@ where
 
 		alice_nonce = alice_nonce.saturating_add(1.into());
 
-		let now = Instant::now();
+		let _now = Instant::now();
 		context.create_block(true);
 
 		const NUM_STORAGE_ITEMS: u64 = 50000;

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -33,11 +33,7 @@ pub use moonbeam_runtime;
 #[cfg(feature = "moonriver-native")]
 pub use moonriver_runtime;
 use sc_service::BasePath;
-use std::{
-	collections::{BTreeMap, HashMap},
-	sync::Mutex,
-	time::Duration,
-};
+use std::{collections::BTreeMap, sync::Mutex, time::Duration};
 pub mod rpc;
 use cumulus_client_network::build_block_announce_validator;
 use cumulus_client_service::{

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -32,14 +32,14 @@ use cumulus_pallet_parachain_system::RelaychainBlockNumberProvider;
 use fp_rpc::TransactionStatus;
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{Contains, Everything, Get, Imbalance, InstanceFilter, OnUnbalanced},
+	traits::{Contains, Get, Imbalance, InstanceFilter, OnUnbalanced},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_PER_SECOND},
 		DispatchClass, GetDispatchInfo, IdentityFee, Weight,
 	},
 	PalletId,
 };
-use frame_system::{EnsureOneOf, EnsureRoot, EnsureSigned};
+use frame_system::{EnsureOneOf, EnsureRoot};
 pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, Balance, BlockNumber, DigestItem, Hash, Header, Index,
 	Signature,

--- a/runtime/moonbeam/tests/runtime_apis.rs
+++ b/runtime/moonbeam/tests/runtime_apis.rs
@@ -24,7 +24,6 @@ use pallet_evm::{Account as EVMAccount, AddressMapping, FeeCalculator, GenesisAc
 use sp_core::{Public, H160, H256, U256};
 
 use fp_rpc::runtime_decl_for_EthereumRuntimeRPCApi::EthereumRuntimeRPCApi;
-use frame_support::assert_noop;
 use moonbeam_rpc_primitives_txpool::runtime_decl_for_TxPoolRuntimeApi::TxPoolRuntimeApi;
 use std::collections::BTreeMap;
 use std::str::FromStr;


### PR DESCRIPTION
### What does it do?

Forbids rustc warnings only during the build in the CI. Warnings are still allowed when you compile locally. Clippy warnings are not concerned.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
