### PR TITLE
CI: skip some jobs on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,7 @@ jobs:
   prepare-polkadot:
     runs-on: self-hosted
     needs: ["set-tags"]
+    if: github.repository == 'purestake/moonbeam'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -460,7 +461,7 @@ jobs:
   docker-parachain:
     runs-on: ubuntu-latest
     needs: ["set-tags", "build"]
-    if: ${{ needs.set-tags.outputs.image_exists }} == false
+    if: ${{ needs.set-tags.outputs.image_exists }} == false && github.repository == 'purestake/moonbeam'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -511,7 +512,7 @@ jobs:
   docker-moonbeam:
     runs-on: ubuntu-latest
     needs: ["set-tags", "build"]
-    if: ${{ needs.set-tags.outputs.image_exists }} == false
+    if: ${{ needs.set-tags.outputs.image_exists }} == false && github.repository == 'purestake/moonbeam'
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
### What does it do?

Skip the following CI jobs on forks:

- prepare-polkadot
- docker-parachain
- docker-moonbeam

These jobs need docker credentials to run, so they can't run on a fork.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
