### PR TITLE
Max weight defined in the runtime for transactors

### DIFF
--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -179,6 +179,7 @@ pub mod pallet {
 		NotCrossChainTransferableCurrency,
 		XcmExecuteError,
 		BadVersion,
+		MaxWeightTransactReached,
 	}
 
 	#[pallet::event]
@@ -242,6 +243,12 @@ pub mod pallet {
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
+			// Ensure the specified destination transact_weight is not reached
+			ensure!(
+				dest_weight < dest.clone().max_transact_weight(),
+				Error::<T>::MaxWeightTransactReached
+			);
+
 			let fee_location =
 				MultiLocation::try_from(fee_location).map_err(|()| Error::<T>::BadVersion)?;
 			// The index exists
@@ -297,6 +304,12 @@ pub mod pallet {
 			inner_call: Vec<u8>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
+
+			// Ensure the specified destination transact_weight is not reached
+			ensure!(
+				dest_weight < dest.clone().max_transact_weight(),
+				Error::<T>::MaxWeightTransactReached
+			);
 
 			let fee_location: MultiLocation = T::CurrencyIdToMultiLocation::convert(currency_id)
 				.ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;

--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -269,6 +269,11 @@ impl XcmTransact for Transactors {
 			Transactors::Relay => MultiLocation::parent(),
 		}
 	}
+	fn max_transact_weight(self) -> Weight {
+		match self {
+			Transactors::Relay => 20000000000,
+		}
+	}
 }
 
 impl UtilityEncodeCall for Transactors {

--- a/pallets/xcm-transactor/src/tests.rs
+++ b/pallets/xcm-transactor/src/tests.rs
@@ -109,6 +109,22 @@ fn test_transact_through_derivative_errors() {
 				),
 				Error::<Test>::TransactorInfoNotSet
 			);
+
+			// Cannot exceed the max weight
+			assert_noop!(
+				XcmTransactor::transact_through_derivative_multilocation(
+					Origin::signed(1u64),
+					Transactors::Relay,
+					1,
+					xcm::VersionedMultiLocation::V1(MultiLocation::new(
+						1,
+						Junctions::X1(Junction::PalletInstance(1))
+					)),
+					21000000000u64,
+					vec![0u8]
+				),
+				Error::<Test>::MaxWeightTransactReached
+			);
 		})
 }
 

--- a/precompiles/xcm_transactor/src/mock.rs
+++ b/precompiles/xcm_transactor/src/mock.rs
@@ -462,6 +462,11 @@ impl xcm_primitives::XcmTransact for MockTransactors {
 			MockTransactors::Relay => MultiLocation::parent(),
 		}
 	}
+	fn max_transact_weight(self) -> Weight {
+		match self {
+			MockTransactors::Relay => 20000000000,
+		}
+	}
 }
 
 impl xcm_primitives::UtilityEncodeCall for MockTransactors {

--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -302,6 +302,8 @@ pub trait UtilityEncodeCall {
 pub trait XcmTransact: UtilityEncodeCall {
 	/// Encode call from the relay.
 	fn destination(self) -> MultiLocation;
+	/// Maximum weight for the entire Transact operation
+	fn max_transact_weight(self) -> Weight;
 }
 
 /// This trait ensure we can convert AccountIds to CurrencyIds

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1394,6 +1394,14 @@ impl XcmTransact for Transactors {
 			Transactors::Relay => MultiLocation::parent(),
 		}
 	}
+	fn max_transact_weight(self) -> Weight {
+		match self {
+			// Westend is 20,000,000,000
+			// This needs to take into account the rest of the message
+			// We use 12,000,000,000 to be safe
+			Transactors::Relay => 12_000_000_000,
+		}
+	}
 }
 
 impl xcm_transactor::Config for Runtime {

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -32,7 +32,7 @@ use frame_support::{
 use moonbase_runtime::{
 	currency::UNIT, AccountId, AssetId, AssetManager, AssetRegistrarMetadata, AssetType, Assets,
 	Balances, BlockWeights, Call, CrowdloanRewards, Event, ParachainStaking, PolkadotXcm,
-	Precompiles, Runtime, System, XTokens,
+	Precompiles, Runtime, System, XTokens, XcmTransactor,
 };
 use nimbus_primitives::NimbusId;
 use pallet_evm::PrecompileSet;
@@ -1651,6 +1651,60 @@ fn root_can_change_default_xcm_vers() {
 				Box::new(xcm::VersionedMultiLocation::V1(dest)),
 				4000000000
 			));
+		})
+}
+
+#[test]
+fn transactor_cannot_use_more_than_max_weight() {
+	ExtBuilder::default()
+		.with_balances(vec![
+			(AccountId::from(ALICE), 2_000 * UNIT),
+			(AccountId::from(BOB), 1_000 * UNIT),
+		])
+		.with_xcm_assets(vec![(
+			AssetType::Xcm(MultiLocation::parent()),
+			AssetRegistrarMetadata {
+				name: b"RelayToken".to_vec(),
+				symbol: b"Relay".to_vec(),
+				decimals: 12,
+				is_frozen: false,
+			},
+			vec![(AccountId::from(ALICE), 1_000_000_000_000_000)],
+		)])
+		.build()
+		.execute_with(|| {
+			let source_location = AssetType::Xcm(MultiLocation::parent());
+			let source_id: moonbase_runtime::AssetId = source_location.clone().into();
+			assert_ok!(XcmTransactor::register(
+				root_origin(),
+				AccountId::from(ALICE),
+				0,
+			));
+
+			assert_noop!(
+				XcmTransactor::transact_through_derivative_multilocation(
+					origin_of(AccountId::from(ALICE)),
+					moonbase_runtime::Transactors::Relay,
+					0,
+					xcm::VersionedMultiLocation::V1(MultiLocation::parent()),
+					// 12000000000 is the max
+					13000000000,
+					vec![],
+				),
+				xcm_transactor::Error::<Runtime>::MaxWeightTransactReached
+			);
+			assert_noop!(
+				XcmTransactor::transact_through_derivative(
+					origin_of(AccountId::from(ALICE)),
+					moonbase_runtime::Transactors::Relay,
+					0,
+					moonbase_runtime::CurrencyId::OtherReserve(source_id),
+					// 12000000000 is the max
+					13000000000,
+					vec![],
+				),
+				xcm_transactor::Error::<Runtime>::MaxWeightTransactReached
+			);
 		})
 }
 

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -712,6 +712,14 @@ impl xcm_primitives::XcmTransact for MockTransactors {
 			MockTransactors::Relay => MultiLocation::parent(),
 		}
 	}
+	fn max_transact_weight(self) -> Weight {
+		match self {
+			// Westend is 20,000,000,000
+			// This needs to take into account the rest of the message
+			// We use 12,000,000,000 to be safe
+			MockTransactors::Relay => 12_000_000_000,
+		}
+	}
 }
 
 impl xcm_primitives::UtilityEncodeCall for MockTransactors {


### PR DESCRIPTION
### What does it do?
Avoids stalling the queue in the relay when sending a transact operation of more weight than permitted. This ideally should go into the transactInfo storage item, but we declare it in the runtime for now.

Follow-up PRs will make sure this information is set in storage
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
