### PR TITLE
Updating bootnodes

### DIFF
--- a/specs/moonriver/parachain-embedded-specs.json
+++ b/specs/moonriver/parachain-embedded-specs.json
@@ -3,10 +3,10 @@
   "id": "moonriver",
   "chainType": "Live",
   "bootNodes": [
-    "/dns4/bootnode1.moonriver.moonbeam.network/tcp/30334/p2p/12D3KooWDh3gKFpsY9GrzYcWR8iqdBagMjkgHC1a7QNHVVWg8FC3",
-    "/dns4/bootnode2.moonriver.moonbeam.network/tcp/30334/p2p/12D3KooWBaQTfVqXtjgNCDiWwawfs4txPqV7Q1MU6SKp75AHuAv9",
-    "/dns4/bootnode3.moonriver.moonbeam.network/tcp/30334/p2p/12D3KooWPiX8VNtGR27k4g4pueFZwfdpUsQTrjozQoB9Wo6VkYnD",
-    "/dns4/bootnode4.moonriver.moonbeam.network/tcp/30334/p2p/12D3KooWJBVsJCh61QD98NACNDENtamETuLRnPhoWzPwNYeH7WFB",
+    "/dns4/frag-moonriver-boot-0.g.moonriver.moonbeam.network/tcp/30333/p2p/12D3KooWETqnA44kqfmP27qUnHSvPWgrBPytVutnP9FxwKLAU57p",
+    "/dns4/lona-moonriver-boot-0.a.moonriver.moonbeam.network/tcp/30333/p2p/12D3KooWCW7mEdj6hmq3rVRjH3QoexzZ36EAg5ighJGxrfNz3xqb",
+    "/dns4/sina-moonriver-boot-0.a.moonriver.moonbeam.network/tcp/30333/p2p/12D3KooWHVKiJnTUd7uAR9XHKnT4NwBWUZ6fuZFTCYvHgGYeefAt",
+    "/dns4/mtlg-moonriver-boot-0.g.moonriver.moonbeam.network/tcp/30333/p2p/12D3KooWEuSCBb17SeRHRm5Whs3RvT1Y7hukYEMh8ecC5Knr7sdx",
     "/dns4/node-6844441322559299584-0.p2p.onfinality.io/tcp/27387/ws/p2p/12D3KooWPtd4griLrKn6XnrGfBCacNVvBGj8vnYGVbyC7iHetKq4",
     "/dns4/node-6844484891634491392-0.p2p.onfinality.io/tcp/14108/ws/p2p/12D3KooWRGTB3pGd95amXNGTqVuVQW7oeTP5BDemD1d63TSnini8"
   ],


### PR DESCRIPTION
### What does it do?
Updates Moonrivers bootnode list
### What important points reviewers should know?
Address updates, two bootnodes in aws and two in gcp
Ports are switched, parachain using 30333 and relay chain using 30334
### Is there something left for follow-up PRs?
No
### What alternative implementations were considered?
None
### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?
No
### What value does it bring to the blockchain users?
Continued access to bootnodes