### PR TITLE
fix: decode legacy transaction properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "ethereum"
 version = "0.11.1"
-source = "git+https://github.com/purestake/ethereum?branch=tgm-0.11.1-typeinfo-patch#42ee428264e27773da5e93f264f0aa7daf1a8a7f"
+source = "git+https://github.com/purestake/ethereum?branch=moonbeam-v0.9.13#456030fd418ba275a78ab678612cc1de82f8e0b3"
 dependencies = [
  "bytes 1.0.1",
  "ethereum-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [patch.crates-io]
-ethereum = { git = "https://github.com/purestake/ethereum", branch = "tgm-0.11.1-typeinfo-patch" }
+ethereum = { git = "https://github.com/purestake/ethereum", branch = "moonbeam-v0.9.13" }
 evm = { git = "https://github.com/purestake/evm", branch = "moonbeam-polkadot-v0.9.13" }
 evm-gasometer = { git = "https://github.com/purestake/evm", branch = "moonbeam-polkadot-v0.9.13" }
 evm-runtime = { git = "https://github.com/purestake/evm", branch = "moonbeam-polkadot-v0.9.13" }


### PR DESCRIPTION
### What does it do?

Patch ethereum crate dependency to include this fix: https://github.com/PureStake/ethereum/pull/1/files

### What important points reviewers should know?

We have to implement SCALE decode by hand to handle correctly `LegacyTransaction` without enum

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
