### PR TITLE
Finality RPC: add RPC methods isBlockFinalized & isTxFinalize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,6 +5330,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moonbeam-finality-rpc"
+version = "0.1.0"
+dependencies = [
+ "fc-db",
+ "fc-rpc",
+ "futures 0.3.17",
+ "jsonrpc-core",
+ "jsonrpc-derive",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-runtime",
+ "tokio",
+]
+
+[[package]]
 name = "moonbeam-primitives-ext"
 version = "0.1.0"
 dependencies = [
@@ -5649,6 +5666,7 @@ dependencies = [
  "moonbase-runtime",
  "moonbeam-cli-opt",
  "moonbeam-core-primitives",
+ "moonbeam-finality-rpc",
  "moonbeam-primitives-ext",
  "moonbeam-rpc-debug",
  "moonbeam-rpc-primitives-debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 exclude = [ "bin/utils/moonkey" ]
 members = [
 	"bin/utils/moonkey",
+	"client/rpc/finality",
 	"client/rpc/manual-xcm",
 	"node",
 	"node/cli",

--- a/client/rpc/finality/Cargo.toml
+++ b/client/rpc/finality/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "moonbeam-finality-rpc"
+authors = [ "PureStake" ]
+description = "An experimental RPC to check for block and transaction finality in the moonbeam parachain"
+edition = "2018"
+homepage = "https://moonbeam.network"
+license = "GPL-3.0-only"
+repository = "https://github.com/PureStake/moonbeam/"
+version = "0.1.0"
+
+[dependencies]
+futures = { version = "0.3", features = [ "compat" ] }
+jsonrpc-core = "18.0.0"
+jsonrpc-derive = "18.0.0"
+parity-scale-codec = "2.2"
+tokio = { version = "1.12.0", features = [ "sync", "time" ] }
+
+fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.13" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.13" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.13" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.13" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.13" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.13" }

--- a/client/rpc/finality/src/lib.rs
+++ b/client/rpc/finality/src/lib.rs
@@ -29,12 +29,12 @@ use sp_runtime::traits::Block;
 /// An RPC endpoint to check for finality of blocks and transactions in Moonbeam
 #[rpc(server)]
 pub trait MoonbeamFinalityApi {
-	/// Reports whether a Moonbeam or Ethereum block is finalized.
+	/// Reports whether a Substrate or Ethereum block is finalized.
 	/// Returns false if the block is not found.
 	#[rpc(name = "moon_isBlockFinalized")]
 	fn is_block_finalized(&self, block_hash: H256) -> BoxFuture<'static, RpcResult<bool>>;
 
-	/// Reports whether a Moonbeam or Ethereum transaction is finalized.
+	/// Reports whether an Ethereum transaction is finalized.
 	/// Returns false if the transaction is not found
 	#[rpc(name = "moon_isTxFinalized")]
 	fn is_tx_finalized(&self, tx_hash: H256) -> BoxFuture<'static, RpcResult<bool>>;

--- a/client/rpc/finality/src/lib.rs
+++ b/client/rpc/finality/src/lib.rs
@@ -1,0 +1,117 @@
+// Copyright 2019-2021 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+use fc_rpc::frontier_backend_client::{self, is_canon};
+use futures::{future::BoxFuture, FutureExt as _};
+use jsonrpc_core::Result as RpcResult;
+use jsonrpc_derive::rpc;
+use sp_core::H256;
+use std::{marker::PhantomData, sync::Arc};
+//TODO ideally we wouldn't depend on BlockId here. Can we change frontier
+// so it's load_hash helper returns an H256 instead of wrapping it in a BlockId?
+use fc_db::Backend as FrontierBackend;
+use sp_api::BlockId;
+use sp_blockchain::HeaderBackend;
+use sp_runtime::traits::Block;
+
+/// An RPC endpoint to check for finality of blocks and transactions in Moonbeam
+#[rpc(server)]
+pub trait MoonbeamFinalityApi {
+	/// Reports whether a Moonbeam or Ethereum block is finalized.
+	/// Returns false if the block is not found.
+	#[rpc(name = "moon_isBlockFinalized")]
+	fn is_block_finalized(&self, block_hash: H256) -> BoxFuture<'static, RpcResult<bool>>;
+
+	/// Reports whether a Moonbeam or Ethereum transaction is finalized.
+	/// Returns false if the transaction is not found
+	#[rpc(name = "moon_isTxFinalized")]
+	fn is_tx_finalized(&self, tx_hash: H256) -> BoxFuture<'static, RpcResult<bool>>;
+}
+
+pub struct MoonbeamFinality<B: Block, C> {
+	pub backend: Arc<FrontierBackend<B>>,
+	pub client: Arc<C>,
+	_phdata: PhantomData<B>,
+}
+
+impl<B: Block, C> MoonbeamFinality<B, C> {
+	pub fn new(client: Arc<C>, backend: Arc<FrontierBackend<B>>) -> Self {
+		Self {
+			backend,
+			client,
+			_phdata: Default::default(),
+		}
+	}
+}
+
+impl<B, C> MoonbeamFinalityApi for MoonbeamFinality<B, C>
+where
+	B: Block<Hash = H256>,
+	C: HeaderBackend<B> + Send + Sync + 'static,
+{
+	fn is_block_finalized(&self, raw_hash: H256) -> BoxFuture<'static, RpcResult<bool>> {
+		let backend = self.backend.clone();
+		let client = self.client.clone();
+		async move { is_block_finalized_inner::<B, C>(&backend, &client, raw_hash) }.boxed()
+	}
+
+	fn is_tx_finalized(&self, tx_hash: H256) -> BoxFuture<'static, RpcResult<bool>> {
+		let backend = self.backend.clone();
+		let client = self.client.clone();
+		async move {
+			if let Some((ethereum_block_hash, _ethereum_index)) =
+				frontier_backend_client::load_transactions::<B, C>(
+					&client,
+					backend.as_ref(),
+					tx_hash,
+					true,
+				)? {
+				is_block_finalized_inner::<B, C>(&backend, &client, ethereum_block_hash)
+			} else {
+				Ok(false)
+			}
+		}
+		.boxed()
+	}
+}
+
+fn is_block_finalized_inner<B: Block<Hash = H256>, C: HeaderBackend<B> + 'static>(
+	backend: &FrontierBackend<B>,
+	client: &C,
+	raw_hash: H256,
+) -> RpcResult<bool> {
+	let substrate_hash = match frontier_backend_client::load_hash::<B>(backend, raw_hash)? {
+		// If we find this hash in the frontier data base, we know it is an eth hash
+		Some(BlockId::Hash(hash)) => hash,
+		Some(BlockId::Number(_)) => panic!("is_canon test only works with hashes."),
+		// Otherwise, we assume this is a Substrate hash.
+		None => raw_hash,
+	};
+
+	// First check whether the block is in the best chain
+	if !is_canon(client, substrate_hash) {
+		return Ok(false);
+	}
+
+	// At this point we know the block in question is in the current best chain.
+	// It's just a question of whether it is in the finalized prefix or not
+	let query_height = client
+		.number(substrate_hash)
+		.expect("No sp_blockchain::Error should be thrown when looking up hash")
+		.expect("Block is already known to be canon, so it must be in the chain");
+	let finalized_height = client.info().finalized_number;
+
+	Ok(query_height <= finalized_height)
+}

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -32,6 +32,7 @@ trie-root = "0.15.2"
 cli-opt = { package = "moonbeam-cli-opt", path = "../cli-opt" }
 manual-xcm-rpc = { path = "../../client/rpc/manual-xcm" }
 moonbeam-core-primitives = { path = "../../core-primitives" }
+moonbeam-finality-rpc = { path = "../../client/rpc/finality" }
 moonbeam-primitives-ext = { path = "../../primitives/ext" }
 moonbeam-rpc-debug = { path = "../../client/rpc/debug" }
 moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug" }

--- a/node/service/src/rpc.rs
+++ b/node/service/src/rpc.rs
@@ -38,6 +38,7 @@ use futures::StreamExt;
 use jsonrpc_pubsub::manager::SubscriptionManager;
 use manual_xcm_rpc::{ManualXcm, ManualXcmApi};
 use moonbeam_core_primitives::{Block, Hash};
+use moonbeam_finality_rpc::{MoonbeamFinality, MoonbeamFinalityApi};
 use moonbeam_rpc_txpool::{TxPool, TxPoolServer};
 use pallet_ethereum::EthereumStorageSchema;
 use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
@@ -207,7 +208,7 @@ where
 	if let Some(filter_pool) = filter_pool {
 		io.extend_with(EthFilterApiServer::to_delegate(EthFilterApi::new(
 			client.clone(),
-			frontier_backend,
+			frontier_backend.clone(),
 			filter_pool,
 			500_usize, // max stored filters
 			overrides.clone(),
@@ -238,6 +239,11 @@ where
 			graph,
 		)));
 	}
+
+	io.extend_with(MoonbeamFinalityApi::to_delegate(MoonbeamFinality::new(
+		client.clone(),
+		frontier_backend.clone(),
+	)));
 
 	if let Some(command_sink) = command_sink {
 		io.extend_with(


### PR DESCRIPTION
### What does it do?

This PR is a replacement for #998.

This PR adds two new RPC endpoints to the Moonbeam node, that are useful for checking whether an on-chain event is finalized.

- [x] `moon_isBlockFinalized`
- [x] `moon_isTxFinalized`

The method `moon_isBlockFinalized` accept either Substrate-style or ethereum-style hashes as its input.
The method `moon_isTxFinalized` accept **only ethereum-style hashes** as its input.

These methods are useful for high-stakes projects that require a strong notion of finality, such as bridges. Typically, in Ethereum mainnet, such applications will wait for a certain number of block confirmations which guarantees a certain degree of finality according to the PoW mechanism. However, in Moonbeam, we do not have PoW and we do have deterministic finality provided by the relay chain's Grandpa validators. These RPC endpoints provide a simple way for applications to adapt to moonbeam with minimal changes to their code.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
