### PR TITLE
Adapt tracing tests to EVM london configuration

### DIFF
--- a/tests/tracing-tests/test-trace-gas.ts
+++ b/tests/tracing-tests/test-trace-gas.ts
@@ -11,8 +11,8 @@ describeDevMoonbeamAllEthTxTypes("Trace filter - Gas Loop", (context) => {
     expectedGas: number;
   }[] = [
     { count: 0, expectedGas: 21630 },
-    { count: 100, expectedGas: 245542 },
-    { count: 1000, expectedGas: 2068654 },
+    { count: 100, expectedGas: 108242 },
+    { count: 1000, expectedGas: 670654 },
   ];
 
   before("Setup: Create 4 blocks with 1 contract loop execution each", async function () {


### PR DESCRIPTION
### What does it do?

Tracing tests were broken by this PR: #1132 
Specifically, the cause is a change in frontier, this particular commit: https://github.com/PureStake/frontier/commit/760bbf8e2109bd69263ab14129cf5297d63a7c05

This commit in frontier has changed the configuration of the EVM from Istanbul to London, which changes the amount of gas consumed in some cases.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
