### PR TITLE
Girazoki support both pre and post 0.9.16 anchoring logics for native token

### DIFF
--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -22,9 +22,12 @@ use frame_support::{
 	traits::{tokens::fungibles::Mutate, Get, OriginTrait},
 	weights::{constants::WEIGHT_PER_SECOND, Weight},
 };
-use sp_runtime::traits::Zero;
-use sp_std::borrow::Borrow;
-use sp_std::{convert::TryInto, marker::PhantomData};
+use sp_runtime::traits::{CheckedConversion, Zero};
+use sp_std::{borrow::Borrow, vec::Vec};
+use sp_std::{
+	convert::{TryFrom, TryInto},
+	marker::PhantomData,
+};
 use xcm::latest::{
 	AssetId as xcmAssetId, Error as XcmError, Fungibility,
 	Junction::{AccountKey20, Parachain},
@@ -32,13 +35,7 @@ use xcm::latest::{
 	MultiAsset, MultiLocation, NetworkId,
 };
 use xcm_builder::TakeRevenue;
-use xcm_executor::traits::{FilterAssetLocation, MatchesFungibles, WeightTrader};
-
-use sp_runtime::traits::CheckedConversion;
-use sp_std::convert::TryFrom;
-use sp_std::vec::Vec;
-use xcm::latest::Fungibility::Fungible;
-use xcm_executor::traits::MatchesFungible;
+use xcm_executor::traits::{FilterAssetLocation, MatchesFungible, MatchesFungibles, WeightTrader};
 
 /// Converter struct implementing `AssetIdConversion` converting a numeric asset ID
 /// (must be `TryFrom/TryInto<u128>`) into a MultiLocation Value and Viceversa through

--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -358,6 +358,8 @@ impl<
 
 // Multi IsConcrete Implementation. Allows us to route both pre and post 0.9.16 anchoring versions
 // of our native token to the same currency
+// The incoming MultiAsset is matched against a Vec of multilocations and returned Some
+// if matches
 pub struct MultiIsConcrete<T>(PhantomData<T>);
 impl<T: Get<Vec<MultiLocation>>, B: TryFrom<u128>> MatchesFungible<B> for MultiIsConcrete<T> {
 	fn matches_fungible(a: &MultiAsset) -> Option<B> {

--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -361,7 +361,9 @@ pub struct MultiIsConcrete<T>(PhantomData<T>);
 impl<T: Get<Vec<MultiLocation>>, B: TryFrom<u128>> MatchesFungible<B> for MultiIsConcrete<T> {
 	fn matches_fungible(a: &MultiAsset) -> Option<B> {
 		match (&a.id, &a.fun) {
-			(xcmAssetId::Concrete(ref id), Fungible(ref amount)) if T::get().contains(id) => {
+			(xcmAssetId::Concrete(ref id), Fungibility::Fungible(ref amount))
+				if T::get().contains(id) =>
+			{
 				CheckedConversion::checked_from(*amount)
 			}
 			_ => None,

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1095,7 +1095,7 @@ pub type LocalAssetTransactor = XcmCurrencyAdapter<
 	LocationToAccountId,
 	// Our chain's account ID type (we can't get away without mentioning it explicitly):
 	AccountId,
-	// We track our teleports in/out to keep total issuance correct.
+	// We dont allow teleport
 	(),
 >;
 // We use all transactors

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1450,9 +1450,10 @@ where
 {
 	fn convert(currency: CurrencyId) -> Option<MultiLocation> {
 		match currency {
-			// For now (and until we upgrade to 0.9.16 is adapted) we need to use the old anchoring here
-			// This is not a problem in either cases, since the view of the destination chain does not
-			// change
+			// For now (and until we upgrade to 0.9.16 is adapted) we need to use the old anchoring
+			// here
+			// This is not a problem in either cases, since the view of the destination chain
+			// does not change
 			// TODO! change this to NewAnchoringSelfReserve once we uprade to 0.9.16
 			CurrencyId::SelfReserve => {
 				let multi: MultiLocation = OldAnchoringSelfReserve::get();

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1018,9 +1018,10 @@ parameter_types! {
 	pub RelayChainOrigin: Origin = cumulus_pallet_xcm::Origin::Relay.into();
 	// The ancestry, defines the multilocation describing this consensus system
 	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
-	// Self Reserve location, defines the multilocation identifiying the self-reserve currency
+	// Old Self Reserve location, defines the multilocation identifiying the self-reserve currency
 	// This is used to match it against our Balances pallet when we receive such a MultiLocation
 	// (Parent, Self Para Id, Self Balances pallet index)
+	// This is the old anchoring way
 	pub OldAnchoringSelfReserve: MultiLocation = MultiLocation {
 		parents:1,
 		interior: Junctions::X2(
@@ -1028,12 +1029,19 @@ parameter_types! {
 			PalletInstance(<Runtime as frame_system::Config>::PalletInfo::index::<Balances>().unwrap() as u8)
 		)
 	};
+	// Bew Self Reserve location, defines the multilocation identifiying the self-reserve currency
+	// This is used to match it also against our Balances pallet when we receive such
+	// a MultiLocation: (Self Balances pallet index)
+	// This is the new anchoring way
 	pub NewAnchoringSelfReserve: MultiLocation = MultiLocation {
 		parents:0,
 		interior: Junctions::X1(
 			PalletInstance(<Runtime as frame_system::Config>::PalletInfo::index::<Balances>().unwrap() as u8)
 		)
 	};
+
+	// The Locations we accept to refer to our own currency. We need to support both pre and
+	// post 0.9.16 versions, hence the reason for this being a Vec
 	pub SelfReserveRepresentations: Vec<MultiLocation> = vec![
 		OldAnchoringSelfReserve::get(),
 		NewAnchoringSelfReserve::get()
@@ -1080,7 +1088,8 @@ pub type FungiblesTransactor = FungiblesAdapter<
 pub type LocalAssetTransactor = XcmCurrencyAdapter<
 	// Use this currency:
 	Balances,
-	// Use this currency when it is a fungible asset matching the given location or name:
+	// Use this currency when it is a fungible asset matching any of the locations in
+	// SelfReserveRepresentations
 	xcm_primitives::MultiIsConcrete<SelfReserveRepresentations>,
 	// We can convert the MultiLocations with our converter above:
 	LocationToAccountId,
@@ -1444,6 +1453,7 @@ where
 			// For now (and until we upgrade to 0.9.16 is adapted) we need to use the old anchoring here
 			// This is not a problem in either cases, since the view of the destination chain does not
 			// change
+			// TODO! change this to NewAnchoringSelfReserve once we uprade to 0.9.16
 			CurrencyId::SelfReserve => {
 				let multi: MultiLocation = OldAnchoringSelfReserve::get();
 				Some(multi)

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1090,10 +1090,7 @@ pub type LocalAssetTransactor = XcmCurrencyAdapter<
 	(),
 >;
 // We use all transactors
-pub type AssetTransactors = (
-	LocalAssetTransactor,
-	FungiblesTransactor,
-);
+pub type AssetTransactors = (LocalAssetTransactor, FungiblesTransactor);
 
 /// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
 /// ready for dispatching a transaction with Xcm's `Transact`. There is an `OriginKind` which can

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -54,7 +54,7 @@ use xcm_builder::{
 	AccountKey20Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, ConvertedConcreteAssetId,
 	CurrencyAdapter as XcmCurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds, FungiblesAdapter,
-	IsConcrete, LocationInverter, ParentAsSuperuser, ParentIsDefault, RelayChainAsNative,
+	LocationInverter, ParentAsSuperuser, ParentIsDefault, RelayChainAsNative,
 	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountKey20AsNative,
 	SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
 };
@@ -1034,6 +1034,10 @@ parameter_types! {
 			PalletInstance(<Runtime as frame_system::Config>::PalletInfo::index::<Balances>().unwrap() as u8)
 		)
 	};
+	pub SelfReserveRepresentations: Vec<MultiLocation> = vec![
+		OldAnchoringSelfReserve::get(),
+		NewAnchoringSelfReserve::get()
+	];
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -1072,38 +1076,22 @@ pub type FungiblesTransactor = FungiblesAdapter<
 	(),
 >;
 
-/// The transactor for our own chain currency based on the old anchoring logic.
-pub type LocalAssetTransactorOldAnchoring = XcmCurrencyAdapter<
+/// The transactor for our own chain currency.
+pub type LocalAssetTransactor = XcmCurrencyAdapter<
 	// Use this currency:
 	Balances,
 	// Use this currency when it is a fungible asset matching the given location or name:
-	IsConcrete<OldAnchoringSelfReserve>,
+	xcm_primitives::MultiIsConcrete<SelfReserveRepresentations>,
 	// We can convert the MultiLocations with our converter above:
 	LocationToAccountId,
 	// Our chain's account ID type (we can't get away without mentioning it explicitly):
 	AccountId,
-	// We dont allow teleport
+	// We track our teleports in/out to keep total issuance correct.
 	(),
 >;
-
-/// The transactor for our own chain currency based on the new anchoring logic.
-pub type LocalAssetTransactorNewAnchoring = XcmCurrencyAdapter<
-	// Use this currency:
-	Balances,
-	// Use this currency when it is a fungible asset matching the given location or name:
-	IsConcrete<NewAnchoringSelfReserve>,
-	// We can convert the MultiLocations with our converter above:
-	LocationToAccountId,
-	// Our chain's account ID type (we can't get away without mentioning it explicitly):
-	AccountId,
-	// We dont allow teleport
-	(),
->;
-
 // We use all transactors
 pub type AssetTransactors = (
-	LocalAssetTransactorOldAnchoring,
-	LocalAssetTransactorNewAnchoring,
+	LocalAssetTransactor,
 	FungiblesTransactor,
 );
 
@@ -1456,8 +1444,11 @@ where
 {
 	fn convert(currency: CurrencyId) -> Option<MultiLocation> {
 		match currency {
+			// For now (and until we upgrade to 0.9.16 is adapted) we need to use the old anchoring here
+			// This is not a problem in either cases, since the view of the destination chain does not
+			// change
 			CurrencyId::SelfReserve => {
-				let multi: MultiLocation = NewAnchoringSelfReserve::get();
+				let multi: MultiLocation = OldAnchoringSelfReserve::get();
 				Some(multi)
 			}
 			CurrencyId::OtherReserve(asset) => AssetXConverter::reverse_ref(asset).ok(),

--- a/runtime/moonbase/tests/xcm_mock/mod.rs
+++ b/runtime/moonbase/tests/xcm_mock/mod.rs
@@ -17,7 +17,7 @@
 pub mod parachain;
 pub mod relay_chain;
 pub mod statemint_like;
-
+pub mod xcm_weight;
 use cumulus_primitives_core::ParaId;
 use polkadot_parachain::primitives::AccountIdConversion;
 use sp_runtime::AccountId32;

--- a/runtime/moonbase/tests/xcm_mock/mod.rs
+++ b/runtime/moonbase/tests/xcm_mock/mod.rs
@@ -17,7 +17,6 @@
 pub mod parachain;
 pub mod relay_chain;
 pub mod statemint_like;
-pub mod xcm_weight;
 use cumulus_primitives_core::ParaId;
 use polkadot_parachain::primitives::AccountIdConversion;
 use sp_runtime::AccountId32;

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -262,7 +262,9 @@ parameter_types! {
 		parents:1,
 		interior: Junctions::X2(
 			Parachain(MsgQueue::parachain_id().into()),
-			PalletInstance(<Runtime as frame_system::Config>::PalletInfo::index::<Balances>().unwrap() as u8)
+			PalletInstance(
+				<Runtime as frame_system::Config>::PalletInfo::index::<Balances>().unwrap() as u8
+			)
 		)
 	};
 	// Bew Self Reserve location, defines the multilocation identifiying the self-reserve currency
@@ -272,7 +274,9 @@ parameter_types! {
 	pub NewAnchoringSelfReserve: MultiLocation = MultiLocation {
 		parents:0,
 		interior: Junctions::X1(
-			PalletInstance(<Runtime as frame_system::Config>::PalletInfo::index::<Balances>().unwrap() as u8)
+			PalletInstance(
+				<Runtime as frame_system::Config>::PalletInfo::index::<Balances>().unwrap() as u8
+			)
 		)
 	};
 	// The Locations we accept to refer to our own currency. We need to support both pre and

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -245,6 +245,7 @@ pub type XcmFeesToAccount_ = xcm_primitives::XcmFeesToAccount<
 parameter_types! {
 	// We cannot skip the native trader for some specific tests, so we will have to work with
 	// a native trader that charges same number of units as weight
+	// We use both the old and new anchoring logics
 	pub ParaTokensPerSecondOld: (XcmAssetId, u128) = (Concrete(OldAnchoringSelfReserve::get()), 1000000000000);
 	pub ParaTokensPerSecondNew: (XcmAssetId, u128) = (Concrete(NewAnchoringSelfReserve::get()), 1000000000000);
 }

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -45,9 +45,9 @@ use xcm_builder::{
 	AccountKey20Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
 	AllowTopLevelPaidExecutionFrom, ConvertedConcreteAssetId,
 	CurrencyAdapter as XcmCurrencyAdapter, EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds,
-	FungiblesAdapter, LocationInverter, ParentAsSuperuser, ParentIsDefault,
-	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
-	SignedAccountKey20AsNative, SovereignSignedViaLocation, TakeWeightCredit,
+	FungiblesAdapter, LocationInverter, ParentAsSuperuser, ParentIsDefault, RelayChainAsNative,
+	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountKey20AsNative,
+	SovereignSignedViaLocation, TakeWeightCredit,
 };
 use xcm_executor::{traits::JustTry, Config, XcmExecutor};
 

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -247,8 +247,14 @@ parameter_types! {
 	// We cannot skip the native trader for some specific tests, so we will have to work with
 	// a native trader that charges same number of units as weight
 	// We use both the old and new anchoring logics
-	pub ParaTokensPerSecondOld: (XcmAssetId, u128) = (Concrete(OldAnchoringSelfReserve::get()), 1000000000000);
-	pub ParaTokensPerSecondNew: (XcmAssetId, u128) = (Concrete(NewAnchoringSelfReserve::get()), 1000000000000);
+	pub ParaTokensPerSecondOld: (XcmAssetId, u128) = (
+		Concrete(OldAnchoringSelfReserve::get()),
+		1000000000000
+	);
+	pub ParaTokensPerSecondNew: (XcmAssetId, u128) = (
+		Concrete(NewAnchoringSelfReserve::get()),
+		1000000000000
+	);
 }
 
 parameter_types! {

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -176,7 +176,8 @@ parameter_types! {
 pub type FungiblesTransactor = FungiblesAdapter<
 	// Use this fungibles implementation:
 	Assets,
-	// Use this currency when it is a fungible asset matching the given location or name:
+	// Use this currency when it is a fungible asset matching any of the locations in
+	// SelfReserveRepresentations
 	(
 		ConvertedConcreteAssetId<
 			AssetId,
@@ -254,6 +255,9 @@ parameter_types! {
 	pub const RelayNetwork: NetworkId = NetworkId::Polkadot;
 	pub RelayChainOrigin: Origin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub Ancestry: MultiLocation = Parachain(MsgQueue::parachain_id().into()).into();
+	// Old Self Reserve location, defines the multilocation identifiying the self-reserve currency
+	// This is used to match it against our Balances pallet when we receive such a MultiLocation
+	// (Parent, Self Para Id, Self Balances pallet index)
 	pub OldAnchoringSelfReserve: MultiLocation = MultiLocation {
 		parents:1,
 		interior: Junctions::X2(
@@ -261,12 +265,18 @@ parameter_types! {
 			PalletInstance(<Runtime as frame_system::Config>::PalletInfo::index::<Balances>().unwrap() as u8)
 		)
 	};
+	// Bew Self Reserve location, defines the multilocation identifiying the self-reserve currency
+	// This is used to match it also against our Balances pallet when we receive such
+	// a MultiLocation: (Self Balances pallet index)
+	// This is the new anchoring way
 	pub NewAnchoringSelfReserve: MultiLocation = MultiLocation {
 		parents:0,
 		interior: Junctions::X1(
 			PalletInstance(<Runtime as frame_system::Config>::PalletInfo::index::<Balances>().unwrap() as u8)
 		)
 	};
+	// The Locations we accept to refer to our own currency. We need to support both pre and
+	// post 0.9.16 versions, hence the reason for this being a Vec
 	pub SelfReserveRepresentations: Vec<MultiLocation> = vec![
 		OldAnchoringSelfReserve::get(),
 		NewAnchoringSelfReserve::get()
@@ -283,6 +293,10 @@ impl Config for XcmConfig {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
+	// We use three traders
+	// When we receive either representation of the self-reserve asset,
+	// When we receive a non-reserve asset, we use AssetManager to fetch how many
+	// units per second we should charge
 	type Trader = (
 		FixedRateOfFungible<ParaTokensPerSecondOld, ()>,
 		FixedRateOfFungible<ParaTokensPerSecondNew, ()>,
@@ -317,6 +331,11 @@ where
 	fn convert(currency: CurrencyId) -> Option<MultiLocation> {
 		match currency {
 			CurrencyId::SelfReserve => {
+				// For now (and until we upgrade to 0.9.16 is adapted) we need to use
+				// the old anchoring here
+				// This is not a problem in either cases, since the view of the destination
+				// chain does not change
+				// TODO! change this to NewAnchoringSelfReserve once we uprade to 0.9.16
 				let multi: MultiLocation = OldAnchoringSelfReserve::get();
 				Some(multi)
 			}

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -206,7 +206,7 @@ pub type LocalAssetTransactor = XcmCurrencyAdapter<
 	LocationToAccountId,
 	// Our chain's account ID type (we can't get away without mentioning it explicitly):
 	AccountId,
-	// We track our teleports in/out to keep total issuance correct.
+	// We dont allow teleport
 	(),
 >;
 

--- a/runtime/moonbase/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonbase/tests/xcm_mock/relay_chain.rs
@@ -38,6 +38,70 @@ use xcm_executor::{Config, XcmExecutor};
 pub type AccountId = AccountId32;
 pub type Balance = u128;
 
+
+use sp_std::marker::PhantomData;
+use xcm_executor::traits::WeightBounds;
+use frame_support::traits::Get;
+use frame_support::weights::GetDispatchInfo;
+use parity_scale_codec::Decode;
+
+pub struct LocalWeightInfoBounds<W, C, M>(PhantomData<(W, C, M)>);
+impl<W, C, M> WeightBounds<C> for LocalWeightInfoBounds<W, C, M>
+where
+	W: XcmWeightInfo<C>,
+	C: Decode + GetDispatchInfo,
+	M: Get<u32>,
+	Instruction<C>: xcm::GetWeight<W>,
+{
+	fn weight(message: &mut Xcm<C>) -> Result<Weight, ()> {
+		println!("About to weight");
+		log::trace!(target: "xcm::weight", "WeightInfoBounds message: {:?}", message);
+		let mut instructions_left = M::get();
+		println!("Instructions left {:?}", instructions_left);
+		Self::weight_with_limit(message, &mut instructions_left)
+	}
+	fn instr_weight(instruction: &Instruction<C>) -> Result<Weight, ()> {
+		Self::instr_weight_with_limit(instruction, &mut u32::max_value())
+	}
+}
+
+impl<W, C, M> LocalWeightInfoBounds<W, C, M>
+where
+	W: XcmWeightInfo<C>,
+	C: Decode + GetDispatchInfo,
+	M: Get<u32>,
+	Instruction<C>: xcm::GetWeight<W>,
+{
+	fn weight_with_limit(message: &Xcm<C>, instrs_limit: &mut u32) -> Result<Weight, ()> {
+		let mut r: Weight = 0;
+		*instrs_limit = instrs_limit.checked_sub(message.0.len() as u32).ok_or(())?;
+		for m in message.0.iter() {
+			println!("Going to analize instruction {:?}", m);
+			let weight_inst = Self::instr_weight_with_limit(m, instrs_limit)?;
+			println!("Weight of Instruction {:?} is {:?}", m, weight_inst);
+			r = r.checked_add(weight_inst).ok_or(())?;
+			println!("TOtal is {:?}", r);
+		}
+		Ok(r)
+	}
+	fn instr_weight_with_limit(
+		instruction: &Instruction<C>,
+		instrs_limit: &mut u32,
+	) -> Result<Weight, ()> {
+		use xcm::GetWeight;
+		let weight_inst = instruction.weight();
+		println!("Weight of i {:?} inside is {:?}", instruction, weight_inst);
+		weight_inst
+			.checked_add(match instruction {
+				Transact { require_weight_at_most, .. } => *require_weight_at_most,
+				SetErrorHandler(xcm) | SetAppendix(xcm) =>
+					Self::weight_with_limit(xcm, instrs_limit)?,
+				_ => 0,
+			})
+			.ok_or(())
+	}
+}
+
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 }
@@ -61,7 +125,7 @@ impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
-	type DbWeight = ();
+	type DbWeight = frame_support::weights::constants::RocksDbWeight;
 	type BaseCallFilter = Everything;
 	type SystemWeightInfo = ();
 	type SS58Prefix = ();

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -30,12 +30,12 @@ use xcm_primitives::UtilityEncodeCall;
 
 use sp_std::boxed::Box;
 use xcm::latest::prelude::QueryResponse;
+use xcm::latest::prelude::*;
 use xcm::latest::{
 	Junction::{self, AccountId32, AccountKey20, PalletInstance, Parachain},
 	Junctions::*,
 	MultiLocation, NetworkId, Response, Xcm,
 };
-use xcm::latest::prelude::*;
 use xcm_executor::traits::Convert;
 use xcm_simulator::TestExt;
 // Send a relay asset (like DOT) to a parachain A
@@ -603,8 +603,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a_with_new_reanchoring() {
 
 	let dest = MultiLocation {
 		parents: 1,
-		interior: X1(
-			Parachain(1))
+		interior: X1(Parachain(1)),
 	};
 
 	let reanchored_para_a_balances = MultiLocation::new(0, X1(PalletInstance(1u8)));
@@ -624,7 +623,7 @@ fn send_para_a_asset_to_para_b_and_back_to_para_a_with_new_reanchoring() {
 				X1(AccountKey20 {
 					network: Any,
 					key: PARAALICE,
-				})
+				}),
 			),
 		},
 	]));
@@ -2010,8 +2009,8 @@ fn test_statemint_like_prefix_change() {
 #[test]
 fn test_weigher() {
 	MockNet::reset();
-	use xcm_executor::traits::WeightBounds;
 	use xcm::latest::prelude::*;
+	use xcm_executor::traits::WeightBounds;
 	let location = MultiLocation::new(0, Here);
 	// Construct MultiAsset
 	let fee = MultiAsset {
@@ -2037,7 +2036,6 @@ fn test_weigher() {
 	.encode();
 	encoded.append(&mut call_bytes);
 
-
 	let mut message: Xcm<relay_chain::Call> = Xcm(vec![
 		WithdrawAsset(fee.clone().into()),
 		BuyExecution {
@@ -2050,7 +2048,11 @@ fn test_weigher() {
 			call: encoded.into(),
 		},
 	]);
-	let weight = relay_chain::LocalWeightInfoBounds::<xcm_weight::WestendXcmWeight<relay_chain::Call>, relay_chain::Call, relay_chain::MaxInstructions>::weight(& mut message);
+	let weight = relay_chain::LocalWeightInfoBounds::<
+		xcm_weight::WestendXcmWeight<relay_chain::Call>,
+		relay_chain::Call,
+		relay_chain::MaxInstructions,
+	>::weight(&mut message);
 	println!("Weight {:?}", weight);
 }
 

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -23,19 +23,11 @@ use frame_support::{
 	weights::constants::WEIGHT_PER_SECOND,
 };
 use xcm::{VersionedMultiLocation, WrapVersion};
-use xcm_mock::parachain;
-use xcm_mock::relay_chain;
 use xcm_mock::*;
 use xcm_primitives::UtilityEncodeCall;
 
 use sp_std::boxed::Box;
-use xcm::latest::prelude::QueryResponse;
 use xcm::latest::prelude::*;
-use xcm::latest::{
-	Junction::{self, AccountId32, AccountKey20, PalletInstance, Parachain},
-	Junctions::*,
-	MultiLocation, NetworkId, Response, Xcm,
-};
 use xcm_executor::traits::Convert;
 use xcm_simulator::TestExt;
 // Send a relay asset (like DOT) to a parachain A

--- a/tests/tests/test-mock-hrmp.ts
+++ b/tests/tests/test-mock-hrmp.ts
@@ -494,3 +494,131 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer of DEV", (context) =
     expect(randomBalance.toString()).to.eq(expectedRandomBalance.toString());
   });
 });
+
+describeDevMoonbeam("Mock XCM - receive horizontal transfer of DEV with new reanchor", (context) => {
+  let alith: KeyringPair;
+  let random: KeyringPair;
+  let paraId: ParaId;
+  let transferredBalance;
+  let sovereignAddress;
+
+  before("Should send DEV to the parachain sovereign", async function () {
+    const keyringEth = new Keyring({ type: "ethereum" });
+    alith = keyringEth.addFromUri(ALITH_PRIV_KEY, null, "ethereum");
+    random = keyringEth.addFromUri(RANDOM_PRIV_KEY, null, "ethereum");
+
+    paraId = context.polkadotApi.createType("ParaId", 2000);
+    sovereignAddress = u8aToHex(
+      new Uint8Array([...new TextEncoder().encode("sibl"), ...paraId.toU8a()])
+    ).padEnd(42, "0");
+
+    transferredBalance = new BN(100000000000000);
+
+    // We first fund parachain 2000 sovreign account
+    await createBlockWithExtrinsic(
+      context,
+      alith,
+      context.polkadotApi.tx.balances.transfer(sovereignAddress, transferredBalance)
+    );
+    let balance = (
+      (await context.polkadotApi.query.system.account(sovereignAddress)) as any
+    ).data.free.toBigInt();
+    expect(balance.toString()).to.eq(transferredBalance.toString());
+  });
+
+  it("Should receive MOVR from para Id 2000 with new reanchor logic", async function () {
+    let ownParaId = (await context.polkadotApi.query.parachainInfo.parachainId()) as any;
+    // Get Pallet balances index
+    const metadata = await context.polkadotApi.rpc.state.getMetadata();
+    const balancesPalletIndex = (metadata.asLatest.toHuman().pallets as Array<any>).find(
+      (pallet) => {
+        return pallet.name === "Balances";
+      }
+    ).index;
+    // We are charging 100_000_000 weight for every XCM instruction
+    // We are executing 4 instructions
+    // 100_000_000 * 4 * 50000 = 20000000000000
+    // We are charging 20 micro DEV for this operation
+    // The rest should be going to the deposit account
+    let xcmMessage = {
+      V2: [
+        {
+          WithdrawAsset: [
+            {
+              // This is the new reanchored logic
+              id: {
+                Concrete: {
+                  parents: 0,
+                  interior: {
+                    X1: { PalletInstance: balancesPalletIndex },
+                  },
+                },
+              },
+              fun: { Fungible: transferredBalance },
+            },
+          ],
+        },
+        { ClearOrigin: null },
+        {
+          BuyExecution: {
+            fees: {
+              id: {
+                // This is the new reanchored logic
+                Concrete: {
+                  parents: 0,
+                  interior: {
+                    X1: { PalletInstance: balancesPalletIndex },
+                  },
+                },
+              },
+              fun: { Fungible: transferredBalance },
+            },
+            weightLimit: { Limited: new BN(4000000000) },
+          },
+        },
+        {
+          DepositAsset: {
+            assets: { Wild: "All" },
+            maxAssets: new BN(1),
+            beneficiary: {
+              parents: 0,
+              interior: { X1: { AccountKey20: { network: "Any", key: random.address } } },
+            },
+          },
+        },
+      ],
+    };
+    const xcmpFormat: XcmpMessageFormat = context.polkadotApi.createType(
+      "XcmpMessageFormat",
+      "ConcatenatedVersionedXcm"
+    );
+    const receivedMessage: XcmVersionedXcm = context.polkadotApi.createType(
+      "XcmVersionedXcm",
+      xcmMessage
+    );
+
+    const totalMessage = [...xcmpFormat.toU8a(), ...receivedMessage.toU8a()];
+
+    // Send RPC call to inject XCM message
+    // We will set a specific message knowing that it should mint the statemint asset
+    await customWeb3Request(context.web3, "xcm_injectHrmpMessage", [2000, totalMessage]);
+
+    // Create a block in which the XCM will be executed
+    await context.createBlock();
+
+    // We should expect sovereign balance to be 0, since we have transferred the full amount
+    let balance = (
+      (await context.polkadotApi.query.system.account(sovereignAddress)) as any
+    ).data.free.toBigInt();
+    expect(balance.toString()).to.eq(0n.toString());
+
+    // In the case of the random address: we have transferred 100000000000000,
+    // but 20000000000000 have been deducted
+    // for weight payment
+    let randomBalance = (
+      (await context.polkadotApi.query.system.account(random.address)) as any
+    ).data.free.toBigInt();
+    let expectedRandomBalance = 80000000000000n;
+    expect(randomBalance.toString()).to.eq(expectedRandomBalance.toString());
+  });
+});

--- a/tests/tests/test-mock-hrmp.ts
+++ b/tests/tests/test-mock-hrmp.ts
@@ -495,130 +495,133 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer of DEV", (context) =
   });
 });
 
-describeDevMoonbeam("Mock XCM - receive horizontal transfer of DEV with new reanchor", (context) => {
-  let alith: KeyringPair;
-  let random: KeyringPair;
-  let paraId: ParaId;
-  let transferredBalance;
-  let sovereignAddress;
+describeDevMoonbeam(
+  "Mock XCM - receive horizontal transfer of DEV with new reanchor",
+  (context) => {
+    let alith: KeyringPair;
+    let random: KeyringPair;
+    let paraId: ParaId;
+    let transferredBalance;
+    let sovereignAddress;
 
-  before("Should send DEV to the parachain sovereign", async function () {
-    const keyringEth = new Keyring({ type: "ethereum" });
-    alith = keyringEth.addFromUri(ALITH_PRIV_KEY, null, "ethereum");
-    random = keyringEth.addFromUri(RANDOM_PRIV_KEY, null, "ethereum");
+    before("Should send DEV to the parachain sovereign", async function () {
+      const keyringEth = new Keyring({ type: "ethereum" });
+      alith = keyringEth.addFromUri(ALITH_PRIV_KEY, null, "ethereum");
+      random = keyringEth.addFromUri(RANDOM_PRIV_KEY, null, "ethereum");
 
-    paraId = context.polkadotApi.createType("ParaId", 2000);
-    sovereignAddress = u8aToHex(
-      new Uint8Array([...new TextEncoder().encode("sibl"), ...paraId.toU8a()])
-    ).padEnd(42, "0");
+      paraId = context.polkadotApi.createType("ParaId", 2000);
+      sovereignAddress = u8aToHex(
+        new Uint8Array([...new TextEncoder().encode("sibl"), ...paraId.toU8a()])
+      ).padEnd(42, "0");
 
-    transferredBalance = new BN(100000000000000);
+      transferredBalance = new BN(100000000000000);
 
-    // We first fund parachain 2000 sovreign account
-    await createBlockWithExtrinsic(
-      context,
-      alith,
-      context.polkadotApi.tx.balances.transfer(sovereignAddress, transferredBalance)
-    );
-    let balance = (
-      (await context.polkadotApi.query.system.account(sovereignAddress)) as any
-    ).data.free.toBigInt();
-    expect(balance.toString()).to.eq(transferredBalance.toString());
-  });
+      // We first fund parachain 2000 sovreign account
+      await createBlockWithExtrinsic(
+        context,
+        alith,
+        context.polkadotApi.tx.balances.transfer(sovereignAddress, transferredBalance)
+      );
+      let balance = (
+        (await context.polkadotApi.query.system.account(sovereignAddress)) as any
+      ).data.free.toBigInt();
+      expect(balance.toString()).to.eq(transferredBalance.toString());
+    });
 
-  it("Should receive MOVR from para Id 2000 with new reanchor logic", async function () {
-    let ownParaId = (await context.polkadotApi.query.parachainInfo.parachainId()) as any;
-    // Get Pallet balances index
-    const metadata = await context.polkadotApi.rpc.state.getMetadata();
-    const balancesPalletIndex = (metadata.asLatest.toHuman().pallets as Array<any>).find(
-      (pallet) => {
-        return pallet.name === "Balances";
-      }
-    ).index;
-    // We are charging 100_000_000 weight for every XCM instruction
-    // We are executing 4 instructions
-    // 100_000_000 * 4 * 50000 = 20000000000000
-    // We are charging 20 micro DEV for this operation
-    // The rest should be going to the deposit account
-    let xcmMessage = {
-      V2: [
-        {
-          WithdrawAsset: [
-            {
-              // This is the new reanchored logic
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: transferredBalance },
-            },
-          ],
-        },
-        { ClearOrigin: null },
-        {
-          BuyExecution: {
-            fees: {
-              id: {
+    it("Should receive MOVR from para Id 2000 with new reanchor logic", async function () {
+      let ownParaId = (await context.polkadotApi.query.parachainInfo.parachainId()) as any;
+      // Get Pallet balances index
+      const metadata = await context.polkadotApi.rpc.state.getMetadata();
+      const balancesPalletIndex = (metadata.asLatest.toHuman().pallets as Array<any>).find(
+        (pallet) => {
+          return pallet.name === "Balances";
+        }
+      ).index;
+      // We are charging 100_000_000 weight for every XCM instruction
+      // We are executing 4 instructions
+      // 100_000_000 * 4 * 50000 = 20000000000000
+      // We are charging 20 micro DEV for this operation
+      // The rest should be going to the deposit account
+      let xcmMessage = {
+        V2: [
+          {
+            WithdrawAsset: [
+              {
                 // This is the new reanchored logic
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
+                id: {
+                  Concrete: {
+                    parents: 0,
+                    interior: {
+                      X1: { PalletInstance: balancesPalletIndex },
+                    },
                   },
                 },
+                fun: { Fungible: transferredBalance },
               },
-              fun: { Fungible: transferredBalance },
-            },
-            weightLimit: { Limited: new BN(4000000000) },
+            ],
           },
-        },
-        {
-          DepositAsset: {
-            assets: { Wild: "All" },
-            maxAssets: new BN(1),
-            beneficiary: {
-              parents: 0,
-              interior: { X1: { AccountKey20: { network: "Any", key: random.address } } },
+          { ClearOrigin: null },
+          {
+            BuyExecution: {
+              fees: {
+                id: {
+                  // This is the new reanchored logic
+                  Concrete: {
+                    parents: 0,
+                    interior: {
+                      X1: { PalletInstance: balancesPalletIndex },
+                    },
+                  },
+                },
+                fun: { Fungible: transferredBalance },
+              },
+              weightLimit: { Limited: new BN(4000000000) },
             },
           },
-        },
-      ],
-    };
-    const xcmpFormat: XcmpMessageFormat = context.polkadotApi.createType(
-      "XcmpMessageFormat",
-      "ConcatenatedVersionedXcm"
-    );
-    const receivedMessage: XcmVersionedXcm = context.polkadotApi.createType(
-      "XcmVersionedXcm",
-      xcmMessage
-    );
+          {
+            DepositAsset: {
+              assets: { Wild: "All" },
+              maxAssets: new BN(1),
+              beneficiary: {
+                parents: 0,
+                interior: { X1: { AccountKey20: { network: "Any", key: random.address } } },
+              },
+            },
+          },
+        ],
+      };
+      const xcmpFormat: XcmpMessageFormat = context.polkadotApi.createType(
+        "XcmpMessageFormat",
+        "ConcatenatedVersionedXcm"
+      );
+      const receivedMessage: XcmVersionedXcm = context.polkadotApi.createType(
+        "XcmVersionedXcm",
+        xcmMessage
+      );
 
-    const totalMessage = [...xcmpFormat.toU8a(), ...receivedMessage.toU8a()];
+      const totalMessage = [...xcmpFormat.toU8a(), ...receivedMessage.toU8a()];
 
-    // Send RPC call to inject XCM message
-    // We will set a specific message knowing that it should mint the statemint asset
-    await customWeb3Request(context.web3, "xcm_injectHrmpMessage", [2000, totalMessage]);
+      // Send RPC call to inject XCM message
+      // We will set a specific message knowing that it should mint the statemint asset
+      await customWeb3Request(context.web3, "xcm_injectHrmpMessage", [2000, totalMessage]);
 
-    // Create a block in which the XCM will be executed
-    await context.createBlock();
+      // Create a block in which the XCM will be executed
+      await context.createBlock();
 
-    // We should expect sovereign balance to be 0, since we have transferred the full amount
-    let balance = (
-      (await context.polkadotApi.query.system.account(sovereignAddress)) as any
-    ).data.free.toBigInt();
-    expect(balance.toString()).to.eq(0n.toString());
+      // We should expect sovereign balance to be 0, since we have transferred the full amount
+      let balance = (
+        (await context.polkadotApi.query.system.account(sovereignAddress)) as any
+      ).data.free.toBigInt();
+      expect(balance.toString()).to.eq(0n.toString());
 
-    // In the case of the random address: we have transferred 100000000000000,
-    // but 20000000000000 have been deducted
-    // for weight payment
-    let randomBalance = (
-      (await context.polkadotApi.query.system.account(random.address)) as any
-    ).data.free.toBigInt();
-    let expectedRandomBalance = 80000000000000n;
-    expect(randomBalance.toString()).to.eq(expectedRandomBalance.toString());
-  });
-});
+      // In the case of the random address: we have transferred 100000000000000,
+      // but 20000000000000 have been deducted
+      // for weight payment
+      let randomBalance = (
+        (await context.polkadotApi.query.system.account(random.address)) as any
+      ).data.free.toBigInt();
+      let expectedRandomBalance = 80000000000000n;
+      expect(randomBalance.toString()).to.eq(expectedRandomBalance.toString());
+    });
+  }
+);


### PR DESCRIPTION
### What does it do?
It adds support for mapping both pre and post 0.9.16 anchoring changes to the same token (in this case, the native token).

The reanchoring logic change will stop from marking us see our token as 

```
MultiLocation {
  parents: 1,
  interior: X2(Parachain(para_id), PalletInstance(balances_pallet))
  }
```

To make it see it as 

```
MultiLocation {
  parents: 0,
  interior: X1(PalletInstance(balances_pallet)
 }
```

This PR does yet not add the possibility of transferring the local token for Moonriver and Moonbeam. I wanted this review to be easier, so I will make a follow up PR enabling transfer of the local asset in XCM
### What important points reviewers should know?

### Is there something left for follow-up PRs?
Adding the possibility of transferring the local token for Moonriver and Moonbeam
### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
