### PR TITLE
ci: don't cancel past builds on master

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -3,6 +3,7 @@ on: [push]
 jobs:
   cancel:
     name: "Cancel Previous Build"
+    if: github.ref != 'refs/heads/master'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:


### PR DESCRIPTION
### What does it do?

#950 introduced the cancellation of past builds in case of a new push. This is what we want for PR, but not for master, because we need to build the docker `sha-********` image between each PR.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
