### PR TITLE
[Staking] Reduce round transition PoV by only reading CandidateSnapshot at round changes instead of entire CandidateState

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1829,6 +1829,6 @@ mod tests {
 	// Required migration is parachain_staking::migrations::IncreaseMaxDelegatorsPerCandidate
 	// Purpose of this test is to remind of required migration if constant is ever changed
 	fn updating_maximum_delegators_per_candidate_requires_configuring_required_migration() {
-		assert_eq!(MaxDelegatorsPerCandidate::get(), 500);
+		assert_eq!(MaxDelegatorsPerCandidate::get(), 300);
 	}
 }

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1183,6 +1183,6 @@ mod tests {
 	// Required migration is parachain_staking::migrations::IncreaseMaxDelegatorsPerCandidate
 	// Purpose of this test is to remind of required migration if constant is ever changed
 	fn updating_maximum_delegators_per_candidate_requires_configuring_required_migration() {
-		assert_eq!(MaxDelegatorsPerCandidate::get(), 1000);
+		assert_eq!(MaxDelegatorsPerCandidate::get(), 300);
 	}
 }

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1809,6 +1809,6 @@ mod tests {
 	// Required migration is parachain_staking::migrations::IncreaseMaxDelegatorsPerCandidate
 	// Purpose of this test is to remind of required migration if constant is ever changed
 	fn updating_maximum_delegators_per_candidate_requires_configuring_required_migration() {
-		assert_eq!(MaxDelegatorsPerCandidate::get(), 500);
+		assert_eq!(MaxDelegatorsPerCandidate::get(), 300);
 	}
 }


### PR DESCRIPTION
### What does it do?

Instead of reading CandidateState at round transitions and inserting the CollatorSnapshot storage item, the changes sync CandidateSnapshot with CandidateState and only read CandidateSnapshot at the round transitions (and puts this value into CollatorSnapshot where it is used just as before for the reward payout computation done later).

The cost is 1 more read/write for the extrinsics that change the subset of CandidateState which is being stored separately specifically for the round transition snapshot.

TODO:
- [ ] update benchmarking for extrinsics that added reads/writes
- [ ] write tests to ensure all changes to the subset of CandidateState that are used in CandidateSnapshot are pushed to CandidateSnapshot

> Syncs new storage item CandidateSnapshot with CollatorCandidate but only stores a subset of CollatorCandidate in this storage item (so only requires updates when the relevant subset changes).

This change ensures that the snapshot that happens at round transitions for future payout computation no longer reads the entire CandidateState.

### What important points reviewers should know?

please verify that we update `CandidateSnapshot` whenever the relevant subset of `CandidateState` changes,

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

Patches critical bug where filling up bottom delegations could brick the chain (by leading to a large PoV)
