### PR TITLE
Use storage overrides in debug and tracing modules

### DIFF
--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -448,7 +448,7 @@ where
 
 		// Get DebugRuntimeApi version
 		let trace_api_version = if let Ok(Some(api_version)) =
-			api.api_version::<dyn DebugRuntimeApi<B>>(&reference_id)
+			api.api_version::<dyn DebugRuntimeApi<B>>(&parent_block_id)
 		{
 			api_version
 		} else {

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -23,19 +23,19 @@ use tokio::{
 };
 
 use ethereum_types::H256;
-use fc_rpc::{frontier_backend_client, internal_err};
+use fc_rpc::{frontier_backend_client, internal_err, OverrideHandle};
 use fp_rpc::EthereumRuntimeRPCApi;
 use moonbeam_client_evm_tracing::{formatters::ResponseFormatter, types::single};
 use moonbeam_rpc_core_types::{RequestBlockId, RequestBlockTag};
 use moonbeam_rpc_primitives_debug::{DebugRuntimeApi, TracerInput};
-use sc_client_api::backend::Backend;
+use sc_client_api::backend::{Backend, StateBackend, StorageProvider};
 use sc_utils::mpsc::TracingUnboundedSender;
 use sp_api::{ApiExt, BlockId, Core, HeaderT, ProvideRuntimeApi};
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{
 	Backend as BlockchainBackend, Error as BlockChainError, HeaderBackend, HeaderMetadata,
 };
-use sp_runtime::traits::{Block as BlockT, UniqueSaturatedInto};
+use sp_runtime::traits::{BlakeTwo256, Block as BlockT, UniqueSaturatedInto};
 use std::{future::Future, marker::PhantomData, sync::Arc};
 
 pub enum RequesterInput {
@@ -137,7 +137,9 @@ pub struct DebugHandler<B: BlockT, C, BE>(PhantomData<(B, C, BE)>);
 impl<B, C, BE> DebugHandler<B, C, BE>
 where
 	BE: Backend<B> + 'static,
+	BE::State: StateBackend<BlakeTwo256>,
 	C: ProvideRuntimeApi<B>,
+	C: StorageProvider<B, BE>,
 	C: HeaderMetadata<B, Error = BlockChainError> + HeaderBackend<B>,
 	C: Send + Sync + 'static,
 	B: BlockT<Hash = H256> + Send + Sync + 'static,
@@ -153,6 +155,7 @@ where
 		backend: Arc<BE>,
 		frontier_backend: Arc<fc_db::Backend<B>>,
 		permit_pool: Arc<Semaphore>,
+		overrides: Arc<OverrideHandle<B>>,
 	) -> (impl Future<Output = ()>, DebugRequester) {
 		let (tx, mut rx): (DebugRequester, _) =
 			sc_utils::mpsc::tracing_unbounded("debug-requester");
@@ -168,6 +171,7 @@ where
 						let backend = backend.clone();
 						let frontier_backend = frontier_backend.clone();
 						let permit_pool = permit_pool.clone();
+						let overrides = overrides.clone();
 
 						tokio::task::spawn(async move {
 							let _ = response_tx.send(
@@ -180,6 +184,7 @@ where
 											frontier_backend.clone(),
 											transaction_hash,
 											params,
+											overrides.clone(),
 										)
 									})
 									.await
@@ -199,6 +204,7 @@ where
 						let backend = backend.clone();
 						let frontier_backend = frontier_backend.clone();
 						let permit_pool = permit_pool.clone();
+						let overrides = overrides.clone();
 
 						tokio::task::spawn(async move {
 							let _ = response_tx.send(
@@ -212,6 +218,7 @@ where
 											frontier_backend.clone(),
 											request_block_id,
 											params,
+											overrides.clone(),
 										)
 									})
 									.await
@@ -287,6 +294,7 @@ where
 		frontier_backend: Arc<fc_db::Backend<B>>,
 		request_block_id: RequestBlockId,
 		params: Option<TraceParams>,
+		overrides: Arc<OverrideHandle<B>>,
 	) -> RpcResult<Response> {
 		let (tracer_input, trace_type) = Self::handle_params(params)?;
 
@@ -319,14 +327,22 @@ where
 		// Get parent blockid.
 		let parent_block_id = BlockId::Hash(*header.parent_hash());
 
-		let statuses = api
-			.current_transaction_statuses(&reference_id)
-			.map_err(|e| {
-				internal_err(format!(
-					"Failed to get Ethereum block data for Substrate block {:?} : {:?}",
-					request_block_id, e
-				))
-			})?;
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			client.as_ref(),
+			reference_id,
+		);
+
+		// Using storage overrides we align with `:ethereum_schema` which will result in proper
+		// SCALE decoding in case of migration.
+		let statuses = match overrides.schemas.get(&schema) {
+			Some(schema) => schema.current_transaction_statuses(&reference_id),
+			_ => {
+				return Err(internal_err(format!(
+					"No storage override at {:?}",
+					reference_id
+				)))
+			}
+		};
 
 		// Get the extrinsics.
 		let ext = blockchain.body(reference_id).unwrap().unwrap();
@@ -397,6 +413,7 @@ where
 		frontier_backend: Arc<fc_db::Backend<B>>,
 		transaction_hash: H256,
 		params: Option<TraceParams>,
+		overrides: Arc<OverrideHandle<B>>,
 	) -> RpcResult<Response> {
 		let (tracer_input, trace_type) = Self::handle_params(params)?;
 
@@ -440,32 +457,20 @@ where
 			));
 		};
 
-		// Get EthereumRuntimeRPCApi version
-		let ethereum_api_version = if let Ok(Some(api_version)) =
-			api.api_version::<dyn EthereumRuntimeRPCApi<B>>(&reference_id)
-		{
-			api_version
-		} else {
-			return Err(internal_err("Runtime api version call failed".to_string()));
-		};
+		let schema = frontier_backend_client::onchain_storage_schema::<B, C, BE>(
+			client.as_ref(),
+			reference_id,
+		);
 
-		// Get the block that contains the requested transaction.
-		let reference_block = if ethereum_api_version >= 2 {
-			match api.current_block(&reference_id) {
-				Ok(block) => block,
-				Err(e) => {
-					return Err(internal_err(format!(
-						"Runtime block call failed (version >= 2): {:?}",
-						e
-					)))
-				}
-			}
-		} else {
-			#[allow(deprecated)]
-			match api.current_block_before_version_2(&reference_id) {
-				Ok(Some(block)) => Some(block.into()),
-				Ok(None) => return Err(internal_err("Runtime block call failed".to_string())),
-				Err(e) => return Err(internal_err(format!("Runtime block call failed: {:?}", e))),
+		// Get the block that contains the requested transaction. Using storage overrides we align
+		// with `:ethereum_schema` which will result in proper SCALE decoding in case of migration.
+		let reference_block = match overrides.schemas.get(&schema) {
+			Some(schema) => schema.current_block(&reference_id),
+			_ => {
+				return Err(internal_err(format!(
+					"No storage override at {:?}",
+					reference_id
+				)))
 			}
 		};
 

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -344,14 +344,20 @@ where
 			}
 		};
 
-		// Get the extrinsics.
-		let ext = blockchain.body(reference_id).unwrap().unwrap();
 		// Known ethereum transaction hashes.
-		let eth_tx_hashes = statuses
+		let eth_tx_hashes: Vec<_> = statuses
 			.unwrap()
 			.iter()
 			.map(|t| t.transaction_hash)
 			.collect();
+
+		// If there are no ethereum transactions in the block return empty trace right away.
+		if eth_tx_hashes.is_empty() {
+			return Ok(Response::Block(vec![]));
+		}
+
+		// Get the extrinsics.
+		let ext = blockchain.body(reference_id).unwrap().unwrap();
 
 		// Trace the block.
 		let f = || -> RpcResult<_> {

--- a/node/service/src/rpc/tracing.rs
+++ b/node/service/src/rpc/tracing.rs
@@ -64,6 +64,7 @@ pub fn spawn_tracing_tasks<B, C, BE>(
 ) -> RpcRequesters
 where
 	C: ProvideRuntimeApi<B> + BlockOf,
+	C: StorageProvider<B, BE>,
 	C: HeaderBackend<B> + HeaderMetadata<B, Error = BlockChainError> + 'static,
 	C: BlockchainEvents<B>,
 	C: Send + Sync + 'static,
@@ -83,6 +84,7 @@ where
 				Arc::clone(&params.substrate_backend),
 				Duration::from_secs(rpc_config.ethapi_trace_cache_duration),
 				Arc::clone(&permit_pool),
+				Arc::clone(&params.overrides),
 			);
 			(Some(trace_filter_task), Some(trace_filter_requester))
 		} else {
@@ -95,6 +97,7 @@ where
 			Arc::clone(&params.substrate_backend),
 			Arc::clone(&params.frontier_backend),
 			Arc::clone(&permit_pool),
+			Arc::clone(&params.overrides),
 		);
 		(Some(debug_task), Some(debug_requester))
 	} else {

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -5179,9 +5179,9 @@
       }
     },
     "multiformats": {
-      "version": "9.5.8",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.5.8.tgz",
-      "integrity": "sha512-GY154q1yPPdHX4ArXHE8Z1Mm9BxZcJetzEqfwQg/ongo91qIJDHJEio3zboHIKGEvBLrhVqKwlRuDqwa7+xECQ=="
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.6.3.tgz",
+      "integrity": "sha512-yfXKI66fL0nFzt0nJl26i4wV1qAqbAEIBvfFbkbsne9GrLz6IHvHUoRyxUtlJcdP181ssOgjama6E/VSk4pbrA=="
     },
     "multihashes": {
       "version": "0.4.21",
@@ -5578,7 +5578,7 @@
     },
     "polkadot-launch": {
       "version": "git+https://github.com/PureStake/polkadot-launch.git#b6b8efb23bd08fc7229e2b93f49f7908a9260718",
-      "from": "git+https://github.com/PureStake/polkadot-launch.git#crystalin-para-id",
+      "from": "git+https://github.com/PureStake/polkadot-launch.git#b6b8efb23bd08fc7229e2b93f49f7908a9260718",
       "requires": {
         "@polkadot/api": "^6.10.3",
         "@polkadot/keyring": "^8.0.5",

--- a/tests/package.json
+++ b/tests/package.json
@@ -62,7 +62,7 @@
     "ethers": "^5.4.6",
     "mocha": "^9.1.3",
     "npm-watch": "^0.9.0",
-    "polkadot-launch": "https://github.com/PureStake/polkadot-launch.git#crystalin-para-id",
+    "polkadot-launch": "https://github.com/PureStake/polkadot-launch.git#b6b8efb23bd08fc7229e2b93f49f7908a9260718",
     "rimraf": "^3.0.2",
     "solc": "^0.8.3",
     "tcp-port-used": "^1.0.2",


### PR DESCRIPTION
### What does it do?

Use frontier storage overrides instead runtime api for getting block data in the `debug` and `trace` modules.

When using the overrides we rely on the known key `:ethereum_schema` value, which is always updated on runtime upgrade and thus we are aligned with sensible `pallet_ethereum` storage changes. The goal is to guarantee proper decoding without relying on RuntimeApi version metadata.

### What important points reviewers should know?

Note that we don't use override fallback - which is the runtime api access - and instead we just `Err`. This fallback is only meant for projects that don't want to use storage overrides, which is not the case for us.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

https://github.com/PureStake/moonbeam/pull/1269

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
