### PR TITLE
AuthorMapping: fix self key rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6275,7 +6275,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-author-mapping"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/pallets/author-mapping/Cargo.toml
+++ b/pallets/author-mapping/Cargo.toml
@@ -3,7 +3,7 @@ name = "pallet-author-mapping"
 authors = [ "PureStake" ]
 description = "Maps AuthorIds to AccountIds Useful for associating consensus authors with in-runtime accounts"
 edition = "2018"
-version = "2.0.4"
+version = "2.0.5"
 
 [dependencies]
 log = { version = "0.4", default-features = false }

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -146,8 +146,8 @@ pub mod pallet {
 				Error::<T>::NotYourAssociation
 			);
 
-			MappingWithDeposit::<T>::insert(&new_author_id, &stored_info);
 			MappingWithDeposit::<T>::remove(&old_author_id);
+			MappingWithDeposit::<T>::insert(&new_author_id, &stored_info);
 
 			<Pallet<T>>::deposit_event(Event::AuthorRotated(new_author_id, stored_info.account));
 

--- a/pallets/author-mapping/src/tests.rs
+++ b/pallets/author-mapping/src/tests.rs
@@ -231,8 +231,21 @@ fn registered_author_cannot_be_rotated_by_non_owner() {
 		})
 }
 
-//TODO Test ideas in case we bring back the narc extrinsic
-// unstaked account can be narced after period
-// unstaked account cannot be narced before period
-// staked account can be narced after period
-// staked account cannot be narced before period
+#[test]
+fn rotating_to_the_same_author_id_leaves_registration_in_tact() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 1000)])
+		.with_mappings(vec![(TestAuthor::Alice.into(), 1)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(AuthorMapping::update_association(
+				Origin::signed(1),
+				TestAuthor::Alice.into(),
+				TestAuthor::Alice.into()
+			));
+			assert_eq!(
+				AuthorMapping::account_id_of(&TestAuthor::Alice.into()),
+				Some(1)
+			);
+		})
+}


### PR DESCRIPTION
This PR fixes a bug where calling `AuthorMapping.updateAssociation(a, a)` where the same NimbusId is used for both the old and new ids, caused the mapping to be removed.

While there is no valid use case for making such a call, it's clear that the semantics should be leaving the association unchanged (or perhaps erroring).

Also adds a test for this case.