### PR TITLE
Adds support for optimized binary testing

### DIFF
--- a/.github/workflows/prepare-binary.yml
+++ b/.github/workflows/prepare-binary.yml
@@ -45,53 +45,53 @@ jobs:
           path: build
 
   ####### Prepare the release draft #######
-docker-moonbeam:
-  runs-on: ubuntu-latest
-  needs: ["build"]
-  steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.inputs.sha }}
-    - uses: actions/download-artifact@v2
-      with:
-        name: moonbeam
-        path: build
-    - name: Prepare
-      id: prep
-      run: |
-        DOCKER_IMAGE=purestake/moonbeam
-        SHA8="$(git log -1 --format="%H" | cut -c1-8)"
-        TAGS="${DOCKER_IMAGE}:sha-${SHA8}-opt"
-        echo ::set-output name=tags::${TAGS}
-        echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-      with:
-        version: latest
-        driver-opts: |
-          image=moby/buildkit:master
-    - name: Login to DockerHub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build and push moonbeam
-      id: docker_build
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./docker/moonbeam.Dockerfile
-        platforms: linux/amd64
-        push: true
-        tags: ${{ steps.prep.outputs.tags }}
-        labels: |
-          org.opencontainers.image.title=${{ github.event.repository.name }}
-          org.opencontainers.image.description=${{ github.event.repository.description }}
-          org.opencontainers.image.url=${{ github.event.repository.html_url }}
-          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
-          org.opencontainers.image.created=${{ steps.prep.outputs.created }}
-          org.opencontainers.image.revision=${{ github.sha }}
-          org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+  docker-moonbeam:
+    runs-on: ubuntu-latest
+    needs: ["build"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.sha }}
+      - uses: actions/download-artifact@v2
+        with:
+          name: moonbeam
+          path: build
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=purestake/moonbeam
+          SHA8="$(git log -1 --format="%H" | cut -c1-8)"
+          TAGS="${DOCKER_IMAGE}:sha-${SHA8}-opt"
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          driver-opts: |
+            image=moby/buildkit:master
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push moonbeam
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/moonbeam.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=${{ github.event.repository.name }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}

--- a/.github/workflows/prepare-binary.yml
+++ b/.github/workflows/prepare-binary.yml
@@ -1,0 +1,97 @@
+name: Prepare Optimized Binary Draft (internal only)
+
+# The code (like generate-release-body) will be taken from the tag version, not master
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 8-digit sha (ex. d1fdc903) to build the binary from
+        required: true
+
+jobs:
+  ####### Building binaries #######
+
+  build-binary:
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        cpu: ["", "skylake", "znver3"]
+    env:
+      RUSTFLAGS: "-C codegen-units=1 -C target-cpu=${{ matrix.cpu }}"
+      CARGO_PROFILE_RELEASE_LTO: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.to }}
+      - name: Setup Rust toolchain
+        run: rustup show
+      - name: Build Node
+        run: cargo build --release --all
+      - name: Save parachain binary
+        if: ${{ matrix.cpu == '' }}
+        run: |
+          mkdir -p build
+          cp target/release/moonbeam build/moonbeam
+      - name: Save parachain custom binary
+        if: ${{ matrix.cpu != '' }}
+        run: |
+          mkdir -p build
+          cp target/release/moonbeam build/moonbeam-${{matrix.cpu}}
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: moonbeam
+          path: build
+
+  ####### Prepare the release draft #######
+docker-moonbeam:
+  runs-on: ubuntu-latest
+  needs: ["set-tags", "build"]
+  if: ${{ needs.set-tags.outputs.image_exists }} == false && github.repository == 'purestake/moonbeam'
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ needs.set-tags.outputs.git_ref }}
+    - uses: actions/download-artifact@v2
+      with:
+        name: moonbeam
+        path: build
+    - name: Prepare
+      id: prep
+      run: |
+        DOCKER_IMAGE=purestake/moonbeam
+        TAGS="${DOCKER_IMAGE}:sha-${{ needs.set-tags.outputs.sha8 }}-opt"
+        echo ::set-output name=tags::${TAGS}
+        echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      with:
+        version: latest
+        driver-opts: |
+          image=moby/buildkit:master
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push moonbeam
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./docker/moonbeam.Dockerfile
+        platforms: linux/amd64
+        push: true
+        tags: ${{ steps.prep.outputs.tags }}
+        labels: |
+          org.opencontainers.image.title=${{ github.event.repository.name }}
+          org.opencontainers.image.description=${{ github.event.repository.description }}
+          org.opencontainers.image.url=${{ github.event.repository.html_url }}
+          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+          org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}

--- a/.github/workflows/prepare-binary.yml
+++ b/.github/workflows/prepare-binary.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: 8-digit sha (ex. d1fdc903) to build the binary from
+        description: full sha to build the binary from
         required: true
 
 jobs:
@@ -61,7 +61,8 @@ docker-moonbeam:
       id: prep
       run: |
         DOCKER_IMAGE=purestake/moonbeam
-        TAGS="${DOCKER_IMAGE}:sha-${{ github.event.inputs.sha }}-opt"
+        SHA8="$(git log -1 --format="%H" | cut -c1-8)"
+        TAGS="${DOCKER_IMAGE}:sha-${SHA8}-opt"
         echo ::set-output name=tags::${TAGS}
         echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
     - name: Set up QEMU

--- a/.github/workflows/prepare-binary.yml
+++ b/.github/workflows/prepare-binary.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.inputs.to }}
+          ref: ${{ github.event.inputs.sha }}
       - name: Setup Rust toolchain
         run: rustup show
       - name: Build Node
@@ -47,13 +47,12 @@ jobs:
   ####### Prepare the release draft #######
 docker-moonbeam:
   runs-on: ubuntu-latest
-  needs: ["set-tags", "build"]
-  if: ${{ needs.set-tags.outputs.image_exists }} == false && github.repository == 'purestake/moonbeam'
+  needs: ["build"]
   steps:
     - name: Checkout
       uses: actions/checkout@v2
       with:
-        ref: ${{ needs.set-tags.outputs.git_ref }}
+        ref: ${{ github.event.inputs.sha }}
     - uses: actions/download-artifact@v2
       with:
         name: moonbeam
@@ -62,7 +61,7 @@ docker-moonbeam:
       id: prep
       run: |
         DOCKER_IMAGE=purestake/moonbeam
-        TAGS="${DOCKER_IMAGE}:sha-${{ needs.set-tags.outputs.sha8 }}-opt"
+        TAGS="${DOCKER_IMAGE}:sha-${{ github.event.inputs.sha }}-opt"
         echo ::set-output name=tags::${TAGS}
         echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
     - name: Set up QEMU

--- a/docker/moonbeam.Dockerfile
+++ b/docker/moonbeam.Dockerfile
@@ -21,15 +21,15 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 
 USER moonbeam
 
-COPY --chown=moonbeam build/moonbeam /moonbeam/moonbeam
-RUN chmod uog+x /moonbeam/moonbeam
+COPY --chown=moonbeam build/* /moonbeam
+RUN chmod uog+x /moonbeam/moonbeam*
 
-# 30333 for parachain p2p 
-# 30334 for relaychain p2p 
+# 30333 for parachain p2p
+# 30334 for relaychain p2p
 # 9933 for RPC call
 # 9944 for Websocket
 # 9615 for Prometheus (metrics)
-EXPOSE 30333 30334 9933 9944 9615 
+EXPOSE 30333 30334 9933 9944 9615
 
 VOLUME ["/data"]
 


### PR DESCRIPTION
This adds a CI action to build a new docker image matching the moonbeam one, including optimized binary.
This is intended for internal (to Purestake) use only, in order to test the optimized binaries without performing a release