### PR TITLE
fix impl Debug for AccountId20

### DIFF
--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -55,8 +55,8 @@ impl std::fmt::Display for AccountId20 {
 	}
 }
 
-impl std::fmt::Debug for AccountId20 {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for AccountId20 {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
 		write!(f, "{:?}", H160(self.0))
 	}
 }

--- a/primitives/account/src/lib.rs
+++ b/primitives/account/src/lib.rs
@@ -38,20 +38,10 @@ pub use serde::{de::DeserializeOwned, Deserialize, Serialize};
 /// Polkadot JS.
 
 #[derive(
-	Eq,
-	PartialEq,
-	Copy,
-	Clone,
-	Encode,
-	Decode,
-	Debug,
-	TypeInfo,
-	MaxEncodedLen,
-	Default,
-	PartialOrd,
-	Ord,
+	Eq, PartialEq, Copy, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Default, PartialOrd, Ord,
 )]
 pub struct AccountId20(pub [u8; 20]);
+
 #[cfg(feature = "std")]
 impl_serde::impl_fixed_hash_serde!(AccountId20, 20);
 
@@ -62,6 +52,12 @@ impl std::fmt::Display for AccountId20 {
 	// Maybe this one https://github.com/miguelmota/rust-eth-checksum
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		write!(f, "{:?}", self.0)
+	}
+}
+
+impl std::fmt::Debug for AccountId20 {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{:?}", H160(self.0))
 	}
 }
 


### PR DESCRIPTION
### What does it do?

The default `Debug` implemetation for `AccountId20` print accounts address like `AccountId20([242, 79, 243, 169, 207, 4, 199, 29, 188, 148, 208, 181, 102, 247, 162, 123, 148, 86, 108, 172])` in the logs.

This PR modify the `Debug` implementation for `AccountId20` to print the address in a better format

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
