### PR TITLE
Fix client debug unwrap issue

### DIFF
--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -323,7 +323,11 @@ where
 		// Get Blockchain backend
 		let blockchain = backend.blockchain();
 		// Get the header I want to work with.
-		let header = client.header(reference_id).unwrap().unwrap();
+		let header =  match client.header(reference_id) {
+			Ok(Some(h)) => h,
+			_ => return Err(internal_err("Block header not found")),
+		};
+
 		// Get parent blockid.
 		let parent_block_id = BlockId::Hash(*header.parent_hash());
 
@@ -445,7 +449,10 @@ where
 		// Get Blockchain backend
 		let blockchain = backend.blockchain();
 		// Get the header I want to work with.
-		let header = client.header(reference_id).unwrap().unwrap();
+		let header =  match client.header(reference_id) {
+			Ok(Some(h)) => h,
+			_ => return Err(internal_err("Block header not found")),
+		};
 		// Get parent blockid.
 		let parent_block_id = BlockId::Hash(*header.parent_hash());
 

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -323,7 +323,7 @@ where
 		// Get Blockchain backend
 		let blockchain = backend.blockchain();
 		// Get the header I want to work with.
-		let header =  match client.header(reference_id) {
+		let header = match client.header(reference_id) {
 			Ok(Some(h)) => h,
 			_ => return Err(internal_err("Block header not found")),
 		};
@@ -449,7 +449,7 @@ where
 		// Get Blockchain backend
 		let blockchain = backend.blockchain();
 		// Get the header I want to work with.
-		let header =  match client.header(reference_id) {
+		let header = match client.header(reference_id) {
 			Ok(Some(h)) => h,
 			_ => return Err(internal_err("Block header not found")),
 		};


### PR DESCRIPTION
### What does it do?

The client will panic if we post a `debug_traceBlockByNumber` request to get the block unsynced block. This should not happen in my view. See more https://github.com/darwinia-network/darwinia-common/issues/1076

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
