### PR TITLE
Patch ethereum `0.11.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,8 +2241,7 @@ dependencies = [
 [[package]]
 name = "ethereum"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c90e0a755da706ce0970ec0fa8cc48aabcc8e8efa1245336acf718dab06ffe"
+source = "git+https://github.com/purestake/ethereum?branch=tgm-0.11.1-typeinfo-patch#90fd8599616b349ac615e681422c26d77d6d2c0d"
 dependencies = [
  "bytes 1.0.1",
  "ethereum-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ members = [
 
 [profile.release]
 panic = "unwind"
+
+[patch.crates-io]
+ethereum = { git = "https://github.com/purestake/ethereum", branch = "tgm-0.11.1-typeinfo-patch" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ members = [
 	"runtime/moonriver",
 ]
 
-[profile.release]
-panic = "unwind"
-
 [patch.crates-io]
 ethereum = { git = "https://github.com/purestake/ethereum", branch = "tgm-0.11.1-typeinfo-patch" }
+
+[profile.release]
+panic = "unwind"

--- a/tests/tests/test-ext-eth-data.ts
+++ b/tests/tests/test-ext-eth-data.ts
@@ -3,28 +3,133 @@ import { GENESIS_ACCOUNT } from "../util/constants";
 import { describeDevMoonbeam } from "../util/setup-dev-tests";
 import { createTransfer } from "../util/transactions";
 
-describeDevMoonbeam("Ethereum Extrinsic", (context) => {
-  it("should contain valid Ethereum data", async function () {
-    const testAddress = "0x1111111111111111111111111111111111111111";
-    await context.createBlock({
-      transactions: [await createTransfer(context, testAddress, 512)],
-    });
+describeDevMoonbeam(
+  "Ethereum Extrinsic (Legacy)",
+  (context) => {
+    it("should contain valid legacy Ethereum data", async function () {
+      const testAddress = "0x1111111111111111111111111111111111111111";
+      await context.createBlock({
+        transactions: [await createTransfer(context, testAddress, 512)],
+      });
 
-    const signedBlock = await context.polkadotApi.rpc.chain.getBlock();
-    expect(
-      signedBlock.block.extrinsics.find((ex) => ex.method.section == "ethereum").args[0].toJSON()
-    ).to.include({
-      nonce: 0,
-      gasPrice: 1000000000,
-      gasLimit: 12000000,
-      action: { call: "0x1111111111111111111111111111111111111111" },
-      value: 512,
-      input: "0x",
-      signature: {
-        v: 2598,
-        r: "0x8c69faf613b9f72dbb029bb5d5acf42742d214c79743507e75fdc8adecdee928",
-        s: "0x01be4f58ff278ac61125a81a582a717d9c5d6554326c01b878297c6522b12282",
-      },
+      const signedBlock = await context.polkadotApi.rpc.chain.getBlock();
+      let extrinsic = signedBlock.block.extrinsics.find((ex) => ex.method.section == "ethereum")
+        .args[0] as any;
+      expect(extrinsic.isLegacy).to.be.true;
+      expect(extrinsic.asLegacy.toJSON()).to.deep.equal({
+        nonce: 0,
+        gasPrice: 1000000000,
+        gasLimit: 12000000,
+        action: { call: "0x1111111111111111111111111111111111111111" },
+        value: 512,
+        input: "0x",
+        signature: {
+          v: 2598,
+          r: "0x8c69faf613b9f72dbb029bb5d5acf42742d214c79743507e75fdc8adecdee928",
+          s: "0x01be4f58ff278ac61125a81a582a717d9c5d6554326c01b878297c6522b12282",
+        },
+      });
     });
-  });
-});
+  },
+  "Legacy",
+  false
+);
+
+describeDevMoonbeam(
+  "Ethereum Extrinsic (EIP2930)",
+  (context) => {
+    it("should contain valid EIP2930 Ethereum data", async function () {
+      const testAddress = "0x1111111111111111111111111111111111111111";
+      // Accesslist mock data, it doesn't matter.
+      await context.createBlock({
+        transactions: [
+          await createTransfer(context, testAddress, 512, {
+            accessList: [
+              [
+                "0x0000000000000000000000000000000000000000",
+                ["0x0000000000000000000000000000000000000000000000000000000000000000"],
+              ],
+            ],
+          }),
+        ],
+      });
+
+      const signedBlock = await context.polkadotApi.rpc.chain.getBlock();
+      let extrinsic = signedBlock.block.extrinsics.find((ex) => ex.method.section == "ethereum")
+        .args[0] as any;
+      expect(extrinsic.isEip2930).to.be.true;
+      expect(extrinsic.asEip2930.toJSON()).to.deep.equal({
+        chainId: 1281,
+        nonce: 0,
+        gasPrice: 1000000000,
+        gasLimit: 12000000,
+        action: {
+          call: "0x1111111111111111111111111111111111111111",
+        },
+        value: 512,
+        input: "0x",
+        accessList: [
+          {
+            address: "0x0000000000000000000000000000000000000000",
+            storageKeys: ["0x0000000000000000000000000000000000000000000000000000000000000000"],
+          },
+        ],
+        oddYParity: true,
+        r: "0xb3afc47c1048d0a7d02bd90cfd90dffcdaa26fddc1644df23439b5ce94d19f1a",
+        s: "0x5cfa40c0c59e5c67fd2dac5bc0934c8d7f8b9970c153c878e2c8a1f23c67a3b9",
+      });
+    });
+  },
+  "EIP2930",
+  false
+);
+
+describeDevMoonbeam(
+  "Ethereum Extrinsic (EIP1559)",
+  (context) => {
+    it("should contain valid EIP1559 Ethereum data", async function () {
+      const testAddress = "0x1111111111111111111111111111111111111111";
+      // Accesslist mock data, it doesn't matter.
+      await context.createBlock({
+        transactions: [
+          await createTransfer(context, testAddress, 512, {
+            accessList: [
+              [
+                "0x0000000000000000000000000000000000000000",
+                ["0x0000000000000000000000000000000000000000000000000000000000000000"],
+              ],
+            ],
+          }),
+        ],
+      });
+
+      const signedBlock = await context.polkadotApi.rpc.chain.getBlock();
+      let extrinsic = signedBlock.block.extrinsics.find((ex) => ex.method.section == "ethereum")
+        .args[0] as any;
+      expect(extrinsic.isEip1559).to.be.true;
+      expect(extrinsic.asEip1559.toJSON()).to.deep.equal({
+        chainId: 1281,
+        nonce: 0,
+        maxPriorityFeePerGas: 0,
+        maxFeePerGas: 1000000000,
+        gasLimit: 12000000,
+        action: {
+          call: "0x1111111111111111111111111111111111111111",
+        },
+        value: 512,
+        input: "0x",
+        accessList: [
+          {
+            address: "0x0000000000000000000000000000000000000000",
+            storageKeys: ["0x0000000000000000000000000000000000000000000000000000000000000000"],
+          },
+        ],
+        oddYParity: false,
+        r: "0x7477d1ec3db20e2726a69e7aab7e1b6beda2a312222e4db85c316cc796e655bf",
+        s: "0x53b7ae2a82b3cebaaec6086620bcf683c5171d5669152280f56bdfc9e322f284",
+      });
+    });
+  },
+  "EIP1559",
+  false
+);

--- a/tests/tests/test-ext-eth-data.ts
+++ b/tests/tests/test-ext-eth-data.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+import { GENESIS_ACCOUNT } from "../util/constants";
+import { describeDevMoonbeam } from "../util/setup-dev-tests";
+import { createTransfer } from "../util/transactions";
+
+describeDevMoonbeam("Ethereum Extrinsic", (context) => {
+  it("should contain valid Ethereum data", async function () {
+    const testAddress = "0x1111111111111111111111111111111111111111";
+    await context.createBlock({
+      transactions: [await createTransfer(context, testAddress, 512)],
+    });
+
+    const signedBlock = await context.polkadotApi.rpc.chain.getBlock();
+    expect(
+      signedBlock.block.extrinsics.find((ex) => ex.method.section == "ethereum").args[0].toJSON()
+    ).to.include({
+      nonce: 0,
+      gasPrice: 1000000000,
+      gasLimit: 12000000,
+      action: { call: "0x1111111111111111111111111111111111111111" },
+      value: 512,
+      input: "0x",
+      signature: {
+        v: 2598,
+        r: "0x8c69faf613b9f72dbb029bb5d5acf42742d214c79743507e75fdc8adecdee928",
+        s: "0x01be4f58ff278ac61125a81a582a717d9c5d6554326c01b878297c6522b12282",
+      },
+    });
+  });
+});

--- a/tests/tests/test-nonce.ts
+++ b/tests/tests/test-nonce.ts
@@ -55,7 +55,7 @@ describeDevMoonbeam("Nonce - Pending transaction", (context) => {
 });
 
 describeDevMoonbeam("Nonce - Transferring", (context) => {
-  it("Setup: Sending token", async function () {
+  before("Setup: Sending token", async function () {
     await context.createBlock({
       transactions: [
         await createTransfer(context, "0x1111111111111111111111111111111111111111", 512),


### PR DESCRIPTION
### What does it do?

- Include https://github.com/rust-blockchain/ethereum/pull/35
- Add ts tests

### What important points reviewers should know?

With the introduction of Ethereum enveloped transactions, type metadata for the Ethereum extrinsics changed.

Previously a unique composite object contained the metadata for a transaction. Now there are 3 supported transaction types: `Legacy`, `EIP2930` and `EIP1559`.

Using PolkadotJS library, one can identify which transaction type is wrapped in a extrinsic:

```
let ethTxWrapper = extrinsic.method.args[0] as any;
if (ethTxWrapper.isLegacy) {
    let tx = ethTxWrapper.asLegacy;
    // ..
} else if (ethTxWrapper.isEip2930) {
    let tx = ethTxWrapper.asEip2930;
    // ..
} else if (ethTxWrapper.isEip1559) {
    let tx = ethTxWrapper.asEip1559;
    // ..
}
```

### Legacy transaction

```
nonce: number,
gasPrice: number,
gasLimit: number,
action: object // { call: .. } | { create: .. },
value: number,
input: bytes,
signature: object // {v: .., r: .., s: ..},
```

### EIP2930 transaction

```
chainId: number,
nonce: number,
gasPrice: number,
gasLimit: number,
action: object // { call: .. } | { create: .. },
value: number,
input: bytes,
accessList: array<{address: 20-byte hash, storageKeys: array<32-byte hash>}>,
oddYParity: bool,
r: 32-byte hash
s: 32-byte hash
```

### EIP1559 transaction

```
chainId: number,
nonce: number,
maxPriorityFeePerGas: number,
masFeePerGas: number,
gasLimit: number,
action: object // { call: .. } | { create: .. },
value: number,
input: bytes,
accessList: array<{address: 20-byte hash, storageKeys: array<32-byte hash>}>,
oddYParity: bool,
r: 32-byte hash
s: 32-byte hash
```
### Is there something left for follow-up PRs?

Move to ethereum 0.11.2 once it's merged and released.
