### PR TITLE
Early return in trader when amount to be charged is 0

### DIFF
--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -154,7 +154,7 @@ impl<
 				{
 					let amount = units_per_second.saturating_mul(weight as u128)
 						/ (WEIGHT_PER_SECOND as u128);
-					
+
 					// We dont need to proceed if the amount is 0
 					// For cases (specially tests) where the asset is very cheap with respect
 					// to the weight needed

--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -154,6 +154,14 @@ impl<
 				{
 					let amount = units_per_second.saturating_mul(weight as u128)
 						/ (WEIGHT_PER_SECOND as u128);
+					
+					// We dont need to proceed if the amount is 0
+					// For cases (specially tests) where the asset is very cheap with respect
+					// to the weight needed
+					if amount == 0 {
+						return Ok(payment);
+					}
+
 					let required = MultiAsset {
 						fun: Fungibility::Fungible(amount),
 						id: xcmAssetId::Concrete(id.clone()),

--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -158,7 +158,7 @@ impl<
 					// We dont need to proceed if the amount is 0
 					// For cases (specially tests) where the asset is very cheap with respect
 					// to the weight needed
-					if amount == 0 {
+					if amount.is_zero() {
 						return Ok(payment);
 					}
 


### PR DESCRIPTION
### What does it do?
Some of our xcm tests have been reported by @notlesh to be panicking when running in debug mode (our CI runs in release mode, thats the reason why this has not been triggered). The issue stems from the following line:

https://github.com/paritytech/polkadot/blob/e920b2f907629764b542cd8ebe78a7f550821f0f/xcm/src/v1/multiasset.rs#L164

Since some of our tests, for simplicity purposes, are set to not charge for xcm execution weight, this panick is triggered when converting a 0 amount to be charged to a MultiAsset.

This PR adds an early return in the trader if the amount to be charged is 0, fixing the above situation
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
