### PR TITLE
WETH withdraw/deposit should only exist for the native currency

### DIFF
--- a/precompiles/balances-erc20/ERC20.sol
+++ b/precompiles/balances-erc20/ERC20.sol
@@ -83,20 +83,6 @@ interface IERC20 {
   function transferFrom(address from, address to, uint256 value)
     external returns (bool);
 
-  /**
-   * @dev Provide compatibility for contracts that expect wETH design.
-   * Returns funds to sender as this precompile tokens and the native tokens are the same.
-   * Selector: d0e30db0
-   */
-  function deposit() external payable;
-
-  /**
-   * @dev Provide compatibility for contracts that expect wETH design.
-   * Does nothing.
-   * Selector: 2e1a7d4d
-   * @param Amount to withdraw/unwrap.
-   */
-  function withdraw(uint256 value) external;
 
   /**
    * @dev Event emited when a transfer has been performed.
@@ -123,6 +109,29 @@ interface IERC20 {
     address indexed spender,
     uint256 value
   );
+}
+
+/**
+ * @title Native currency wrapper interface.
+ * @dev Allow compatibility with dApps expecting this precompile to be
+ * a WETH-like contract.
+ * Moonbase address : 0x0000000000000000000000000000000000000802
+ */
+interface WrappedNativeCurrency {
+  /**
+   * @dev Provide compatibility for contracts that expect wETH design.
+   * Returns funds to sender as this precompile tokens and the native tokens are the same.
+   * Selector: d0e30db0
+   */
+  function deposit() external payable;
+
+  /**
+   * @dev Provide compatibility for contracts that expect wETH design.
+   * Does nothing.
+   * Selector: 2e1a7d4d
+   * @param Amount to withdraw/unwrap.
+   */
+  function withdraw(uint256 value) external;
 
   /**
    * @dev Event emited when deposit() has been called.
@@ -135,7 +144,7 @@ interface IERC20 {
     uint value
   );
 
-    /**
+  /**
    * @dev Event emited when withdraw(uint256) has been called.
    * Selector: 7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65
    * @param owner address Owner of the tokens

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -493,7 +493,7 @@ where
 		context: &Context,
 	) -> EvmResult<PrecompileOutput> {
 		// Deposit only makes sense for the native currency.
-		if !Erc20Metadata::is_native_currency() {
+		if !Metadata::is_native_currency() {
 			return Err(gasometer.revert("unknown selector"));
 		}
 
@@ -537,7 +537,7 @@ where
 		context: &Context,
 	) -> EvmResult<PrecompileOutput> {
 		// Withdraw only makes sense for the native currency.
-		if !Erc20Metadata::is_native_currency() {
+		if !Metadata::is_native_currency() {
 			return Err(gasometer.revert("unknown selector"));
 		}
 

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -146,6 +146,10 @@ pub trait Erc20Metadata {
 
 	/// Returns the decimals places of the token.
 	fn decimals() -> u8;
+
+	/// Must return `true` only if it represents the main native currency of
+	/// the network. It must be the currency used in `pallet_evm`.
+	fn is_native_currency() -> bool;
 }
 
 /// Precompile exposing a pallet_balance as an ERC20.
@@ -488,6 +492,11 @@ where
 		gasometer: &mut Gasometer,
 		context: &Context,
 	) -> EvmResult<PrecompileOutput> {
+		// Deposit only makes sense for the native currency.
+		if !Erc20Metadata::is_native_currency() {
+			return Err(gasometer.revert("unknown selector"));
+		}
+
 		let caller: Runtime::AccountId = Runtime::AddressMapping::into_account_id(context.caller);
 		let precompile = Runtime::AddressMapping::into_account_id(context.address);
 		let amount = Self::u256_to_amount(gasometer, context.apparent_value)?;
@@ -527,6 +536,11 @@ where
 		gasometer: &mut Gasometer,
 		context: &Context,
 	) -> EvmResult<PrecompileOutput> {
+		// Withdraw only makes sense for the native currency.
+		if !Erc20Metadata::is_native_currency() {
+			return Err(gasometer.revert("unknown selector"));
+		}
+
 		gasometer.record_log_costs_manual(2, 32)?;
 
 		let withdrawn_amount: U256 = input.read(gasometer)?;

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -215,6 +215,12 @@ impl Erc20Metadata for NativeErc20Metadata {
 	fn decimals() -> u8 {
 		18
 	}
+
+	/// Must return `true` only if it represents the main native currency of
+	/// the network. It must be the currency used in `pallet_evm`.
+	fn is_native_currency() -> bool {
+		true
+	}
 }
 
 #[derive(Default)]

--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -54,6 +54,12 @@ impl Erc20Metadata for NativeErc20Metadata {
 	fn decimals() -> u8 {
 		18
 	}
+
+	/// Must return `true` only if it represents the main native currency of
+	/// the network. It must be the currency used in `pallet_evm`.
+	fn is_native_currency() -> bool {
+		true
+	}
 }
 
 /// The asset precompile address prefix. Addresses that match against this prefix will be routed

--- a/runtime/moonriver/src/precompiles.rs
+++ b/runtime/moonriver/src/precompiles.rs
@@ -52,6 +52,12 @@ impl Erc20Metadata for NativeErc20Metadata {
 	fn decimals() -> u8 {
 		18
 	}
+
+	/// Must return `true` only if it represents the main native currency of
+	/// the network. It must be the currency used in `pallet_evm`.
+	fn is_native_currency() -> bool {
+		true
+	}
 }
 
 /// The asset precompile address prefix. Addresses that match against this prefix will be routed


### PR DESCRIPTION
### What does it do?

Currently we only use 1 pallet_balances for the native currency. However in the future we may use others, which is supported by the precompile code. However, #1106 introduced functions `withdraw`/`deposit` which only makes sense for an ERC20 that wraps the native currency. This PR fixes that.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

Not have a manually implemented `is_native_currency`, and instead statically check if the pallet instance corresponds to the currency used in pallet_evm. However I was not able to find how to do it, since it seems to require "negative trait bounds" which are not yet available in Rust. (if same => this impl; if **not** same => that impl)

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
