### PR TITLE
[Staking] Update `delegate` new error message

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -546,7 +546,7 @@ pub mod pallet {
 						if matches!(self.bottom_capacity, CapacityStatus::Full) {
 							ensure!(
 								delegation.amount.into() > self.lowest_bottom_delegation_amount,
-								Error::<T>::CannotDelegateLessThanLowestBottomWhenBottomIsFull
+								Error::<T>::CannotDelegateLessThanOrEqualToLowestBottomWhenBottomIsFull
 							);
 							// need to subtract from total staked
 							less_total_staked = Some(self.lowest_bottom_delegation_amount);
@@ -1934,7 +1934,7 @@ pub mod pallet {
 		PendingDelegationRequestDNE,
 		PendingDelegationRequestAlreadyExists,
 		PendingDelegationRequestNotDueYet,
-		CannotDelegateLessThanLowestBottomWhenBottomIsFull,
+		CannotDelegateLessThanOrEqualToLowestBottomWhenBottomIsFull,
 	}
 
 	#[pallet::event]
@@ -2789,8 +2789,6 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			candidate: T::AccountId,
 			amount: BalanceOf<T>,
-			// will_be_in_top: bool // weight hint
-			// look into returning weight in DispatchResult
 			candidate_delegation_count: u32,
 			delegation_count: u32,
 		) -> DispatchResultWithPostInfo {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -546,7 +546,7 @@ pub mod pallet {
 						if matches!(self.bottom_capacity, CapacityStatus::Full) {
 							ensure!(
 								delegation.amount.into() > self.lowest_bottom_delegation_amount,
-								Error::<T>::CannotDelegateLessThanOrEqualToLowestBottomWhenBottomIsFull
+								Error::<T>::CannotDelegateLessThanOrEqualToLowestBottomWhenFull
 							);
 							// need to subtract from total staked
 							less_total_staked = Some(self.lowest_bottom_delegation_amount);
@@ -1934,7 +1934,7 @@ pub mod pallet {
 		PendingDelegationRequestDNE,
 		PendingDelegationRequestAlreadyExists,
 		PendingDelegationRequestNotDueYet,
-		CannotDelegateLessThanOrEqualToLowestBottomWhenBottomIsFull,
+		CannotDelegateLessThanOrEqualToLowestBottomWhenFull,
 	}
 
 	#[pallet::event]

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -1785,7 +1785,7 @@ fn cannot_delegate_if_full_and_new_delegation_less_than_or_equal_lowest_bottom()
 		.execute_with(|| {
 			assert_noop!(
 				ParachainStaking::delegate(Origin::signed(11), 1, 10, 8, 0),
-				Error::<Test>::CannotDelegateLessThanOrEqualToLowestBottomWhenBottomIsFull
+				Error::<Test>::CannotDelegateLessThanOrEqualToLowestBottomWhenFull
 			);
 		});
 }


### PR DESCRIPTION
Updates `delegate`error message for when the new delegation is less than OR EQUAL to lowest bottom delegation (and bottom delegations are full) from `CannotDelegateLessThanLowestBottomWhenBottomIsFull` -> `CannotDelegateLessThanOrEqualToLowestBottomWhenFull`

Also adds unit tests for when this error is emitted and when it is not emitted. This is a new error path introduced by the new bounded bottom constraint in #1117 
