### PR TITLE
[Staking] Immediate block rewards, claimable via extrinsic

### DIFF
--- a/pallets/parachain-staking/src/inflation.rs
+++ b/pallets/parachain-staking/src/inflation.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Helper methods for computing issuance based on inflation
-use crate::pallet::{BalanceOf, Config, Pallet};
+//! Helper methods for computing block issuance based on annual inflation
+use crate::pallet::{BalanceOf, Config};
 use frame_support::traits::Currency;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
@@ -29,11 +29,6 @@ use substrate_fixed::types::{I32F32, I64F64};
 const SECONDS_PER_YEAR: u32 = 31557600;
 const SECONDS_PER_BLOCK: u32 = 12;
 const BLOCKS_PER_YEAR: u32 = SECONDS_PER_YEAR / SECONDS_PER_BLOCK;
-
-fn rounds_per_year<T: Config>() -> u32 {
-	let blocks_per_round = <Pallet<T>>::round().length;
-	BLOCKS_PER_YEAR / blocks_per_round
-}
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Eq, PartialEq, Clone, Copy, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
@@ -58,14 +53,14 @@ impl<T: Ord + Copy> From<T> for Range<T> {
 		}
 	}
 }
-/// Convert an annual inflation to a round inflation
-/// round = 1 - (1+annual)^(1/rounds_per_year)
-fn perbill_annual_to_perbill_round(annual: Range<Perbill>, rounds_per_year: u32) -> Range<Perbill> {
-	let exponent = I32F32::from_num(1) / I32F32::from_num(rounds_per_year);
-	let annual_to_round = |annual: Perbill| -> Perbill {
+/// Convert an annual inflation to a block inflation
+/// block = 1 - (1+annual)^(1/blocks_per_year)
+fn perbill_annual_to_perbill_block(annual: Range<Perbill>) -> Range<Perbill> {
+	let exponent = I32F32::from_num(1) / I32F32::from_num(BLOCKS_PER_YEAR);
+	let year_to_block = |annual: Perbill| -> Perbill {
 		let x = I32F32::from_num(annual.deconstruct()) / I32F32::from_num(Perbill::ACCURACY);
 		let y: I64F64 = floatpow(I32F32::from_num(1) + x, exponent)
-			.expect("Cannot overflow since rounds_per_year is u32 so worst case 0; QED");
+			.expect("Cannot overflow since blocks_per_year < u32::MAX");
 		Perbill::from_parts(
 			((y - I64F64::from_num(1)) * I64F64::from_num(Perbill::ACCURACY))
 				.ceil()
@@ -73,29 +68,29 @@ fn perbill_annual_to_perbill_round(annual: Range<Perbill>, rounds_per_year: u32)
 		)
 	};
 	Range {
-		min: annual_to_round(annual.min),
-		ideal: annual_to_round(annual.ideal),
-		max: annual_to_round(annual.max),
+		min: year_to_block(annual.min),
+		ideal: year_to_block(annual.ideal),
+		max: year_to_block(annual.max),
 	}
 }
-/// Convert annual inflation rate range to round inflation range
-pub fn annual_to_round<T: Config>(annual: Range<Perbill>) -> Range<Perbill> {
-	let periods = rounds_per_year::<T>();
-	perbill_annual_to_perbill_round(annual, periods)
+/// Convert annual inflation rate range to block inflation rate
+pub fn annual_to_block<T: Config>(annual: Range<Perbill>) -> Range<Perbill> {
+	perbill_annual_to_perbill_block(annual)
 }
 
-/// Compute round issuance range from round inflation range and current total issuance
-pub fn round_issuance_range<T: Config>(round: Range<Perbill>) -> Range<BalanceOf<T>> {
+/// Compute block issuance range from block inflation range and current total issuance
+pub fn block_issuance_range<T: Config>(block: Range<Perbill>) -> Range<BalanceOf<T>> {
 	let circulating = T::Currency::total_issuance();
 	Range {
-		min: round.min * circulating,
-		ideal: round.ideal * circulating,
-		max: round.max * circulating,
+		min: block.min * circulating,
+		ideal: block.ideal * circulating,
+		max: block.max * circulating,
 	}
 }
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[derive(Eq, PartialEq, Clone, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
+/// DEPRECATED
 pub struct InflationInfo<Balance> {
 	/// Staking expectations
 	pub expect: Range<Balance>,
@@ -105,7 +100,18 @@ pub struct InflationInfo<Balance> {
 	pub round: Range<Perbill>,
 }
 
-impl<Balance> InflationInfo<Balance> {
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(Eq, PartialEq, Clone, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
+pub struct InflationInformation<Balance> {
+	/// Staking expectations
+	pub expect: Range<Balance>,
+	/// Annual inflation range
+	pub annual: Range<Perbill>,
+	/// Block inflation range
+	pub block: Range<Perbill>,
+}
+
+impl<Balance> InflationInformation<Balance> {
 	pub fn new<T: Config>(
 		annual: Range<Perbill>,
 		expect: Range<Balance>,
@@ -113,17 +119,16 @@ impl<Balance> InflationInfo<Balance> {
 		InflationInfo {
 			expect,
 			annual,
-			round: annual_to_round::<T>(annual),
+			round: annual_to_block::<T>(annual),
 		}
 	}
-	/// Set round inflation range according to input annual inflation range
-	pub fn set_round_from_annual<T: Config>(&mut self, new: Range<Perbill>) {
-		self.round = annual_to_round::<T>(new);
+	/// Set block inflation range according to input annual inflation range
+	pub fn set_block_from_annual<T: Config>(&mut self, new: Range<Perbill>) {
+		self.block = annual_to_block::<T>(new);
 	}
-	/// Reset round inflation rate based on changes to round length
-	pub fn reset_round(&mut self, new_length: u32) {
-		let periods = BLOCKS_PER_YEAR / new_length;
-		self.round = perbill_annual_to_perbill_round(self.annual, periods);
+	/// Reset block inflation rate based on changes to blocks per year
+	pub fn reset_block(&mut self) {
+		self.block = perbill_annual_to_perbill_block(self.annual);
 	}
 	/// Set staking expectations
 	pub fn set_expectations(&mut self, expect: Range<Balance>) {
@@ -134,19 +139,19 @@ impl<Balance> InflationInfo<Balance> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	fn mock_annual_to_round(annual: Range<Perbill>, rounds_per_year: u32) -> Range<Perbill> {
-		perbill_annual_to_perbill_round(annual, rounds_per_year)
+	fn mock_annual_to_block(annual: Range<Perbill>) -> Range<Perbill> {
+		perbill_annual_to_perbill_block(annual)
 	}
-	fn mock_round_issuance_range(
+	fn mock_block_issuance_range(
 		// Total circulating before minting
 		circulating: u128,
-		// Round inflation range
-		round: Range<Perbill>,
+		// Block inflation range
+		block: Range<Perbill>,
 	) -> Range<u128> {
 		Range {
-			min: round.min * circulating,
-			ideal: round.ideal * circulating,
-			max: round.max * circulating,
+			min: block.min * circulating,
+			ideal: block.ideal * circulating,
+			max: block.max * circulating,
 		}
 	}
 	#[test]
@@ -166,7 +171,7 @@ mod tests {
 		};
 		assert_eq!(
 			expected_round_issuance_range,
-			mock_round_issuance_range(10_000_000, mock_annual_to_round(schedule, 10))
+			mock_round_issuance_range(10_000_000, mock_annual_to_block(schedule))
 		);
 	}
 	#[test]


### PR DESCRIPTION
Changes the `note_author` implementation in staking to immediately calculate and store the due rewards for the block author and all of its counted delegations. Rewards can be claimed via the `claim` extrinsic.

This approach makes sense because all implementations have constant issuance per block (blocks authored earlier or later in the round need not be worth more/less points). Might as well calculate the block reward to the block author (and its counted delegations) in the block that they author.

This PR is a draft so code is messy; it is merely suggesting an idea. It would remove the need to track the `Points` for all the block authors in the round and calculate + distribute rewards later on in proportion to relative `Points` earned in the round.
