### PR TITLE
fix tracing tests: revert changes in expected values introduced by #1140

### DIFF
--- a/tests/tracing-tests/test-trace-filter.ts
+++ b/tests/tracing-tests/test-trace-filter.ts
@@ -49,12 +49,12 @@ describeDevMoonbeamAllEthTxTypes("Trace filter - Contract creation ", (context) 
     expect(response.result[0].action).to.include({
       creationMethod: "create",
       from: "0x6be02d1d3665660d22ff9624b7be0551ee1ac91b",
-      gas: "0xb60b2701",
+      gas: "0xb60b27",
       value: "0x0",
     });
     expect(response.result[0].result).to.include({
       address: "0xc2bf5f29a4384b1ab0c063e1c666f02121b6084a",
-      gasUsed: "0x336b0", // TODO : Compare with value from another (comparable) network.
+      gasUsed: "0x10fd9", // TODO : Compare with value from another (comparable) network.
     });
 
     expect(response.result[0]).to.include({
@@ -80,7 +80,7 @@ describeDevMoonbeamAllEthTxTypes("Trace filter - Contract creation ", (context) 
     expect(response.result.length).to.equal(1);
     expect(response.result[0].action.creationMethod).to.equal("create");
     expect(response.result[0].action.from).to.equal("0x6be02d1d3665660d22ff9624b7be0551ee1ac91b");
-    expect(response.result[0].action.gas).to.equal("0xb60bd001");
+    expect(response.result[0].action.gas).to.equal("0xb60bd0");
     expect(response.result[0].action.init).to.be.a("string");
     expect(response.result[0].action.value).to.equal("0x0");
     expect(response.result[0].blockHash).to.be.a("string");

--- a/tests/tracing-tests/test-trace-gas.ts
+++ b/tests/tracing-tests/test-trace-gas.ts
@@ -10,9 +10,9 @@ describeDevMoonbeamAllEthTxTypes("Trace filter - Gas Loop", (context) => {
     blockNumber?: number;
     expectedGas: number;
   }[] = [
-    { count: 0, expectedGas: 133320 },
-    { count: 100, expectedGas: 57451732 },
-    { count: 1000, expectedGas: 524165344 },
+    { count: 0, expectedGas: 21630 },
+    { count: 100, expectedGas: 245542 },
+    { count: 1000, expectedGas: 2068654 },
   ];
 
   before("Setup: Create 4 blocks with 1 contract loop execution each", async function () {


### PR DESCRIPTION
### What does it do?

#1140 restored the tracing tests, but some expected values had been wrongly modified. The discrepancy came from a bad change in the override repository code: https://github.com/PureStake/moonbeam-runtime-overrides/commit/6d06d391a78cdde61c836a708b8ff7804aea0e30

These bad changes have been corrected in https://github.com/PureStake/moonbeam-runtime-overrides/pull/32, so the tests now pass well with the old values.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
