### PR TITLE
Update frontier `b4729e6`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2399,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2425,7 +2425,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "fp-storage",
  "kvdb",
@@ -2441,7 +2441,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "fc-consensus",
  "fc-db",
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2505,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "evm",
  "parity-scale-codec",
@@ -2652,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -2686,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 
 [[package]]
 name = "frame-benchmarking"
@@ -6652,7 +6652,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6907,7 +6907,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -6948,7 +6948,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "evm",
  "evm-gasometer",
@@ -7028,7 +7028,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7038,7 +7038,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7049,7 +7049,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7062,7 +7062,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "fp-evm",
  "num",
@@ -7073,7 +7073,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7084,7 +7084,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#f2d122d1d07a58d04253f019329bbe10d3671ee9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.13#b4729e6456e91e976c1bd8eda8de72202edcad76"
 dependencies = [
  "fp-evm",
  "ripemd160",


### PR DESCRIPTION
### What does it do?

- Use versioned `extrinsic_filter` on pending transactions rpc.
- Use versioned `current_block` in `eth_call` when no gas limit is specified.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
