### PR TITLE
Pin nimbus branch to 94e54bd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5810,7 +5810,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.1.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.12#c5ad2f22c90da43f10d38e5e818cd0a66dda3d2e"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.12#94e54bda47592b86cd5f8f11320068b4a1dd244f"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -5841,7 +5841,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.1.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.12#c5ad2f22c90da43f10d38e5e818cd0a66dda3d2e"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.12#94e54bda47592b86cd5f8f11320068b4a1dd244f"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -6210,7 +6210,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.12#c5ad2f22c90da43f10d38e5e818cd0a66dda3d2e"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.12#94e54bda47592b86cd5f8f11320068b4a1dd244f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6248,7 +6248,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.1.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.12#c5ad2f22c90da43f10d38e5e818cd0a66dda3d2e"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.12#94e54bda47592b86cd5f8f11320068b4a1dd244f"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/node/service/src/client.rs
+++ b/node/service/src/client.rs
@@ -42,7 +42,7 @@ pub trait RuntimeApiCollection:
 	+ fp_rpc::EthereumRuntimeRPCApi<Block>
 	+ moonbeam_rpc_primitives_debug::DebugRuntimeApi<Block>
 	+ moonbeam_rpc_primitives_txpool::TxPoolRuntimeApi<Block>
-	+ nimbus_primitives::NimbusApi<Block, nimbus_primitives::NimbusId>
+	+ nimbus_primitives::AuthorFilterAPI<Block, nimbus_primitives::NimbusId>
 	+ cumulus_primitives_core::CollectCollationInfo<Block>
 where
 	<Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
@@ -62,7 +62,7 @@ where
 		+ fp_rpc::EthereumRuntimeRPCApi<Block>
 		+ moonbeam_rpc_primitives_debug::DebugRuntimeApi<Block>
 		+ moonbeam_rpc_primitives_txpool::TxPoolRuntimeApi<Block>
-		+ nimbus_primitives::NimbusApi<Block, nimbus_primitives::NimbusId>
+		+ nimbus_primitives::AuthorFilterAPI<Block, nimbus_primitives::NimbusId>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>,
 	<Self as sp_api::ApiExt<Block>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
 {

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -335,7 +335,7 @@ macro_rules! impl_runtime_apis_plus_common {
 				}
 			}
 
-			impl nimbus_primitives::NimbusApi<Block, nimbus_primitives::NimbusId> for Runtime {
+			impl nimbus_primitives::AuthorFilterAPI<Block, nimbus_primitives::NimbusId> for Runtime {
 				fn can_author(
 					author: nimbus_primitives::NimbusId,
 					slot: u32,


### PR DESCRIPTION
### What does it do?

Updates Nimbus to a new commit which reverts the renaming of its runtime API, which avoids conflicts between client and runtime.

Without this, the client in this release would not be able to find the correct runtime API for NimbusApi and would throw this error:

```
Could not find `NimbusApi` version.
```