### PR TITLE
payable/view checks in precompiles

### DIFF
--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -28,8 +28,8 @@ use frame_support::{
 };
 use pallet_evm::{AddressMapping, PrecompileSet};
 use precompile_utils::{
-	keccak256, Address, Bytes, EvmData, EvmDataReader, EvmDataWriter, EvmResult, Gasometer,
-	LogsBuilder, RuntimeHelper,
+	keccak256, Address, Bytes, EvmData, EvmDataReader, EvmDataWriter, EvmResult, FunctionModifier,
+	Gasometer, LogsBuilder, RuntimeHelper,
 };
 use sp_runtime::traits::Zero;
 
@@ -112,7 +112,7 @@ where
 		input: &[u8],
 		target_gas: Option<u64>,
 		context: &Context,
-		_is_static: bool,
+		is_static: bool,
 	) -> Option<EvmResult<PrecompileOutput>> {
 		if let Some(asset_id) =
 			Runtime::account_to_asset_id(Runtime::AddressMapping::into_account_id(address))
@@ -135,6 +135,19 @@ where
 							Err(e) => return Some(Err(e)),
 						};
 					let input = &mut input;
+
+					if let Err(err) = gasometer.check_function_modifier(
+						context,
+						is_static,
+						match selector {
+							Action::Approve | Action::Transfer | Action::TransferFrom => {
+								FunctionModifier::NonPayable
+							}
+							_ => FunctionModifier::View,
+						},
+					) {
+						return Some(Err(err));
+					}
 
 					match selector {
 						Action::TotalSupply => Self::total_supply(asset_id, input, gasometer),

--- a/precompiles/author-mapping/src/lib.rs
+++ b/precompiles/author-mapping/src/lib.rs
@@ -24,7 +24,7 @@ use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
 use pallet_author_mapping::Call as AuthorMappingCall;
 use pallet_evm::AddressMapping;
 use pallet_evm::Precompile;
-use precompile_utils::{EvmDataReader, EvmResult, Gasometer, RuntimeHelper};
+use precompile_utils::{EvmDataReader, EvmResult, FunctionModifier, Gasometer, RuntimeHelper};
 use sp_core::crypto::UncheckedFrom;
 use sp_core::H256;
 use sp_std::{fmt::Debug, marker::PhantomData};
@@ -57,7 +57,7 @@ where
 		input: &[u8], //Reminder this is big-endian
 		target_gas: Option<u64>,
 		context: &Context,
-		_is_static: bool,
+		is_static: bool,
 	) -> EvmResult<PrecompileOutput> {
 		log::trace!(target: "author-mapping-precompile", "In author mapping wrapper");
 
@@ -66,6 +66,8 @@ where
 
 		let (mut input, selector) = EvmDataReader::new_with_selector(gasometer, input)?;
 		let input = &mut input;
+
+		gasometer.check_function_modifier(context, is_static, FunctionModifier::NonPayable)?;
 
 		match selector {
 			// Dispatchables

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -183,9 +183,10 @@ where
 			context,
 			is_static,
 			match selector {
-				Action::Approve | Action::Transfer | Action::TransferFrom => {
+				Action::Approve | Action::Transfer | Action::TransferFrom | Action::Withdraw => {
 					FunctionModifier::NonPayable
 				}
+				Action::Deposit => FunctionModifier::Payable,
 				_ => FunctionModifier::View,
 			},
 		)?;

--- a/precompiles/crowdloan-rewards/src/lib.rs
+++ b/precompiles/crowdloan-rewards/src/lib.rs
@@ -26,7 +26,7 @@ use frame_support::{
 };
 use pallet_evm::{AddressMapping, Precompile};
 use precompile_utils::{
-	Address, EvmDataReader, EvmDataWriter, EvmResult, Gasometer, RuntimeHelper,
+	Address, EvmDataReader, EvmDataWriter, EvmResult, FunctionModifier, Gasometer, RuntimeHelper,
 };
 
 use sp_core::{H160, U256};
@@ -70,10 +70,19 @@ where
 		input: &[u8], //Reminder this is big-endian
 		target_gas: Option<u64>,
 		context: &Context,
-		_is_static: bool,
+		is_static: bool,
 	) -> EvmResult<PrecompileOutput> {
 		let mut gasometer = Gasometer::new(target_gas);
 		let (mut input, selector) = EvmDataReader::new_with_selector(&mut gasometer, input)?;
+
+		gasometer.check_function_modifier(
+			context,
+			is_static,
+			match selector {
+				Action::Claim | Action::UpdateRewardAddress => FunctionModifier::NonPayable,
+				_ => FunctionModifier::View,
+			},
+		)?;
 
 		match selector {
 			// Check for accessor methods first. These return results immediately

--- a/precompiles/pallet-democracy/src/lib.rs
+++ b/precompiles/pallet-democracy/src/lib.rs
@@ -26,7 +26,8 @@ use pallet_democracy::{AccountVote, Call as DemocracyCall, Vote};
 use pallet_evm::AddressMapping;
 use pallet_evm::Precompile;
 use precompile_utils::{
-	Address, Bytes, EvmData, EvmDataReader, EvmDataWriter, EvmResult, Gasometer, RuntimeHelper,
+	Address, Bytes, EvmData, EvmDataReader, EvmDataWriter, EvmResult, FunctionModifier, Gasometer,
+	RuntimeHelper,
 };
 use sp_core::{H160, H256, U256};
 use sp_std::{
@@ -86,7 +87,7 @@ where
 		input: &[u8], //Reminder this is big-endian
 		target_gas: Option<u64>,
 		context: &Context,
-		_is_static: bool,
+		is_static: bool,
 	) -> EvmResult<PrecompileOutput> {
 		log::trace!(target: "democracy-precompile", "In democracy wrapper");
 
@@ -95,6 +96,23 @@ where
 
 		let (mut input, selector) = EvmDataReader::new_with_selector(gasometer, input)?;
 		let input = &mut input;
+
+		gasometer.check_function_modifier(
+			context,
+			is_static,
+			match selector {
+				Action::Propose
+				| Action::Second
+				| Action::StandardVote
+				| Action::RemoveVote
+				| Action::Delegate
+				| Action::UnDelegate
+				| Action::Unlock
+				| Action::NotePreimage
+				| Action::NoteImminentPreimage => FunctionModifier::NonPayable,
+				_ => FunctionModifier::View,
+			},
+		)?;
 
 		match selector {
 			// Storage Accessors

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -30,7 +30,8 @@ use frame_support::traits::{Currency, Get};
 use pallet_evm::AddressMapping;
 use pallet_evm::Precompile;
 use precompile_utils::{
-	Address, EvmData, EvmDataReader, EvmDataWriter, EvmResult, Gasometer, RuntimeHelper,
+	Address, EvmData, EvmDataReader, EvmDataWriter, EvmResult, FunctionModifier, Gasometer,
+	RuntimeHelper,
 };
 use sp_std::convert::TryInto;
 use sp_std::fmt::Debug;
@@ -116,13 +117,33 @@ where
 		input: &[u8],
 		target_gas: Option<u64>,
 		context: &Context,
-		_is_static: bool,
+		is_static: bool,
 	) -> EvmResult<PrecompileOutput> {
 		let mut gasometer = Gasometer::new(target_gas);
 		let gasometer = &mut gasometer;
 
 		let (mut input, selector) = EvmDataReader::new_with_selector(gasometer, input)?;
 		let input = &mut input;
+
+		gasometer.check_function_modifier(
+			context,
+			is_static,
+			match selector {
+				Action::IsNominator
+				| Action::IsDelegator
+				| Action::IsCandidate
+				| Action::IsSelectedCandidate
+				| Action::Points
+				| Action::MinNomination
+				| Action::MinDelegation
+				| Action::CandidateCount
+				| Action::CollatorNominationCount
+				| Action::CandidateDelegationCount
+				| Action::NominatorNominationCount
+				| Action::DelegatorDelegationCount => FunctionModifier::View,
+				_ => FunctionModifier::NonPayable,
+			},
+		)?;
 
 		// Return early if storage getter; return (origin, call) if dispatchable
 		let (origin, call) = match selector {

--- a/precompiles/relay-encoder/src/lib.rs
+++ b/precompiles/relay-encoder/src/lib.rs
@@ -28,7 +28,8 @@ use frame_support::{
 use pallet_evm::Precompile;
 use pallet_staking::RewardDestination;
 use precompile_utils::{
-	Bytes, EvmData, EvmDataReader, EvmDataWriter, EvmResult, Gasometer, RuntimeHelper,
+	Bytes, EvmData, EvmDataReader, EvmDataWriter, EvmResult, FunctionModifier, Gasometer,
+	RuntimeHelper,
 };
 use sp_core::{H256, U256};
 use sp_runtime::AccountId32;
@@ -91,14 +92,16 @@ where
 	fn execute(
 		input: &[u8], //Reminder this is big-endian
 		target_gas: Option<u64>,
-		_context: &Context,
-		_is_static: bool,
+		context: &Context,
+		is_static: bool,
 	) -> EvmResult<PrecompileOutput> {
 		let mut gasometer = Gasometer::new(target_gas);
 		let gasometer = &mut gasometer;
 
 		let (mut input, selector) = EvmDataReader::new_with_selector(gasometer, input)?;
 		let input = &mut input;
+
+		gasometer.check_function_modifier(context, is_static, FunctionModifier::View)?;
 
 		// Parse the function selector
 		// These are the four-byte function selectors calculated from the RelayEncoder.sol

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -19,13 +19,13 @@
 extern crate alloc;
 
 use crate::alloc::borrow::ToOwned;
-use fp_evm::{ExitError, ExitRevert, PrecompileFailure};
+use fp_evm::{Context, ExitError, ExitRevert, PrecompileFailure};
 use frame_support::{
 	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
 	traits::Get,
 };
 use pallet_evm::{GasWeightMapping, Log};
-use sp_core::{H160, H256};
+use sp_core::{H160, H256, U256};
 use sp_std::{marker::PhantomData, vec, vec::Vec};
 
 mod data;
@@ -228,9 +228,24 @@ where
 	}
 }
 
+/// Represents modifiers a Solidity function can be annotated with.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum FunctionModifier {
+	/// Function that doesn't modify the state.
+	View,
+	/// Function that modifies the state but refuse receiving funds.
+	/// Correspond to a Solidity function with no modifiers.
+	NonPayable,
+	/// Function that modifies the state and accept funds.
+	Payable,
+}
+
 /// Custom Gasometer to record costs in precompiles.
 /// It is advised to record known costs as early as possible to
 /// avoid unecessary computations if there is an Out of Gas.
+///
+/// Provides functions related to reverts, as reverts takes the recorded amount
+/// of gas into account.
 #[derive(Clone, Copy, Debug)]
 pub struct Gasometer {
 	target_gas: Option<u64>,
@@ -253,6 +268,7 @@ impl Gasometer {
 	}
 
 	/// Record cost, and return error if it goes out of gas.
+	#[must_use]
 	pub fn record_cost(&mut self, cost: u64) -> EvmResult {
 		self.used_gas = self
 			.used_gas
@@ -271,6 +287,7 @@ impl Gasometer {
 
 	/// Record cost of a log manualy.
 	/// This can be useful to record log costs early when their content have static size.
+	#[must_use]
 	pub fn record_log_costs_manual(&mut self, topics: usize, data_len: usize) -> EvmResult {
 		// Cost calculation is copied from EVM code that is not publicly exposed by the crates.
 		// https://github.com/rust-blockchain/evm/blob/master/gasometer/src/costs.rs#L148
@@ -299,6 +316,7 @@ impl Gasometer {
 	}
 
 	/// Record cost of logs.
+	#[must_use]
 	pub fn record_log_costs(&mut self, logs: &[Log]) -> EvmResult {
 		for log in logs {
 			self.record_log_costs_manual(log.topics.len(), log.data.len())?;
@@ -310,6 +328,7 @@ impl Gasometer {
 	/// Compute remaining gas.
 	/// Returns error if out of gas.
 	/// Returns None if no gas limit.
+	#[must_use]
 	pub fn remaining_gas(&self) -> EvmResult<Option<u64>> {
 		Ok(match self.target_gas {
 			None => None,
@@ -328,11 +347,32 @@ impl Gasometer {
 	///
 	/// TODO : Record cost of the input based on its size and handle Out of Gas ?
 	/// This might be required if we format revert messages using user data.
+	#[must_use]
 	pub fn revert(&self, output: impl AsRef<[u8]>) -> PrecompileFailure {
 		PrecompileFailure::Revert {
 			exit_status: ExitRevert::Reverted,
 			output: output.as_ref().to_owned(),
 			cost: self.used_gas,
 		}
+	}
+
+	#[must_use]
+	/// Check that a function call is compatible with the context it is
+	/// called into.
+	pub fn check_function_modifier(
+		&self,
+		context: &Context,
+		is_static: bool,
+		modifier: FunctionModifier,
+	) -> EvmResult {
+		if is_static && modifier != FunctionModifier::View {
+			return Err(self.revert("can't call non-static function in static context"));
+		}
+
+		if modifier != FunctionModifier::Payable && context.apparent_value > U256::zero() {
+			return Err(self.revert("function is not payable"));
+		}
+
+		Ok(())
 	}
 }

--- a/precompiles/utils/src/tests.rs
+++ b/precompiles/utils/src/tests.rs
@@ -995,3 +995,75 @@ fn network_id_decoder_works() {
 		Ok(NetworkId::Polkadot)
 	);
 }
+
+#[test]
+fn check_function_modifier() {
+	let mut gasometer = Gasometer::new(None);
+	let _ = gasometer.record_cost(500);
+
+	let context = |value: u32| Context {
+		address: H160::zero(),
+		caller: H160::zero(),
+		apparent_value: U256::from(value),
+	};
+
+	let payable_error = || gasometer.revert("function is not payable");
+	let static_error = || gasometer.revert("can't call non-static function in static context");
+
+	// Can't call non-static functions in static context.
+	assert_eq!(
+		gasometer.check_function_modifier(&context(0), true, FunctionModifier::Payable),
+		Err(static_error())
+	);
+	assert_eq!(
+		gasometer.check_function_modifier(&context(0), true, FunctionModifier::NonPayable),
+		Err(static_error())
+	);
+	assert_eq!(
+		gasometer.check_function_modifier(&context(0), true, FunctionModifier::View),
+		Ok(())
+	);
+
+	// Static check is performed before non-payable check.
+	assert_eq!(
+		gasometer.check_function_modifier(&context(1), true, FunctionModifier::Payable),
+		Err(static_error())
+	);
+	assert_eq!(
+		gasometer.check_function_modifier(&context(1), true, FunctionModifier::NonPayable),
+		Err(static_error())
+	);
+	// FunctionModifier::View pass static check but fail for payable.
+	assert_eq!(
+		gasometer.check_function_modifier(&context(1), true, FunctionModifier::View),
+		Err(payable_error())
+	);
+
+	// Can't send funds to non payable function
+	assert_eq!(
+		gasometer.check_function_modifier(&context(1), false, FunctionModifier::Payable),
+		Ok(())
+	);
+	assert_eq!(
+		gasometer.check_function_modifier(&context(1), false, FunctionModifier::NonPayable),
+		Err(payable_error())
+	);
+	assert_eq!(
+		gasometer.check_function_modifier(&context(1), false, FunctionModifier::View),
+		Err(payable_error())
+	);
+
+	// Any function can be called without funds.
+	assert_eq!(
+		gasometer.check_function_modifier(&context(0), false, FunctionModifier::Payable),
+		Ok(())
+	);
+	assert_eq!(
+		gasometer.check_function_modifier(&context(0), false, FunctionModifier::NonPayable),
+		Ok(())
+	);
+	assert_eq!(
+		gasometer.check_function_modifier(&context(0), false, FunctionModifier::View),
+		Ok(())
+	);
+}

--- a/precompiles/xtokens/src/lib.rs
+++ b/precompiles/xtokens/src/lib.rs
@@ -22,7 +22,9 @@
 use fp_evm::{Context, ExitSucceed, PrecompileOutput};
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
 use pallet_evm::{AddressMapping, Precompile};
-use precompile_utils::{Address, EvmData, EvmDataReader, EvmResult, Gasometer, RuntimeHelper};
+use precompile_utils::{
+	Address, EvmData, EvmDataReader, EvmResult, FunctionModifier, Gasometer, RuntimeHelper,
+};
 
 use sp_core::{H160, U256};
 use sp_std::boxed::Box;
@@ -71,13 +73,15 @@ where
 		input: &[u8], //Reminder this is big-endian
 		target_gas: Option<u64>,
 		context: &Context,
-		_is_static: bool,
+		is_static: bool,
 	) -> EvmResult<PrecompileOutput> {
 		let mut gasometer = Gasometer::new(target_gas);
 		let gasometer = &mut gasometer;
 
 		let (mut input, selector) = EvmDataReader::new_with_selector(gasometer, input)?;
 		let input = &mut input;
+
+		gasometer.check_function_modifier(context, is_static, FunctionModifier::NonPayable)?;
 
 		match selector {
 			Action::Transfer => Self::transfer(input, gasometer, context),


### PR DESCRIPTION
### What does it do?

Add util to ensure constraints expressed by the `payable` and `view` keywords in Solidity.

- `view` will prevent to be able to call a state modifying function inside a static context.
- `payable` functions will be the only functions that accepts a non-zero value. This will prevent most silly ways to lose funds by sending them to precompile addresses.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
