### PR TITLE
Prevents people to kick other authorMapping associations

### DIFF
--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -143,6 +143,10 @@ pub mod pallet {
 				account_id == stored_info.account,
 				Error::<T>::NotYourAssociation
 			);
+			ensure!(
+				MappingWithDeposit::<T>::get(&new_author_id).is_none(),
+				Error::<T>::AlreadyAssociated
+			);
 
 			MappingWithDeposit::<T>::remove(&old_author_id);
 			MappingWithDeposit::<T>::insert(&new_author_id, &stored_info);

--- a/pallets/author-mapping/src/tests.rs
+++ b/pallets/author-mapping/src/tests.rs
@@ -262,11 +262,13 @@ fn rotating_to_the_same_author_id_leaves_registration_in_tact() {
 		.with_mappings(vec![(TestAuthor::Alice.into(), 1)])
 		.build()
 		.execute_with(|| {
-			assert_noop!(AuthorMapping::update_association(
-				Origin::signed(1),
-				TestAuthor::Alice.into(),
-				TestAuthor::Alice.into()
-			),
-			Error::<Runtime>::AlreadyAssociated);
+			assert_noop!(
+				AuthorMapping::update_association(
+					Origin::signed(1),
+					TestAuthor::Alice.into(),
+					TestAuthor::Alice.into()
+				),
+				Error::<Runtime>::AlreadyAssociated
+			);
 		})
 }

--- a/pallets/author-mapping/src/tests.rs
+++ b/pallets/author-mapping/src/tests.rs
@@ -262,14 +262,11 @@ fn rotating_to_the_same_author_id_leaves_registration_in_tact() {
 		.with_mappings(vec![(TestAuthor::Alice.into(), 1)])
 		.build()
 		.execute_with(|| {
-			assert_ok!(AuthorMapping::update_association(
+			assert_noop!(AuthorMapping::update_association(
 				Origin::signed(1),
 				TestAuthor::Alice.into(),
 				TestAuthor::Alice.into()
-			));
-			assert_eq!(
-				AuthorMapping::account_id_of(&TestAuthor::Alice.into()),
-				Some(1)
-			);
+			),
+			Error::<Runtime>::AlreadyAssociated);
 		})
 }


### PR DESCRIPTION
Someone can actually use the `authorMapping.updateAssociation("your_own_nmbs_key", "someone_else_nmbs_key")` to take someone else authorMapping at the same time.