### PR TITLE
Adds --parachain-runtime parameter to launch script

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -23,7 +23,7 @@ npm install
 ### Usage
 
 ```
-npm run launch -- --parachain moonbase-0.11.2
+npm run launch -- --parachain moonbase-0.18.1
 ```
 
 The launch script accepts a preconfigured network (default is "local", see further).
@@ -66,8 +66,9 @@ local: {
   binary: "../../polkadot/target/release/polkadot",
   chain: "rococo-local",
 },
-
 ```
+
+In addition, you can run a runtime different from the client using `--parachain-runtime <git-tag>`
 
 - "binary" is the path to the binary to execute (related to the tools folder)
 
@@ -91,6 +92,8 @@ Options:
                      [choices: "moonbase", "moonriver", "moonbeam",
                       "moonbase-local", "moonriver-local",
                       "moonbeam-local"]
+
+  --parachain-runtime <git-tag> to use for runtime specs                [string]
 
   --parachain-id     overrides parachain-id             [number] [default: 1000]
 

--- a/tools/launch.ts
+++ b/tools/launch.ts
@@ -189,6 +189,24 @@ const relayNames = Object.keys(relays);
 // We support 3 parachains for now
 const validatorNames = ["Alice", "Bob", "Charlie", "Dave", "Eve", "Ferdie"];
 
+const retrieveBinaryFromDocker = async (binaryPath: string, dockerImage: string) => {
+  if (process.platform != "linux") {
+    console.error(
+      `docker binaries are only supported on linux. Use "local" config for compiled binaries`
+    );
+    process.exit(1);
+  }
+  const parachainPath = path.join(__dirname, binaryPath);
+  if (!fs.existsSync(parachainPath)) {
+    console.log(`     Missing ${binaryPath} locally, downloading it...`);
+    child_process.execSync(`mkdir -p ${path.dirname(parachainPath)} && \
+        docker create --name moonbeam-tmp ${dockerImage} && \
+        docker cp moonbeam-tmp:/moonbeam/moonbeam ${parachainPath} && \
+        docker rm moonbeam-tmp`);
+    console.log(`${binaryPath} downloaded !`);
+  }
+};
+
 async function start() {
   const argv = yargs(process.argv.slice(2))
     .usage("Usage: npm run launch [args]")
@@ -203,6 +221,11 @@ async function start() {
       "parachain-chain": {
         type: "string",
         describe: "overrides parachain chain/runtime",
+      },
+      "parachain-runtime": {
+        type: "string",
+        describe: "overrides parachain runtime",
+        conflicts: ["parachain-chain"],
       },
       "parachain-id": { type: "number", default: 1000, describe: "overrides parachain-id" },
       relay: {
@@ -252,6 +275,24 @@ async function start() {
     }
   }
 
+  if (argv["parachain-runtime"]) {
+    const sha = child_process.execSync(`git rev-list -1 ${argv["parachain-runtime"]}`);
+    if (!sha) {
+      console.error(`Invalid runtime tag ${argv["parachain-runtime"]}`);
+      return;
+    }
+    const sha8 = sha.slice(0, 8);
+    console.log(`Using runtime from sha: ${sha8}`);
+
+    const parachainBinary = `build/sha-${sha8}/moonbeam`;
+    const parachainPath = path.join(__dirname, parachainBinary);
+    retrieveBinaryFromDocker(parachainBinary, `purestake/moonbeam:sha-${sha8}`);
+
+    child_process.execSync(
+      `${parachainBinary} build-spec --chain moonbase-local --raw > moonbase-${argv["parachain-runtime"]}-raw-spec.json`
+    );
+  }
+
   if (Array.isArray(argv.parachain)) {
     for (let i = 0; i < argv.parachain.length; i++) {
       if (i >= paraIds.length) {
@@ -267,8 +308,11 @@ async function start() {
       const parachainName = argv.parachain[i].toString();
       parasNames.push(parachainName);
       paras.push(parachains[parachainName]);
+      if (argv["parachain-runtime"]) {
+        parachainsChains.push(`moonbase-${argv["parachain-runtime"]}-raw-spec.json`);
+      }
       // If it is an array, push the position at which we are
-      if (Array.isArray(argv["parachain-chain"])) {
+      else if (Array.isArray(argv["parachain-chain"])) {
         parachainsChains.push(argv["parachain-chain"] || parachains[parachainName].chain);
       }
       // Else, push the value to the first parachain if it exists, else the default
@@ -287,7 +331,12 @@ async function start() {
     const parachainName = argv.parachain.toString();
     parasNames.push(parachainName);
     paras.push(parachains[parachainName]);
-    parachainsChains.push(argv["parachain-chain"] || parachains[parachainName].chain);
+
+    parachainsChains.push(
+      argv["parachain-runtime"]
+        ? `moonbase-${argv["parachain-runtime"]}-raw-spec.json`
+        : argv["parachain-chain"] || parachains[parachainName].chain
+    );
   }
 
   const relayName = argv.relay || paras[0].relay;
@@ -319,22 +368,10 @@ async function start() {
       }
       parachainPaths.push(parachainPath);
     } else {
-      if (process.platform != "linux") {
-        console.log(
-          `docker binaries are only supported on linux. Use "local" config for compiled binaries`
-        );
-        return;
-      }
       const parachainBinary = `build/${parasNames[i]}/moonbeam`;
       const parachainPath = path.join(__dirname, parachainBinary);
-      if (!fs.existsSync(parachainPath)) {
-        console.log(`     Missing ${parachainBinary} locally, downloading it...`);
-        child_process.execSync(`mkdir -p ${path.dirname(parachainPath)} && \
-            docker create --name moonbeam-tmp ${paras[i].docker} && \
-            docker cp moonbeam-tmp:/moonbeam/moonbeam ${parachainPath} && \
-            docker rm moonbeam-tmp`);
-        console.log(`${parachainBinary} downloaded !`);
-      }
+
+      retrieveBinaryFromDocker(parachainBinary, paras[i].docker);
       parachainBinaries.push(parachainBinary);
       parachainPaths.push(parachainPath);
     }

--- a/tools/launch.ts
+++ b/tools/launch.ts
@@ -224,7 +224,7 @@ async function start() {
       },
       "parachain-runtime": {
         type: "string",
-        describe: "overrides parachain runtime",
+        describe: "<git-tag> to use for runtime specs",
         conflicts: ["parachain-chain"],
       },
       "parachain-id": { type: "number", default: 1000, describe: "overrides parachain-id" },

--- a/tools/launch.ts
+++ b/tools/launch.ts
@@ -289,7 +289,8 @@ async function start() {
     retrieveBinaryFromDocker(parachainBinary, `purestake/moonbeam:sha-${sha8}`);
 
     child_process.execSync(
-      `${parachainBinary} build-spec --chain moonbase-local --raw > moonbase-${argv["parachain-runtime"]}-raw-spec.json`
+      `${parachainBinary} build-spec --chain moonbase-local --raw > ` +
+        `moonbase-${argv["parachain-runtime"]}-raw-spec.json`
     );
   }
 


### PR DESCRIPTION
Using `--parachain-runtime <git-tag>` will force the specs to be generated from that given moonbeam version.