### PR TITLE
CI: not retrigger CI when PR description is edited + autocancel previous build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ name: Build
 # 2. It includes the PR/Commit text in the action item
 # 3. Artifacts are not available between workflows.
 
-# This is only allowing pushes on the moonbeam repo for pull requests.
-####### DO NOT CHANGE THIS !! #######
 on:
   pull_request:
     types: [opened, edited, unassigned, synchronize]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ name: Build
 
 on:
   pull_request:
-    types: [opened, edited, unassigned, synchronize]
   push:
     branches:
       - master

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -1,0 +1,13 @@
+name: Cancel
+on: [push]
+jobs:
+  cancel:
+    name: 'Cancel Previous Build'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          workflow_id: ".github/workflows/build.yml"
+          all_but_latest: true
+          access_token: ${{ github.token }}

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -2,7 +2,7 @@ name: Cancel
 on: [push]
 jobs:
   cancel:
-    name: 'Cancel Previous Build'
+    name: "Cancel Previous Build"
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:


### PR DESCRIPTION
### What does it do?

Fixes two small problems with the CI:

1. The CI relaunches entirely when someone changes the description of a PR
2. When someone pushes a new commit on a PR, a new action is launched (and this is normal), but if the previous action was still in progress, it is not cancelled automatically, which makes the CI server work harder for nothing.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
