### PR TITLE
Even better readme for types

### DIFF
--- a/moonbeam-types-bundle/README.md
+++ b/moonbeam-types-bundle/README.md
@@ -50,13 +50,25 @@ Those types are being changed:
   }
 ```
 
-## How to upgrade your tools/scripts
+## How to upgrade your tools/scripts using moonbeam-types-bundle
 
 Ultimately it is necessary to use the new type naming as the previous one won't be supported, but
-you can import `typesBundleDeprecated` to buy yourself some time. (Upgrade to runtime 900 is 
-planned on Thursday 18th November)
+you can import `typesBundleDeprecated` to buy yourself some time.
 
-### Step 1: Change your import
+* moonbeam-types-bundle v1.x.x will break on runtime upgrade 900
+(planned Thursday 18th November on Mooniver)
+* moonbeam-types-bundle v2.x.x `typesBundleDeprecated` (using previous naming case) 
+will **break on runtime 1000**
+* **moonbeam-types-bundle v2.x.x** `typesBundlePre900` (using new naming case) 
+will be **maintained**.
+
+### Step 1: Install new package
+
+```
+npm install moonbeam-types-bundle@2
+```
+
+### Step 2: Change your import
 
 ```
 import { typesBundlePre900 } from "moonbeam-types-bundle"
@@ -67,7 +79,7 @@ const api = await ApiPromise.create({
 });
 ```
 
-### Step 2: Updates the object property names
+### Step 3: Updates the object property names
 
 Exemple:
 

--- a/moonbeam-types-bundle/README.md
+++ b/moonbeam-types-bundle/README.md
@@ -52,11 +52,16 @@ Those types are being changed:
 
 ## How to upgrade your tools/scripts using moonbeam-types-bundle
 
+*(If your tool/script is not requesting past blocks, you can simply use the `typesBundleDeprecated` 
+for now and fully remove it once the network has been upgraded to runtime 900, 
+around Nov 18th 2021)*
+
+
 Ultimately it is necessary to use the new type naming as the previous one won't be supported, but
 you can import `typesBundleDeprecated` to buy yourself some time.
 
 * moonbeam-types-bundle v1.x.x will break on runtime upgrade 900
-(planned Thursday 18th November on Mooniver)
+(planned Thursday 18th November 2021 on Mooniver)
 * moonbeam-types-bundle v2.x.x `typesBundleDeprecated` (using previous naming case) 
 will **break on runtime 1000**
 * **moonbeam-types-bundle v2.x.x** `typesBundlePre900` (using new naming case) 

--- a/moonbeam-types-bundle/README.md
+++ b/moonbeam-types-bundle/README.md
@@ -85,12 +85,14 @@ Exemple:
 
 ```
 console.log(collatorState2.unwrap().top_nominators);
+                                    ^^^^^^^^^^^^^^
 ```
 
 becomes:
 
 ```
 console.log(collatorState2.unwrap().topNominators);
+                                    ^^^^^^^^^^^^^
 ```
 
 All changes were listed [previously](#breaking-changes-in-typesbundlepre900)

--- a/moonbeam-types-bundle/README.md
+++ b/moonbeam-types-bundle/README.md
@@ -32,8 +32,8 @@ Those types are being changed:
   },
   Nominator2: {
     ...
-    scheduledRevocationsCount: "u32", // was claimed_reward
-    scheduledRevocationsTotal: "Balance", // was claimed_reward
+    scheduledRevocationsCount: "u32", // was scheduled_revocations_count
+    scheduledRevocationsTotal: "Balance", // was scheduled_revocations_total
   },
   ExitQ: {
     ...

--- a/moonbeam-types-bundle/README.md
+++ b/moonbeam-types-bundle/README.md
@@ -61,7 +61,7 @@ Ultimately it is necessary to use the new type naming as the previous one won't 
 you can import `typesBundleDeprecated` to buy yourself some time.
 
 * moonbeam-types-bundle v1.x.x will break on runtime upgrade 900
-(planned Thursday 18th November 2021 on Mooniver)
+(planned Thursday 18th November 2021 on Moonriver)
 * moonbeam-types-bundle v2.x.x `typesBundleDeprecated` (using previous naming case) 
 will **break on runtime 1000**
 * **moonbeam-types-bundle v2.x.x** `typesBundlePre900` (using new naming case) 


### PR DESCRIPTION
@JoshOrndorff , I think we can't say to not use the typesBundle after runtime 900 if not requesting past blocks, as we also need the name mapping for the modules (see https://github.com/PureStake/moonbeam/blob/master/moonbeam-types-bundle/index.ts#L12) 

@jacogr the pallet name mapping (alias) is used also in the PolkadotJS api right ? (I know is it necessary for Apps but not sure for the Api)