### PR TITLE
Adds missing bond to total counted staking

### DIFF
--- a/pallets/parachain-staking/migrations.md
+++ b/pallets/parachain-staking/migrations.md
@@ -1,5 +1,10 @@
 # Migration History
 
+## Increase max delegations per candidate
+
+- [Migration PR `#1096`](https://github.com/PureStake/moonbeam/pull/1096)
+- [Migratio bugfix `#1112`](https://github.com/PureStake/moonbeam/pull/1112)
+
 ## Manual Exits and Patch Lack of Delay for bond\_{more, less}
 
 - [Migration PR `#810`](https://github.com/PureStake/moonbeam/pull/810)

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -65,7 +65,7 @@ impl<T: Config> OnRuntimeUpgrade for IncreaseMaxDelegationsPerCandidate<T> {
 				Vec::new()
 			};
 			let (mut total_counted, mut total_backing): (BalanceOf<T>, BalanceOf<T>) =
-				(0u32.into(), 0u32.into());
+				(state.bond.into(), state.bond.into());
 			for Bond { amount, .. } in &top_delegations {
 				total_counted += *amount;
 				total_backing += *amount;

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -39,7 +39,7 @@ impl<T: ParachainStakingConfig> Migration
 	for ParachainStakingIncreaseMaxDelegationsPerCandidate<T>
 {
 	fn friendly_name(&self) -> &str {
-		"MM_Parachain_Staking_IncreaseMaxDelegationsPerCandidate"
+		"MM_Parachain_Staking_IncreaseMaxDelegationsPerCandidate_v2"
 	}
 
 	fn migrate(&self, _available_weight: Weight) -> Weight {


### PR DESCRIPTION
This fixes an issue with the staking migration for MaxDelegatorsPerCollator which is missing the initial bond amount for collator when computing the total_staked.

This created an issue on Moonlama where no collator were selected in the new round (bricking the network) because the collators were only selfbonded and end-up having a 0 total stake after the migration.