### PR TITLE
Adapt to associate and replay attack prevention sig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6533,7 +6533,7 @@ dependencies = [
 [[package]]
 name = "pallet-crowdloan-rewards"
 version = "0.6.0"
-source = "git+https://github.com/purestake/crowdloan-rewards?branch=moonbeam-polkadot-v0.9.12#8e4625df25ebd7ce914fc5c0e82b256663d78572"
+source = "git+https://github.com/purestake/crowdloan-rewards?branch=moonbeam-polkadot-v0.9.12#2668345172159e4f1f79a85bb92abd111aa3b5a8"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",

--- a/precompiles/crowdloan-rewards/src/mock.rs
+++ b/precompiles/crowdloan-rewards/src/mock.rs
@@ -239,6 +239,7 @@ parameter_types! {
 	pub const TestInitialized: bool = false;
 	pub const TestInitializationPayment: Perbill = Perbill::from_percent(20);
 	pub const RelaySignaturesThreshold: Perbill = Perbill::from_percent(100);
+	pub const TestSigantureNetworkIdentifier: &'static [u8] = b"test-";
 }
 
 impl pallet_crowdloan_rewards::Config for Runtime {
@@ -249,8 +250,11 @@ impl pallet_crowdloan_rewards::Config for Runtime {
 	type MinimumReward = TestMinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
+	type RewardAddressAssociateOrigin = EnsureSigned<Self::AccountId>;
 	type RewardAddressRelayVoteThreshold = RelaySignaturesThreshold;
 	type RewardAddressChangeOrigin = EnsureSigned<Self::AccountId>;
+	type SignatureNetworkIdentifier = TestSigantureNetworkIdentifier;
+
 	type VestingBlockNumber = cumulus_primitives_core::relay_chain::BlockNumber;
 	type VestingBlockProvider =
 		cumulus_pallet_parachain_system::RelaychainBlockNumberProvider<Self>;

--- a/precompiles/crowdloan-rewards/src/mock.rs
+++ b/precompiles/crowdloan-rewards/src/mock.rs
@@ -239,7 +239,7 @@ parameter_types! {
 	pub const TestInitialized: bool = false;
 	pub const TestInitializationPayment: Perbill = Perbill::from_percent(20);
 	pub const RelaySignaturesThreshold: Perbill = Perbill::from_percent(100);
-	pub const TestSigantureNetworkIdentifier: &'static [u8] = b"test-";
+	pub const TestSignatureNetworkIdentifier: &'static [u8] = b"test-";
 }
 
 impl pallet_crowdloan_rewards::Config for Runtime {
@@ -253,7 +253,7 @@ impl pallet_crowdloan_rewards::Config for Runtime {
 	type RewardAddressAssociateOrigin = EnsureSigned<Self::AccountId>;
 	type RewardAddressRelayVoteThreshold = RelaySignaturesThreshold;
 	type RewardAddressChangeOrigin = EnsureSigned<Self::AccountId>;
-	type SignatureNetworkIdentifier = TestSigantureNetworkIdentifier;
+	type SignatureNetworkIdentifier = TestSignatureNetworkIdentifier;
 
 	type VestingBlockNumber = cumulus_primitives_core::relay_chain::BlockNumber;
 	type VestingBlockProvider =

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -782,6 +782,8 @@ parameter_types! {
 	pub const InitializationPayment: Perbill = Perbill::from_percent(30);
 	pub const MaxInitContributorsBatchSizes: u32 = 500;
 	pub const RelaySignaturesThreshold: Perbill = Perbill::from_percent(100);
+	pub const SignatureNetworkIdentifier:  &'static [u8] = b"Moonbase-";
+
 }
 
 impl pallet_crowdloan_rewards::Config for Runtime {
@@ -792,8 +794,10 @@ impl pallet_crowdloan_rewards::Config for Runtime {
 	type MinimumReward = MinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
+	type RewardAddressAssociateOrigin = EnsureSigned<Self::AccountId>;
 	type RewardAddressChangeOrigin = EnsureSigned<Self::AccountId>;
 	type RewardAddressRelayVoteThreshold = RelaySignaturesThreshold;
+	type SignatureNetworkIdentifier = SignatureNetworkIdentifier;
 	type VestingBlockNumber = cumulus_primitives_core::relay_chain::BlockNumber;
 	type VestingBlockProvider =
 		cumulus_pallet_parachain_system::RelaychainBlockNumberProvider<Self>;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -782,7 +782,7 @@ parameter_types! {
 	pub const InitializationPayment: Perbill = Perbill::from_percent(30);
 	pub const MaxInitContributorsBatchSizes: u32 = 500;
 	pub const RelaySignaturesThreshold: Perbill = Perbill::from_percent(100);
-	pub const SignatureNetworkIdentifier:  &'static [u8] = b"Moonbase-";
+	pub const SignatureNetworkIdentifier:  &'static [u8] = b"moonbase-";
 
 }
 

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -634,7 +634,8 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			let public1 = pair1.public();
 			let public2 = pair2.public();
 
-			// signature is new_account || previous_account
+			// signature:
+			// WRAP_BYTES|| NetworkIdentifier|| new_account || previous_account || WRAP_BYTES
 			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
 			message.append(&mut b"Moonbase-".to_vec());
 			message.append(&mut AccountId::from(DAVE).encode());

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -637,7 +637,7 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			// signature:
 			// WRAP_BYTES|| NetworkIdentifier|| new_account || previous_account || WRAP_BYTES
 			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
-			message.append(&mut b"Moonbase-".to_vec());
+			message.append(&mut b"moonbase-".to_vec());
 			message.append(&mut AccountId::from(DAVE).encode());
 			message.append(&mut AccountId::from(CHARLIE).encode());
 			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES_POSTFIX.to_vec());

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -636,6 +636,7 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 
 			// signature is new_account || previous_account
 			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
+			message.append(&mut b"Moonbase-".to_vec());
 			message.append(&mut AccountId::from(DAVE).encode());
 			message.append(&mut AccountId::from(CHARLIE).encode());
 			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES_POSTFIX.to_vec());

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -740,7 +740,7 @@ parameter_types! {
 	pub const InitializationPayment: Perbill = Perbill::from_percent(30);
 	pub const MaxInitContributorsBatchSizes: u32 = 500;
 	pub const RelaySignaturesThreshold: Perbill = Perbill::from_percent(100);
-	pub const SignatureNetworkIdentifier:  &'static [u8] = b"Moonbeam-";
+	pub const SignatureNetworkIdentifier:  &'static [u8] = b"moonbeam-";
 }
 
 impl pallet_crowdloan_rewards::Config for Runtime {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -740,6 +740,7 @@ parameter_types! {
 	pub const InitializationPayment: Perbill = Perbill::from_percent(30);
 	pub const MaxInitContributorsBatchSizes: u32 = 500;
 	pub const RelaySignaturesThreshold: Perbill = Perbill::from_percent(100);
+	pub const SignatureNetworkIdentifier:  &'static [u8] = b"Moonbeam-";
 }
 
 impl pallet_crowdloan_rewards::Config for Runtime {
@@ -750,9 +751,10 @@ impl pallet_crowdloan_rewards::Config for Runtime {
 	type MinimumReward = MinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
-	// This will get accessible to users in future phases.
-	type RewardAddressChangeOrigin = EnsureRoot<Self::AccountId>;
+	type RewardAddressAssociateOrigin = EnsureSigned<Self::AccountId>;
+	type RewardAddressChangeOrigin = EnsureSigned<Self::AccountId>;
 	type RewardAddressRelayVoteThreshold = RelaySignaturesThreshold;
+	type SignatureNetworkIdentifier = SignatureNetworkIdentifier;
 	type VestingBlockNumber = cumulus_primitives_core::relay_chain::BlockNumber;
 	type VestingBlockProvider =
 		cumulus_pallet_parachain_system::RelaychainBlockNumberProvider<Self>;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -40,7 +40,7 @@ use frame_support::{
 	},
 	PalletId,
 };
-use frame_system::{EnsureOneOf, EnsureRoot};
+use frame_system::{EnsureOneOf, EnsureRoot, EnsureSigned};
 pub use moonbeam_core_primitives::{
 	AccountId, AccountIndex, Address, Balance, BlockNumber, DigestItem, Hash, Header, Index,
 	Signature,

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -653,7 +653,7 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 
 			// signature is new_account || previous_account
 			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
-			message.append(&mut b"Moonbeam-".to_vec());
+			message.append(&mut b"moonbeam-".to_vec());
 			message.append(&mut AccountId::from(DAVE).encode());
 			message.append(&mut AccountId::from(CHARLIE).encode());
 			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES_POSTFIX.to_vec());

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -653,6 +653,7 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 
 			// signature is new_account || previous_account
 			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
+			message.append(&mut b"Moonbeam-".to_vec());
 			message.append(&mut AccountId::from(DAVE).encode());
 			message.append(&mut AccountId::from(CHARLIE).encode());
 			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES_POSTFIX.to_vec());

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -721,7 +721,7 @@ parameter_types! {
 	pub const InitializationPayment: Perbill = Perbill::from_percent(30);
 	pub const MaxInitContributorsBatchSizes: u32 = 500;
 	pub const RelaySignaturesThreshold: Perbill = Perbill::from_percent(100);
-	pub const SignatureNetworkIdentifier:  &'static [u8] = b"Moonriver-";
+	pub const SignatureNetworkIdentifier:  &'static [u8] = b"moonriver-";
 
 }
 

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -721,6 +721,8 @@ parameter_types! {
 	pub const InitializationPayment: Perbill = Perbill::from_percent(30);
 	pub const MaxInitContributorsBatchSizes: u32 = 500;
 	pub const RelaySignaturesThreshold: Perbill = Perbill::from_percent(100);
+	pub const SignatureNetworkIdentifier:  &'static [u8] = b"Moonriver-";
+
 }
 
 impl pallet_crowdloan_rewards::Config for Runtime {
@@ -731,8 +733,10 @@ impl pallet_crowdloan_rewards::Config for Runtime {
 	type MinimumReward = MinimumReward;
 	type RewardCurrency = Balances;
 	type RelayChainAccountId = [u8; 32];
+	type RewardAddressAssociateOrigin = EnsureSigned<Self::AccountId>;
 	type RewardAddressChangeOrigin = EnsureSigned<Self::AccountId>;
 	type RewardAddressRelayVoteThreshold = RelaySignaturesThreshold;
+	type SignatureNetworkIdentifier = SignatureNetworkIdentifier;
 	type VestingBlockNumber = cumulus_primitives_core::relay_chain::BlockNumber;
 	type VestingBlockProvider =
 		cumulus_pallet_parachain_system::RelaychainBlockNumberProvider<Self>;

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -622,7 +622,8 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			let public1 = pair1.public();
 			let public2 = pair2.public();
 
-			// signature is new_account || previous_account
+			// signature:
+			// WRAP_BYTES|| NetworkIdentifier|| new_account || previous_account || WRAP_BYTES
 			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
 			message.append(&mut b"Moonriver-".to_vec());
 			message.append(&mut AccountId::from(DAVE).encode());

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -624,6 +624,7 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 
 			// signature is new_account || previous_account
 			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
+			message.append(&mut b"Moonriver-".to_vec());
 			message.append(&mut AccountId::from(DAVE).encode());
 			message.append(&mut AccountId::from(CHARLIE).encode());
 			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES_POSTFIX.to_vec());

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -625,7 +625,7 @@ fn initialize_crowdloan_address_and_change_with_relay_key_sig() {
 			// signature:
 			// WRAP_BYTES|| NetworkIdentifier|| new_account || previous_account || WRAP_BYTES
 			let mut message = pallet_crowdloan_rewards::WRAPPED_BYTES_PREFIX.to_vec();
-			message.append(&mut b"Moonriver-".to_vec());
+			message.append(&mut b"moonriver-".to_vec());
 			message.append(&mut AccountId::from(DAVE).encode());
 			message.append(&mut AccountId::from(CHARLIE).encode());
 			message.append(&mut pallet_crowdloan_rewards::WRAPPED_BYTES_POSTFIX.to_vec());

--- a/tests/tests/test-crowdloan.ts
+++ b/tests/tests/test-crowdloan.ts
@@ -693,9 +693,15 @@ describeDevMoonbeam("Crowdloan", (context) => {
     // toAssociateAccount should not be in accounts payable
     expect(await getAccountPayable(context, toAssociateAccount.address)).to.be.null;
 
+    let message = new Uint8Array([
+      ...stringToU8a("<Bytes>"),
+      ...stringToU8a("Moonbase-"),
+      ...toAssociateAccount.addressRaw,
+      ...stringToU8a("</Bytes>"),
+    ]);
     // Construct the signature
     let signature = {};
-    signature["Ed25519"] = relayAccount.sign(toAssociateAccount.address);
+    signature["Ed25519"] = relayAccount.sign(message);
 
     // Associate the identity
     await context.polkadotApi.tx.crowdloanRewards
@@ -794,6 +800,7 @@ describeDevMoonbeam("Crowdloan", (context) => {
 
     let message = new Uint8Array([
       ...stringToU8a("<Bytes>"),
+      ...stringToU8a("Moonbase-"),
       ...toAssociateAccount.addressRaw,
       ...firstAccount.addressRaw,
       ...stringToU8a("</Bytes>"),

--- a/tests/tests/test-crowdloan.ts
+++ b/tests/tests/test-crowdloan.ts
@@ -695,7 +695,7 @@ describeDevMoonbeam("Crowdloan", (context) => {
 
     let message = new Uint8Array([
       ...stringToU8a("<Bytes>"),
-      ...stringToU8a("Moonbase-"),
+      ...stringToU8a("moonbase-"),
       ...toAssociateAccount.addressRaw,
       ...stringToU8a("</Bytes>"),
     ]);
@@ -800,7 +800,7 @@ describeDevMoonbeam("Crowdloan", (context) => {
 
     let message = new Uint8Array([
       ...stringToU8a("<Bytes>"),
-      ...stringToU8a("Moonbase-"),
+      ...stringToU8a("moonbase-"),
       ...toAssociateAccount.addressRaw,
       ...firstAccount.addressRaw,
       ...stringToU8a("</Bytes>"),


### PR DESCRIPTION
### What does it do?
Adapts associate_reward_address tests to use wrap byets and network identifier. The latter is used to prevent replay attacks over different networks
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
