### PR TITLE
derive num_enum traits in macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8921,6 +8921,7 @@ dependencies = [
 name = "precompile-utils-macro"
 version = "0.1.0"
 dependencies = [
+ "num_enum",
  "proc-macro2",
  "quote",
  "sha3 0.8.2",

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -54,7 +54,7 @@ pub type BalanceOf<Runtime, Instance = ()> = <Runtime as pallet_assets::Config<I
 pub type AssetIdOf<Runtime, Instance = ()> = <Runtime as pallet_assets::Config<Instance>>::AssetId;
 
 #[precompile_utils::generate_function_selector]
-#[derive(Debug, PartialEq, num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
+#[derive(Debug, PartialEq)]
 pub enum Action {
 	TotalSupply = "totalSupply()",
 	BalanceOf = "balanceOf(address)",

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -115,7 +115,7 @@ pub type ApprovesStorage<Runtime, Instance> = StorageDoubleMap<
 >;
 
 #[precompile_utils::generate_function_selector]
-#[derive(Debug, PartialEq, num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
+#[derive(Debug, PartialEq)]
 pub enum Action {
 	TotalSupply = "totalSupply()",
 	BalanceOf = "balanceOf(address)",

--- a/precompiles/crowdloan-rewards/src/lib.rs
+++ b/precompiles/crowdloan-rewards/src/lib.rs
@@ -46,7 +46,7 @@ pub type BalanceOf<Runtime> =
 	>>::Balance;
 
 #[precompile_utils::generate_function_selector]
-#[derive(Debug, PartialEq, num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
+#[derive(Debug, PartialEq)]
 enum Action {
 	IsContributor = "is_contributor(address)",
 	RewardInfo = "reward_info(address)",

--- a/precompiles/pallet-democracy/src/lib.rs
+++ b/precompiles/pallet-democracy/src/lib.rs
@@ -48,7 +48,7 @@ type BalanceOf<Runtime> = <<Runtime as pallet_democracy::Config>::Currency as Cu
 type DemocracyOf<Runtime> = pallet_democracy::Pallet<Runtime>;
 
 #[precompile_utils::generate_function_selector]
-#[derive(Debug, PartialEq, num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
+#[derive(Debug, PartialEq)]
 enum Action {
 	PublicPropCount = "public_prop_count()",
 	DepositOf = "deposit_of(uint256)",

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -41,7 +41,7 @@ type BalanceOf<Runtime> = <<Runtime as parachain_staking::Config>::Currency as C
 >>::Balance;
 
 #[precompile_utils::generate_function_selector]
-#[derive(Debug, PartialEq, num_enum::TryFromPrimitive)]
+#[derive(Debug, PartialEq)]
 enum Action {
 	MinNomination = "min_nomination()",
 	Points = "points(uint256)",

--- a/precompiles/relay-encoder/src/lib.rs
+++ b/precompiles/relay-encoder/src/lib.rs
@@ -64,7 +64,7 @@ pub trait StakeEncodeCall {
 }
 
 #[precompile_utils::generate_function_selector]
-#[derive(Debug, PartialEq, num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
+#[derive(Debug, PartialEq)]
 enum Action {
 	EncodeBond = "encode_bond(uint256,uint256,bytes)",
 	EncodeBondExtra = "encode_bond_extra(uint256)",

--- a/precompiles/utils/macro/Cargo.toml
+++ b/precompiles/utils/macro/Cargo.toml
@@ -17,3 +17,4 @@ quote = "1.0"
 proc-macro2 = "1.0"
 sha3 = "0.8"
 syn = { version = "1.0", features = ["full", "fold", "extra-traits", "visit"] }
+num_enum = { version = "0.5.3", default-features = false }

--- a/precompiles/utils/macro/src/lib.rs
+++ b/precompiles/utils/macro/src/lib.rs
@@ -132,6 +132,7 @@ pub fn generate_function_selector(_: TokenStream, input: TokenStream) -> TokenSt
 
 	(quote! {
 		#(#attrs)*
+		#[derive(num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
 		#[repr(u32)]
 		#vis #enum_token #ident {
 			#(

--- a/precompiles/utils/src/tests.rs
+++ b/precompiles/utils/src/tests.rs
@@ -133,7 +133,7 @@ fn read_selector() {
 	use sha3::{Digest, Keccak256};
 
 	#[precompile_utils_macro::generate_function_selector]
-	#[derive(Debug, PartialEq, num_enum::TryFromPrimitive)]
+	#[derive(Debug, PartialEq)]
 	enum FakeAction {
 		Action1 = "action1()",
 	}
@@ -676,7 +676,7 @@ impl EvmData for MultiLocation {
 }
 
 #[crate::generate_function_selector]
-#[derive(Debug, PartialEq, num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
+#[derive(Debug, PartialEq)]
 pub enum Action {
 	TransferMultiAsset = "transfer_multiasset((uint8,bytes[]),uint256,(uint8,bytes[]),uint64)",
 }

--- a/precompiles/xcm_transactor/src/lib.rs
+++ b/precompiles/xcm_transactor/src/lib.rs
@@ -44,7 +44,7 @@ pub type TransactorOf<Runtime> = <Runtime as xcm_transactor::Config>::Transactor
 pub type CurrencyIdOf<Runtime> = <Runtime as xcm_transactor::Config>::CurrencyId;
 
 #[precompile_utils::generate_function_selector]
-#[derive(Debug, PartialEq, num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
+#[derive(Debug, PartialEq)]
 pub enum Action {
 	IndexToAccount = "index_to_account(uint16)",
 	TransactInfo = "transact_info((uint8,bytes[]))",

--- a/precompiles/xtokens/src/lib.rs
+++ b/precompiles/xtokens/src/lib.rs
@@ -46,7 +46,7 @@ pub type XBalanceOf<Runtime> = <Runtime as orml_xtokens::Config>::Balance;
 pub type CurrencyIdOf<Runtime> = <Runtime as orml_xtokens::Config>::CurrencyId;
 
 #[precompile_utils::generate_function_selector]
-#[derive(Debug, PartialEq, num_enum::TryFromPrimitive, num_enum::IntoPrimitive)]
+#[derive(Debug, PartialEq)]
 pub enum Action {
 	Transfer = "transfer(address,uint256,(uint8,bytes[]),uint64)",
 	TransferMultiAsset = "transfer_multiasset((uint8,bytes[]),uint256,(uint8,bytes[]),uint64)",


### PR DESCRIPTION
### What does it do?

Add the derives of `num_enum` traits inside the macro, such that it is no longer necessary to derive them in each precompile crate. However it still seems necessary to include `num_enum` dependency in each precompile crate.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
