### PR TITLE
Handle potential overflow when calculating fee to be substracted

### DIFF
--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -151,7 +151,8 @@ impl<
 				let asset_type: AssetType = id.clone().into();
 				let asset_id: AssetId = AssetId::from(asset_type);
 				if let Some(units_per_second) = AssetIdInfoGetter::get_units_per_second(asset_id) {
-					let amount = units_per_second * (weight as u128) / (WEIGHT_PER_SECOND as u128);
+					let amount = units_per_second.saturating_mul(weight as u128)
+						/ (WEIGHT_PER_SECOND as u128);
 					let required = MultiAsset {
 						fun: Fungibility::Fungible(amount),
 						id: xcmAssetId::Concrete(id.clone()),


### PR DESCRIPTION
### What does it do?
Probably not exploitable because the queue would prevent a message with that much weight from beign executed, but still

plus weight is u64
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
