### PR TITLE
Optional instant finality

### DIFF
--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -144,6 +144,11 @@ pub struct RunCmd {
 	#[structopt(long, default_value = "instant")]
 	pub sealing: Sealing,
 
+	/// Whether to instantly finalize blocks in the dev service
+	/// This will have no effect when using manual seal. There finality is also manual.
+	#[structopt(long)]
+	pub instant_finality: bool,
+
 	/// Public authoring identity to be inserted in the author inherent
 	/// This is not currently used, but we may want a way to use it in the dev service.
 	// #[structopt(long)]

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -635,23 +635,48 @@ pub fn run() -> Result<()> {
 						spec if spec.is_moonriver() => service::new_dev::<
 							service::moonriver_runtime::RuntimeApi,
 							service::MoonriverExecutor,
-						>(config, author_id, cli.run.sealing, rpc_config)
+						>(
+							config,
+							author_id,
+							cli.run.sealing,
+							rpc_config,
+							cli.run.instant_finality,
+						)
 						.map_err(Into::into),
 						#[cfg(feature = "moonbeam-native")]
 						spec if spec.is_moonbeam() => service::new_dev::<
 							service::moonbeam_runtime::RuntimeApi,
 							service::MoonbeamExecutor,
-						>(config, author_id, cli.run.sealing, rpc_config)
+						>(
+							config,
+							author_id,
+							cli.run.sealing,
+							rpc_config,
+							cli.run.instant_finality,
+						)
 						.map_err(Into::into),
 						#[cfg(feature = "moonbase-native")]
 						_ => service::new_dev::<
 							service::moonbase_runtime::RuntimeApi,
 							service::MoonbaseExecutor,
-						>(config, author_id, cli.run.sealing, rpc_config)
+						>(
+							config,
+							author_id,
+							cli.run.sealing,
+							rpc_config,
+							cli.run.instant_finality,
+						)
 						.map_err(Into::into),
 						#[cfg(not(feature = "moonbase-native"))]
 						_ => panic!("invalid chain spec"),
 					};
+				}
+
+				if cli.run.instant_finality {
+					log::warn!(
+						"You have specified --instant-finality \
+						but it is ignored in the parachain context.00"
+					);
 				}
 
 				let polkadot_cli = RelayChainCli::new(

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -817,7 +817,7 @@ where
 							.pool()
 							.validated_pool()
 							.import_notification_stream()
-							.map(|_| EngineCommand::SealNewBlock {
+							.map(move |_| EngineCommand::SealNewBlock {
 								create_empty: false,
 								finalize: instant_finality,
 								parent_hash: None,
@@ -828,7 +828,7 @@ where
 				cli_opt::Sealing::Manual => {
 					let (sink, stream) = futures::channel::mpsc::channel(1000);
 					if instant_finality {
-						log::warn!("You have specified --instant-finality but it will be ignored in manual seal mode.")
+						log::warn!("You have specified --instant-finality but it is ignored in manual seal mode.");
 					}
 
 					// Keep a reference to the other end of the channel. It goes to the RPC.
@@ -837,7 +837,7 @@ where
 				}
 				cli_opt::Sealing::Interval(millis) => Box::new(StreamExt::map(
 					Timer::interval(Duration::from_millis(millis)),
-					|_| EngineCommand::SealNewBlock {
+					move |_| EngineCommand::SealNewBlock {
 						create_empty: true,
 						finalize: instant_finality,
 						parent_hash: None,


### PR DESCRIPTION
This PR adds ` --instant-finality` flag to the dev service to finalize blocks as they are authored. This is useful for testing offchain applications that will wait for a transaction to be finalized before proceeding.

As requested by @sicco-moonbeam

Example cli:
```
moonbeam --dev --tmp --instant-finality --sealing 3000
```

This seems to work from the Substrate perspective as blocks are reported finalized in the database and the node's logs. However, we're not getting the finalized notification from Polkadot JS yet.