### PR TITLE
Add tech and council to moonriver-local to be able to test locally

### DIFF
--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -252,11 +252,11 @@ pub fn testnet_genesis(
 		},
 		council_collective: CouncilCollectiveConfig {
 			phantom: Default::default(),
-			members: vec![], // TODO : Set members
+			members: council_members, // TODO : Set members
 		},
 		tech_committee_collective: TechCommitteeCollectiveConfig {
 			phantom: Default::default(),
-			members: vec![], // TODO : Set members
+			members: tech_comittee_members, // TODO : Set members
 		},
 		author_filter: AuthorFilterConfig {
 			eligible_ratio: sp_runtime::Percent::from_percent(50),

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -55,15 +55,10 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 		ChainType::Development,
 		move || {
 			testnet_genesis(
-				vec![
-					AccountId::from_str("3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0").unwrap(),
-					AccountId::from_str("798d4Ba9baf0064Ec19eB4F0a1a45785ae9D6DFc").unwrap(),
-					AccountId::from_str("773539d4Ac0e786233D90A233654ccEE26a613D9").unwrap(),
-				],
-				vec![
-					AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap(),
-					AccountId::from_str("3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0").unwrap(),
-				],
+				// Council members: Baltathar, Charleth and Dorothy
+				vec![accounts[1], accounts[2], accounts[3]],
+				// Tech comitee members: Alith and Baltathar
+				vec![accounts[0], accounts[1]],
 				// Collator Candidate: Alice -> Alith
 				vec![(
 					AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap(),
@@ -106,11 +101,13 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		ChainType::Local,
 		move || {
 			testnet_genesis(
+				// Council members: Baltathar, Charleth and Dorothy
 				vec![
 					AccountId::from_str("3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0").unwrap(),
 					AccountId::from_str("798d4Ba9baf0064Ec19eB4F0a1a45785ae9D6DFc").unwrap(),
 					AccountId::from_str("773539d4Ac0e786233D90A233654ccEE26a613D9").unwrap(),
 				],
+				// Tech comitee members: Alith and Baltathar
 				vec![
 					AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap(),
 					AccountId::from_str("3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0").unwrap(),

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -55,6 +55,15 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 		ChainType::Development,
 		move || {
 			testnet_genesis(
+				vec![
+					AccountId::from_str("3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0").unwrap(),
+					AccountId::from_str("798d4Ba9baf0064Ec19eB4F0a1a45785ae9D6DFc").unwrap(),
+					AccountId::from_str("773539d4Ac0e786233D90A233654ccEE26a613D9").unwrap(),
+				],
+				vec![
+					AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap(),
+					AccountId::from_str("3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0").unwrap(),
+				],
 				// Collator Candidate: Alice -> Alith
 				vec![(
 					AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap(),
@@ -97,6 +106,15 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 		ChainType::Local,
 		move || {
 			testnet_genesis(
+				vec![
+					AccountId::from_str("3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0").unwrap(),
+					AccountId::from_str("798d4Ba9baf0064Ec19eB4F0a1a45785ae9D6DFc").unwrap(),
+					AccountId::from_str("773539d4Ac0e786233D90A233654ccEE26a613D9").unwrap(),
+				],
+				vec![
+					AccountId::from_str("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac").unwrap(),
+					AccountId::from_str("3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0").unwrap(),
+				],
 				// Collator Candidates
 				vec![
 					// Alice -> Alith
@@ -167,6 +185,8 @@ pub fn moonbeam_inflation_config() -> InflationInfo<Balance> {
 }
 
 pub fn testnet_genesis(
+	council_members: Vec<AccountId>,
+	tech_comittee_members: Vec<AccountId>,
 	candidates: Vec<(AccountId, NimbusId, Balance)>,
 	delegations: Vec<(AccountId, AccountId, Balance)>,
 	endowed_accounts: Vec<AccountId>,

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -249,11 +249,11 @@ pub fn testnet_genesis(
 		},
 		council_collective: CouncilCollectiveConfig {
 			phantom: Default::default(),
-			members: council_members, // TODO : Set members
+			members: council_members,
 		},
 		tech_committee_collective: TechCommitteeCollectiveConfig {
 			phantom: Default::default(),
-			members: tech_comittee_members, // TODO : Set members
+			members: tech_comittee_members,
 		},
 		author_filter: AuthorFilterConfig {
 			eligible_ratio: sp_runtime::Percent::from_percent(50),


### PR DESCRIPTION
### What does it do?
In order to properly test with moonriver runtime locally, we need tech and council commitee to be set. This PR adds both
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
