### PR TITLE
[Staking] Remove delays for bond_more

### DIFF
--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -18,7 +18,7 @@
 
 //! Benchmarking
 use crate::{
-	BalanceOf, Call, CandidateBondChange, CandidateBondRequest, Config, DelegationChange,
+	BalanceOf, Call, CandidateBondChange, CandidateBondLessRequest, Config, DelegationChange,
 	DelegationRequest, Pallet, Range,
 };
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
@@ -338,9 +338,8 @@ benchmarks! {
 		let state = Pallet::<T>::candidate_state(&caller).expect("request bonded less so exists");
 		assert_eq!(
 			state.request,
-			Some(CandidateBondRequest {
+			Some(CandidateBondLessRequest {
 				amount: min_candidate_stk,
-				change: CandidateBondChange::Decrease,
 				when_executable: 3,
 			})
 		);

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -18,8 +18,8 @@
 
 //! Benchmarking
 use crate::{
-	BalanceOf, Call, CandidateBondChange, CandidateBondLessRequest, Config, DelegationChange,
-	DelegationRequest, Pallet, Range,
+	BalanceOf, Call, CandidateBondLessRequest, Config, DelegationChange, DelegationRequest, Pallet,
+	Range,
 };
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::traits::{Currency, Get, OnFinalize, OnInitialize, ReservableCurrency};

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1013,7 +1013,6 @@ pub mod pallet {
 	}
 
 	#[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
-	/// TODO: add leaving logic to this?
 	/// Pending requests to mutate delegations for each delegator
 	pub struct PendingDelegationRequests<AccountId, Balance> {
 		/// Number of pending revocations (necessary for determining whether revoke is exit)
@@ -1334,8 +1333,6 @@ pub mod pallet {
 		JoinedCollatorCandidates(T::AccountId, BalanceOf<T>, BalanceOf<T>),
 		/// Round, Collator Account, Total Exposed Amount (includes all delegations)
 		CollatorChosen(RoundIndex, T::AccountId, BalanceOf<T>),
-		/// Candidate, Amount To Increase, Round at which request can be executed by caller
-		CandidateBondMoreRequested(T::AccountId, BalanceOf<T>, RoundIndex),
 		/// Candidate, Amount To Decrease, Round at which request can be executed by caller
 		CandidateBondLessRequested(T::AccountId, BalanceOf<T>, RoundIndex),
 		/// Candidate, Amount, New Bond Total
@@ -1354,8 +1351,6 @@ pub mod pallet {
 		CancelledCandidateBondChange(T::AccountId, CandidateBondRequest<BalanceOf<T>>),
 		/// Ex-Candidate, Amount Unlocked, New Total Amt Locked
 		CandidateLeft(T::AccountId, BalanceOf<T>, BalanceOf<T>),
-		/// Delegator, Candidate, Amount to be increased, Round at which can be executed
-		DelegationIncreaseScheduled(T::AccountId, T::AccountId, BalanceOf<T>, RoundIndex),
 		/// Delegator, Candidate, Amount to be decreased, Round at which can be executed
 		DelegationDecreaseScheduled(T::AccountId, T::AccountId, BalanceOf<T>, RoundIndex),
 		// Delegator, Candidate, Amount, If in top delegations for candidate after increase

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -181,7 +181,6 @@ pub mod pallet {
 	#[derive(PartialEq, Clone, Copy, Encode, Decode, RuntimeDebug, TypeInfo)]
 	/// Changes allowed by an active collator candidate to their self bond
 	pub enum CandidateBondChange {
-		Increase,
 		Decrease,
 	}
 
@@ -264,33 +263,25 @@ pub mod pallet {
 				Err(Error::<T>::CandidateNotLeaving.into())
 			}
 		}
-		/// Schedule executable increase of collator candidate self bond
-		/// Returns the round at which the collator can execute the pending request
-		pub fn schedule_bond_more<T: Config>(
-			&mut self,
-			more: B,
-		) -> Result<RoundIndex, DispatchError>
+		pub fn bond_more<T: Config>(&mut self, more: B) -> DispatchResult
 		where
-			T::AccountId: From<A>,
 			BalanceOf<T>: From<B>,
+			T::AccountId: From<A>,
+			CollatorCandidate<T::AccountId, BalanceOf<T>>: From<Self>,
 		{
-			// ensure no pending request
-			ensure!(
-				self.request.is_none(),
-				Error::<T>::PendingCandidateRequestAlreadyExists
-			);
-			let candidate_id: T::AccountId = self.id.clone().into();
-			ensure!(
-				T::Currency::can_reserve(&candidate_id, more.into()),
-				Error::<T>::InsufficientBalance
-			);
-			let when_executable = <Round<T>>::get().current + T::CandidateBondDelay::get();
-			self.request = Some(CandidateBondRequest {
-				change: CandidateBondChange::Increase,
-				amount: more,
-				when_executable,
-			});
-			Ok(when_executable)
+			let caller: T::AccountId = self.id.clone().into();
+			T::Currency::reserve(&caller, more.into())?;
+			let new_total = <Total<T>>::get().saturating_add(more.into());
+			<Total<T>>::put(new_total);
+			self.bond += more;
+			self.total_counted += more;
+			self.total_backing += more;
+			<Pallet<T>>::deposit_event(Event::CandidateBondedMore(
+				self.id.clone().into(),
+				more.into(),
+				self.bond.into(),
+			));
+			Ok(())
 		}
 		/// Schedule executable decrease of collator candidate self bond
 		/// Returns the round at which the collator can execute the pending request
@@ -312,7 +303,7 @@ pub mod pallet {
 				self.bond - less >= T::MinCandidateStk::get().into(),
 				Error::<T>::CandidateBondBelowMin
 			);
-			let when_executable = <Round<T>>::get().current + T::CandidateBondDelay::get();
+			let when_executable = <Round<T>>::get().current + T::CandidateBondLessDelay::get();
 			self.request = Some(CandidateBondRequest {
 				change: CandidateBondChange::Decrease,
 				amount: less,
@@ -336,19 +327,6 @@ pub mod pallet {
 			);
 			let caller: T::AccountId = self.id.clone().into();
 			let event = match request.change {
-				CandidateBondChange::Increase => {
-					T::Currency::reserve(&caller, request.amount.into())?;
-					let new_total = <Total<T>>::get().saturating_add(request.amount.into());
-					<Total<T>>::put(new_total);
-					self.bond += request.amount;
-					self.total_counted += request.amount;
-					self.total_backing += request.amount;
-					Event::CandidateBondedMore(
-						self.id.clone().into(),
-						request.amount.into(),
-						self.bond.into(),
-					)
-				}
 				CandidateBondChange::Decrease => {
 					T::Currency::unreserve(&caller, request.amount.into());
 					let new_total_staked = <Total<T>>::get().saturating_sub(request.amount.into());
@@ -762,28 +740,50 @@ pub mod pallet {
 				None
 			}
 		}
-		/// Schedule increase delegation
-		pub fn schedule_increase_delegation<T: Config>(
+		pub fn increase_delegation<T: Config>(
 			&mut self,
-			collator: AccountId,
-			more: Balance,
-		) -> Result<RoundIndex, DispatchError>
+			candidate: AccountId,
+			amount: Balance,
+		) -> DispatchResult
 		where
 			BalanceOf<T>: From<Balance>,
 			T::AccountId: From<AccountId>,
+			Delegator<T::AccountId, BalanceOf<T>>: From<Delegator<AccountId, Balance>>,
 		{
-			ensure!(
-				&self.delegations.0.iter().any(|x| x.owner == collator),
-				Error::<T>::DelegationDNE
-			);
-			let delegator_id: T::AccountId = self.id.clone().into();
-			ensure!(
-				T::Currency::can_reserve(&delegator_id, more.into()),
-				Error::<T>::InsufficientBalance
-			);
-			let when = <Round<T>>::get().current + T::DelegationBondDelay::get();
-			self.requests.bond_more::<T>(collator, more, when)?;
-			Ok(when)
+			let delegator_id = self.id.clone().into();
+			let candidate_id: T::AccountId = candidate.clone().into();
+			let balance_amt: BalanceOf<T> = amount.into();
+			// increase delegation
+			for x in &mut self.delegations.0 {
+				if x.owner == candidate {
+					x.amount += amount;
+					self.total += amount;
+					// update collator state delegation
+					let mut collator_state =
+						<CandidateState<T>>::get(&candidate_id).ok_or(Error::<T>::CandidateDNE)?;
+					T::Currency::reserve(&self.id.clone().into(), balance_amt)?;
+					let before = collator_state.total_counted;
+					let in_top =
+						collator_state.increase_delegation(self.id.clone().into(), balance_amt);
+					let after = collator_state.total_counted;
+					if collator_state.is_active() && (before != after) {
+						Pallet::<T>::update_active(candidate_id.clone(), after);
+					}
+					<CandidateState<T>>::insert(&candidate_id, collator_state);
+					let new_total_staked = <Total<T>>::get().saturating_add(balance_amt);
+					<Total<T>>::put(new_total_staked);
+					let nom_st: Delegator<T::AccountId, BalanceOf<T>> = self.clone().into();
+					<DelegatorState<T>>::insert(&delegator_id, nom_st);
+					Pallet::<T>::deposit_event(Event::DelegationIncreased(
+						delegator_id,
+						candidate_id,
+						balance_amt,
+						in_top,
+					));
+					return Ok(());
+				}
+			}
+			Err(Error::<T>::DelegationDNE.into())
 		}
 		/// Schedule decrease delegation
 		pub fn schedule_decrease_delegation<T: Config>(
@@ -815,7 +815,7 @@ pub mod pallet {
 				less <= max_subtracted_amount,
 				Error::<T>::DelegatorBondBelowMin
 			);
-			let when = <Round<T>>::get().current + T::DelegationBondDelay::get();
+			let when = <Round<T>>::get().current + T::DelegationBondLessDelay::get();
 			self.requests.bond_less::<T>(collator, less, when)?;
 			Ok(when)
 		}
@@ -920,41 +920,6 @@ pub mod pallet {
 					}
 					Ok(())
 				}
-				DelegationChange::Increase => {
-					// remove from pending requests
-					self.requests.more_total -= amount;
-					// increase delegation
-					for x in &mut self.delegations.0 {
-						if x.owner == candidate {
-							x.amount += amount;
-							self.total += amount;
-							// update collator state delegation
-							let mut collator_state = <CandidateState<T>>::get(&candidate_id)
-								.ok_or(Error::<T>::CandidateDNE)?;
-							T::Currency::reserve(&self.id.clone().into(), balance_amt)?;
-							let before = collator_state.total_counted;
-							let in_top = collator_state
-								.increase_delegation(self.id.clone().into(), balance_amt);
-							let after = collator_state.total_counted;
-							if collator_state.is_active() && (before != after) {
-								Pallet::<T>::update_active(candidate_id.clone(), after);
-							}
-							<CandidateState<T>>::insert(&candidate_id, collator_state);
-							let new_total_staked = <Total<T>>::get().saturating_add(balance_amt);
-							<Total<T>>::put(new_total_staked);
-							let nom_st: Delegator<T::AccountId, BalanceOf<T>> = self.clone().into();
-							<DelegatorState<T>>::insert(&delegator_id, nom_st);
-							Pallet::<T>::deposit_event(Event::DelegationIncreased(
-								delegator_id,
-								candidate_id,
-								balance_amt,
-								in_top,
-							));
-							return Ok(());
-						}
-					}
-					Err(Error::<T>::DelegationDNE.into())
-				}
 				DelegationChange::Decrease => {
 					// remove from pending requests
 					self.requests.less_total -= amount;
@@ -1026,9 +991,6 @@ pub mod pallet {
 				DelegationChange::Decrease => {
 					self.requests.less_total -= order.amount;
 				}
-				DelegationChange::Increase => {
-					self.requests.more_total -= order.amount;
-				}
 			}
 			Ok(order)
 		}
@@ -1037,10 +999,8 @@ pub mod pallet {
 	#[derive(Clone, Eq, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
 	/// Changes requested by the delegator
 	/// - limit of 1 ongoing change per delegation
-	/// - no changes allowed if delegator is leaving
 	pub enum DelegationChange {
 		Revoke,
-		Increase,
 		Decrease,
 	}
 
@@ -1053,6 +1013,7 @@ pub mod pallet {
 	}
 
 	#[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
+	/// TODO: add leaving logic to this?
 	/// Pending requests to mutate delegations for each delegator
 	pub struct PendingDelegationRequests<AccountId, Balance> {
 		/// Number of pending revocations (necessary for determining whether revoke is exit)
@@ -1061,8 +1022,6 @@ pub mod pallet {
 		pub requests: BTreeMap<AccountId, DelegationRequest<AccountId, Balance>>,
 		/// Sum of pending revocation amounts + bond less amounts
 		pub less_total: Balance,
-		/// Sum of pending bond more amounts
-		pub more_total: Balance,
 	}
 
 	impl<A: Ord, B: Zero> Default for PendingDelegationRequests<A, B> {
@@ -1071,7 +1030,6 @@ pub mod pallet {
 				revocations_count: 0u32,
 				requests: BTreeMap::new(),
 				less_total: B::zero(),
-				more_total: B::zero(),
 			}
 		}
 	}
@@ -1091,29 +1049,6 @@ pub mod pallet {
 		/// New default (empty) pending requests
 		pub fn new() -> PendingDelegationRequests<A, B> {
 			PendingDelegationRequests::default()
-		}
-		/// Add bond more order to pending requests
-		pub fn bond_more<T: Config>(
-			&mut self,
-			collator: A,
-			amount: B,
-			when_executable: RoundIndex,
-		) -> DispatchResult {
-			ensure!(
-				self.requests.get(&collator).is_none(),
-				Error::<T>::PendingDelegationRequestAlreadyExists
-			);
-			self.requests.insert(
-				collator.clone(),
-				DelegationRequest {
-					collator,
-					amount,
-					when_executable,
-					action: DelegationChange::Increase,
-				},
-			);
-			self.more_total += amount;
-			Ok(())
 		}
 		/// Add bond less order to pending requests, only succeeds if returns true
 		/// - limit is the maximum amount allowed that can be subtracted from the delegation
@@ -1302,18 +1237,18 @@ pub mod pallet {
 		/// Number of rounds that candidates remain bonded before exit request is executable
 		#[pallet::constant]
 		type LeaveCandidatesDelay: Get<RoundIndex>;
-		/// Number of rounds that candidate requests to adjust self-bond must wait to be executable
+		/// Number of rounds candidate requests to decrease self-bond must wait to be executable
 		#[pallet::constant]
-		type CandidateBondDelay: Get<RoundIndex>;
+		type CandidateBondLessDelay: Get<RoundIndex>;
 		/// Number of rounds that delegators remain bonded before exit request is executable
 		#[pallet::constant]
 		type LeaveDelegatorsDelay: Get<RoundIndex>;
 		/// Number of rounds that delegations remain bonded before revocation request is executable
 		#[pallet::constant]
 		type RevokeDelegationDelay: Get<RoundIndex>;
-		/// Number of rounds that delegation {more, less} requests must wait before executable
+		/// Number of rounds that delegation less requests must wait before executable
 		#[pallet::constant]
-		type DelegationBondDelay: Get<RoundIndex>;
+		type DelegationBondLessDelay: Get<RoundIndex>;
 		/// Number of rounds after which block authors are rewarded
 		#[pallet::constant]
 		type RewardPaymentDelay: Get<RoundIndex>;
@@ -2063,16 +1998,15 @@ pub mod pallet {
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_candidate_bond_more())]
-		/// Request by collator candidate to increase self bond by `more`
-		pub fn schedule_candidate_bond_more(
+		/// Increase collator candidate self bond by `more`
+		pub fn candidate_bond_more(
 			origin: OriginFor<T>,
 			more: BalanceOf<T>,
 		) -> DispatchResultWithPostInfo {
 			let collator = ensure_signed(origin)?;
 			let mut state = <CandidateState<T>>::get(&collator).ok_or(Error::<T>::CandidateDNE)?;
-			let when = state.schedule_bond_more::<T>(more)?;
+			state.bond_more::<T>(more)?;
 			<CandidateState<T>>::insert(&collator, state);
-			Self::deposit_event(Event::CandidateBondMoreRequested(collator, more, when));
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_candidate_bond_less())]
@@ -2090,7 +2024,7 @@ pub mod pallet {
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::execute_candidate_bond_more())]
 		/// Execute pending request to adjust the collator candidate self bond
-		pub fn execute_candidate_bond_request(
+		pub fn execute_candidate_bond_less(
 			origin: OriginFor<T>,
 			candidate: T::AccountId,
 		) -> DispatchResultWithPostInfo {
@@ -2103,7 +2037,7 @@ pub mod pallet {
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::cancel_candidate_bond_more())]
 		/// Cancel pending request to adjust the collator candidate self bond
-		pub fn cancel_candidate_bond_request(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+		pub fn cancel_candidate_bond_less(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let collator = ensure_signed(origin)?;
 			let mut state = <CandidateState<T>>::get(&collator).ok_or(Error::<T>::CandidateDNE)?;
 			let event = state.cancel_pending_request::<T>()?;
@@ -2248,19 +2182,15 @@ pub mod pallet {
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_delegator_bond_more())]
-		/// Request to bond more for delegators wrt a specific collator candidate.
-		pub fn schedule_delegator_bond_more(
+		/// Bond more for delegators wrt a specific collator candidate.
+		pub fn delegator_bond_more(
 			origin: OriginFor<T>,
 			candidate: T::AccountId,
 			more: BalanceOf<T>,
 		) -> DispatchResultWithPostInfo {
 			let delegator = ensure_signed(origin)?;
 			let mut state = <DelegatorState<T>>::get(&delegator).ok_or(Error::<T>::DelegatorDNE)?;
-			let when = state.schedule_increase_delegation::<T>(candidate.clone(), more)?;
-			<DelegatorState<T>>::insert(&delegator, state);
-			Self::deposit_event(Event::DelegationIncreaseScheduled(
-				delegator, candidate, more, when,
-			));
+			state.increase_delegation::<T>(candidate.clone(), more)?;
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_delegator_bond_less())]

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1985,7 +1985,7 @@ pub mod pallet {
 			));
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::schedule_candidate_bond_more())]
+		#[pallet::weight(<T as Config>::WeightInfo::candidate_bond_more())]
 		/// Increase collator candidate self bond by `more`
 		pub fn candidate_bond_more(
 			origin: OriginFor<T>,
@@ -2010,7 +2010,7 @@ pub mod pallet {
 			Self::deposit_event(Event::CandidateBondLessRequested(collator, less, when));
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::execute_candidate_bond_more())]
+		#[pallet::weight(<T as Config>::WeightInfo::execute_candidate_bond_less())]
 		/// Execute pending request to adjust the collator candidate self bond
 		pub fn execute_candidate_bond_less(
 			origin: OriginFor<T>,
@@ -2023,7 +2023,7 @@ pub mod pallet {
 			Self::deposit_event(event);
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::cancel_candidate_bond_more())]
+		#[pallet::weight(<T as Config>::WeightInfo::cancel_candidate_bond_less())]
 		/// Cancel pending request to adjust the collator candidate self bond
 		pub fn cancel_candidate_bond_less(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let collator = ensure_signed(origin)?;
@@ -2169,7 +2169,7 @@ pub mod pallet {
 			));
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::schedule_delegator_bond_more())]
+		#[pallet::weight(<T as Config>::WeightInfo::delegator_bond_more())]
 		/// Bond more for delegators wrt a specific collator candidate.
 		pub fn delegator_bond_more(
 			origin: OriginFor<T>,
@@ -2197,7 +2197,7 @@ pub mod pallet {
 			));
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::execute_delegator_bond_more())]
+		#[pallet::weight(<T as Config>::WeightInfo::execute_delegator_bond_less())]
 		/// Execute pending request to change an existing delegation
 		pub fn execute_delegation_request(
 			origin: OriginFor<T>,
@@ -2209,7 +2209,7 @@ pub mod pallet {
 			state.execute_pending_request::<T>(candidate)?;
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::cancel_delegator_bond_more())]
+		#[pallet::weight(<T as Config>::WeightInfo::cancel_delegator_bond_less())]
 		/// Cancel request to change an existing delegation.
 		pub fn cancel_delegation_request(
 			origin: OriginFor<T>,

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -100,10 +100,10 @@ parameter_types! {
 	pub const MinBlocksPerRound: u32 = 3;
 	pub const DefaultBlocksPerRound: u32 = 5;
 	pub const LeaveCandidatesDelay: u32 = 2;
-	pub const CandidateBondDelay: u32 = 2;
+	pub const CandidateBondLessDelay: u32 = 2;
 	pub const LeaveDelegatorsDelay: u32 = 2;
 	pub const RevokeDelegationDelay: u32 = 2;
-	pub const DelegationBondDelay: u32 = 2;
+	pub const DelegationBondLessDelay: u32 = 2;
 	pub const RewardPaymentDelay: u32 = 2;
 	pub const MinSelectedCandidates: u32 = 5;
 	pub const MaxDelegatorsPerCandidate: u32 = 4;
@@ -121,10 +121,10 @@ impl Config for Test {
 	type MinBlocksPerRound = MinBlocksPerRound;
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type LeaveCandidatesDelay = LeaveCandidatesDelay;
-	type CandidateBondDelay = CandidateBondDelay;
+	type CandidateBondLessDelay = CandidateBondLessDelay;
 	type LeaveDelegatorsDelay = LeaveDelegatorsDelay;
 	type RevokeDelegationDelay = RevokeDelegationDelay;
-	type DelegationBondDelay = DelegationBondDelay;
+	type DelegationBondLessDelay = DelegationBondLessDelay;
 	type RewardPaymentDelay = RewardPaymentDelay;
 	type MinSelectedCandidates = MinSelectedCandidates;
 	type MaxDelegatorsPerCandidate = MaxDelegatorsPerCandidate;

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -25,9 +25,8 @@ use crate::mock::{
 	roll_to, set_author, Balances, Event as MetaEvent, ExtBuilder, Origin, Stake, Test,
 };
 use crate::{
-	assert_eq_events, assert_event_emitted, assert_last_event, Bond, CandidateBondChange,
-	CandidateBondRequest, CollatorStatus, DelegationChange, DelegationRequest, DelegatorAdded,
-	Error, Event, Range,
+	assert_eq_events, assert_event_emitted, assert_last_event, Bond, CollatorStatus,
+	DelegationChange, DelegationRequest, DelegatorAdded, Error, Event, Range,
 };
 use frame_support::{assert_noop, assert_ok};
 use sp_runtime::{traits::Zero, DispatchError, Perbill, Percent};
@@ -1332,13 +1331,8 @@ fn cancel_candidate_bond_less_emits_event() {
 		.execute_with(|| {
 			assert_ok!(Stake::schedule_candidate_bond_less(Origin::signed(1), 10));
 			assert_ok!(Stake::cancel_candidate_bond_less(Origin::signed(1)));
-			assert_last_event!(MetaEvent::Stake(Event::CancelledCandidateBondChange(
-				1,
-				CandidateBondRequest {
-					amount: 10,
-					change: CandidateBondChange::Decrease,
-					when_executable: 3,
-				},
+			assert_last_event!(MetaEvent::Stake(Event::CancelledCandidateBondLess(
+				1, 10, 3,
 			)));
 		});
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -1061,111 +1061,90 @@ fn cannot_go_online_if_leaving() {
 		});
 }
 
-// SCHEDULE CANDIDATE BOND MORE
+// CANDIDATE BOND MORE
 
 #[test]
-fn schedule_candidate_bond_more_event_emits_correctly() {
+fn candidate_bond_more_emits_correct_event() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 50)])
 		.with_candidates(vec![(1, 20)])
 		.build()
 		.execute_with(|| {
-			assert_ok!(Stake::schedule_candidate_bond_more(Origin::signed(1), 30));
-			assert_last_event!(MetaEvent::Stake(Event::CandidateBondMoreRequested(
-				1, 30, 3,
-			)));
+			assert_ok!(Stake::candidate_bond_more(Origin::signed(1), 30));
+			assert_last_event!(MetaEvent::Stake(Event::CandidateBondedMore(1, 30, 50)));
 		});
 }
 
 #[test]
-fn schedule_candidate_bond_more_updates_candidate_state() {
+fn candidate_bond_more_reserves_balance() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 50)])
 		.with_candidates(vec![(1, 20)])
 		.build()
 		.execute_with(|| {
-			assert_ok!(Stake::schedule_candidate_bond_more(Origin::signed(1), 30));
-			let state = Stake::candidate_state(&1).expect("request bonded more so exists");
+			assert_eq!(Balances::reserved_balance(&1), 20);
+			assert_eq!(Balances::free_balance(&1), 30);
+			assert_ok!(Stake::candidate_bond_more(Origin::signed(1), 30));
+			assert_eq!(Balances::reserved_balance(&1), 50);
+			assert_eq!(Balances::free_balance(&1), 0);
+		});
+}
+
+#[test]
+fn candidate_bond_more_increases_total() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 50)])
+		.with_candidates(vec![(1, 20)])
+		.build()
+		.execute_with(|| {
+			let mut total = Stake::total();
+			assert_ok!(Stake::candidate_bond_more(Origin::signed(1), 30));
+			total += 30;
+			assert_eq!(Stake::total(), total);
+		});
+}
+
+#[test]
+fn candidate_bond_more_updates_candidate_state() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 50)])
+		.with_candidates(vec![(1, 20)])
+		.build()
+		.execute_with(|| {
+			let candidate_state = Stake::candidate_state(1).expect("updated => exists");
+			assert_eq!(candidate_state.bond, 20);
+			assert_ok!(Stake::candidate_bond_more(Origin::signed(1), 30));
+			let candidate_state = Stake::candidate_state(1).expect("updated => exists");
+			assert_eq!(candidate_state.bond, 50);
+		});
+}
+
+#[test]
+fn candidate_bond_more_updates_candidate_pool() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 50)])
+		.with_candidates(vec![(1, 20)])
+		.build()
+		.execute_with(|| {
 			assert_eq!(
-				state.request,
-				Some(CandidateBondRequest {
-					amount: 30,
-					change: CandidateBondChange::Increase,
-					when_executable: 3,
-				})
+				Stake::candidate_pool().0[0],
+				Bond {
+					owner: 1,
+					amount: 20
+				}
+			);
+			assert_ok!(Stake::candidate_bond_more(Origin::signed(1), 30));
+			assert_eq!(
+				Stake::candidate_pool().0[0],
+				Bond {
+					owner: 1,
+					amount: 50
+				}
 			);
 		});
 }
 
-#[test]
-fn cannot_schedule_candidate_bond_more_if_request_exists() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 40)])
-		.with_candidates(vec![(1, 30)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Stake::schedule_candidate_bond_more(Origin::signed(1), 5));
-			assert_noop!(
-				Stake::schedule_candidate_bond_more(Origin::signed(1), 5),
-				Error::<Test>::PendingCandidateRequestAlreadyExists
-			);
-		});
-}
-
-#[test]
-fn cannot_schedule_candidate_bond_more_if_not_candidate() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_noop!(
-			Stake::schedule_candidate_bond_more(Origin::signed(6), 50),
-			Error::<Test>::CandidateDNE
-		);
-	});
-}
-
-#[test]
-fn cannot_schedule_candidate_bond_more_if_insufficient_balance() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 30)])
-		.with_candidates(vec![(1, 30)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Stake::schedule_candidate_bond_more(Origin::signed(1), 1),
-				Error::<Test>::InsufficientBalance
-			);
-		});
-}
-
-#[test]
-fn can_schedule_candidate_bond_more_if_leaving_candidates() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 50)])
-		.with_candidates(vec![(1, 20)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Stake::schedule_leave_candidates(Origin::signed(1), 1));
-			assert_ok!(Stake::schedule_candidate_bond_more(Origin::signed(1), 30));
-		});
-}
-
-#[test]
-fn cannot_schedule_candidate_bond_more_if_exited_candidates() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 50)])
-		.with_candidates(vec![(1, 20)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Stake::schedule_leave_candidates(Origin::signed(1), 1));
-			roll_to(10);
-			assert_ok!(Stake::execute_leave_candidates(Origin::signed(1), 1));
-			assert_noop!(
-				Stake::schedule_candidate_bond_more(Origin::signed(1), 30),
-				Error::<Test>::CandidateDNE
-			);
-		});
-}
-
-// CANDIDATE BOND LESS
+// SCHEDULE CANDIDATE BOND LESS
 
 #[test]
 fn schedule_candidate_bond_less_event_emits_correctly() {
@@ -1249,101 +1228,7 @@ fn cannot_schedule_candidate_bond_less_if_exited_candidates() {
 		});
 }
 
-// EXECUTE CANDIDATE BOND REQUEST
-// 1. BOND MORE REQUEST
-
-#[test]
-fn execute_candidate_bond_more_emits_correct_event() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 50)])
-		.with_candidates(vec![(1, 20)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Stake::schedule_candidate_bond_more(Origin::signed(1), 30));
-			roll_to(10);
-			assert_ok!(Stake::execute_candidate_bond_request(Origin::signed(1), 1));
-			assert_last_event!(MetaEvent::Stake(Event::CandidateBondedMore(1, 30, 50)));
-		});
-}
-
-#[test]
-fn execute_candidate_bond_more_reserves_balance() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 50)])
-		.with_candidates(vec![(1, 20)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(Balances::reserved_balance(&1), 20);
-			assert_eq!(Balances::free_balance(&1), 30);
-			assert_ok!(Stake::schedule_candidate_bond_more(Origin::signed(1), 30));
-			roll_to(10);
-			assert_ok!(Stake::execute_candidate_bond_request(Origin::signed(1), 1));
-			assert_eq!(Balances::reserved_balance(&1), 50);
-			assert_eq!(Balances::free_balance(&1), 0);
-		});
-}
-
-#[test]
-fn execute_candidate_bond_more_increases_total() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 50)])
-		.with_candidates(vec![(1, 20)])
-		.build()
-		.execute_with(|| {
-			let mut total = Stake::total();
-			assert_ok!(Stake::schedule_candidate_bond_more(Origin::signed(1), 30));
-			roll_to(10);
-			assert_ok!(Stake::execute_candidate_bond_request(Origin::signed(1), 1));
-			total += 30;
-			assert_eq!(Stake::total(), total);
-		});
-}
-
-#[test]
-fn execute_candidate_bond_more_updates_candidate_state() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 50)])
-		.with_candidates(vec![(1, 20)])
-		.build()
-		.execute_with(|| {
-			let candidate_state = Stake::candidate_state(1).expect("updated => exists");
-			assert_eq!(candidate_state.bond, 20);
-			assert_ok!(Stake::schedule_candidate_bond_more(Origin::signed(1), 30));
-			roll_to(10);
-			assert_ok!(Stake::execute_candidate_bond_request(Origin::signed(1), 1));
-			let candidate_state = Stake::candidate_state(1).expect("updated => exists");
-			assert_eq!(candidate_state.bond, 50);
-		});
-}
-
-#[test]
-fn execute_candidate_bond_more_updates_candidate_pool() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 50)])
-		.with_candidates(vec![(1, 20)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(
-				Stake::candidate_pool().0[0],
-				Bond {
-					owner: 1,
-					amount: 20
-				}
-			);
-			assert_ok!(Stake::schedule_candidate_bond_more(Origin::signed(1), 30));
-			roll_to(10);
-			assert_ok!(Stake::execute_candidate_bond_request(Origin::signed(1), 1));
-			assert_eq!(
-				Stake::candidate_pool().0[0],
-				Bond {
-					owner: 1,
-					amount: 50
-				}
-			);
-		});
-}
-
-// 2. BOND LESS REQUEST
+// 2. EXECUTE BOND LESS REQUEST
 
 #[test]
 fn execute_candidate_bond_less_emits_correct_event() {
@@ -1354,7 +1239,7 @@ fn execute_candidate_bond_less_emits_correct_event() {
 		.execute_with(|| {
 			assert_ok!(Stake::schedule_candidate_bond_less(Origin::signed(1), 30));
 			roll_to(10);
-			assert_ok!(Stake::execute_candidate_bond_request(Origin::signed(1), 1));
+			assert_ok!(Stake::execute_candidate_bond_less(Origin::signed(1), 1));
 			assert_last_event!(MetaEvent::Stake(Event::CandidateBondedLess(1, 30, 20)));
 		});
 }
@@ -1370,7 +1255,7 @@ fn execute_candidate_bond_less_unreserves_balance() {
 			assert_eq!(Balances::free_balance(&1), 0);
 			assert_ok!(Stake::schedule_candidate_bond_less(Origin::signed(1), 10));
 			roll_to(10);
-			assert_ok!(Stake::execute_candidate_bond_request(Origin::signed(1), 1));
+			assert_ok!(Stake::execute_candidate_bond_less(Origin::signed(1), 1));
 			assert_eq!(Balances::reserved_balance(&1), 20);
 			assert_eq!(Balances::free_balance(&1), 10);
 		});
@@ -1386,7 +1271,7 @@ fn execute_candidate_bond_less_decreases_total() {
 			let mut total = Stake::total();
 			assert_ok!(Stake::schedule_candidate_bond_less(Origin::signed(1), 10));
 			roll_to(10);
-			assert_ok!(Stake::execute_candidate_bond_request(Origin::signed(1), 1));
+			assert_ok!(Stake::execute_candidate_bond_less(Origin::signed(1), 1));
 			total -= 10;
 			assert_eq!(Stake::total(), total);
 		});
@@ -1403,7 +1288,7 @@ fn execute_candidate_bond_less_updates_candidate_state() {
 			assert_eq!(candidate_state.bond, 30);
 			assert_ok!(Stake::schedule_candidate_bond_less(Origin::signed(1), 10));
 			roll_to(10);
-			assert_ok!(Stake::execute_candidate_bond_request(Origin::signed(1), 1));
+			assert_ok!(Stake::execute_candidate_bond_less(Origin::signed(1), 1));
 			let candidate_state = Stake::candidate_state(1).expect("updated => exists");
 			assert_eq!(candidate_state.bond, 20);
 		});
@@ -1425,7 +1310,7 @@ fn execute_candidate_bond_less_updates_candidate_pool() {
 			);
 			assert_ok!(Stake::schedule_candidate_bond_less(Origin::signed(1), 10));
 			roll_to(10);
-			assert_ok!(Stake::execute_candidate_bond_request(Origin::signed(1), 1));
+			assert_ok!(Stake::execute_candidate_bond_less(Origin::signed(1), 1));
 			assert_eq!(
 				Stake::candidate_pool().0[0],
 				Bond {
@@ -1436,58 +1321,7 @@ fn execute_candidate_bond_less_updates_candidate_pool() {
 		});
 }
 
-// CANCEL CANDIDATE BOND REQUEST
-// 1. CANCEL CANDIDATE BOND MORE REQUEST
-
-#[test]
-fn cancel_candidate_bond_more_emits_event() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 40)])
-		.with_candidates(vec![(1, 30)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Stake::schedule_candidate_bond_more(Origin::signed(1), 10));
-			assert_ok!(Stake::cancel_candidate_bond_request(Origin::signed(1)));
-			assert_last_event!(MetaEvent::Stake(Event::CancelledCandidateBondChange(
-				1,
-				CandidateBondRequest {
-					amount: 10,
-					change: CandidateBondChange::Increase,
-					when_executable: 3,
-				},
-			)));
-		});
-}
-
-#[test]
-fn cancel_candidate_bond_more_updates_candidate_state() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 40)])
-		.with_candidates(vec![(1, 30)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Stake::schedule_candidate_bond_more(Origin::signed(1), 10));
-			assert_ok!(Stake::cancel_candidate_bond_request(Origin::signed(1)));
-			assert!(Stake::candidate_state(&1).unwrap().request.is_none());
-		});
-}
-
-#[test]
-fn only_candidate_can_cancel_candidate_bond_more_request() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 40)])
-		.with_candidates(vec![(1, 30)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Stake::schedule_candidate_bond_more(Origin::signed(1), 10));
-			assert_noop!(
-				Stake::cancel_candidate_bond_request(Origin::signed(2)),
-				Error::<Test>::CandidateDNE
-			);
-		});
-}
-
-// 2. CANCEL CANDIDATE BOND LESS REQUEST
+// CANCEL CANDIDATE BOND LESS REQUEST
 
 #[test]
 fn cancel_candidate_bond_less_emits_event() {
@@ -1497,7 +1331,7 @@ fn cancel_candidate_bond_less_emits_event() {
 		.build()
 		.execute_with(|| {
 			assert_ok!(Stake::schedule_candidate_bond_less(Origin::signed(1), 10));
-			assert_ok!(Stake::cancel_candidate_bond_request(Origin::signed(1)));
+			assert_ok!(Stake::cancel_candidate_bond_less(Origin::signed(1)));
 			assert_last_event!(MetaEvent::Stake(Event::CancelledCandidateBondChange(
 				1,
 				CandidateBondRequest {
@@ -1517,7 +1351,7 @@ fn cancel_candidate_bond_less_updates_candidate_state() {
 		.build()
 		.execute_with(|| {
 			assert_ok!(Stake::schedule_candidate_bond_less(Origin::signed(1), 10));
-			assert_ok!(Stake::cancel_candidate_bond_request(Origin::signed(1)));
+			assert_ok!(Stake::cancel_candidate_bond_less(Origin::signed(1)));
 			assert!(Stake::candidate_state(&1).unwrap().request.is_none());
 		});
 }
@@ -1531,7 +1365,7 @@ fn only_candidate_can_cancel_candidate_bond_less_request() {
 		.execute_with(|| {
 			assert_ok!(Stake::schedule_candidate_bond_less(Origin::signed(1), 10));
 			assert_noop!(
-				Stake::cancel_candidate_bond_request(Origin::signed(2)),
+				Stake::cancel_candidate_bond_less(Origin::signed(2)),
 				Error::<Test>::CandidateDNE
 			);
 		});
@@ -2101,20 +1935,35 @@ fn can_schedule_revoke_delegation_below_min_delegator_stake() {
 		});
 }
 
-// SCHEDULE DELEGATOR BOND MORE
+// DELEGATOR BOND MORE
 
 #[test]
-fn delegator_bond_more_event_emits_correctly() {
+fn delegator_bond_more_reserves_balance() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 30), (2, 15)])
 		.with_candidates(vec![(1, 30)])
 		.with_delegations(vec![(2, 1, 10)])
 		.build()
 		.execute_with(|| {
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5));
-			assert_last_event!(MetaEvent::Stake(Event::DelegationIncreaseScheduled(
-				2, 1, 5, 3,
-			)));
+			assert_eq!(Balances::reserved_balance(&2), 10);
+			assert_eq!(Balances::free_balance(&2), 5);
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(2), 1, 5));
+			assert_eq!(Balances::reserved_balance(&2), 15);
+			assert_eq!(Balances::free_balance(&2), 0);
+		});
+}
+
+#[test]
+fn delegator_bond_more_increases_total_staked() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 30), (2, 15)])
+		.with_candidates(vec![(1, 30)])
+		.with_delegations(vec![(2, 1, 10)])
+		.build()
+		.execute_with(|| {
+			assert_eq!(Stake::total(), 40);
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(2), 1, 5));
+			assert_eq!(Stake::total(), 45);
 		});
 }
 
@@ -2126,101 +1975,99 @@ fn delegator_bond_more_updates_delegator_state() {
 		.with_delegations(vec![(2, 1, 10)])
 		.build()
 		.execute_with(|| {
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5));
-			let state = Stake::delegator_state(&2).expect("just request bonded less so exists");
-			assert_eq!(
-				state.requests().get(&1),
-				Some(&DelegationRequest {
-					collator: 1,
-					amount: 5,
-					when_executable: 3,
-					action: DelegationChange::Increase
-				})
-			);
+			assert_eq!(Stake::delegator_state(2).expect("exists").total, 10);
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(2), 1, 5));
+			assert_eq!(Stake::delegator_state(2).expect("exists").total, 15);
 		});
 }
 
 #[test]
-fn can_delegator_bond_more_if_leaving() {
+fn delegator_bond_more_updates_candidate_state_top_delegations() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 30), (2, 15)])
 		.with_candidates(vec![(1, 30)])
 		.with_delegations(vec![(2, 1, 10)])
 		.build()
 		.execute_with(|| {
-			assert_ok!(Stake::schedule_leave_delegators(Origin::signed(2)));
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5));
-		});
-}
-
-#[test]
-fn cannot_delegator_bond_more_if_revoking() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 25), (3, 20)])
-		.with_candidates(vec![(1, 30), (3, 20)])
-		.with_delegations(vec![(2, 1, 10), (2, 3, 10)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Stake::schedule_revoke_delegation(Origin::signed(2), 1));
-			assert_noop!(
-				Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5),
-				Error::<Test>::PendingDelegationRequestAlreadyExists
+			assert_eq!(
+				Stake::candidate_state(1).expect("exists").top_delegations[0],
+				Bond {
+					owner: 2,
+					amount: 10
+				}
+			);
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(2), 1, 5));
+			assert_eq!(
+				Stake::candidate_state(1).expect("exists").top_delegations[0],
+				Bond {
+					owner: 2,
+					amount: 15
+				}
 			);
 		});
 }
 
 #[test]
-fn cannot_delegator_bond_more_if_not_delegator() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_noop!(
-			Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5),
-			Error::<Test>::DelegatorDNE
-		);
-	});
+fn delegator_bond_more_updates_candidate_state_bottom_delegations() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 30), (2, 20), (3, 20), (4, 20), (5, 20), (6, 20)])
+		.with_candidates(vec![(1, 30)])
+		.with_delegations(vec![
+			(2, 1, 10),
+			(3, 1, 20),
+			(4, 1, 20),
+			(5, 1, 20),
+			(6, 1, 20),
+		])
+		.build()
+		.execute_with(|| {
+			assert_eq!(
+				Stake::candidate_state(1)
+					.expect("exists")
+					.bottom_delegations[0],
+				Bond {
+					owner: 2,
+					amount: 10
+				}
+			);
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(2), 1, 5));
+			assert_last_event!(MetaEvent::Stake(Event::DelegationIncreased(2, 1, 5, false)));
+			assert_eq!(
+				Stake::candidate_state(1)
+					.expect("exists")
+					.bottom_delegations[0],
+				Bond {
+					owner: 2,
+					amount: 15
+				}
+			);
+		});
 }
 
 #[test]
-fn cannot_delegator_bond_more_if_candidate_dne() {
+fn delegator_bond_more_increases_total() {
 	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 10)])
+		.with_balances(vec![(1, 30), (2, 15)])
 		.with_candidates(vec![(1, 30)])
 		.with_delegations(vec![(2, 1, 10)])
 		.build()
 		.execute_with(|| {
-			assert_noop!(
-				Stake::schedule_delegator_bond_more(Origin::signed(2), 3, 5),
-				Error::<Test>::DelegationDNE
-			);
+			assert_eq!(Stake::total(), 40);
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(2), 1, 5));
+			assert_eq!(Stake::total(), 45);
 		});
 }
 
 #[test]
-fn cannot_delegator_bond_more_if_delegation_dne() {
+fn can_delegator_bond_more_for_leaving_candidate() {
 	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 10), (3, 30)])
-		.with_candidates(vec![(1, 30), (3, 30)])
-		.with_delegations(vec![(2, 1, 10)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Stake::schedule_delegator_bond_more(Origin::signed(2), 3, 5),
-				Error::<Test>::DelegationDNE
-			);
-		});
-}
-
-#[test]
-fn cannot_delegator_bond_more_if_insufficient_balance() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 10)])
+		.with_balances(vec![(1, 30), (2, 15)])
 		.with_candidates(vec![(1, 30)])
 		.with_delegations(vec![(2, 1, 10)])
 		.build()
 		.execute_with(|| {
-			assert_noop!(
-				Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5),
-				Error::<Test>::InsufficientBalance
-			);
+			assert_ok!(Stake::schedule_leave_candidates(Origin::signed(1), 1));
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(2), 1, 5));
 		});
 }
 
@@ -2619,18 +2466,9 @@ fn delegator_bond_more_after_revoke_delegation_does_not_effect_exit() {
 		.build()
 		.execute_with(|| {
 			assert_ok!(Stake::schedule_revoke_delegation(Origin::signed(2), 1));
-			assert_noop!(
-				Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 10),
-				Error::<Test>::PendingDelegationRequestAlreadyExists
-			);
-			assert_ok!(Stake::schedule_delegator_bond_more(
-				Origin::signed(2),
-				3,
-				10
-			));
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(2), 3, 10));
 			roll_to(10);
 			assert_ok!(Stake::execute_delegation_request(Origin::signed(2), 2, 1));
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(2), 2, 3));
 			assert!(Stake::is_delegator(&2));
 			assert_eq!(Balances::reserved_balance(&2), 20);
 			assert_eq!(Balances::free_balance(&2), 10);
@@ -2664,158 +2502,7 @@ fn delegator_bond_less_after_revoke_delegation_does_not_effect_exit() {
 		});
 }
 
-// 2. EXECUTE BOND MORE
-
-#[test]
-fn execute_delegator_bond_more_reserves_balance() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 15)])
-		.with_candidates(vec![(1, 30)])
-		.with_delegations(vec![(2, 1, 10)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(Balances::reserved_balance(&2), 10);
-			assert_eq!(Balances::free_balance(&2), 5);
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5));
-			roll_to(10);
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(2), 2, 1));
-			assert_eq!(Balances::reserved_balance(&2), 15);
-			assert_eq!(Balances::free_balance(&2), 0);
-		});
-}
-
-#[test]
-fn execute_delegator_bond_more_increases_total_staked() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 15)])
-		.with_candidates(vec![(1, 30)])
-		.with_delegations(vec![(2, 1, 10)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(Stake::total(), 40);
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5));
-			roll_to(10);
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(2), 2, 1));
-			assert_eq!(Stake::total(), 45);
-		});
-}
-
-#[test]
-fn execute_delegator_bond_more_updates_delegator_state() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 15)])
-		.with_candidates(vec![(1, 30)])
-		.with_delegations(vec![(2, 1, 10)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(Stake::delegator_state(2).expect("exists").total, 10);
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5));
-			roll_to(10);
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(2), 2, 1));
-			assert_eq!(Stake::delegator_state(2).expect("exists").total, 15);
-		});
-}
-
-#[test]
-fn execute_delegator_bond_more_updates_candidate_state_top_delegations() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 15)])
-		.with_candidates(vec![(1, 30)])
-		.with_delegations(vec![(2, 1, 10)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(
-				Stake::candidate_state(1).expect("exists").top_delegations[0],
-				Bond {
-					owner: 2,
-					amount: 10
-				}
-			);
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5));
-			roll_to(10);
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(2), 2, 1));
-			assert_eq!(
-				Stake::candidate_state(1).expect("exists").top_delegations[0],
-				Bond {
-					owner: 2,
-					amount: 15
-				}
-			);
-		});
-}
-
-#[test]
-fn execute_delegator_bond_more_updates_candidate_state_bottom_delegations() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 20), (3, 20), (4, 20), (5, 20), (6, 20)])
-		.with_candidates(vec![(1, 30)])
-		.with_delegations(vec![
-			(2, 1, 10),
-			(3, 1, 20),
-			(4, 1, 20),
-			(5, 1, 20),
-			(6, 1, 20),
-		])
-		.build()
-		.execute_with(|| {
-			assert_eq!(
-				Stake::candidate_state(1)
-					.expect("exists")
-					.bottom_delegations[0],
-				Bond {
-					owner: 2,
-					amount: 10
-				}
-			);
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5));
-			roll_to(10);
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(2), 2, 1));
-			assert_last_event!(MetaEvent::Stake(Event::DelegationIncreased(2, 1, 5, false)));
-			assert_eq!(
-				Stake::candidate_state(1)
-					.expect("exists")
-					.bottom_delegations[0],
-				Bond {
-					owner: 2,
-					amount: 15
-				}
-			);
-		});
-}
-
-#[test]
-fn execute_delegator_bond_more_increases_total() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 15)])
-		.with_candidates(vec![(1, 30)])
-		.with_delegations(vec![(2, 1, 10)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(Stake::total(), 40);
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5));
-			roll_to(10);
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(2), 2, 1));
-			assert_eq!(Stake::total(), 45);
-		});
-}
-
-#[test]
-fn can_execute_delegator_bond_more_for_leaving_candidate() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 15)])
-		.with_candidates(vec![(1, 30)])
-		.with_delegations(vec![(2, 1, 10)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Stake::schedule_leave_candidates(Origin::signed(1), 1));
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5));
-			roll_to(10);
-			// can execute bond more delegation request for leaving candidate
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(2), 2, 1));
-		});
-}
-
-// 3, EXECUTE BOND LESS
+// 2. EXECUTE BOND LESS
 
 #[test]
 fn execute_delegator_bond_less_unreserves_balance() {
@@ -3107,58 +2794,7 @@ fn cancel_revoke_delegation_updates_delegator_state() {
 		});
 }
 
-// 2. CANCEL DELEGATOR BOND MORE
-
-#[test]
-fn cancel_delegator_bond_more_emits_correct_event() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 15)])
-		.with_candidates(vec![(1, 30)])
-		.with_delegations(vec![(2, 1, 10)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5));
-			assert_ok!(Stake::cancel_delegation_request(Origin::signed(2), 1));
-			assert_last_event!(MetaEvent::Stake(Event::CancelledDelegationRequest(
-				2,
-				DelegationRequest {
-					collator: 1,
-					amount: 5,
-					when_executable: 3,
-					action: DelegationChange::Increase,
-				},
-			)));
-		});
-}
-
-#[test]
-fn cancel_delegator_bond_more_updates_delegator_state() {
-	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 15)])
-		.with_candidates(vec![(1, 30)])
-		.with_delegations(vec![(2, 1, 10)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(2), 1, 5));
-			let state = Stake::delegator_state(&2).unwrap();
-			assert_eq!(
-				state.requests().get(&1),
-				Some(&DelegationRequest {
-					collator: 1,
-					amount: 5,
-					when_executable: 3,
-					action: DelegationChange::Increase,
-				})
-			);
-			assert_eq!(state.requests.more_total, 5);
-			assert_ok!(Stake::cancel_delegation_request(Origin::signed(2), 1));
-			let state = Stake::delegator_state(&2).unwrap();
-			assert!(state.requests().get(&1).is_none());
-			assert_eq!(state.requests.more_total, 0);
-		});
-}
-
-// 3. CANCEL DELEGATOR BOND LESS
+// 2. CANCEL DELEGATOR BOND LESS
 
 #[test]
 fn cancel_delegator_bond_less_correct_event() {
@@ -4289,16 +3925,12 @@ fn candidate_pool_updates_when_total_counted_changes() {
 			}
 			// 15 + 16 + 17 + 18 + 20 = 86 (top 4 + self bond)
 			is_candidate_pool_bond(1, 86);
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(3), 1, 8));
-			roll_to(10);
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(3), 1, 8));
 			// 3: 11 -> 19 => 3 is in top, bumps out 7
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(3), 3, 1));
 			// 16 + 17 + 18 + 19 + 20 = 90 (top 4 + self bond)
 			is_candidate_pool_bond(1, 90);
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(4), 1, 8));
-			roll_to(20);
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(4), 1, 8));
 			// 4: 12 -> 20 => 4 is in top, bumps out 8
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(4), 4, 1));
 			// 17 + 18 + 19 + 20 + 20 = 94 (top 4 + self bond)
 			is_candidate_pool_bond(1, 94);
 			assert_ok!(Stake::schedule_delegator_bond_less(
@@ -4307,7 +3939,6 @@ fn candidate_pool_updates_when_total_counted_changes() {
 				3
 			));
 			roll_to(30);
-			println!("test");
 			// 10: 18 -> 15 => 10 bumped to bottom, 8 bumped to top (- 18 + 16 = -2 for count)
 			assert_ok!(Stake::execute_delegation_request(Origin::signed(10), 10, 1));
 			// 16 + 17 + 19 + 20 + 20 = 92 (top 4 + self bond)
@@ -4361,10 +3992,7 @@ fn only_top_collators_are_counted() {
 				collator_state.total_backing
 			);
 			// bump bottom to the top
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(3), 1, 8));
-			assert_event_emitted!(Event::DelegationIncreaseScheduled(3, 1, 8, 3));
-			roll_to(10);
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(3), 3, 1));
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(3), 1, 8));
 			assert_event_emitted!(Event::DelegationIncreased(3, 1, 8, true));
 			let collator_state = Stake::candidate_state(1).unwrap();
 			// 16 + 17 + 18 + 19 + 20 = 90 (top 4 + self bond)
@@ -4375,10 +4003,7 @@ fn only_top_collators_are_counted() {
 				collator_state.total_backing
 			);
 			// bump bottom to the top
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(4), 1, 8));
-			assert_event_emitted!(Event::DelegationIncreaseScheduled(4, 1, 8, 5));
-			roll_to(20);
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(4), 4, 1));
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(4), 1, 8));
 			assert_event_emitted!(Event::DelegationIncreased(4, 1, 8, true));
 			let collator_state = Stake::candidate_state(1).unwrap();
 			// 17 + 18 + 19 + 20 + 20 = 94 (top 4 + self bond)
@@ -4389,10 +4014,7 @@ fn only_top_collators_are_counted() {
 				collator_state.total_backing
 			);
 			// bump bottom to the top
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(5), 1, 8));
-			assert_event_emitted!(Event::DelegationIncreaseScheduled(5, 1, 8, 7));
-			roll_to(30);
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(5), 5, 1));
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(5), 1, 8));
 			assert_event_emitted!(Event::DelegationIncreased(5, 1, 8, true));
 			let collator_state = Stake::candidate_state(1).unwrap();
 			// 18 + 19 + 20 + 21 + 20 = 98 (top 4 + self bond)
@@ -4403,10 +4025,7 @@ fn only_top_collators_are_counted() {
 				collator_state.total_backing
 			);
 			// bump bottom to the top
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(6), 1, 8));
-			assert_event_emitted!(Event::DelegationIncreaseScheduled(6, 1, 8, 9));
-			roll_to(40);
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(6), 6, 1));
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(6), 1, 8));
 			assert_event_emitted!(Event::DelegationIncreased(6, 1, 8, true));
 			let collator_state = Stake::candidate_state(1).unwrap();
 			// 19 + 20 + 21 + 22 + 20 = 102 (top 4 + self bond)
@@ -4470,10 +4089,7 @@ fn delegation_events_convey_correct_position() {
 				collator1_state.total_backing
 			);
 			// 8 increases delegation to the top
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(8), 1, 3));
-			assert_event_emitted!(Event::DelegationIncreaseScheduled(8, 1, 3, 3));
-			roll_to(10);
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(8), 8, 1));
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(8), 1, 3));
 			assert_event_emitted!(Event::DelegationIncreased(8, 1, 3, true));
 			let collator1_state = Stake::candidate_state(1).unwrap();
 			// 13 + 13 + 14 + 15 + 20 = 75 (top 4 + self bond)
@@ -4484,10 +4100,7 @@ fn delegation_events_convey_correct_position() {
 				collator1_state.total_backing
 			);
 			// 3 increases delegation but stays in bottom
-			assert_ok!(Stake::schedule_delegator_bond_more(Origin::signed(3), 1, 1));
-			assert_event_emitted!(Event::DelegationIncreaseScheduled(3, 1, 1, 5));
-			roll_to(20);
-			assert_ok!(Stake::execute_delegation_request(Origin::signed(3), 3, 1));
+			assert_ok!(Stake::delegator_bond_more(Origin::signed(3), 1, 1));
 			assert_event_emitted!(Event::DelegationIncreased(3, 1, 1, false));
 			let collator1_state = Stake::candidate_state(1).unwrap();
 			// 13 + 13 + 14 + 15 + 20 = 75 (top 4 + self bond)
@@ -4499,7 +4112,7 @@ fn delegation_events_convey_correct_position() {
 			);
 			// 6 decreases delegation but stays in top
 			assert_ok!(Stake::schedule_delegator_bond_less(Origin::signed(6), 1, 2));
-			assert_event_emitted!(Event::DelegationDecreaseScheduled(6, 1, 2, 7));
+			assert_event_emitted!(Event::DelegationDecreaseScheduled(6, 1, 2, 3));
 			roll_to(30);
 			assert_ok!(Stake::execute_delegation_request(Origin::signed(6), 6, 1));
 			assert_event_emitted!(Event::DelegationDecreased(6, 1, 2, true));

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -64,24 +64,20 @@ pub trait WeightInfo {
 	fn cancel_leave_candidates(x: u32) -> Weight;
 	fn go_offline() -> Weight;
 	fn go_online() -> Weight;
-	fn schedule_candidate_bond_more() -> Weight;
+	fn candidate_bond_more() -> Weight;
 	fn schedule_candidate_bond_less() -> Weight;
-	fn execute_candidate_bond_more() -> Weight;
 	fn execute_candidate_bond_less() -> Weight;
-	fn cancel_candidate_bond_more() -> Weight;
 	fn cancel_candidate_bond_less() -> Weight;
 	fn delegate(x: u32, y: u32) -> Weight;
 	fn schedule_leave_delegators() -> Weight;
 	fn execute_leave_delegators(x: u32) -> Weight;
 	fn cancel_leave_delegators() -> Weight;
 	fn schedule_revoke_delegation() -> Weight;
-	fn schedule_delegator_bond_more() -> Weight;
+	fn delegator_bond_more() -> Weight;
 	fn schedule_delegator_bond_less() -> Weight;
 	fn execute_revoke_delegation() -> Weight;
-	fn execute_delegator_bond_more() -> Weight;
 	fn execute_delegator_bond_less() -> Weight;
 	fn cancel_revoke_delegation() -> Weight;
-	fn cancel_delegator_bond_more() -> Weight;
 	fn cancel_delegator_bond_less() -> Weight;
 	fn active_on_initialize(x: u32, y: u32) -> Weight;
 	fn passive_on_initialize() -> Weight;
@@ -160,8 +156,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(7 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
-	fn schedule_candidate_bond_more() -> Weight {
-		(59_735_000 as Weight)
+	fn candidate_bond_more() -> Weight {
+		(58_445_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes(6 as Weight))
 	}
@@ -170,18 +166,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes(6 as Weight))
 	}
-	fn execute_candidate_bond_more() -> Weight {
-		(58_445_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes(6 as Weight))
-	}
 	fn execute_candidate_bond_less() -> Weight {
 		(58_228_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(8 as Weight))
-			.saturating_add(T::DbWeight::get().writes(6 as Weight))
-	}
-	fn cancel_candidate_bond_more() -> Weight {
-		(58_739_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(8 as Weight))
 			.saturating_add(T::DbWeight::get().writes(6 as Weight))
 	}
@@ -221,8 +207,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(7 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
-	fn schedule_delegator_bond_more() -> Weight {
-		(70_867_000 as Weight)
+	fn delegator_bond_more() -> Weight {
+		(71_021_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(9 as Weight))
 			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
@@ -236,11 +222,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(7 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
-	fn execute_delegator_bond_more() -> Weight {
-		(71_021_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(9 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
-	}
 	fn execute_delegator_bond_less() -> Weight {
 		(71_419_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(9 as Weight))
@@ -250,11 +231,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		(37_923_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(7 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
-	}
-	fn cancel_delegator_bond_more() -> Weight {
-		(70_517_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(9 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
 	fn cancel_delegator_bond_less() -> Weight {
 		(70_813_000 as Weight)
@@ -352,8 +328,8 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
 	}
-	fn schedule_candidate_bond_more() -> Weight {
-		(59_735_000 as Weight)
+	fn candidate_bond_more() -> Weight {
+		(58_445_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
 	}
@@ -362,18 +338,8 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
 	}
-	fn execute_candidate_bond_more() -> Weight {
-		(58_445_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
-	}
 	fn execute_candidate_bond_less() -> Weight {
 		(58_228_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
-	}
-	fn cancel_candidate_bond_more() -> Weight {
-		(58_739_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(8 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(6 as Weight))
 	}
@@ -414,10 +380,10 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
 	}
-	fn schedule_delegator_bond_more() -> Weight {
-		(70_867_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(9 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
+	fn delegator_bond_more() -> Weight {
+		(71_021_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
 	}
 	fn schedule_delegator_bond_less() -> Weight {
 		(70_859_000 as Weight)
@@ -429,11 +395,6 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
 	}
-	fn execute_delegator_bond_more() -> Weight {
-		(71_021_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
-	}
 	fn execute_delegator_bond_less() -> Weight {
 		(71_419_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
@@ -441,11 +402,6 @@ impl WeightInfo for () {
 	}
 	fn cancel_revoke_delegation() -> Weight {
 		(37_923_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
-	}
-	fn cancel_delegator_bond_more() -> Weight {
-		(70_517_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(7 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
 	}

--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -129,17 +129,10 @@ interface ParachainStaking {
     /// Selector: d2f73ceb
     function go_online() external;
 
-    /// DEPRECATED, replaced by schedule_candidate_bond_more, execute_candidate_bond_request,
-    /// cancel_candidate_bond_request
     /// @dev Request to bond more for collator candidates
     /// Selector: c57bd3a8
     /// @param more The additional amount self-bonded
     function candidate_bond_more(uint256 more) external;
-
-    /// @dev Request to bond more for collator candidates
-    /// Selector: d6d56bab
-    /// @param more The additional amount self-bonded
-    function schedule_candidate_bond_more(uint256 more) external;
 
     /// DEPRECATED, replaced by schedule_candidate_bond_less, execute_candidate_bond_request,
     /// cancel_candidate_bond_request
@@ -154,13 +147,13 @@ interface ParachainStaking {
     function schedule_candidate_bond_less(uint256 less) external;
 
     /// @dev Execute pending candidate bond request
-    /// Selector: e2c3aacc
+    /// Selector: a9a2b8b7
     /// @param candidate The address for the candidate for which the request will be executed
-    function execute_candidate_bond_request(address candidate) external;
+    function execute_candidate_bond_less(address candidate) external;
 
     /// @dev Cancel pending candidate bond request
-    /// Selector: 39ffe013
-    function cancel_candidate_bond_request() external;
+    /// Selector: 583d0fdc
+    function cancel_candidate_bond_less() external;
 
     /// DEPRECATED, replaced by delegate
     /// @dev Make a nomination in support of a collator candidate
@@ -230,12 +223,11 @@ interface ParachainStaking {
     /// @param more The amount by which the nomination is increased
     function nominator_bond_more(address candidate, uint256 more) external;
 
-    /// @dev Request to bond more for nominators with respect to a specific collator candidate
-    /// Selector: e12d5915
+    /// @dev Bond more for nominators with respect to a specific collator candidate
+    /// Selector: 6d988413
     /// @param candidate The address of the collator candidate for which delegation shall increase
-    /// @param more The amount by which the delegation is increased (upon execution)
-    function schedule_delegator_bond_more(address candidate, uint256 more)
-        external;
+    /// @param more The amount by which the delegation is increased
+    function delegator_bond_more(address candidate, uint256 more) external;
 
     /// DEPRECATED, replaced by schedule_delegator_bond_less, execute_delegation_request,
     /// cancel_delegation_request

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -70,11 +70,9 @@ enum Action {
 	// DEPRECATED
 	CandidateBondLess = "candidate_bond_less(uint256)",
 	ScheduleCandidateBondLess = "schedule_candidate_bond_less(uint256)",
-	// DEPRECATED
 	CandidateBondMore = "candidate_bond_more(uint256)",
-	ScheduleCandidateBondMore = "schedule_candidate_bond_more(uint256)",
-	ExecuteCandidateBondRequest = "execute_candidate_bond_request(address)",
-	CancelCandidateBondRequest = "cancel_candidate_bond_request()",
+	ExecuteCandidateBondLess = "execute_candidate_bond_less(address)",
+	CancelCandidateBondLess = "cancel_candidate_bond_less()",
 	// DEPRECATED
 	Nominate = "nominate(address,uint256,uint256,uint256)",
 	Delegate = "delegate(address,uint256,uint256,uint256)",
@@ -91,7 +89,7 @@ enum Action {
 	ScheduleDelegatorBondLess = "schedule_delegator_bond_less(address,uint256)",
 	// DEPRECATED
 	NominatorBondMore = "nominator_bond_more(address,uint256)",
-	ScheduleDelegatorBondMore = "schedule_delegator_bond_more(address,uint256)",
+	DelegatorBondMore = "delegator_bond_more(address,uint256)",
 	ExecuteDelegationRequest = "execute_delegation_request(address,address)",
 	CancelDelegationRequest = "cancel_delegation_request(address)",
 }
@@ -160,15 +158,9 @@ where
 			Action::ScheduleCandidateBondLess => {
 				Self::schedule_candidate_bond_less(input, context)?
 			}
-			// DEPRECATED
-			Action::CandidateBondMore => Self::schedule_candidate_bond_more(input, context)?,
-			Action::ScheduleCandidateBondMore => {
-				Self::schedule_candidate_bond_more(input, context)?
-			}
-			Action::ExecuteCandidateBondRequest => {
-				Self::execute_candidate_bond_request(input, context)?
-			}
-			Action::CancelCandidateBondRequest => Self::cancel_candidate_bond_request(context)?,
+			Action::CandidateBondMore => Self::candidate_bond_more(input, context)?,
+			Action::ExecuteCandidateBondLess => Self::execute_candidate_bond_less(input, context)?,
+			Action::CancelCandidateBondLess => Self::cancel_candidate_bond_less(context)?,
 			// DEPRECATED
 			Action::Nominate => Self::delegate(input, context)?,
 			Action::Delegate => Self::delegate(input, context)?,
@@ -186,10 +178,8 @@ where
 				Self::schedule_delegator_bond_less(input, context)?
 			}
 			// DEPRECATED
-			Action::NominatorBondMore => Self::schedule_delegator_bond_more(input, context)?,
-			Action::ScheduleDelegatorBondMore => {
-				Self::schedule_delegator_bond_more(input, context)?
-			}
+			Action::NominatorBondMore => Self::delegator_bond_more(input, context)?,
+			Action::DelegatorBondMore => Self::delegator_bond_more(input, context)?,
 			Action::ExecuteDelegationRequest => Self::execute_delegation_request(input, context)?,
 			Action::CancelDelegationRequest => Self::cancel_delegation_request(input, context)?,
 		};
@@ -562,7 +552,7 @@ where
 		Ok((Some(origin).into(), call))
 	}
 
-	fn schedule_candidate_bond_more(
+	fn candidate_bond_more(
 		mut input: EvmDataReader,
 		context: &Context,
 	) -> Result<
@@ -578,7 +568,7 @@ where
 
 		// Build call with origin.
 		let origin = Runtime::AddressMapping::into_account_id(context.caller);
-		let call = parachain_staking::Call::<Runtime>::schedule_candidate_bond_more { more };
+		let call = parachain_staking::Call::<Runtime>::candidate_bond_more { more };
 
 		// Return call information
 		Ok((Some(origin).into(), call))
@@ -606,7 +596,7 @@ where
 		Ok((Some(origin).into(), call))
 	}
 
-	fn execute_candidate_bond_request(
+	fn execute_candidate_bond_less(
 		mut input: EvmDataReader,
 		context: &Context,
 	) -> Result<
@@ -622,13 +612,13 @@ where
 
 		// Build call with origin.
 		let origin = Runtime::AddressMapping::into_account_id(context.caller);
-		let call = parachain_staking::Call::<Runtime>::execute_candidate_bond_request { candidate };
+		let call = parachain_staking::Call::<Runtime>::execute_candidate_bond_less { candidate };
 
 		// Return call information
 		Ok((Some(origin).into(), call))
 	}
 
-	fn cancel_candidate_bond_request(
+	fn cancel_candidate_bond_less(
 		context: &Context,
 	) -> Result<
 		(
@@ -639,7 +629,7 @@ where
 	> {
 		// Build call with origin.
 		let origin = Runtime::AddressMapping::into_account_id(context.caller);
-		let call = parachain_staking::Call::<Runtime>::cancel_candidate_bond_request {};
+		let call = parachain_staking::Call::<Runtime>::cancel_candidate_bond_less {};
 
 		// Return call information
 		Ok((Some(origin).into(), call))
@@ -757,7 +747,7 @@ where
 		Ok((Some(origin).into(), call))
 	}
 
-	fn schedule_delegator_bond_more(
+	fn delegator_bond_more(
 		mut input: EvmDataReader,
 		context: &Context,
 	) -> Result<
@@ -774,8 +764,7 @@ where
 
 		// Build call with origin.
 		let origin = Runtime::AddressMapping::into_account_id(context.caller);
-		let call =
-			parachain_staking::Call::<Runtime>::schedule_delegator_bond_more { candidate, more };
+		let call = parachain_staking::Call::<Runtime>::delegator_bond_more { candidate, more };
 
 		// Return call information
 		Ok((Some(origin).into(), call))

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -223,10 +223,10 @@ parameter_types! {
 	pub const MinBlocksPerRound: u32 = 3;
 	pub const DefaultBlocksPerRound: u32 = 5;
 	pub const LeaveCandidatesDelay: u32 = 2;
-	pub const CandidateBondDelay: u32 = 2;
+	pub const CandidateBondLessDelay: u32 = 2;
 	pub const LeaveDelegatorsDelay: u32 = 2;
 	pub const RevokeDelegationDelay: u32 = 2;
-	pub const DelegationBondDelay: u32 = 2;
+	pub const DelegationBondLessDelay: u32 = 2;
 	pub const RewardPaymentDelay: u32 = 2;
 	pub const MinSelectedCandidates: u32 = 5;
 	pub const MaxDelegatorsPerCandidate: u32 = 4;
@@ -244,10 +244,10 @@ impl parachain_staking::Config for Runtime {
 	type MinBlocksPerRound = MinBlocksPerRound;
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type LeaveCandidatesDelay = LeaveCandidatesDelay;
-	type CandidateBondDelay = CandidateBondDelay;
+	type CandidateBondLessDelay = CandidateBondLessDelay;
 	type LeaveDelegatorsDelay = LeaveDelegatorsDelay;
 	type RevokeDelegationDelay = RevokeDelegationDelay;
-	type DelegationBondDelay = DelegationBondDelay;
+	type DelegationBondLessDelay = DelegationBondLessDelay;
 	type RewardPaymentDelay = RewardPaymentDelay;
 	type MinSelectedCandidates = MinSelectedCandidates;
 	type MaxDelegatorsPerCandidate = MaxDelegatorsPerCandidate;

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -891,15 +891,8 @@ fn cancel_candidate_bond_less_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event = StakingEvent::CancelledCandidateBondChange(
-				TestAccount::Alice,
-				parachain_staking::CandidateBondRequest {
-					amount: 200,
-					change: parachain_staking::CandidateBondChange::Decrease,
-					when_executable: 3,
-				},
-			)
-			.into();
+			let expected: crate::mock::Event =
+				StakingEvent::CancelledCandidateBondLess(TestAccount::Alice, 200, 3).into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -708,13 +708,13 @@ parameter_types! {
 	/// Collator candidate exits are delayed by 2 hours (2 * 300 * block_time)
 	pub const LeaveCandidatesDelay: u32 = 2;
 	/// Collator candidate bond increases/decreases are delayed by 2 hours (2 * 300 block_time)
-	pub const CandidateBondDelay: u32 = 2;
+	pub const CandidateBondLessDelay: u32 = 2;
 	/// Delegator exits are delayed by 2 hours (2 * 300 * block_time)
 	pub const LeaveDelegatorsDelay: u32 = 2;
 	/// Delegation revocations are delayed by 2 hours (2 * 300 * block_time)
 	pub const RevokeDelegationDelay: u32 = 2;
-	/// Delegation bond increases/decreases are delayed by 2 hours (2 * 300 * block_time)
-	pub const DelegationBondDelay: u32 = 2;
+	/// Delegation bond decreases are delayed by 2 hours (2 * 300 * block_time)
+	pub const DelegationBondLessDelay: u32 = 2;
 	/// Reward payments are delayed by 2 hours (2 * 300 * block_time)
 	pub const RewardPaymentDelay: u32 = 2;
 	/// Minimum collators selected per round, default at genesis and minimum forever after
@@ -742,10 +742,10 @@ impl parachain_staking::Config for Runtime {
 	type MinBlocksPerRound = MinBlocksPerRound;
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type LeaveCandidatesDelay = LeaveCandidatesDelay;
-	type CandidateBondDelay = CandidateBondDelay;
+	type CandidateBondLessDelay = CandidateBondLessDelay;
 	type LeaveDelegatorsDelay = LeaveDelegatorsDelay;
 	type RevokeDelegationDelay = RevokeDelegationDelay;
-	type DelegationBondDelay = DelegationBondDelay;
+	type DelegationBondLessDelay = DelegationBondLessDelay;
 	type RewardPaymentDelay = RewardPaymentDelay;
 	type MinSelectedCandidates = MinSelectedCandidates;
 	type MaxDelegatorsPerCandidate = MaxDelegatorsPerCandidate;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -670,13 +670,13 @@ parameter_types! {
 	/// Collator candidate exit delay (number of rounds)
 	pub const LeaveCandidatesDelay: u32 = 2;
 	/// Collator candidate bond increases/decreases delay (number of rounds)
-	pub const CandidateBondDelay: u32 = 2;
+	pub const CandidateBondLessDelay: u32 = 2;
 	/// Delegator exit delay (number of rounds)
 	pub const LeaveDelegatorsDelay: u32 = 2;
 	/// Delegation revocations delay (number of rounds)
 	pub const RevokeDelegationDelay: u32 = 2;
-	/// Delegation bond increases/decreases delay (number of rounds)
-	pub const DelegationBondDelay: u32 = 2;
+	/// Delegation bond decreases delay (number of rounds)
+	pub const DelegationBondLessDelay: u32 = 2;
 	/// Reward payments delay (number of rounds)
 	pub const RewardPaymentDelay: u32 = 2;
 	/// Minimum collators selected per round, default at genesis and minimum forever after
@@ -704,10 +704,10 @@ impl parachain_staking::Config for Runtime {
 	type MinBlocksPerRound = MinBlocksPerRound;
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type LeaveCandidatesDelay = LeaveCandidatesDelay;
-	type CandidateBondDelay = CandidateBondDelay;
+	type CandidateBondLessDelay = CandidateBondLessDelay;
 	type LeaveDelegatorsDelay = LeaveDelegatorsDelay;
 	type RevokeDelegationDelay = RevokeDelegationDelay;
-	type DelegationBondDelay = DelegationBondDelay;
+	type DelegationBondLessDelay = DelegationBondLessDelay;
 	type RewardPaymentDelay = RewardPaymentDelay;
 	type MinSelectedCandidates = MinSelectedCandidates;
 	type MaxDelegatorsPerCandidate = MaxDelegatorsPerCandidate;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -651,13 +651,13 @@ parameter_types! {
 	/// Collator candidate exits are delayed by 2 hours (2 * 300 * block_time)
 	pub const LeaveCandidatesDelay: u32 = 2;
 	/// Collator candidate bond increases/decreases are delayed by 2 hours (2 * 300 block_time)
-	pub const CandidateBondDelay: u32 = 2;
+	pub const CandidateBondLessDelay: u32 = 2;
 	/// Delegator exits are delayed by 2 hours (2 * 300 * block_time)
 	pub const LeaveDelegatorsDelay: u32 = 2;
 	/// Delegation revocations are delayed by 2 hours (2 * 300 * block_time)
 	pub const RevokeDelegationDelay: u32 = 2;
-	/// Delegation bond increases/decreases are delayed by 2 hours (2 * 300 * block_time)
-	pub const DelegationBondDelay: u32 = 2;
+	/// Delegation bond decreases are delayed by 2 hours (2 * 300 * block_time)
+	pub const DelegationBondLessDelay: u32 = 2;
 	/// Reward payments are delayed by 2 hours (2 * 300 * block_time)
 	pub const RewardPaymentDelay: u32 = 2;
 	/// Minimum collators selected per round, default at genesis and minimum forever after
@@ -684,10 +684,10 @@ impl parachain_staking::Config for Runtime {
 	type MinBlocksPerRound = MinBlocksPerRound;
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type LeaveCandidatesDelay = LeaveCandidatesDelay;
-	type CandidateBondDelay = CandidateBondDelay;
+	type CandidateBondLessDelay = CandidateBondLessDelay;
 	type LeaveDelegatorsDelay = LeaveDelegatorsDelay;
 	type RevokeDelegationDelay = RevokeDelegationDelay;
-	type DelegationBondDelay = DelegationBondDelay;
+	type DelegationBondLessDelay = DelegationBondLessDelay;
 	type RewardPaymentDelay = RewardPaymentDelay;
 	type MinSelectedCandidates = MinSelectedCandidates;
 	type MaxDelegatorsPerCandidate = MaxDelegatorsPerCandidate;


### PR DESCRIPTION
Removes the delay for {candidate, delegator}_bond_more so that the increase is executed immediately, like before #810 

### Rationale

Increasing stake is similar to joining {candidates, delegators} so no delay is necessary. The delay for bond_less is more consistent with the delay on {revoke, leave}

**No migration necessary because #810 was never deployed to any networks**