### PR TITLE
Add test for mocked relaychain number

### DIFF
--- a/tests/tests/test-block/test-block-mocked-relay.ts
+++ b/tests/tests/test-block/test-block-mocked-relay.ts
@@ -1,0 +1,21 @@
+import { expect } from "chai";
+import { describeDevMoonbeam } from "../../util/setup-dev-tests";
+
+describeDevMoonbeam("Block - Mocked relaychain block", (context) => {
+  it("should contain mock relay chain block information", async function () {
+    const blockResult = await context.createBlock();
+    const blockData = await context.polkadotApi.rpc.chain.getBlock(blockResult.block.hash);
+    expect(
+      (
+        blockData.block.extrinsics[1].method.args[0] as any
+      ).validationData.relayParentNumber.toString()
+    ).to.eq("1000");
+    const blockResult2 = await context.createBlock();
+    const blockData2 = await context.polkadotApi.rpc.chain.getBlock(blockResult2.block.hash);
+    expect(
+      (
+        blockData2.block.extrinsics[1].method.args[0] as any
+      ).validationData.relayParentNumber.toString()
+    ).to.eq("1002");
+  });
+});


### PR DESCRIPTION
### What does it do?
- create block
- look for validationData.relayParentNumber and check that it is 1000
- create block
- look for validationData.relayParentNumber and check that it is 1002

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
