### PR TITLE
perf-test filtering and add txpool test

### DIFF
--- a/node/perf-test/src/command.rs
+++ b/node/perf-test/src/command.rs
@@ -459,7 +459,7 @@ impl PerfCmd {
 
 		for mut test in tests {
 			if have_filter {
-				if ! enabled_tests.contains(&test.name().as_str()) {
+				if !enabled_tests.contains(&test.name().as_str()) {
 					continue;
 				}
 			}

--- a/node/perf-test/src/command.rs
+++ b/node/perf-test/src/command.rs
@@ -450,7 +450,19 @@ impl PerfCmd {
 
 		let mut all_test_results: Vec<TestResults> = Default::default();
 
+		let (have_filter, enabled_tests) = if let Some(filter) = &cmd.tests {
+			let enabled_tests: Vec<&str> = filter.split(',').collect();
+			(true, enabled_tests)
+		} else {
+			(false, Default::default())
+		};
+
 		for mut test in tests {
+			if have_filter {
+				if ! enabled_tests.contains(&test.name().as_str()) {
+					continue;
+				}
+			}
 			let mut results: Vec<TestResults> = (*test.run(&runner)?).to_vec();
 			all_test_results.append(&mut results);
 		}

--- a/node/perf-test/src/lib.rs
+++ b/node/perf-test/src/lib.rs
@@ -41,4 +41,11 @@ pub struct PerfCmd {
 		help = "File where results should be printed (STDOUT if omitted)."
 	)]
 	pub output_file: Option<PathBuf>,
+
+	// TODO: allow multiple tests (like the -l switch for logging)
+	#[structopt(
+		long = "tests",
+		help = "Comma-separated list of tests to run (if omitted, runs all tests)"
+	)]
+	pub tests: Option<String>,
 }

--- a/node/perf-test/src/tests/block_creation.rs
+++ b/node/perf-test/src/tests/block_creation.rs
@@ -44,6 +44,10 @@ where
 		RuntimeApiCollection<StateBackend = sc_client_api::StateBackendFor<FullBackend, Block>>,
 	Executor: NativeExecutionDispatch + 'static,
 {
+	fn name(&self) -> String {
+		"block_creation".into()
+	}
+
 	fn run(
 		&mut self,
 		context: &TestContext<RuntimeApi, Executor>,

--- a/node/perf-test/src/tests/fibonacci.rs
+++ b/node/perf-test/src/tests/fibonacci.rs
@@ -65,6 +65,10 @@ where
 		RuntimeApiCollection<StateBackend = sc_client_api::StateBackendFor<FullBackend, Block>>,
 	Executor: NativeExecutionDispatch + 'static,
 {
+	fn name(&self) -> String {
+		"fibonacci".into()
+	}
+
 	fn run(
 		&mut self,
 		context: &TestContext<RuntimeApi, Executor>,

--- a/node/perf-test/src/tests/mod.rs
+++ b/node/perf-test/src/tests/mod.rs
@@ -86,6 +86,11 @@ where
 		RuntimeApiCollection<StateBackend = sc_client_api::StateBackendFor<FullBackend, Block>>,
 	Executor: NativeExecutionDispatch + 'static,
 {
+	/// Return a globally unique name for this test. This is used as a filter on the command line
+	/// so a CLI-friendly name is preferred.
+	fn name(&self) -> String;
+
+	/// Run the test
 	fn run(
 		&mut self,
 		context: &TestContext<RuntimeApi, Executor>,

--- a/node/perf-test/src/tests/storage.rs
+++ b/node/perf-test/src/tests/storage.rs
@@ -78,6 +78,10 @@ where
 		RuntimeApiCollection<StateBackend = sc_client_api::StateBackendFor<FullBackend, Block>>,
 	Executor: NativeExecutionDispatch + 'static,
 {
+	fn name(&self) -> String {
+		"storage".into()
+	}
+
 	fn run(
 		&mut self,
 		context: &TestContext<RuntimeApi, Executor>,


### PR DESCRIPTION
### What does it do?

Adds a `--tests` switch to `perf-test` which allows filtering out tests.

EDIT: keeping the scope of this pretty low so it can be merged quickly.