### PR TITLE
Make staking compile for try-runtime tests

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -216,6 +216,63 @@ pub mod pallet {
 		pub state: CollatorStatus,
 	}
 
+	// Temporary manual implementation for migration testing purposes
+	impl<A: PartialEq, B: PartialEq> PartialEq for CollatorCandidate<A, B> {
+		fn eq(&self, other: &Self) -> bool {
+			let must_be_true = self.id == other.id
+				&& self.bond == other.bond
+				&& self.total_counted == other.total_counted
+				&& self.total_backing == other.total_backing
+				&& self.request == other.request
+				&& self.state == other.state;
+			if !must_be_true {
+				return false;
+			}
+			for (x, y) in self.delegators.0.iter().zip(other.delegators.0.iter()) {
+				if x != y {
+					return false;
+				}
+			}
+			for (
+				Bond {
+					owner: o1,
+					amount: a1,
+				},
+				Bond {
+					owner: o2,
+					amount: a2,
+				},
+			) in self
+				.top_delegations
+				.iter()
+				.zip(other.top_delegations.iter())
+			{
+				if o1 != o2 || a1 != a2 {
+					return false;
+				}
+			}
+			for (
+				Bond {
+					owner: o1,
+					amount: a1,
+				},
+				Bond {
+					owner: o2,
+					amount: a2,
+				},
+			) in self
+				.bottom_delegations
+				.iter()
+				.zip(other.bottom_delegations.iter())
+			{
+				if o1 != o2 || a1 != a2 {
+					return false;
+				}
+			}
+			true
+		}
+	}
+
 	/// Convey relevant information describing if a delegator was added to the top or bottom
 	/// Delegations added to the top yield a new total
 	#[derive(Clone, Copy, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
@@ -663,6 +720,35 @@ pub mod pallet {
 		pub status: DelegatorStatus,
 	}
 
+	// Temporary manual implementation for migration testing purposes
+	impl<A: PartialEq, B: PartialEq> PartialEq for Delegator<A, B> {
+		fn eq(&self, other: &Self) -> bool {
+			let must_be_true = self.id == other.id
+				&& self.total == other.total
+				&& self.requests == other.requests
+				&& self.status == other.status;
+			if !must_be_true {
+				return false;
+			}
+			for (
+				Bond {
+					owner: o1,
+					amount: a1,
+				},
+				Bond {
+					owner: o2,
+					amount: a2,
+				},
+			) in self.delegations.0.iter().zip(other.delegations.0.iter())
+			{
+				if o1 != o2 || a1 != a2 {
+					return false;
+				}
+			}
+			true
+		}
+	}
+
 	impl<
 			AccountId: Ord + Clone + Default,
 			Balance: Copy
@@ -1052,7 +1138,7 @@ pub mod pallet {
 		pub action: DelegationChange,
 	}
 
-	#[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
+	#[derive(Clone, Encode, PartialEq, Decode, RuntimeDebug, TypeInfo)]
 	/// Pending requests to mutate delegations for each delegator
 	pub struct PendingDelegationRequests<AccountId, Balance> {
 		/// Number of pending revocations (necessary for determining whether revoke is exit)

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -90,7 +90,6 @@ impl<T: Config> OnRuntimeUpgrade for RemoveExitQueue<T> {
 		use frame_support::{
 			storage::migration::{storage_iter, storage_key_iter},
 			traits::OnRuntimeUpgradeHelpersExt,
-			Twox64Concat,
 		};
 
 		let pallet_prefix: &[u8] = b"ParachainStaking";
@@ -162,7 +161,8 @@ impl<T: Config> OnRuntimeUpgrade for RemoveExitQueue<T> {
 				Collator2<T::AccountId, BalanceOf<T>>,
 			) = Self::get_temp_storage("example_collator").expect("qed");
 			let new_candidate_state = CandidateState::<T>::get(account).expect("qed");
-			let old_candidate_converted: CollatorCandidate<_, _> = original_collator_state.into();
+			let old_candidate_converted: CollatorCandidate<T::AccountId, BalanceOf<T>> =
+				original_collator_state.into();
 			assert_eq!(new_candidate_state, old_candidate_converted);
 		}
 
@@ -172,15 +172,16 @@ impl<T: Config> OnRuntimeUpgrade for RemoveExitQueue<T> {
 		let new_delegator_count = DelegatorState::<T>::iter().count() as u64;
 		assert_eq!(old_nominator_count, new_delegator_count);
 
-		// Check that our example nominator is converted correctly
+		// Check that our example delegator is converted correctly
 		if new_delegator_count > 0 {
-			let (account, original_nominator_state): (
+			let (account, original_delegator_state): (
 				T::AccountId,
 				Nominator2<T::AccountId, BalanceOf<T>>,
 			) = Self::get_temp_storage("example_nominator").expect("qed");
-			let new_candidate_state = DelegatorState::<T>::get(account).expect("qed");
-			let old_candidate_converted: Delegator<_, _> = original_nominator_state.into();
-			assert_eq!(old_candidate_converted, new_candidate_state);
+			let new_delegator_state = DelegatorState::<T>::get(&account).expect("qed");
+			let old_delegator_converted: Delegator<T::AccountId, BalanceOf<T>> =
+				migrate_nominator_to_delegator_state::<T>(account, original_delegator_state);
+			assert_eq!(old_delegator_converted, new_delegator_state);
 		}
 		Ok(())
 	}

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -18,13 +18,16 @@
 use crate::{
 	pallet::{migrate_nominator_to_delegator_state, RoundIndex},
 	BalanceOf, CandidateState, CollatorCandidate, CollatorState2, Config, DelegatorState,
-	ExitQueue2, NominatorState2, Points, Round, Staked, Collator2, Delegator, Nominator2,
+	ExitQueue2, NominatorState2, Points, Round, Staked,
 };
+#[cfg(feature = "try-runtime")]
+use crate::{Collator2, Delegator, Nominator2};
+#[cfg(feature = "try-runtime")]
+use frame_support::Twox64Concat;
 use frame_support::{
 	pallet_prelude::PhantomData,
 	traits::{Get, OnRuntimeUpgrade},
 	weights::Weight,
-	Twox64Concat,
 };
 use sp_std::collections::btree_map::BTreeMap;
 
@@ -85,11 +88,9 @@ impl<T: Config> OnRuntimeUpgrade for RemoveExitQueue<T> {
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<(), &'static str> {
 		use frame_support::{
-			storage::migration::{
-				storage_iter,
-				storage_key_iter,
-			},
+			storage::migration::{storage_iter, storage_key_iter},
 			traits::OnRuntimeUpgradeHelpersExt,
+			Twox64Concat,
 		};
 
 		let pallet_prefix: &[u8] = b"ParachainStaking";


### PR DESCRIPTION
Base branch for these changes is `notlesh-fix-staking-try-runtime-2021-11-19`

- [x] fix PartialEq errors
- [x] fix From impl errors

Fixes errors shown in https://github.com/PureStake/moonbeam/pull/1013#issuecomment-974310522 -- @notlesh the parachain-staking pallet compiles with `features try-runtime` now

## why the manual PartialEq impls?
It is much harder harder to derive for the structs and all its inner field types because we have a custom implementation of `PartialEq` for `Bond` which says two bonds are equal if they have the same owner (this is used to enforce uniqueness in `OrderedSet`).