### PR TITLE
Bump frontier to 6d3139

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "fp-storage",
  "kvdb",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "fc-consensus",
  "fc-db",
@@ -2447,7 +2447,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2493,7 +2493,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2628,7 +2628,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "evm",
  "parity-scale-codec",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2657,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 
 [[package]]
 name = "frame-benchmarking"
@@ -6586,7 +6586,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6841,7 +6841,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -6882,7 +6882,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -6961,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -6971,7 +6971,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -6982,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6995,7 +6995,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "fp-evm",
  "num",
@@ -7006,7 +7006,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7017,7 +7017,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#760bbf8e2109bd69263ab14129cf5297d63a7c05"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#6d3139453fae0339af9d63c6da0b7b1b1da86ceb"
 dependencies = [
  "fp-evm",
  "ripemd160",


### PR DESCRIPTION
### What does it do?

Bumps `frontier` to `6d3139453fae0339af9d63c6da0b7b1b1da86ceb` to keep up with our `moonbeam-polkadot-v0.9.13` branch.