### PR TITLE
Fix staking precompile selector comments

### DIFF
--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -71,7 +71,7 @@ interface ParachainStaking {
         returns (uint256);
 
     /// @dev Get the CandidateDelegationCount weight hint
-    /// Selector: 075bf970
+    /// Selector: 815b796c
     /// @param candidate The address for which we are querying the nomination count
     /// @return The number of nominations backing the collator
     function candidate_delegation_count(address candidate)
@@ -117,8 +117,9 @@ interface ParachainStaking {
     function schedule_leave_candidates(uint256 candidateCount) external;
 
     /// @dev Execute due request to leave the set of collator candidates
-    /// Selector: b10d6643
-    function execute_leave_candidates() external;
+    /// Selector: b0b95649
+    /// @param candidate The candidate to exit if call is successful
+    function execute_leave_candidates(address candidate) external;
 
     /// @dev Cancel request to leave the set of collator candidates
     /// Selector: 0880b3e2
@@ -198,10 +199,13 @@ interface ParachainStaking {
     function schedule_leave_delegators() external;
 
     /// @dev Execute request to leave the set of delegators and revoke all delegations
-    /// Selector: 4f7cfb20
-    /// @param delegatorDelegationCount The number of active delegations to be revoked by caller
-    function execute_leave_delegators(uint256 delegatorDelegationCount)
-        external;
+    /// Selector: a84a7468
+    /// @param delegator The leaving delegator
+    /// @param delegatorDelegationCount The number of active delegations to be revoked by delegator
+    function execute_leave_delegators(
+        address delegator,
+        uint256 delegatorDelegationCount
+    ) external;
 
     /// @dev Cancel request to leave the set of delegators
     /// Selector: 2a987643
@@ -219,16 +223,15 @@ interface ParachainStaking {
     /// @param candidate The address of the collator candidate which will no longer be supported
     function schedule_revoke_delegation(address candidate) external;
 
-    /// DEPRECATED, replaced by schedule_delegator_bond_more, execute_delegation_request,
-    /// cancel_delegation_request
+    /// DEPRECATED, replaced by delegator_bond_more
     /// @dev Request to bond more for nominators with respect to a specific collator candidate
     /// Selector: 971d44c8
     /// @param candidate The address of the collator candidate for which nomination is increased
     /// @param more The amount by which the nomination is increased
     function nominator_bond_more(address candidate, uint256 more) external;
 
-    /// @dev Bond more for nominators with respect to a specific collator candidate
-    /// Selector: 6d988413
+    /// @dev Bond more for delegators with respect to a specific collator candidate
+    /// Selector: f8331108
     /// @param candidate The address of the collator candidate for which delegation shall increase
     /// @param more The amount by which the delegation is increased
     function delegator_bond_more(address candidate, uint256 more) external;

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -18,7 +18,7 @@ use crate::mock::{
 	events, evm_test_context, precompile_address, roll_to, set_points, Call, ExtBuilder, Origin,
 	ParachainStaking, PrecompilesValue, Runtime, TestAccount, TestPrecompiles,
 };
-use crate::PrecompileOutput;
+use crate::{Action, PrecompileOutput};
 use fp_evm::PrecompileFailure;
 use frame_support::{assert_ok, dispatch::Dispatchable};
 use pallet_evm::{Call as EvmCall, ExitSucceed, PrecompileSet};
@@ -44,6 +44,62 @@ fn evm_call(source: TestAccount, input: Vec<u8>) -> EvmCall<Runtime> {
 		nonce: None, // Use the next nonce
 		access_list: Vec::new(),
 	}
+}
+
+#[test]
+fn selectors() {
+	// DEPRECATED
+	assert_eq!(Action::IsNominator as u32, 0x8e5080e7);
+	assert_eq!(Action::IsDelegator as u32, 0x1f030587);
+	assert_eq!(Action::IsCandidate as u32, 0x8545c833);
+	assert_eq!(Action::IsSelectedCandidate as u32, 0x8f6d27c7);
+	assert_eq!(Action::Points as u32, 0x9799b4e7);
+	// DEPRECATED
+	assert_eq!(Action::MinNomination as u32, 0xc9f593b2);
+	assert_eq!(Action::MinDelegation as u32, 0x72ce8933);
+	assert_eq!(Action::CandidateCount as u32, 0x4b1c4c29);
+	assert_eq!(Action::CollatorNominationCount as u32, 0x0ad6a7be);
+	assert_eq!(Action::CandidateDelegationCount as u32, 0x815b796c);
+	assert_eq!(Action::NominatorNominationCount as u32, 0xdae5659b);
+	assert_eq!(Action::DelegatorDelegationCount as u32, 0xfbc51bca);
+	assert_eq!(Action::JoinCandidates as u32, 0x0a1bff60);
+	// DEPRECATED
+	assert_eq!(Action::LeaveCandidates as u32, 0x72b02a31);
+	assert_eq!(Action::ScheduleLeaveCandidates as u32, 0x60afbac6);
+	assert_eq!(Action::ExecuteLeaveCandidates as u32, 0xb0b95649);
+	assert_eq!(Action::CancelLeaveCandidates as u32, 0x0880b3e2);
+	assert_eq!(Action::GoOffline as u32, 0x767e0450);
+	assert_eq!(Action::GoOnline as u32, 0xd2f73ceb);
+	assert_eq!(Action::CandidateBondMore as u32, 0xc57bd3a8);
+	// DEPRECATED
+	assert_eq!(Action::CandidateBondLess as u32, 0x289b6ba7);
+	assert_eq!(Action::ScheduleCandidateBondLess as u32, 0x034c47bc);
+	assert_eq!(Action::ExecuteCandidateBondLess as u32, 0xa9a2b8b7);
+	assert_eq!(Action::CancelCandidateBondLess as u32, 0x583d0fdc);
+	// DEPRECATED
+	assert_eq!(Action::Nominate as u32, 0x49df6eb3);
+	assert_eq!(Action::Delegate as u32, 0x829f5ee3);
+	// DEPRECATED
+	assert_eq!(Action::LeaveNominators as u32, 0xb71d2153);
+	assert_eq!(Action::ScheduleLeaveDelegators as u32, 0x65a5bbd0);
+	assert_eq!(Action::ExecuteLeaveDelegators as u32, 0xa84a7468);
+	assert_eq!(Action::CancelLeaveDelegators as u32, 0x2a987643);
+	// DEPRECATED
+	assert_eq!(Action::RevokeNomination as u32, 0x4b65c34b);
+	assert_eq!(Action::ScheduleRevokeDelegation as u32, 0x22266e75);
+	assert_eq!(Action::ExecuteLeaveDelegators as u32, 0xa84a7468);
+	assert_eq!(Action::CancelLeaveDelegators as u32, 0x2a987643);
+	// DEPRECATED
+	assert_eq!(Action::RevokeNomination as u32, 0x4b65c34b);
+	assert_eq!(Action::ScheduleRevokeDelegation as u32, 0x22266e75);
+	// DEPRECATED
+	assert_eq!(Action::NominatorBondMore as u32, 0x971d44c8);
+	assert_eq!(Action::DelegatorBondMore as u32, 0xf8331108);
+	// DEPRECATED
+	assert_eq!(Action::NominatorBondLess as u32, 0xf6a52569);
+	assert_eq!(Action::ScheduleDelegatorBondLess as u32, 0x00043acf);
+	assert_eq!(Action::ExecuteDelegationRequest as u32, 0xe42366a6);
+	assert_eq!(Action::CancelDelegationRequest as u32, 0x7284cf50);
 }
 
 #[test]


### PR DESCRIPTION
Adds unit test to staking precompile to verify the function selectors commented above each function in the solidity interface file.

Also fixes the incorrect function selectors.
