### PR TITLE
Adds github token to generate runtime script

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -78,6 +78,8 @@ jobs:
         with:
           node-version: 14.x
       - name: Generate release body
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: generate-release-body
         run: |
           cd tools


### PR DESCRIPTION
This is to prevent the rate limiting for non-authenticated access