### PR TITLE
Unnecessary Private Key Usage When Computing Account ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5495,6 +5495,7 @@ dependencies = [
  "futures 0.3.17",
  "jsonrpc-core",
  "jsonrpc-pubsub",
+ "libsecp256k1 0.6.0",
  "log",
  "moonbase-runtime",
  "moonbeam-cli-opt",

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -15,6 +15,7 @@ exit-future = "0.1.4"
 futures = { version = "0.3.1", features = [ "compat" ] }
 jsonrpc-core = "18.0.0"
 jsonrpc-pubsub = "18.0.0"
+libsecp256k1 = { version = "0.6", features = [ "hmac" ] }
 log = "0.4"
 parking_lot = "0.9.0"
 serde = { version = "1.0.101", features = [ "derive" ] }

--- a/node/service/src/chain_spec/mod.rs
+++ b/node/service/src/chain_spec/mod.rs
@@ -20,8 +20,6 @@ use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup};
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use sp_core::{ecdsa, Pair, Public, H160, H256};
-use sp_runtime::traits::{BlakeTwo256, Hash};
-use std::convert::TryInto;
 use tiny_hderive::bip32::ExtendedPrivKey;
 
 pub mod fake_spec;

--- a/node/service/src/chain_spec/mod.rs
+++ b/node/service/src/chain_spec/mod.rs
@@ -110,21 +110,19 @@ pub fn derive_bip44_pairs_from_mnemonic<TPublic: Public>(
 	childs
 }
 
-/// Helper function to get an AccountId from Key Pair
-/// We need the full decompressed public key to derive an ethereum-style account
-/// Substrate does not provide a method to obtain the full decompressed public key
-/// Therefore, this function uses the secp256k1_ecdsa_recover method to recover the full key
-/// A solution without using the private key would imply solving the secp256k1 curve equation
-/// The latter is currently not possible with current substrate methods
-pub fn get_account_id_from_pair<TPublic: Public>(pair: TPublic::Pair) -> Option<AccountId> {
-	let test_message = [1u8; 32];
-	let signature: [u8; 65] = pair.sign(&test_message).as_ref().try_into().ok()?;
-	let pubkey = sp_io::crypto::secp256k1_ecdsa_recover(
-		&signature,
-		BlakeTwo256::hash_of(&test_message).as_fixed_bytes(),
+/// Helper function to get an `AccountId` from an ECDSA Key Pair.
+pub fn get_account_id_from_pair(pair: ecdsa::Pair) -> Option<AccountId> {
+	let decompressed = libsecp256k1::PublicKey::parse_slice(
+		&pair.public().0,
+		Some(libsecp256k1::PublicKeyFormat::Compressed),
 	)
-	.ok()?;
-	Some(H160::from(H256::from_slice(Keccak256::digest(&pubkey).as_slice())).into())
+	.ok()?
+	.serialize();
+
+	let mut m = [0u8; 64];
+	m.copy_from_slice(&decompressed[1..65]);
+
+	Some(H160::from(H256::from_slice(Keccak256::digest(&m).as_slice())).into())
 }
 
 /// Function to generate accounts given a mnemonic and a number of child accounts to be generated
@@ -135,7 +133,7 @@ pub fn generate_accounts(mnemonic: String, num_accounts: u32) -> Vec<AccountId> 
 	childs
 		.iter()
 		.map(|par| {
-			let account = get_account_id_from_pair::<ecdsa::Public>(par.clone());
+			let account = get_account_id_from_pair(par.clone());
 			debug!(
 				"private_key {} --------> Account {:x?}",
 				sp_core::hexdisplay::HexDisplay::from(&par.clone().seed()),

--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -287,10 +287,8 @@ mod tests {
 			"bottom drive obey lake curtain smoke basket hold race lonely fit walk".to_string();
 		let accounts = 10;
 		let pairs = derive_bip44_pairs_from_mnemonic::<ecdsa::Public>(&mnemonic, accounts);
-		let first_account =
-			get_account_id_from_pair::<ecdsa::Public>(pairs.first().unwrap().clone()).unwrap();
-		let last_account =
-			get_account_id_from_pair::<ecdsa::Public>(pairs.last().unwrap().clone()).unwrap();
+		let first_account = get_account_id_from_pair(pairs.first().unwrap().clone()).unwrap();
+		let last_account = get_account_id_from_pair(pairs.last().unwrap().clone()).unwrap();
 
 		let expected_first_account =
 			AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap();
@@ -307,10 +305,8 @@ mod tests {
 				.to_string();
 		let accounts = 20;
 		let pairs = derive_bip44_pairs_from_mnemonic::<ecdsa::Public>(&mnemonic, accounts);
-		let first_account =
-			get_account_id_from_pair::<ecdsa::Public>(pairs.first().unwrap().clone()).unwrap();
-		let last_account =
-			get_account_id_from_pair::<ecdsa::Public>(pairs.last().unwrap().clone()).unwrap();
+		let first_account = get_account_id_from_pair(pairs.first().unwrap().clone()).unwrap();
+		let last_account = get_account_id_from_pair(pairs.last().unwrap().clone()).unwrap();
 
 		let expected_first_account =
 			AccountId::from_str("1e56ca71b596f2b784a27a2fdffef053dbdeff83").unwrap();

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -266,10 +266,8 @@ mod tests {
 			"bottom drive obey lake curtain smoke basket hold race lonely fit walk".to_string();
 		let accounts = 10;
 		let pairs = derive_bip44_pairs_from_mnemonic::<ecdsa::Public>(&mnemonic, accounts);
-		let first_account =
-			get_account_id_from_pair::<ecdsa::Public>(pairs.first().unwrap().clone()).unwrap();
-		let last_account =
-			get_account_id_from_pair::<ecdsa::Public>(pairs.last().unwrap().clone()).unwrap();
+		let first_account = get_account_id_from_pair(pairs.first().unwrap().clone()).unwrap();
+		let last_account = get_account_id_from_pair(pairs.last().unwrap().clone()).unwrap();
 
 		let expected_first_account =
 			AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap();
@@ -286,10 +284,8 @@ mod tests {
 				.to_string();
 		let accounts = 20;
 		let pairs = derive_bip44_pairs_from_mnemonic::<ecdsa::Public>(&mnemonic, accounts);
-		let first_account =
-			get_account_id_from_pair::<ecdsa::Public>(pairs.first().unwrap().clone()).unwrap();
-		let last_account =
-			get_account_id_from_pair::<ecdsa::Public>(pairs.last().unwrap().clone()).unwrap();
+		let first_account = get_account_id_from_pair(pairs.first().unwrap().clone()).unwrap();
+		let last_account = get_account_id_from_pair(pairs.last().unwrap().clone()).unwrap();
 
 		let expected_first_account =
 			AccountId::from_str("1e56ca71b596f2b784a27a2fdffef053dbdeff83").unwrap();

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -260,10 +260,8 @@ mod tests {
 			"bottom drive obey lake curtain smoke basket hold race lonely fit walk".to_string();
 		let accounts = 10;
 		let pairs = derive_bip44_pairs_from_mnemonic::<ecdsa::Public>(&mnemonic, accounts);
-		let first_account =
-			get_account_id_from_pair::<ecdsa::Public>(pairs.first().unwrap().clone()).unwrap();
-		let last_account =
-			get_account_id_from_pair::<ecdsa::Public>(pairs.last().unwrap().clone()).unwrap();
+		let first_account = get_account_id_from_pair(pairs.first().unwrap().clone()).unwrap();
+		let last_account = get_account_id_from_pair(pairs.last().unwrap().clone()).unwrap();
 
 		let expected_first_account =
 			AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap();
@@ -280,10 +278,8 @@ mod tests {
 				.to_string();
 		let accounts = 20;
 		let pairs = derive_bip44_pairs_from_mnemonic::<ecdsa::Public>(&mnemonic, accounts);
-		let first_account =
-			get_account_id_from_pair::<ecdsa::Public>(pairs.first().unwrap().clone()).unwrap();
-		let last_account =
-			get_account_id_from_pair::<ecdsa::Public>(pairs.last().unwrap().clone()).unwrap();
+		let first_account = get_account_id_from_pair(pairs.first().unwrap().clone()).unwrap();
+		let last_account = get_account_id_from_pair(pairs.last().unwrap().clone()).unwrap();
 
 		let expected_first_account =
 			AccountId::from_str("1e56ca71b596f2b784a27a2fdffef053dbdeff83").unwrap();


### PR DESCRIPTION
### What does it do?

Only use the public key to recover the account ID.
I removed the generic since the current implementation already used a secp256k1 function and thus was not really generic.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
