### PR TITLE
Fix typo in bootnode in spec file

### DIFF
--- a/specs/moonbeam/parachain-embedded-specs.json
+++ b/specs/moonbeam/parachain-embedded-specs.json
@@ -7,7 +7,7 @@
     "/dns4/jpg-moonbeam-boot-1.g.moonbeam.network/tcp/30333/p2p/12D3KooWPwNDUuUVtMRqwHZr2aK498u8gcerRni9jHruFp69W6qA",
     "/dns4/nlg-moonbeam-boot-0.g.moonbeam.network/tcp/30333/p2p/12D3KooWPgkQq2nJyEyB2BDdaqaEcDvRn7KxX9yja9rrrjyDv3yD",
     "/dns4/nlg-moonbeam-boot-1.g.moonbeam.network/tcp/30333/p2p/12D3KooWGvEhGbympsy2eGgsknBqKRXMCT4nS2s95xbYQoF4eG6f",
-    "/dns4/mtla-moonbeam-boot-0.a.moonbeam.network/tcp/30333/p2p/12D3KooWRJfEWQBYSEDhadUQRmtQxNGwVNe4EJxWZJokWwc5EWBhv",
+    "/dns4/mtla-moonbeam-boot-0.a.moonbeam.network/tcp/30333/p2p/12D3KooWRJfEWQBYSEDhadUQRmtQxNGwVNe4EJxWZJokWwc5EWBh",
     "/dns4/mtla-moonbeam-boot-1.a.moonbeam.network/tcp/30333/p2p/12D3KooWCAYdGegd18orL1HVPYuAzGi68bs2F5ueyZm2DFiS8gZw",
     "/dns4/para-moonbeam-boot-0.a.moonbeam.network/tcp/30333/p2p/12D3KooWPNMc5CgbramsajfngvmVpmkrnDw86NcnAiexqaXRgZXB",
     "/dns4/para-moonbeam-boot-1.a.moonbeam.network/tcp/30333/p2p/12D3KooWDFNoNDWKmCpYyyCKHbVFmYF7jBYAKwK1idPqHocSnhvU"


### PR DESCRIPTION
This PR removes a stray `v` character that somehow got appended to to one of the bootnode addresses added in #1063 .