### PR TITLE
`DebugRuntimeApi` version 4

### DIFF
--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -479,7 +479,10 @@ where
 						let _result = api
 							.trace_transaction(&parent_block_id, ext, &transaction)
 							.map_err(|e| {
-								internal_err(format!("Runtime api access error: {:?}", e))
+								internal_err(format!(
+									"Runtime api access error (version {:?}): {:?}",
+									trace_api_version, e
+								))
 							})?
 							.map_err(|e| internal_err(format!("DispatchError: {:?}", e)))?;
 					} else {
@@ -490,7 +493,10 @@ where
 								#[allow(deprecated)]
 								api.trace_transaction_before_version_2(&parent_block_id, ext, &tx)
 									.map_err(|e| {
-										internal_err(format!("Runtime api access error: {:?}", e))
+										internal_err(format!(
+											"Runtime api access error (legacy): {:?}",
+											e
+										))
 									})?
 									.map_err(|e| internal_err(format!("DispatchError: {:?}", e)))?
 							}

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -475,7 +475,7 @@ where
 					api.initialize_block(&parent_block_id, &header)
 						.map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
 
-					if trace_api_version >= 2 {
+					if trace_api_version >= 4 {
 						let _result = api
 							.trace_transaction(&parent_block_id, ext, &transaction)
 							.map_err(|e| {
@@ -491,7 +491,7 @@ where
 							ethereum::TransactionV2::Legacy(tx) =>
 							{
 								#[allow(deprecated)]
-								api.trace_transaction_before_version_2(&parent_block_id, ext, &tx)
+								api.trace_transaction_before_version_4(&parent_block_id, ext, &tx)
 									.map_err(|e| {
 										internal_err(format!(
 											"Runtime api access error (legacy): {:?}",

--- a/primitives/rpc/debug/src/lib.rs
+++ b/primitives/rpc/debug/src/lib.rs
@@ -22,9 +22,17 @@ use ethereum_types::H256;
 use sp_std::vec::Vec;
 
 sp_api::decl_runtime_apis! {
-	#[api_version(2)]
+	// Api version is virtually 4.
+	//
+	// We realized that even using runtime overrides, using the ApiExt interface reads the api
+	// versions from the state runtime, meaning we cannot just reset the versioning as we see fit.
+	//
+	// In order to be able to use ApiExt as part of the RPC handler logic we need to be always
+	// above the version that exists on chain for this Api, even if this Api is only meant
+	// to be used overriden.
+	#[api_version(4)]
 	pub trait DebugRuntimeApi {
-		#[changed_in(2)]
+		#[changed_in(4)]
 		fn trace_transaction(
 			extrinsics: Vec<Block::Extrinsic>,
 			transaction: &LegacyTransaction,


### PR DESCRIPTION
### What does it do?

We realized that even using runtime overrides, using the `ApiExt` interface reads the api versions from the state runtime, meaning we cannot just reset the versioning as we see fit, even if this Api is only meant to be used overriden.
	
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
