### PR TITLE
Patch bug in staking migration of scheduled revocations

### DIFF
--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -29,7 +29,7 @@ use frame_support::{
 	traits::{Get, OnRuntimeUpgrade},
 	weights::Weight,
 };
-use sp_std::collections::btree_map::BTreeMap;
+use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
 /// Migration to replace the automatic ExitQueue with a manual exits API.
 /// This migration is idempotent so it can be run more than once without any risk.
@@ -51,7 +51,8 @@ impl<T: Config> OnRuntimeUpgrade for RemoveExitQueue<T> {
 					new_revocations.push((revoking_candidate, when));
 					delegation_revocations.insert(delegator, new_revocations);
 				} else {
-					delegation_revocations.insert(delegator, vec![(revoking_candidate, when)]);
+					delegation_revocations
+						.insert(delegator, sp_std::vec![(revoking_candidate, when)]);
 				}
 			} else {
 				delegator_exits.insert(delegator, when);


### PR DESCRIPTION
Reported in NCC audit

Before this change, if there were delegators with more than 1 pending revocation request, all except one of their revocation requests will be forgotten about. 

Because the consequences of the original bug do not corrupt storage, this solution need not be deployed on any live networks.

