### PR TITLE
ci: retrigger build workflow if tracing label id added

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
   ####### Check files and formatting #######
 
   set-tags:
-    if: github.event.label == undefined || github.event.label.name == 'A10-evmtracing'
+    if: github.event.label.name == '' || github.event.label.name == 'A10-evmtracing'
     runs-on: ubuntu-latest
     outputs:
       git_branch: ${{ steps.check-git-ref.outputs.git_branch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ name: Build
 
 on:
   pull_request:
+    types: [labeled, opened, reopened, synchronize]
   push:
     branches:
       - master
@@ -20,6 +21,7 @@ jobs:
   ####### Check files and formatting #######
 
   set-tags:
+    if: github.event.label.name || github.event.label.name == 'A10-evmtracing'
     runs-on: ubuntu-latest
     outputs:
       git_branch: ${{ steps.check-git-ref.outputs.git_branch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
   ####### Check files and formatting #######
 
   set-tags:
-    if: github.event.label.name || github.event.label.name == 'A10-evmtracing'
+    if: github.event.label == undefined || github.event.label.name == 'A10-evmtracing'
     runs-on: ubuntu-latest
     outputs:
       git_branch: ${{ steps.check-git-ref.outputs.git_branch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ name: Build
 
 on:
   pull_request:
-    types: [labeled, opened, reopened, synchronize]
+    types: [converted_to_draft, opened, reopened, synchronize]
   push:
     branches:
       - master
@@ -21,7 +21,6 @@ jobs:
   ####### Check files and formatting #######
 
   set-tags:
-    if: github.event.label.name == '' || github.event.label.name == 'A10-evmtracing'
     runs-on: ubuntu-latest
     outputs:
       git_branch: ${{ steps.check-git-ref.outputs.git_branch }}


### PR DESCRIPTION
### What does it do?

Adds a way to manually force the retriggering of the GH workflow build (with re-evaluation of the execution context) if needed.

For example, we need to do this when we add the `A10-tracing` label, because we want the GH workflow build to be replayed with the tracing tests.

### What important points reviewers should know?

Unfortunately, we can't just restart the workflow from the GH actions menu, because the workflow will be restarted with the same "execution context", so it won't take into account the label changes.

We can't add label changes to the events that trigger the workflow build either, because in this case the workflow build is reset at each label change. And even if we add a condition to the workflow that depends on the added/removed label, the previous execution of the workflow is lost, so we will have to replay the whole workflow to merge the PR, even if the added/removed label was not supposed to replay the whole build.

The only solution I found is to have a manual way to force GH to retrigger the workflow build by reevaluating the execution context, to do this I added the `converted_to_draft` event to the list of events that trigger the workflow build.
If needed, we will have to draft the PR and then revert it to "ready to review".

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
