### PR TITLE
Don't remove bins from docker

### DIFF
--- a/docker/moonbeam.Dockerfile
+++ b/docker/moonbeam.Dockerfile
@@ -14,8 +14,7 @@ RUN useradd -m -u 1000 -U -s /bin/sh -d /moonbeam moonbeam && \
 	mkdir -p /moonbeam/.local/share && \
 	mkdir /data && \
 	chown -R moonbeam:moonbeam /data && \
-	ln -s /data /moonbeam/.local/share/moonbeam && \
-	rm -rf /usr/bin /usr/sbin
+	ln -s /data /moonbeam/.local/share/moonbeam
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 


### PR DESCRIPTION
### What does it do?
Doesn't remove the bins in docker

### What important points reviewers should know?
Docker image may be bigger, but i guess the benefits outweigh the disadvantages of keeping the bins or maintaining two versions of dockerfiles (like a all-tools version, but we can go that path).

### Is there something left for follow-up PRs?
No
### What alternative implementations were considered?
Having two dockerfiles for different images like a v0.x.x-alltools, but need to maintain two dockerfiles for such a small need

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
Easier to add scripts into container for operations orchestration in k8s environment or other environments
