### PR TITLE
Fix incorrect check to see if previous migration already passed

### DIFF
--- a/pallets/asset-manager/src/migrations.rs
+++ b/pallets/asset-manager/src/migrations.rs
@@ -365,8 +365,19 @@ where
 						used_weight = used_weight.saturating_add(2 * db_weights.write);
 					}
 
+					// This is checked in case UnitsWithAssetType runs first
+					if let Some(units) = AssetTypeUnitsPerSecond::<T>::get(&asset_type) {
+						// We need to update AssetTypeUnitsPerSecond too
+						AssetTypeUnitsPerSecond::<T>::remove(&asset_type);
+						AssetTypeUnitsPerSecond::<T>::insert(&new_asset_type, units);
+
+						// Update weight due to this branch
+						used_weight = used_weight.saturating_add(2 * db_weights.write);
+					}
+
 					// Update used weight
-					used_weight = used_weight.saturating_add(db_weights.write + db_weights.read);
+					used_weight =
+						used_weight.saturating_add(db_weights.write + 2 * db_weights.read);
 				}
 				_ => continue,
 			}

--- a/pallets/asset-manager/src/migrations.rs
+++ b/pallets/asset-manager/src/migrations.rs
@@ -366,9 +366,8 @@ where
 					}
 
 					// This is checked in case UnitsWithAssetType runs first
-					if let Some(units) = AssetTypeUnitsPerSecond::<T>::get(&asset_type) {
+					if let Some(units) = AssetTypeUnitsPerSecond::<T>::take(&asset_type) {
 						// We need to update AssetTypeUnitsPerSecond too
-						AssetTypeUnitsPerSecond::<T>::remove(&asset_type);
 						AssetTypeUnitsPerSecond::<T>::insert(&new_asset_type, units);
 
 						// Update weight due to this branch

--- a/pallets/asset-manager/src/tests.rs
+++ b/pallets/asset-manager/src/tests.rs
@@ -293,7 +293,7 @@ fn test_asset_manager_change_statemine_prefixes() {
 
 		let asset_id: mock::AssetId = statemine_multilocation.clone().into();
 
-		// We are gonna test thre cases:
+		// We are gonna test three cases:
 		// Case 1: AssetManagerPopulateAssetTypeIdStorage has not executed yet
 		// (only AssetIdType is populated)
 		// Case 2: AssetManagerPopulateAssetTypeIdStorage has already executed
@@ -313,7 +313,7 @@ fn test_asset_manager_change_statemine_prefixes() {
 			statemine_multilocation
 		);
 
-		// To mimic case 2, we can simply register the asset trough the extrinsic
+		// To mimic case 2, we can simply register the asset through the extrinsic
 		assert_ok!(AssetManager::register_asset(
 			Origin::root(),
 			statemine_multilocation_2.clone(),
@@ -322,7 +322,7 @@ fn test_asset_manager_change_statemine_prefixes() {
 			true
 		));
 
-		// To mimic case 3, we can simply register the asset trough the extrinsic
+		// To mimic case 3, we can simply register the asset through the extrinsic
 		// But we also need to set units per second
 		assert_ok!(AssetManager::register_asset(
 			Origin::root(),


### PR DESCRIPTION
### What does it do?
While trying all migrations locally realized that if UnitsWithAssetType runs before ChangeStateminePrefixes we have an inconsistency. This fixes it and adds  a test for it
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
