### PR TITLE
Add field names to pallet Event variants

### DIFF
--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -137,7 +137,7 @@ pub mod pallet {
 			units_per_second: u128
 		},
 		/// Changed the xcm type mapping for a given asset id
-		AssetTypeChanged{
+		AssetTypeChanged {
 			asset_id: T::AssetId,
 			new_asset_type: T::AssetType
 		},
@@ -190,7 +190,7 @@ pub mod pallet {
 			AssetIdType::<T>::insert(&asset_id, &asset);
 			AssetTypeId::<T>::insert(&asset, &asset_id);
 
-			Self::deposit_event(Event::AssetRegistered(asset_id, asset, metadata));
+			Self::deposit_event(Event::AssetRegistered { asset_id, asset, metadata });
 			Ok(())
 		}
 
@@ -210,7 +210,7 @@ pub mod pallet {
 
 			AssetTypeUnitsPerSecond::<T>::insert(&asset_type, &units_per_second);
 
-			Self::deposit_event(Event::UnitsPerSecondChanged(asset_type, units_per_second));
+			Self::deposit_event(Event::UnitsPerSecondChanged { asset_type, units_per_second	});
 			Ok(())
 		}
 
@@ -241,7 +241,7 @@ pub mod pallet {
 				AssetTypeUnitsPerSecond::<T>::insert(&new_asset_type, units);
 			}
 
-			Self::deposit_event(Event::AssetTypeChanged(asset_id, new_asset_type));
+			Self::deposit_event(Event::AssetTypeChanged { asset_id, new_asset_type });
 			Ok(())
 		}
 	}

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -125,9 +125,22 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {
-		AssetRegistered(T::AssetId, T::AssetType, T::AssetRegistrarMetadata),
-		UnitsPerSecondChanged(T::AssetType, u128),
-		AssetTypeChanged(T::AssetId, T::AssetType),
+		/// New asset with the asset manager is registered
+		AssetRegistered {
+			asset_id: T::AssetId,
+			asset: T::AssetType,
+			metadata: T::AssetRegistrarMetadata
+		},
+		/// Changed the amount of units we are charging per execution second for a given asset
+		UnitsPerSecondChanged {
+			asset_type: T::AssetType,
+			units_per_second: u128
+		},
+		/// Changed the xcm type mapping for a given asset id
+		AssetTypeChanged{
+			asset_id: T::AssetId,
+			new_asset_type: T::AssetType
+		},
 	}
 
 	/// Mapping from an asset id to asset type.

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -129,17 +129,17 @@ pub mod pallet {
 		AssetRegistered {
 			asset_id: T::AssetId,
 			asset: T::AssetType,
-			metadata: T::AssetRegistrarMetadata
+			metadata: T::AssetRegistrarMetadata,
 		},
 		/// Changed the amount of units we are charging per execution second for a given asset
 		UnitsPerSecondChanged {
 			asset_type: T::AssetType,
-			units_per_second: u128
+			units_per_second: u128,
 		},
 		/// Changed the xcm type mapping for a given asset id
 		AssetTypeChanged {
 			asset_id: T::AssetId,
-			new_asset_type: T::AssetType
+			new_asset_type: T::AssetType,
 		},
 	}
 
@@ -190,7 +190,11 @@ pub mod pallet {
 			AssetIdType::<T>::insert(&asset_id, &asset);
 			AssetTypeId::<T>::insert(&asset, &asset_id);
 
-			Self::deposit_event(Event::AssetRegistered { asset_id, asset, metadata });
+			Self::deposit_event(Event::AssetRegistered {
+				asset_id,
+				asset,
+				metadata,
+			});
 			Ok(())
 		}
 
@@ -210,7 +214,10 @@ pub mod pallet {
 
 			AssetTypeUnitsPerSecond::<T>::insert(&asset_type, &units_per_second);
 
-			Self::deposit_event(Event::UnitsPerSecondChanged { asset_type, units_per_second	});
+			Self::deposit_event(Event::UnitsPerSecondChanged {
+				asset_type,
+				units_per_second,
+			});
 			Ok(())
 		}
 
@@ -241,7 +248,10 @@ pub mod pallet {
 				AssetTypeUnitsPerSecond::<T>::insert(&new_asset_type, units);
 			}
 
-			Self::deposit_event(Event::AssetTypeChanged { asset_id, new_asset_type });
+			Self::deposit_event(Event::AssetTypeChanged {
+				asset_id,
+				new_asset_type,
+			});
 			Ok(())
 		}
 	}

--- a/pallets/asset-manager/src/tests.rs
+++ b/pallets/asset-manager/src/tests.rs
@@ -44,11 +44,11 @@ fn registering_works() {
 			AssetManager::asset_type_id(MockAssetType::MockAsset(1)).unwrap(),
 			1
 		);
-		expect_events(vec![crate::Event::AssetRegistered(
-			1,
-			MockAssetType::MockAsset(1),
-			0u32,
-		)])
+		expect_events(vec![crate::Event::AssetRegistered {
+			asset_id: 1,
+			asset: MockAssetType::MockAsset(1),
+			metadata: 0u32,
+		}])
 	});
 }
 
@@ -103,8 +103,15 @@ fn test_root_can_change_units_per_second() {
 		);
 
 		expect_events(vec![
-			crate::Event::AssetRegistered(1, MockAssetType::MockAsset(1), 0),
-			crate::Event::UnitsPerSecondChanged(MockAssetType::MockAsset(1), 200),
+			crate::Event::AssetRegistered {
+				asset_id: 1,
+				asset: MockAssetType::MockAsset(1),
+				metadata: 0,
+			},
+			crate::Event::UnitsPerSecondChanged {
+				asset_type: MockAssetType::MockAsset(1),
+				units_per_second: 200,
+			},
 		])
 	});
 }
@@ -189,9 +196,19 @@ fn test_root_can_change_asset_id_type() {
 		assert!(AssetManager::asset_type_id(MockAssetType::MockAsset(1)).is_none());
 
 		expect_events(vec![
-			crate::Event::AssetRegistered(1, MockAssetType::MockAsset(1), 0),
-			crate::Event::UnitsPerSecondChanged(MockAssetType::MockAsset(1), 200),
-			crate::Event::AssetTypeChanged(1, MockAssetType::MockAsset(2)),
+			crate::Event::AssetRegistered {
+				asset_id: 1,
+				asset: MockAssetType::MockAsset(1),
+				metadata: 0,
+			},
+			crate::Event::UnitsPerSecondChanged {
+				asset_type: MockAssetType::MockAsset(1),
+				units_per_second: 200,
+			},
+			crate::Event::AssetTypeChanged {
+				asset_id: 1,
+				new_asset_type: MockAssetType::MockAsset(2),
+			},
 		])
 	});
 }

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -130,7 +130,7 @@ pub mod pallet {
 
 			Self::enact_registration(&author_id, &account_id)?;
 
-			<Pallet<T>>::deposit_event(Event::AuthorRegistered(author_id, account_id));
+			<Pallet<T>>::deposit_event(Event::AuthorRegistered { author_id, account_id });
 
 			Ok(())
 		}
@@ -162,7 +162,10 @@ pub mod pallet {
 			MappingWithDeposit::<T>::remove(&old_author_id);
 			MappingWithDeposit::<T>::insert(&new_author_id, &stored_info);
 
-			<Pallet<T>>::deposit_event(Event::AuthorRotated(new_author_id, stored_info.account));
+			<Pallet<T>>::deposit_event(Event::AuthorRotated { 
+				new_author_id: new_author_id,
+				account_id: stored_info.account
+			});
 
 			Ok(())
 		}
@@ -190,7 +193,7 @@ pub mod pallet {
 
 			T::DepositCurrency::unreserve(&account_id, stored_info.deposit);
 
-			<Pallet<T>>::deposit_event(Event::AuthorDeRegistered(author_id));
+			<Pallet<T>>::deposit_event(Event::AuthorDeRegistered { author_id });
 
 			Ok(().into())
 		}

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -92,14 +92,25 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// A NimbusId has been registered and mapped to an AccountId.
-		AuthorRegistered(NimbusId, T::AccountId),
+		AuthorRegistered {
+			author_id: NimbusId,
+			account_id: T::AccountId
+		},
 		/// An NimbusId has been de-registered, and its AccountId mapping removed.
-		AuthorDeRegistered(NimbusId),
+		AuthorDeRegistered {
+			author_id: NimbusId
+		},
 		/// An NimbusId has been registered, replacing a previous registration and its mapping.
-		AuthorRotated(NimbusId, T::AccountId),
+		AuthorRotated {
+			new_author_id: NimbusId, 
+			account_id: T::AccountId
+		},
 		/// An NimbusId has been forcibly deregistered after not being rotated or cleaned up.
 		/// The reporteing account has been rewarded accordingly.
-		DefunctAuthorBusted(NimbusId, T::AccountId),
+		DefunctAuthorBusted {
+			author_id: NimbusId,
+			account_id: T::AccountId
+		},
 	}
 
 	#[pallet::call]

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -94,22 +94,20 @@ pub mod pallet {
 		/// A NimbusId has been registered and mapped to an AccountId.
 		AuthorRegistered {
 			author_id: NimbusId,
-			account_id: T::AccountId
+			account_id: T::AccountId,
 		},
 		/// An NimbusId has been de-registered, and its AccountId mapping removed.
-		AuthorDeRegistered {
-			author_id: NimbusId
-		},
+		AuthorDeRegistered { author_id: NimbusId },
 		/// An NimbusId has been registered, replacing a previous registration and its mapping.
 		AuthorRotated {
-			new_author_id: NimbusId, 
-			account_id: T::AccountId
+			new_author_id: NimbusId,
+			account_id: T::AccountId,
 		},
 		/// An NimbusId has been forcibly deregistered after not being rotated or cleaned up.
 		/// The reporteing account has been rewarded accordingly.
 		DefunctAuthorBusted {
 			author_id: NimbusId,
-			account_id: T::AccountId
+			account_id: T::AccountId,
 		},
 	}
 
@@ -130,7 +128,10 @@ pub mod pallet {
 
 			Self::enact_registration(&author_id, &account_id)?;
 
-			<Pallet<T>>::deposit_event(Event::AuthorRegistered { author_id, account_id });
+			<Pallet<T>>::deposit_event(Event::AuthorRegistered {
+				author_id,
+				account_id,
+			});
 
 			Ok(())
 		}
@@ -162,9 +163,9 @@ pub mod pallet {
 			MappingWithDeposit::<T>::remove(&old_author_id);
 			MappingWithDeposit::<T>::insert(&new_author_id, &stored_info);
 
-			<Pallet<T>>::deposit_event(Event::AuthorRotated { 
+			<Pallet<T>>::deposit_event(Event::AuthorRotated {
 				new_author_id: new_author_id,
-				account_id: stored_info.account
+				account_id: stored_info.account,
 			});
 
 			Ok(())

--- a/pallets/author-mapping/src/tests.rs
+++ b/pallets/author-mapping/src/tests.rs
@@ -60,7 +60,10 @@ fn eligible_account_can_register() {
 
 			assert_eq!(
 				last_event(),
-				MetaEvent::AuthorMapping(Event::AuthorRegistered(TestAuthor::Bob.into(), 2))
+				MetaEvent::AuthorMapping(Event::AuthorRegistered {
+					author_id: TestAuthor::Bob.into(),
+					account_id: 2
+				})
 			);
 		})
 }
@@ -105,7 +108,10 @@ fn double_registration_costs_twice_as_much() {
 
 			assert_eq!(
 				last_event(),
-				MetaEvent::AuthorMapping(Event::AuthorRegistered(TestAuthor::Bob.into(), 2))
+				MetaEvent::AuthorMapping(Event::AuthorRegistered {
+					author_id: TestAuthor::Bob.into(),
+					account_id: 2
+				})
 			);
 
 			// Register again as Alice
@@ -123,7 +129,10 @@ fn double_registration_costs_twice_as_much() {
 
 			assert_eq!(
 				last_event(),
-				MetaEvent::AuthorMapping(Event::AuthorRegistered(TestAuthor::Alice.into(), 2))
+				MetaEvent::AuthorMapping(Event::AuthorRegistered {
+					author_id: TestAuthor::Bob.into(),
+					account_id: 2
+				})
 			);
 
 			// Should still be registered as Bob as well
@@ -155,7 +164,9 @@ fn registered_account_can_clear() {
 
 			assert_eq!(
 				last_event(),
-				MetaEvent::AuthorMapping(Event::AuthorDeRegistered(TestAuthor::Alice.into()))
+				MetaEvent::AuthorMapping(Event::AuthorDeRegistered {
+					author_id: TestAuthor::Alice.into()
+				})
 			);
 		})
 }

--- a/pallets/author-mapping/src/tests.rs
+++ b/pallets/author-mapping/src/tests.rs
@@ -130,7 +130,7 @@ fn double_registration_costs_twice_as_much() {
 			assert_eq!(
 				last_event(),
 				MetaEvent::AuthorMapping(Event::AuthorRegistered {
-					author_id: TestAuthor::Bob.into(),
+					author_id: TestAuthor::Alice.into(),
 					account_id: 2
 				})
 			);

--- a/pallets/migrations/src/lib.rs
+++ b/pallets/migrations/src/lib.rs
@@ -270,7 +270,9 @@ pub mod pallet {
 			let migration_done = <MigrationState<T>>::get(migration_name_as_bytes);
 
 			if !migration_done {
-				<Pallet<T>>::deposit_event(Event::MigrationStarted(migration_name_as_bytes.into()));
+				<Pallet<T>>::deposit_event(Event::MigrationStarted { 
+					migration_name: migration_name_as_bytes.into()
+				});
 
 				// when we go overweight, leave a warning... there's nothing we can really do about
 				// this scenario other than hope that the block is actually accepted.
@@ -293,10 +295,10 @@ pub mod pallet {
 				);
 
 				let consumed_weight = migration.migrate(available_for_step);
-				<Pallet<T>>::deposit_event(Event::MigrationCompleted(
-					migration_name_as_bytes.into(),
-					consumed_weight,
-				));
+				<Pallet<T>>::deposit_event(Event::MigrationCompleted {
+					migration_name: migration_name_as_bytes.into(),
+					consumed_weight: consumed_weight,
+				});
 				<MigrationState<T>>::insert(migration_name_as_bytes, true);
 
 				weight = weight.saturating_add(consumed_weight);
@@ -313,7 +315,7 @@ pub mod pallet {
 
 		<FullyUpgraded<T>>::put(true);
 		weight += T::DbWeight::get().writes(1);
-		<Pallet<T>>::deposit_event(Event::RuntimeUpgradeCompleted(weight));
+		<Pallet<T>>::deposit_event(Event::RuntimeUpgradeCompleted { weight });
 
 		weight
 	}

--- a/pallets/migrations/src/lib.rs
+++ b/pallets/migrations/src/lib.rs
@@ -99,10 +99,17 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {
+		/// Runtime upgrade started
 		RuntimeUpgradeStarted(),
-		RuntimeUpgradeCompleted(Weight),
-		MigrationStarted(Vec<u8>),
-		MigrationCompleted(Vec<u8>, Weight),
+		/// Runtime upgrade completed
+		RuntimeUpgradeCompleted { weight: Weight },
+		/// Migration started
+		MigrationStarted { migration_name: Vec<u8> },
+		/// Migration completed
+		MigrationCompleted {
+			migration_name: Vec<u8>, 
+			consumed_weight: Weight
+		},
 	}
 
 	#[pallet::hooks]

--- a/pallets/migrations/src/lib.rs
+++ b/pallets/migrations/src/lib.rs
@@ -107,8 +107,8 @@ pub mod pallet {
 		MigrationStarted { migration_name: Vec<u8> },
 		/// Migration completed
 		MigrationCompleted {
-			migration_name: Vec<u8>, 
-			consumed_weight: Weight
+			migration_name: Vec<u8>,
+			consumed_weight: Weight,
 		},
 	}
 
@@ -270,8 +270,8 @@ pub mod pallet {
 			let migration_done = <MigrationState<T>>::get(migration_name_as_bytes);
 
 			if !migration_done {
-				<Pallet<T>>::deposit_event(Event::MigrationStarted { 
-					migration_name: migration_name_as_bytes.into()
+				<Pallet<T>>::deposit_event(Event::MigrationStarted {
+					migration_name: migration_name_as_bytes.into(),
 				});
 
 				// when we go overweight, leave a warning... there's nothing we can really do about

--- a/pallets/migrations/src/tests.rs
+++ b/pallets/migrations/src/tests.rs
@@ -191,7 +191,7 @@ fn migration_should_only_be_invoked_once() {
 					expected.append(&mut vec![
 						Event::RuntimeUpgradeStarted(),
 						Event::RuntimeUpgradeCompleted {
-							weight: 100000001u32.into(),
+							weight: 100000000u32.into(),
 						},
 					]);
 					assert_eq!(events(), expected);

--- a/pallets/migrations/src/tests.rs
+++ b/pallets/migrations/src/tests.rs
@@ -106,7 +106,9 @@ fn on_runtime_upgrade_emits_events() {
 
 		let expected = vec![
 			Event::RuntimeUpgradeStarted(),
-			Event::RuntimeUpgradeCompleted(100000000u64.into()),
+			Event::RuntimeUpgradeCompleted {
+				weight: 100000000u64.into(),
+			},
 		];
 		assert_eq!(events(), expected);
 	});
@@ -157,9 +159,16 @@ fn migration_should_only_be_invoked_once() {
 					);
 					let mut expected = vec![
 						Event::RuntimeUpgradeStarted(),
-						Event::MigrationStarted("migration1".into()),
-						Event::MigrationCompleted("migration1".into(), 1u32.into()),
-						Event::RuntimeUpgradeCompleted(100000001u32.into()), // includes reads/writes
+						Event::MigrationStarted {
+							migration_name: "migration1".into(),
+						},
+						Event::MigrationCompleted {
+							migration_name: "migration1".into(),
+							consumed_weight: 1u32.into(),
+						},
+						Event::RuntimeUpgradeCompleted {
+							weight: 100000001u32.into(),
+						}, // includes reads/writes
 					];
 					assert_eq!(events(), expected);
 
@@ -181,7 +190,9 @@ fn migration_should_only_be_invoked_once() {
 					);
 					expected.append(&mut vec![
 						Event::RuntimeUpgradeStarted(),
-						Event::RuntimeUpgradeCompleted(100000000u32.into()),
+						Event::RuntimeUpgradeCompleted {
+							weight: 100000001u32.into(),
+						},
 					]);
 					assert_eq!(events(), expected);
 

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1517,7 +1517,7 @@ pub mod pallet {
 						<DelegatorState<T>>::remove(&delegator_id);
 						Pallet::<T>::deposit_event(Event::DelegatorLeft {
 							delegator: delegator_id,
-							unstaked_amount: balance_amt
+							unstaked_amount: balance_amt,
 						});
 					} else {
 						let nom_st: Delegator<T::AccountId, BalanceOf<T>> = self.clone().into();
@@ -1944,131 +1944,123 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// Started new round.
-		NewRound { 
-			starting_block: T::BlockNumber, 
-			round: RoundIndex, 
-			selected_collators_number: u32, 
-			total_balance: BalanceOf<T> 
+		NewRound {
+			starting_block: T::BlockNumber,
+			round: RoundIndex,
+			selected_collators_number: u32,
+			total_balance: BalanceOf<T>,
 		},
 		/// Account joined the set of collator candidates.
 		JoinedCollatorCandidates {
 			account: T::AccountId,
 			amount_locked: BalanceOf<T>,
-			new_total_amt_locked: BalanceOf<T>
+			new_total_amt_locked: BalanceOf<T>,
 		},
 		/// Candidate selected for collators. Total Exposed Amount includes all delegations.
 		CollatorChosen {
 			round: RoundIndex,
 			collator_account: T::AccountId,
-			total_exposed_amount: BalanceOf<T>
+			total_exposed_amount: BalanceOf<T>,
 		},
 		/// Сandidate requested to decrease a self bond.
 		CandidateBondLessRequested {
 			candidate: T::AccountId,
 			amount_to_decrease: BalanceOf<T>,
-			execute_round: RoundIndex
+			execute_round: RoundIndex,
 		},
 		/// Сandidate has increased a self bond.
 		CandidateBondedMore {
 			candidate: T::AccountId,
 			amount: BalanceOf<T>,
-			new_total_bond: BalanceOf<T>
+			new_total_bond: BalanceOf<T>,
 		},
 		/// Сandidate has decreased a self bond.
-		CandidateBondedLess{
+		CandidateBondedLess {
 			candidate: T::AccountId,
 			amount: BalanceOf<T>,
-			new_bond: BalanceOf<T>
+			new_bond: BalanceOf<T>,
 		},
 		/// Candidate temporarily leave the set of collator candidates without unbonding.
-		CandidateWentOffline {
-			candidate: T::AccountId
-		},
+		CandidateWentOffline { candidate: T::AccountId },
 		/// Candidate rejoins the set of collator candidates.
-		CandidateBackOnline {
-			candidate: T::AccountId
-		},
+		CandidateBackOnline { candidate: T::AccountId },
 		/// Сandidate has requested to leave the set of candidates.
 		CandidateScheduledExit {
 			exit_allowed_round: RoundIndex,
 			candidate: T::AccountId,
-			scheduled_exit: RoundIndex
+			scheduled_exit: RoundIndex,
 		},
 		/// Cancelled request to leave the set of candidates.
-		CancelledCandidateExit {
-			candidate: T::AccountId
-		},
+		CancelledCandidateExit { candidate: T::AccountId },
 		/// Cancelled request to decrease candidate's bond.
 		CancelledCandidateBondLess {
 			candidate: T::AccountId,
 			amount: BalanceOf<T>,
-			execute_round: RoundIndex
+			execute_round: RoundIndex,
 		},
 		/// Candidate has left the set of candidates.
 		CandidateLeft {
 			ex_candidate: T::AccountId,
 			unlocked_amount: BalanceOf<T>,
-			new_total_amt_locked: BalanceOf<T>
+			new_total_amt_locked: BalanceOf<T>,
 		},
 		/// Delegator requested to decrease a bond for the collator candidate.
 		DelegationDecreaseScheduled {
 			delegator: T::AccountId,
 			candidate: T::AccountId,
 			amount_to_decrease: BalanceOf<T>,
-			execute_round: RoundIndex
+			execute_round: RoundIndex,
 		},
 		// Delegation increased.
 		DelegationIncreased {
 			delegator: T::AccountId,
 			candidate: T::AccountId,
 			amount: BalanceOf<T>,
-			in_top: bool
+			in_top: bool,
 		},
 		// Delegation decreased.
 		DelegationDecreased {
 			delegator: T::AccountId,
 			candidate: T::AccountId,
 			amount: BalanceOf<T>,
-			in_top: bool
+			in_top: bool,
 		},
 		/// Delegator requested to leave the set of delegators.
 		DelegatorExitScheduled {
 			round: RoundIndex,
 			delegator: T::AccountId,
-			scheduled_exit: RoundIndex
+			scheduled_exit: RoundIndex,
 		},
 		/// Delegator requested to revoke delegation.
 		DelegationRevocationScheduled {
 			round: RoundIndex,
 			delegator: T::AccountId,
 			candidate: T::AccountId,
-			scheduled_exit: RoundIndex			
+			scheduled_exit: RoundIndex,
 		},
 		/// Delegator has left the set of delegators.
 		DelegatorLeft {
 			delegator: T::AccountId,
-			unstaked_amount: BalanceOf<T>
+			unstaked_amount: BalanceOf<T>,
 		},
 		/// Delegation revoked.
 		DelegationRevoked {
 			delegator: T::AccountId,
 			candidate: T::AccountId,
-			unstaked_amount: BalanceOf<T>
+			unstaked_amount: BalanceOf<T>,
 		},
 		/// Delegation kicked.
 		DelegationKicked {
 			delegator: T::AccountId,
 			candidate: T::AccountId,
-			unstaked_amount: BalanceOf<T>			
+			unstaked_amount: BalanceOf<T>,
 		},
 		/// Cancelled a pending request to exit the set of delegators.
-		DelegatorExitCancelled {
-			delegator: T::AccountId,
-		},
+		DelegatorExitCancelled { delegator: T::AccountId },
 		/// Cancelled request to change an existing delegation.
 		CancelledDelegationRequest {
 			delegator: T::AccountId,
-			cancelled_request: DelegationRequest<T::AccountId, BalanceOf<T>>
+			cancelled_request: DelegationRequest<T::AccountId, BalanceOf<T>>,
 		},
 		/// New delegation (increase of the existing one).
 		Delegation {
@@ -2081,29 +2073,26 @@ pub mod pallet {
 		DelegatorLeftCandidate {
 			delegator: T::AccountId,
 			candidate: T::AccountId,
-			unstaked_amount: BalanceOf<T>,	
-			total_candidate_staked: BalanceOf<T>
+			unstaked_amount: BalanceOf<T>,
+			total_candidate_staked: BalanceOf<T>,
 		},
 		/// Paid the account (delegator or collator) the balance as liquid rewards.
 		Rewarded {
 			account: T::AccountId,
-			rewards: BalanceOf<T>
+			rewards: BalanceOf<T>,
 		},
 		/// Transferred to account which holds funds reserved for parachain bond.
 		ReservedForParachainBond {
 			account: T::AccountId,
-			value: BalanceOf<T>
+			value: BalanceOf<T>,
 		},
 		/// Account (re)set for parachain bond treasury.
 		ParachainBondAccountSet {
 			old: T::AccountId,
-			new: T::AccountId
+			new: T::AccountId,
 		},
 		/// Percent of inflation reserved for parachain bond (re)set.
-		ParachainBondReservePercentSet {
-			old: Percent,
-			new: Percent
-		},
+		ParachainBondReservePercentSet { old: Percent, new: Percent },
 		/// Annual inflation input (first 3) was used to derive new per-round inflation (last 3)
 		InflationSet {
 			annual_min: Perbill,
@@ -2111,26 +2100,20 @@ pub mod pallet {
 			annual_max: Perbill,
 			round_min: Perbill,
 			round_ideal: Perbill,
-			round_max: Perbill
+			round_max: Perbill,
 		},
 		/// Staking expectations set.
-		StakeExpectationsSet{
+		StakeExpectationsSet {
 			expect_min: BalanceOf<T>,
 			expect_ideal: BalanceOf<T>,
-			expect_max: BalanceOf<T>
+			expect_max: BalanceOf<T>,
 		},
 		/// Set total selected candidates to this value.
-		TotalSelectedSet {
-			old: u32,
-			new: u32
-		},
+		TotalSelectedSet { old: u32, new: u32 },
 		/// Set collator commission to this value.
-		CollatorCommissionSet {
-			old: Perbill,
-			new: Perbill
-		},
+		CollatorCommissionSet { old: Perbill, new: Perbill },
 		/// Set blocks per round
-		BlocksPerRoundSet{
+		BlocksPerRoundSet {
 			current_round: RoundIndex,
 			first_block: T::BlockNumber,
 			old: u32,
@@ -2690,8 +2673,8 @@ pub mod pallet {
 			<Total<T>>::put(new_total);
 			Self::deposit_event(Event::JoinedCollatorCandidates {
 				account: acc,
-				amount_locked: bond, 
-				new_total_amt_locked: new_total
+				amount_locked: bond,
+				new_total_amt_locked: new_total,
 			});
 			Ok(().into())
 		}
@@ -2714,10 +2697,10 @@ pub mod pallet {
 				<CandidatePool<T>>::put(candidates);
 			}
 			<CandidateInfo<T>>::insert(&collator, state);
-			Self::deposit_event(Event::CandidateScheduledExit { 
+			Self::deposit_event(Event::CandidateScheduledExit {
 				exit_allowed_round: now,
 				candidate: collator,
-				scheduled_exit: when
+				scheduled_exit: when,
 			});
 			Ok(().into())
 		}
@@ -2816,7 +2799,9 @@ pub mod pallet {
 			);
 			<CandidatePool<T>>::put(candidates);
 			<CandidateInfo<T>>::insert(&collator, state);
-			Self::deposit_event(Event::CancelledCandidateExit { candidate: collator });
+			Self::deposit_event(Event::CancelledCandidateExit {
+				candidate: collator,
+			});
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::go_offline())]
@@ -2831,7 +2816,9 @@ pub mod pallet {
 				<CandidatePool<T>>::put(candidates);
 			}
 			<CandidateInfo<T>>::insert(&collator, state);
-			Self::deposit_event(Event::CandidateWentOffline { candidate: collator });
+			Self::deposit_event(Event::CandidateWentOffline {
+				candidate: collator,
+			});
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::go_online())]
@@ -2852,7 +2839,9 @@ pub mod pallet {
 			);
 			<CandidatePool<T>>::put(candidates);
 			<CandidateInfo<T>>::insert(&collator, state);
-			Self::deposit_event(Event::CandidateBackOnline { candidate: collator });
+			Self::deposit_event(Event::CandidateBackOnline {
+				candidate: collator,
+			});
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::candidate_bond_more())]
@@ -2884,7 +2873,7 @@ pub mod pallet {
 			Self::deposit_event(Event::CandidateBondLessRequested {
 				candidate: collator,
 				amount_to_decrease: less,
-				execute_round: when
+				execute_round: when,
 			});
 			Ok(().into())
 		}
@@ -3011,10 +3000,10 @@ pub mod pallet {
 			ensure!(!state.is_leaving(), Error::<T>::DelegatorAlreadyLeaving);
 			let (now, when) = state.schedule_leave::<T>();
 			<DelegatorState<T>>::insert(&acc, state);
-			Self::deposit_event(Event::DelegatorExitScheduled { 
+			Self::deposit_event(Event::DelegatorExitScheduled {
 				round: now,
 				delegator: acc,
-				scheduled_exit: when
+				scheduled_exit: when,
 			});
 			Ok(().into())
 		}
@@ -3041,9 +3030,9 @@ pub mod pallet {
 				}
 			}
 			<DelegatorState<T>>::remove(&delegator);
-			Self::deposit_event(Event::DelegatorLeft { 
-				delegator: delegator, 
-				unstaked_amount: state.total
+			Self::deposit_event(Event::DelegatorLeft {
+				delegator: delegator,
+				unstaked_amount: state.total,
 			});
 			Ok(().into())
 		}
@@ -3136,7 +3125,7 @@ pub mod pallet {
 			<DelegatorState<T>>::insert(&delegator, state);
 			Self::deposit_event(Event::CancelledDelegationRequest {
 				delegator: delegator,
-				cancelled_request: request
+				cancelled_request: request,
 			});
 			Ok(().into())
 		}
@@ -3291,7 +3280,7 @@ pub mod pallet {
 				if let Ok(amount_transferred) = T::Currency::deposit_into_existing(&to, amt) {
 					Self::deposit_event(Event::Rewarded {
 						account: to.clone(),
-						rewards: amount_transferred.peek()
+						rewards: amount_transferred.peek(),
 					});
 				}
 			};
@@ -3381,7 +3370,7 @@ pub mod pallet {
 				Self::deposit_event(Event::CollatorChosen {
 					round: now,
 					collator_account: account.clone(),
-					total_exposed_amount: snapshot_total
+					total_exposed_amount: snapshot_total,
 				});
 			}
 			// insert canonical collator set

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -409,11 +409,11 @@ pub mod pallet {
 			<Total<T>>::put(new_total);
 			self.bond += more;
 			self.total_counted += more;
-			<Pallet<T>>::deposit_event(Event::CandidateBondedMore(
-				who.clone(),
-				more.into(),
-				self.bond.into(),
-			));
+			<Pallet<T>>::deposit_event(Event::CandidateBondedMore {
+				candidate: who.clone(),
+				amount: more.into(),
+				new_total_bond: self.bond.into(),
+			});
 			Ok(())
 		}
 		/// Schedule executable decrease of collator candidate self bond
@@ -463,11 +463,11 @@ pub mod pallet {
 			// (assumptions enforced by `schedule_bond_less`; if storage corrupts, must re-verify)
 			self.bond -= request.amount;
 			self.total_counted -= request.amount;
-			let event = Event::CandidateBondedLess(
-				who.clone().into(),
-				request.amount.into(),
-				self.bond.into(),
-			);
+			let event = Event::CandidateBondedLess {
+				candidate: who.clone().into(),
+				amount: request.amount.into(),
+				new_bond: self.bond.into(),
+			};
 			// reset s.t. no pending request
 			self.request = None;
 			// update candidate pool value because it must change if self bond changes
@@ -485,11 +485,11 @@ pub mod pallet {
 			let request = self
 				.request
 				.ok_or(Error::<T>::PendingCandidateRequestsDNE)?;
-			let event = Event::CancelledCandidateBondLess(
-				who.clone().into(),
-				request.amount.into(),
-				request.when_executable,
-			);
+			let event = Event::CancelledCandidateBondLess {
+				candidate: who.clone().into(),
+				amount: request.amount.into(),
+				execute_round: request.when_executable,
+			};
 			self.request = None;
 			Pallet::<T>::deposit_event(event);
 			Ok(())
@@ -645,17 +645,17 @@ pub mod pallet {
 						.expect("Delegation existence => DelegatorState existence");
 				let leaving = delegator_state.delegations.0.len() == 1usize;
 				delegator_state.rm_delegation(candidate);
-				Pallet::<T>::deposit_event(Event::DelegationKicked(
-					lowest_bottom_to_be_kicked.owner.clone(),
-					candidate.clone(),
-					lowest_bottom_to_be_kicked.amount,
-				));
+				Pallet::<T>::deposit_event(Event::DelegationKicked {
+					delegator: lowest_bottom_to_be_kicked.owner.clone(),
+					candidate: candidate.clone(),
+					unstaked_amount: lowest_bottom_to_be_kicked.amount,
+				});
 				if leaving {
 					<DelegatorState<T>>::remove(&lowest_bottom_to_be_kicked.owner);
-					Pallet::<T>::deposit_event(Event::DelegatorLeft(
-						lowest_bottom_to_be_kicked.owner,
-						lowest_bottom_to_be_kicked.amount,
-					));
+					Pallet::<T>::deposit_event(Event::DelegatorLeft {
+						delegator: lowest_bottom_to_be_kicked.owner,
+						unstaked_amount: lowest_bottom_to_be_kicked.amount,
+					});
 				} else {
 					<DelegatorState<T>>::insert(&lowest_bottom_to_be_kicked.owner, delegator_state);
 				}
@@ -1375,12 +1375,12 @@ pub mod pallet {
 					<Total<T>>::put(new_total_staked);
 					let nom_st: Delegator<T::AccountId, BalanceOf<T>> = self.clone().into();
 					<DelegatorState<T>>::insert(&delegator_id, nom_st);
-					Pallet::<T>::deposit_event(Event::DelegationIncreased(
-						delegator_id,
-						candidate_id,
-						balance_amt,
-						in_top,
-					));
+					Pallet::<T>::deposit_event(Event::DelegationIncreased {
+						delegator: delegator_id,
+						candidate: candidate_id,
+						amount: balance_amt,
+						in_top: in_top,
+					});
 					return Ok(());
 				}
 			}
@@ -1508,14 +1508,17 @@ pub mod pallet {
 						delegator_id.clone(),
 						balance_amt,
 					)?;
-					Pallet::<T>::deposit_event(Event::DelegationRevoked(
-						delegator_id.clone(),
-						candidate_id,
-						balance_amt,
-					));
+					Pallet::<T>::deposit_event(Event::DelegationRevoked {
+						delegator: delegator_id.clone(),
+						candidate: candidate_id,
+						unstaked_amount: balance_amt,
+					});
 					if leaving {
 						<DelegatorState<T>>::remove(&delegator_id);
-						Pallet::<T>::deposit_event(Event::DelegatorLeft(delegator_id, balance_amt));
+						Pallet::<T>::deposit_event(Event::DelegatorLeft {
+							delegator: delegator_id,
+							unstaked_amount: balance_amt
+						});
 					} else {
 						let nom_st: Delegator<T::AccountId, BalanceOf<T>> = self.clone().into();
 						<DelegatorState<T>>::insert(&delegator_id, nom_st);
@@ -1563,12 +1566,12 @@ pub mod pallet {
 								let nom_st: Delegator<T::AccountId, BalanceOf<T>> =
 									self.clone().into();
 								<DelegatorState<T>>::insert(&delegator_id, nom_st);
-								Pallet::<T>::deposit_event(Event::DelegationDecreased(
-									delegator_id,
-									candidate_id,
-									balance_amt,
-									in_top,
-								));
+								Pallet::<T>::deposit_event(Event::DelegationDecreased {
+									delegator: delegator_id,
+									candidate: candidate_id,
+									amount: balance_amt,
+									in_top: in_top,
+								});
 								return Ok(());
 							} else {
 								// must rm entire delegation if x.amount <= less or cancel request
@@ -2019,14 +2022,14 @@ pub mod pallet {
 			delegator: T::AccountId,
 			candidate: T::AccountId,
 			amount: BalanceOf<T>,
-			if_in_top: bool
+			in_top: bool
 		},
 		// Delegation decreased.
 		DelegationDecreased {
 			delegator: T::AccountId,
 			candidate: T::AccountId,
 			amount: BalanceOf<T>,
-			if_in_top: bool
+			in_top: bool
 		},
 		/// Delegator requested to leave the set of delegators.
 		DelegatorExitScheduled {
@@ -2079,7 +2082,7 @@ pub mod pallet {
 			delegator: T::AccountId,
 			candidate: T::AccountId,
 			unstaked_amount: BalanceOf<T>	
-			total_candidate_staked_amount: BalanceOf<T>
+			total_candidate_staked: BalanceOf<T>
 		},
 		/// Paid the account (delegator or collator) the balance as liquid rewards.
 		Rewarded {
@@ -2156,12 +2159,12 @@ pub mod pallet {
 				<Round<T>>::put(round);
 				// snapshot total stake
 				<Staked<T>>::insert(round.current, <Total<T>>::get());
-				Self::deposit_event(Event::NewRound(
-					round.first,
-					round.current,
-					collator_count,
-					total_staked,
-				));
+				Self::deposit_event(Event::NewRound {
+					starting_block: round.first,
+					round: round.current,
+					selected_collators_number: collator_count,
+					total_balance: total_staked,
+				});
 				weight +=
 					T::WeightInfo::round_transition_on_initialize(collator_count, delegation_count);
 			}
@@ -2435,12 +2438,12 @@ pub mod pallet {
 			<Round<T>>::put(round);
 			// Snapshot total stake
 			<Staked<T>>::insert(1u32, <Total<T>>::get());
-			<Pallet<T>>::deposit_event(Event::NewRound(
-				T::BlockNumber::zero(),
-				1u32,
-				v_count,
-				total_staked,
-			));
+			<Pallet<T>>::deposit_event(Event::NewRound {
+				starting_block: T::BlockNumber::zero(),
+				round: 1u32,
+				selected_collators_number: v_count,
+				total_balance: total_staked,
+			});
 		}
 	}
 
@@ -2511,11 +2514,11 @@ pub mod pallet {
 				Error::<T>::NoWritingSameValue
 			);
 			config.set_expectations(expectations);
-			Self::deposit_event(Event::StakeExpectationsSet(
-				config.expect.min,
-				config.expect.ideal,
-				config.expect.max,
-			));
+			Self::deposit_event(Event::StakeExpectationsSet {
+				expect_min: config.expect.min,
+				expect_ideal: config.expect.ideal,
+				expect_max: config.expect.max,
+			});
 			<InflationConfig<T>>::put(config);
 			Ok(().into())
 		}
@@ -2531,14 +2534,14 @@ pub mod pallet {
 			ensure!(config.annual != schedule, Error::<T>::NoWritingSameValue);
 			config.annual = schedule;
 			config.set_round_from_annual::<T>(schedule);
-			Self::deposit_event(Event::InflationSet(
-				config.annual.min,
-				config.annual.ideal,
-				config.annual.max,
-				config.round.min,
-				config.round.ideal,
-				config.round.max,
-			));
+			Self::deposit_event(Event::InflationSet {
+				annual_min: config.annual.min,
+				annual_ideal: config.annual.ideal,
+				annual_max: config.annual.max,
+				round_min: config.round.min,
+				round_ideal: config.round.ideal,
+				round_max: config.round.max,
+			});
 			<InflationConfig<T>>::put(config);
 			Ok(().into())
 		}
@@ -2558,7 +2561,7 @@ pub mod pallet {
 				account: new.clone(),
 				percent,
 			});
-			Self::deposit_event(Event::ParachainBondAccountSet(old, new));
+			Self::deposit_event(Event::ParachainBondAccountSet { old, new });
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::set_parachain_bond_reserve_percent())]
@@ -2577,7 +2580,7 @@ pub mod pallet {
 				account,
 				percent: new,
 			});
-			Self::deposit_event(Event::ParachainBondReservePercentSet(old, new));
+			Self::deposit_event(Event::ParachainBondReservePercentSet { old, new });
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::set_total_selected())]
@@ -2596,7 +2599,7 @@ pub mod pallet {
 				Error::<T>::RoundLengthMustBeAtLeastTotalSelectedCollators,
 			);
 			<TotalSelected<T>>::put(new);
-			Self::deposit_event(Event::TotalSelectedSet(old, new));
+			Self::deposit_event(Event::TotalSelectedSet { old, new });
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::set_collator_commission())]
@@ -2609,7 +2612,7 @@ pub mod pallet {
 			let old = <CollatorCommission<T>>::get();
 			ensure!(old != new, Error::<T>::NoWritingSameValue);
 			<CollatorCommission<T>>::put(new);
-			Self::deposit_event(Event::CollatorCommissionSet(old, new));
+			Self::deposit_event(Event::CollatorCommissionSet { old, new });
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::set_blocks_per_round())]
@@ -2635,15 +2638,15 @@ pub mod pallet {
 			let mut inflation_config = <InflationConfig<T>>::get();
 			inflation_config.reset_round(new);
 			<Round<T>>::put(round);
-			Self::deposit_event(Event::BlocksPerRoundSet(
-				now,
-				first,
-				old,
-				new,
-				inflation_config.round.min,
-				inflation_config.round.ideal,
-				inflation_config.round.max,
-			));
+			Self::deposit_event(Event::BlocksPerRoundSet {
+				current_round: now,
+				first_block: first,
+				old: old,
+				new: new,
+				new_per_round_inflation_min: inflation_config.round.min,
+				new_per_round_inflation_ideal: inflation_config.round.ideal,
+				new_per_round_inflation_max: inflation_config.round.max,
+			});
 			<InflationConfig<T>>::put(inflation_config);
 			Ok(().into())
 		}
@@ -2685,7 +2688,11 @@ pub mod pallet {
 			<CandidatePool<T>>::put(candidates);
 			let new_total = <Total<T>>::get().saturating_add(bond);
 			<Total<T>>::put(new_total);
-			Self::deposit_event(Event::JoinedCollatorCandidates(acc, bond, new_total));
+			Self::deposit_event(Event::JoinedCollatorCandidates {
+				account: acc,
+				amount_locked: bond, 
+				new_total_amt_locked: new_total
+			});
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_leave_candidates(*candidate_count))]
@@ -2707,7 +2714,11 @@ pub mod pallet {
 				<CandidatePool<T>>::put(candidates);
 			}
 			<CandidateInfo<T>>::insert(&collator, state);
-			Self::deposit_event(Event::CandidateScheduledExit(now, collator, when));
+			Self::deposit_event(Event::CandidateScheduledExit { 
+				exit_allowed_round: now,
+				candidate: collator,
+				scheduled_exit: when
+			});
 			Ok(().into())
 		}
 		#[pallet::weight(
@@ -2772,11 +2783,11 @@ pub mod pallet {
 			<BottomDelegations<T>>::remove(&candidate);
 			let new_total_staked = <Total<T>>::get().saturating_sub(total_backing);
 			<Total<T>>::put(new_total_staked);
-			Self::deposit_event(Event::CandidateLeft(
-				candidate,
-				total_backing,
-				new_total_staked,
-			));
+			Self::deposit_event(Event::CandidateLeft {
+				ex_candidate: candidate,
+				unlocked_amount: total_backing,
+				new_total_amt_locked: new_total_staked,
+			});
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::cancel_leave_candidates(*candidate_count))]
@@ -2805,7 +2816,7 @@ pub mod pallet {
 			);
 			<CandidatePool<T>>::put(candidates);
 			<CandidateInfo<T>>::insert(&collator, state);
-			Self::deposit_event(Event::CancelledCandidateExit(collator));
+			Self::deposit_event(Event::CancelledCandidateExit { candidate: collator });
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::go_offline())]
@@ -2820,7 +2831,7 @@ pub mod pallet {
 				<CandidatePool<T>>::put(candidates);
 			}
 			<CandidateInfo<T>>::insert(&collator, state);
-			Self::deposit_event(Event::CandidateWentOffline(collator));
+			Self::deposit_event(Event::CandidateWentOffline { candidate: collator });
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::go_online())]
@@ -2841,7 +2852,7 @@ pub mod pallet {
 			);
 			<CandidatePool<T>>::put(candidates);
 			<CandidateInfo<T>>::insert(&collator, state);
-			Self::deposit_event(Event::CandidateBackOnline(collator));
+			Self::deposit_event(Event::CandidateBackOnline { candidate: collator });
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::candidate_bond_more())]
@@ -2870,7 +2881,11 @@ pub mod pallet {
 			let mut state = <CandidateInfo<T>>::get(&collator).ok_or(Error::<T>::CandidateDNE)?;
 			let when = state.schedule_bond_less::<T>(less)?;
 			<CandidateInfo<T>>::insert(&collator, state);
-			Self::deposit_event(Event::CandidateBondLessRequested(collator, less, when));
+			Self::deposit_event(Event::CandidateBondLessRequested {
+				candidate: collator,
+				amount_to_decrease: less,
+				execute_round: when
+			});
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::execute_candidate_bond_less())]
@@ -2978,12 +2993,12 @@ pub mod pallet {
 			<Total<T>>::put(new_total_locked);
 			<CandidateInfo<T>>::insert(&candidate, state);
 			<DelegatorState<T>>::insert(&delegator, delegator_state);
-			Self::deposit_event(Event::Delegation(
-				delegator,
-				amount,
-				candidate,
-				delegator_position,
-			));
+			Self::deposit_event(Event::Delegation {
+				delegator: delegator,
+				locked_amount: amount,
+				candidate: candidate,
+				delegator_position: delegator_position,
+			});
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_leave_delegators())]
@@ -2996,7 +3011,11 @@ pub mod pallet {
 			ensure!(!state.is_leaving(), Error::<T>::DelegatorAlreadyLeaving);
 			let (now, when) = state.schedule_leave::<T>();
 			<DelegatorState<T>>::insert(&acc, state);
-			Self::deposit_event(Event::DelegatorExitScheduled(now, acc, when));
+			Self::deposit_event(Event::DelegatorExitScheduled { 
+				round: now,
+				delegator: acc,
+				scheduled_exit: when
+			});
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::execute_leave_delegators(*delegation_count))]
@@ -3022,7 +3041,10 @@ pub mod pallet {
 				}
 			}
 			<DelegatorState<T>>::remove(&delegator);
-			Self::deposit_event(Event::DelegatorLeft(delegator, state.total));
+			Self::deposit_event(Event::DelegatorLeft { 
+				delegator: delegator, 
+				unstaked_amount: state.total
+			});
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::cancel_leave_delegators())]
@@ -3037,7 +3059,7 @@ pub mod pallet {
 			// cancel exit request
 			state.cancel_leave();
 			<DelegatorState<T>>::insert(&delegator, state);
-			Self::deposit_event(Event::DelegatorExitCancelled(delegator));
+			Self::deposit_event(Event::DelegatorExitCancelled { delegator });
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_revoke_delegation())]
@@ -3051,9 +3073,12 @@ pub mod pallet {
 			let mut state = <DelegatorState<T>>::get(&delegator).ok_or(Error::<T>::DelegatorDNE)?;
 			let (now, when) = state.schedule_revoke::<T>(collator.clone())?;
 			<DelegatorState<T>>::insert(&delegator, state);
-			Self::deposit_event(Event::DelegationRevocationScheduled(
-				now, delegator, collator, when,
-			));
+			Self::deposit_event(Event::DelegationRevocationScheduled {
+				round: now,
+				delegator: delegator,
+				candidate: collator,
+				scheduled_exit: when,
+			});
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::delegator_bond_more())]
@@ -3079,9 +3104,12 @@ pub mod pallet {
 			let mut state = <DelegatorState<T>>::get(&caller).ok_or(Error::<T>::DelegatorDNE)?;
 			let when = state.schedule_decrease_delegation::<T>(candidate.clone(), less)?;
 			<DelegatorState<T>>::insert(&caller, state);
-			Self::deposit_event(Event::DelegationDecreaseScheduled(
-				caller, candidate, less, when,
-			));
+			Self::deposit_event(Event::DelegationDecreaseScheduled {
+				delegator: caller,
+				candidate: candidate,
+				amount_to_decrease: less,
+				execute_round: when,
+			});
 			Ok(().into())
 		}
 		#[pallet::weight(<T as Config>::WeightInfo::execute_delegator_bond_less())]
@@ -3106,7 +3134,10 @@ pub mod pallet {
 			let mut state = <DelegatorState<T>>::get(&delegator).ok_or(Error::<T>::DelegatorDNE)?;
 			let request = state.cancel_pending_request::<T>(candidate)?;
 			<DelegatorState<T>>::insert(&delegator, state);
-			Self::deposit_event(Event::CancelledDelegationRequest(delegator, request));
+			Self::deposit_event(Event::CancelledDelegationRequest {
+				delegator: delegator,
+				cancelled_request: request
+			});
 			Ok(().into())
 		}
 	}
@@ -3162,9 +3193,12 @@ pub mod pallet {
 			<Total<T>>::put(new_total_locked);
 			let new_total = state.total_counted;
 			<CandidateInfo<T>>::insert(&candidate, state);
-			Self::deposit_event(Event::DelegatorLeftCandidate(
-				delegator, candidate, amount, new_total,
-			));
+			Self::deposit_event(Event::DelegatorLeftCandidate {
+				delegator: delegator,
+				candidate: candidate,
+				unstaked_amount: amount,
+				total_candidate_staked: new_total,
+			});
 			Ok(())
 		}
 		fn prepare_staking_payouts(now: RoundIndex) {
@@ -3189,10 +3223,10 @@ pub mod pallet {
 			{
 				// update round issuance iff transfer succeeds
 				left_issuance -= imb.peek();
-				Self::deposit_event(Event::ReservedForParachainBond(
-					bond_config.account,
-					imb.peek(),
-				));
+				Self::deposit_event(Event::ReservedForParachainBond {
+					account: bond_config.account,
+					value: imb.peek(),
+				});
 			}
 
 			let payout = DelayedPayout {
@@ -3255,7 +3289,10 @@ pub mod pallet {
 
 			let mint = |amt: BalanceOf<T>, to: T::AccountId| {
 				if let Ok(amount_transferred) = T::Currency::deposit_into_existing(&to, amt) {
-					Self::deposit_event(Event::Rewarded(to.clone(), amount_transferred.peek()));
+					Self::deposit_event(Event::Rewarded {
+						account: to.clone(),
+						rewards: amount_transferred.peek()
+					});
 				}
 			};
 
@@ -3341,7 +3378,11 @@ pub mod pallet {
 					total: state.total_counted,
 				};
 				<AtStake<T>>::insert(now, account, snapshot);
-				Self::deposit_event(Event::CollatorChosen(now, account.clone(), snapshot_total));
+				Self::deposit_event(Event::CollatorChosen {
+					round: now,
+					collator_account: account.clone(),
+					total_exposed_amount: snapshot_total
+				});
 			}
 			// insert canonical collator set
 			<SelectedCandidates<T>>::put(collators);

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1993,7 +1993,7 @@ pub mod pallet {
 			exit_allowed_round: RoundIndex,
 			candidate: T::AccountId,
 			scheduled_exit: RoundIndex
-		}
+		},
 		/// Cancelled request to leave the set of candidates.
 		CancelledCandidateExit {
 			candidate: T::AccountId
@@ -2081,7 +2081,7 @@ pub mod pallet {
 		DelegatorLeftCandidate {
 			delegator: T::AccountId,
 			candidate: T::AccountId,
-			unstaked_amount: BalanceOf<T>	
+			unstaked_amount: BalanceOf<T>,	
 			total_candidate_staked: BalanceOf<T>
 		},
 		/// Paid the account (delegator or collator) the balance as liquid rewards.

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -90,17 +90,17 @@ impl<T: Config> OnRuntimeUpgrade for SplitCandidateStateToDecreasePoV<T> {
 								.expect("Delegation existence => DelegatorState existence");
 							let leaving = delegator_state.delegations.0.len() == 1usize;
 							delegator_state.rm_delegation(&account);
-							Pallet::<T>::deposit_event(Event::DelegationKicked(
-								owner.clone(),
-								account.clone(),
-								*amount,
-							));
+							Pallet::<T>::deposit_event(Event::DelegationKicked {
+								delegator: owner.clone(),
+								candidate: account.clone(),
+								unstaked_amount: *amount,
+							});
 							if leaving {
 								<DelegatorState<T>>::remove(&owner);
-								Pallet::<T>::deposit_event(Event::DelegatorLeft(
-									owner.clone(),
-									*amount,
-								));
+								Pallet::<T>::deposit_event(Event::DelegatorLeft {
+									delegator: owner.clone(),
+									unstaked_amount: *amount,
+								});
 							} else {
 								<DelegatorState<T>>::insert(&owner, delegator_state);
 							}

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -291,7 +291,7 @@ macro_rules! assert_last_event {
 	($event:expr) => {
 		match &$event {
 			e => assert_eq!(*e, crate::mock::last_event()),
-			}
+		}
 	};
 }
 
@@ -302,7 +302,7 @@ macro_rules! assert_eq_events {
 	($events:expr) => {
 		match &$events {
 			e => similar_asserts::assert_eq!(*e, crate::mock::events()),
-			}
+		}
 	};
 }
 
@@ -339,11 +339,11 @@ macro_rules! assert_tail_eq {
 
 			if $tail.len() > $arr.len() {
 				similar_asserts::assert_eq!($tail, $arr); // will fail
-				}
+			}
 
 			let len_diff = $arr.len() - $tail.len();
 			similar_asserts::assert_eq!($tail, $arr[len_diff..]);
-			}
+		}
 	};
 }
 
@@ -359,8 +359,8 @@ macro_rules! assert_event_emitted {
 					e,
 					crate::mock::events()
 				);
-				}
 			}
+		}
 	};
 }
 
@@ -376,8 +376,8 @@ macro_rules! assert_event_not_emitted {
 					e,
 					crate::mock::events()
 				);
-				}
 			}
+		}
 	};
 }
 

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -291,7 +291,7 @@ macro_rules! assert_last_event {
 	($event:expr) => {
 		match &$event {
 			e => assert_eq!(*e, crate::mock::last_event()),
-		}
+			}
 	};
 }
 
@@ -302,7 +302,7 @@ macro_rules! assert_eq_events {
 	($events:expr) => {
 		match &$events {
 			e => similar_asserts::assert_eq!(*e, crate::mock::events()),
-		}
+			}
 	};
 }
 
@@ -339,11 +339,11 @@ macro_rules! assert_tail_eq {
 
 			if $tail.len() > $arr.len() {
 				similar_asserts::assert_eq!($tail, $arr); // will fail
-			}
+				}
 
 			let len_diff = $arr.len() - $tail.len();
 			similar_asserts::assert_eq!($tail, $arr[len_diff..]);
-		}
+			}
 	};
 }
 
@@ -359,8 +359,8 @@ macro_rules! assert_event_emitted {
 					e,
 					crate::mock::events()
 				);
+				}
 			}
-		}
 	};
 }
 
@@ -376,8 +376,8 @@ macro_rules! assert_event_not_emitted {
 					e,
 					crate::mock::events()
 				);
+				}
 			}
-		}
 	};
 }
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -6085,17 +6085,14 @@ fn payouts_follow_delegation_changes() {
 					account: 1,
 					rewards: 42,
 				},
-				(1, 42),
 				Event::Rewarded {
 					account: 7,
 					rewards: 14,
 				},
-				(7, 14),
 				Event::Rewarded {
 					account: 10,
 					rewards: 14,
 				},
-				(10, 14),
 			];
 			expected.append(&mut new6);
 			assert_eq_events!(expected.clone());
@@ -6968,7 +6965,6 @@ fn deferred_payment_steady_state_event_flow() {
 						account: 2,
 						rewards: 19,
 					},
-					(2, 19),
 					Event::Rewarded {
 						account: 11,
 						rewards: 6,

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -5051,7 +5051,7 @@ fn payout_distribution_to_solo_collators() {
 					rewards: 192,
 				},
 				Event::Rewarded {
-					account: 1,
+					account: 2,
 					rewards: 128,
 				},
 			];
@@ -5233,7 +5233,7 @@ fn multiple_delegations() {
 					delegator: 6,
 					locked_amount: 10,
 					candidate: 2,
-					delegator_position: DelegatorAdded::AddedToTop { new_total: 30 },
+					delegator_position: DelegatorAdded::AddedToTop { new_total: 50 },
 				},
 				Event::Delegation {
 					delegator: 6,
@@ -6595,7 +6595,7 @@ fn no_rewards_paid_until_after_reward_payment_delay() {
 			roll_one_block();
 			expected.push(Event::Rewarded {
 				account: 1,
-				rewards: 2,
+				rewards: 1,
 			});
 			assert_eq_events!(expected);
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -3969,22 +3969,18 @@ fn parachain_bond_inflation_reserve_matches_config() {
 					account: 1,
 					rewards: 22,
 				},
-				(1, 22),
 				Event::Rewarded {
 					account: 6,
 					rewards: 6,
 				},
-				(6, 6),
 				Event::Rewarded {
 					account: 7,
 					rewards: 6,
 				},
-				(7, 6),
 				Event::Rewarded {
 					account: 10,
 					rewards: 6,
 				},
-				(10, 6),
 				Event::DelegatorLeftCandidate {
 					delegator: 6,
 					candidate: 1,

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -3835,19 +3835,19 @@ fn parachain_bond_inflation_reserve_matches_config() {
 				},
 				Event::Rewarded {
 					account: 1,
-					value: 20,
+					rewards: 20,
 				},
 				Event::Rewarded {
 					account: 6,
-					value: 5,
+					rewards: 5,
 				},
 				Event::Rewarded {
 					account: 7,
-					value: 5,
+					rewards: 5,
 				},
 				Event::Rewarded {
 					account: 10,
-					value: 5,
+					rewards: 5,
 				},
 			];
 			expected.append(&mut new);
@@ -3916,24 +3916,20 @@ fn parachain_bond_inflation_reserve_matches_config() {
 				},
 				Event::Rewarded {
 					account: 1,
-					value: 21,
+					rewards: 21,
 				},
-				(1, 21),
 				Event::Rewarded {
 					account: 6,
-					value: 5,
+					rewards: 5,
 				},
-				(6, 5),
 				Event::Rewarded {
 					account: 7,
-					value: 5,
+					rewards: 5,
 				},
-				(7, 5),
 				Event::Rewarded {
 					account: 10,
-					value: 5,
+					rewards: 5,
 				},
-				(10, 5),
 				Event::ReservedForParachainBond {
 					account: 11,
 					value: 16,
@@ -3971,22 +3967,22 @@ fn parachain_bond_inflation_reserve_matches_config() {
 				},
 				Event::Rewarded {
 					account: 1,
-					value: 22,
+					rewards: 22,
 				},
 				(1, 22),
 				Event::Rewarded {
 					account: 6,
-					value: 6,
+					rewards: 6,
 				},
 				(6, 6),
 				Event::Rewarded {
 					account: 7,
-					value: 6,
+					rewards: 6,
 				},
 				(7, 6),
 				Event::Rewarded {
 					account: 10,
-					value: 6,
+					rewards: 6,
 				},
 				(10, 6),
 				Event::DelegatorLeftCandidate {
@@ -4036,19 +4032,19 @@ fn parachain_bond_inflation_reserve_matches_config() {
 				},
 				Event::Rewarded {
 					account: 1,
-					value: 24,
+					rewards: 24,
 				},
 				Event::Rewarded {
 					account: 6,
-					value: 6,
+					rewards: 6,
 				},
 				Event::Rewarded {
 					account: 7,
-					value: 6,
+					rewards: 6,
 				},
 				Event::Rewarded {
 					account: 10,
-					value: 6,
+					rewards: 6,
 				},
 			];
 			expected.append(&mut new2);
@@ -4104,19 +4100,19 @@ fn parachain_bond_inflation_reserve_matches_config() {
 				},
 				Event::Rewarded {
 					account: 1,
-					value: 20,
+					rewards: 20,
 				},
 				Event::Rewarded {
 					account: 6,
-					value: 4,
+					rewards: 4,
 				},
 				Event::Rewarded {
 					account: 7,
-					value: 4,
+					rewards: 4,
 				},
 				Event::Rewarded {
 					account: 10,
-					value: 4,
+					rewards: 4,
 				},
 			];
 			expected.append(&mut new3);
@@ -4163,15 +4159,15 @@ fn parachain_bond_inflation_reserve_matches_config() {
 				},
 				Event::Rewarded {
 					account: 1,
-					value: 22,
+					rewards: 22,
 				},
 				Event::Rewarded {
 					account: 7,
-					value: 5,
+					rewards: 5,
 				},
 				Event::Rewarded {
 					account: 10,
-					value: 5,
+					rewards: 5,
 				},
 			];
 			expected.append(&mut new4);
@@ -4225,15 +4221,15 @@ fn parachain_bond_inflation_reserve_matches_config() {
 				},
 				Event::Rewarded {
 					account: 1,
-					value: 23,
+					rewards: 23,
 				},
 				Event::Rewarded {
 					account: 7,
-					value: 5,
+					rewards: 5,
 				},
 				Event::Rewarded {
 					account: 10,
-					value: 5,
+					rewards: 5,
 				},
 			];
 			expected.append(&mut new5);
@@ -4281,15 +4277,15 @@ fn parachain_bond_inflation_reserve_matches_config() {
 				},
 				Event::Rewarded {
 					account: 1,
-					value: 24,
+					rewards: 24,
 				},
 				Event::Rewarded {
 					account: 7,
-					value: 5,
+					rewards: 5,
 				},
 				Event::Rewarded {
 					account: 10,
-					value: 5,
+					rewards: 5,
 				},
 			];
 			expected.append(&mut new6);
@@ -4335,19 +4331,19 @@ fn parachain_bond_inflation_reserve_matches_config() {
 				},
 				Event::Rewarded {
 					account: 1,
-					value: 24,
+					rewards: 24,
 				},
 				Event::Rewarded {
 					account: 7,
-					value: 4,
+					rewards: 4,
 				},
 				Event::Rewarded {
 					account: 10,
-					value: 4,
+					rewards: 4,
 				},
 				Event::Rewarded {
 					account: 8,
-					value: 4,
+					rewards: 4,
 				},
 			];
 			expected.append(&mut new7);
@@ -4480,15 +4476,15 @@ fn paid_collator_commission_matches_config() {
 				},
 				Event::Rewarded {
 					account: 4,
-					value: 18,
+					rewards: 18,
 				},
 				Event::Rewarded {
 					account: 5,
-					value: 6,
+					rewards: 6,
 				},
 				Event::Rewarded {
 					account: 6,
-					value: 6,
+					rewards: 6,
 				},
 			];
 			expected.append(&mut new2);
@@ -5200,42 +5196,36 @@ fn multiple_delegations() {
 			// chooses top TotalSelectedCandidates (5), in order
 			let mut expected = vec![
 				Event::CollatorChosen {
-					round: 8,
-					collator_account: 3,
-					total_exposed_amount: 80,
+					round: 2,
+					collator_account: 1,
+					total_exposed_amount: 50,
 				},
-				(2, 1, 50),
 				Event::CollatorChosen {
-					round: 8,
-					collator_account: 3,
-					total_exposed_amount: 80,
+					round: 2,
+					collator_account: 2,
+					total_exposed_amount: 40,
 				},
-				(2, 2, 40),
 				Event::CollatorChosen {
-					round: 8,
+					round: 2,
 					collator_account: 3,
-					total_exposed_amount: 80,
+					total_exposed_amount: 20,
 				},
-				(2, 3, 20),
 				Event::CollatorChosen {
-					round: 8,
-					collator_account: 3,
-					total_exposed_amount: 80,
+					round: 2,
+					collator_account: 4,
+					total_exposed_amount: 20,
 				},
-				(2, 4, 20),
 				Event::CollatorChosen {
-					round: 8,
-					collator_account: 3,
-					total_exposed_amount: 80,
+					round: 2,
+					collator_account: 5,
+					total_exposed_amount: 10,
 				},
-				(2, 5, 10),
 				Event::NewRound {
-					starting_block: 35,
-					round: 8,
+					starting_block: 5,
+					round: 2,
 					selected_collators_number: 5,
-					total_balance: 400,
+					total_balance: 140,
 				},
-				(5, 2, 5, 140),
 			];
 			assert_eq_events!(expected.clone());
 			assert_ok!(ParachainStaking::delegate(Origin::signed(6), 2, 10, 10, 10));

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -65,9 +65,10 @@ fn set_total_selected_event_emits_correctly() {
 		// before we can bump total_selected we must bump the blocks per round
 		assert_ok!(ParachainStaking::set_blocks_per_round(Origin::root(), 6u32));
 		assert_ok!(ParachainStaking::set_total_selected(Origin::root(), 6u32));
-		assert_last_event!(MetaEvent::ParachainStaking(Event::TotalSelectedSet(
-			5u32, 6u32
-		)));
+		assert_last_event!(MetaEvent::ParachainStaking(Event::TotalSelectedSet {
+			old: 5u32,
+			new: 6u32
+		}));
 	});
 }
 
@@ -183,10 +184,10 @@ fn set_collator_commission_event_emits_correctly() {
 			Origin::root(),
 			Perbill::from_percent(5)
 		));
-		assert_last_event!(MetaEvent::ParachainStaking(Event::CollatorCommissionSet(
-			Perbill::from_percent(20),
-			Perbill::from_percent(5),
-		)));
+		assert_last_event!(MetaEvent::ParachainStaking(Event::CollatorCommissionSet {
+			old: Perbill::from_percent(20),
+			new: Perbill::from_percent(5),
+		}));
 	});
 }
 
@@ -224,15 +225,15 @@ fn cannot_set_collator_commission_to_current_collator_commission() {
 fn set_blocks_per_round_event_emits_correctly() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(ParachainStaking::set_blocks_per_round(Origin::root(), 6u32));
-		assert_last_event!(MetaEvent::ParachainStaking(Event::BlocksPerRoundSet(
-			1,
-			0,
-			5,
-			6,
-			Perbill::from_parts(926),
-			Perbill::from_parts(926),
-			Perbill::from_parts(926),
-		)));
+		assert_last_event!(MetaEvent::ParachainStaking(Event::BlocksPerRoundSet {
+			current_round: 1,
+			first_block: 0,
+			old: 5,
+			new: 6,
+			new_per_round_inflation_min: Perbill::from_parts(926),
+			new_per_round_inflation_ideal: Perbill::from_parts(926),
+			new_per_round_inflation_max: Perbill::from_parts(926),
+		}));
 	});
 }
 
@@ -281,10 +282,20 @@ fn round_immediately_jumps_if_current_duration_exceeds_new_blocks_per_round() {
 			));
 
 			roll_to(17);
-			assert_last_event!(MetaEvent::ParachainStaking(Event::NewRound(10, 2, 1, 20)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::NewRound {
+				starting_block: 10,
+				round: 2,
+				selected_collators_number: 1,
+				total_balance: 20
+			}));
 			assert_ok!(ParachainStaking::set_blocks_per_round(Origin::root(), 5u32));
 			roll_to(18);
-			assert_last_event!(MetaEvent::ParachainStaking(Event::NewRound(18, 3, 1, 20)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::NewRound {
+				starting_block: 18,
+				round: 3,
+				selected_collators_number: 1,
+				total_balance: 20
+			}));
 		});
 }
 
@@ -354,9 +365,11 @@ fn set_staking_event_emits_event_correctly() {
 				max: 5u128,
 			}
 		));
-		assert_last_event!(MetaEvent::ParachainStaking(Event::StakeExpectationsSet(
-			3u128, 4u128, 5u128,
-		)));
+		assert_last_event!(MetaEvent::ParachainStaking(Event::StakeExpectationsSet {
+			expect_min: 3u128,
+			expect_ideal: 4u128,
+			expect_max: 5u128,
+		}));
 	});
 }
 
@@ -447,14 +460,14 @@ fn set_inflation_event_emits_correctly() {
 			Origin::root(),
 			Range { min, ideal, max }
 		));
-		assert_last_event!(MetaEvent::ParachainStaking(Event::InflationSet(
-			min,
-			ideal,
-			max,
-			Perbill::from_parts(57),
-			Perbill::from_parts(75),
-			Perbill::from_parts(93),
-		)));
+		assert_last_event!(MetaEvent::ParachainStaking(Event::InflationSet {
+			annual_min: min,
+			annual_ideal: ideal,
+			annual_max: max,
+			round_min: Perbill::from_parts(57),
+			round_ideal: Perbill::from_parts(75),
+			round_max: Perbill::from_parts(93),
+		}));
 	});
 }
 
@@ -546,9 +559,9 @@ fn set_parachain_bond_account_event_emits_correctly() {
 			Origin::root(),
 			11
 		));
-		assert_last_event!(MetaEvent::ParachainStaking(Event::ParachainBondAccountSet(
-			0, 11
-		)));
+		assert_last_event!(MetaEvent::ParachainStaking(
+			Event::ParachainBondAccountSet { old: 0, new: 11 }
+		));
 	});
 }
 
@@ -574,10 +587,10 @@ fn set_parachain_bond_reserve_percent_event_emits_correctly() {
 			Percent::from_percent(50)
 		));
 		assert_last_event!(MetaEvent::ParachainStaking(
-			Event::ParachainBondReservePercentSet(
-				Percent::from_percent(30),
-				Percent::from_percent(50),
-			)
+			Event::ParachainBondReservePercentSet {
+				old: Percent::from_percent(30),
+				new: Percent::from_percent(50),
+			}
 		));
 	});
 }
@@ -629,7 +642,11 @@ fn join_candidates_event_emits_correctly() {
 				0u32
 			));
 			assert_last_event!(MetaEvent::ParachainStaking(
-				Event::JoinedCollatorCandidates(1, 10u128, 10u128,)
+				Event::JoinedCollatorCandidates {
+					account: 1,
+					amount_locked: 10u128,
+					new_total_amt_locked: 10u128,
+				}
 			));
 		});
 }
@@ -821,9 +838,11 @@ fn leave_candidates_event_emits_correctly() {
 				Origin::signed(1),
 				1u32
 			));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateScheduledExit(
-				1, 1, 3
-			)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateScheduledExit {
+				exit_allowed_round: 1,
+				candidate: 1,
+				scheduled_exit: 3
+			}));
 		});
 }
 
@@ -924,7 +943,11 @@ fn execute_leave_candidates_emits_event() {
 				1,
 				0
 			));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateLeft(1, 10, 0)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateLeft {
+				ex_candidate: 1,
+				unlocked_amount: 10,
+				new_total_amt_locked: 0
+			}));
 		});
 }
 
@@ -1092,9 +1115,9 @@ fn cancel_leave_candidates_emits_event() {
 				Origin::signed(1),
 				1
 			));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::CancelledCandidateExit(
-				1
-			)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::CancelledCandidateExit {
+				candidate: 1
+			}));
 		});
 }
 
@@ -1149,7 +1172,9 @@ fn go_offline_event_emits_correctly() {
 		.build()
 		.execute_with(|| {
 			assert_ok!(ParachainStaking::go_offline(Origin::signed(1)));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateWentOffline(1)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateWentOffline {
+				candidate: 1
+			}));
 		});
 }
 
@@ -1218,7 +1243,9 @@ fn go_online_event_emits_correctly() {
 		.execute_with(|| {
 			assert_ok!(ParachainStaking::go_offline(Origin::signed(1)));
 			assert_ok!(ParachainStaking::go_online(Origin::signed(1)));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateBackOnline(1)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateBackOnline {
+				candidate: 1
+			}));
 		});
 }
 
@@ -1306,9 +1333,11 @@ fn candidate_bond_more_emits_correct_event() {
 		.build()
 		.execute_with(|| {
 			assert_ok!(ParachainStaking::candidate_bond_more(Origin::signed(1), 30));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateBondedMore(
-				1, 30, 50
-			)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateBondedMore {
+				candidate: 1,
+				amount: 30,
+				new_total_bond: 50
+			}));
 		});
 }
 
@@ -1385,7 +1414,11 @@ fn schedule_candidate_bond_less_event_emits_correctly() {
 				10
 			));
 			assert_last_event!(MetaEvent::ParachainStaking(
-				Event::CandidateBondLessRequested(1, 10, 3,)
+				Event::CandidateBondLessRequested {
+					candidate: 1,
+					amount_to_decrease: 10,
+					execute_round: 3,
+				}
 			));
 		});
 }
@@ -1492,9 +1525,11 @@ fn execute_candidate_bond_less_emits_correct_event() {
 				Origin::signed(1),
 				1
 			));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateBondedLess(
-				1, 30, 20
-			)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateBondedLess {
+				candidate: 1,
+				amount: 30,
+				new_bond: 20
+			}));
 		});
 }
 
@@ -1606,7 +1641,11 @@ fn cancel_candidate_bond_less_emits_event() {
 				Origin::signed(1)
 			));
 			assert_last_event!(MetaEvent::ParachainStaking(
-				Event::CancelledCandidateBondLess(1, 10, 3,)
+				Event::CancelledCandidateBondLess {
+					candidate: 1,
+					amount: 10,
+					execute_round: 3,
+				}
 			));
 		});
 }
@@ -1660,12 +1699,12 @@ fn delegate_event_emits_correctly() {
 		.build()
 		.execute_with(|| {
 			assert_ok!(ParachainStaking::delegate(Origin::signed(2), 1, 10, 0, 0));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::Delegation(
-				2,
-				10,
-				1,
-				DelegatorAdded::AddedToTop { new_total: 40 },
-			)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::Delegation {
+				delegator: 2,
+				locked_amount: 10,
+				candidate: 1,
+				delegator_position: DelegatorAdded::AddedToTop { new_total: 40 },
+			}));
 		});
 }
 
@@ -1922,9 +1961,11 @@ fn schedule_leave_delegators_event_emits_correctly() {
 			assert_ok!(ParachainStaking::schedule_leave_delegators(Origin::signed(
 				2
 			)));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::DelegatorExitScheduled(
-				1, 2, 3
-			)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::DelegatorExitScheduled {
+				round: 1,
+				delegator: 2,
+				scheduled_exit: 3
+			}));
 		});
 }
 
@@ -1979,7 +2020,10 @@ fn execute_leave_delegators_event_emits_correctly() {
 				2,
 				1
 			));
-			assert_event_emitted!(Event::DelegatorLeft(2, 10));
+			assert_event_emitted!(Event::DelegatorLeft {
+				delegator: 2,
+				unstaked_amount: 10
+			});
 		});
 }
 
@@ -2183,9 +2227,9 @@ fn cancel_leave_delegators_emits_correct_event() {
 				2
 			)));
 			assert_ok!(ParachainStaking::cancel_leave_delegators(Origin::signed(2)));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::DelegatorExitCancelled(
-				2
-			)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::DelegatorExitCancelled {
+				delegator: 2
+			}));
 		});
 }
 
@@ -2222,7 +2266,12 @@ fn revoke_delegation_event_emits_correctly() {
 				1
 			));
 			assert_last_event!(MetaEvent::ParachainStaking(
-				Event::DelegationRevocationScheduled(1, 2, 1, 3,)
+				Event::DelegationRevocationScheduled {
+					round: 1,
+					delegator: 2,
+					candidate: 1,
+					scheduled_exit: 3,
+				}
 			));
 			roll_to(10);
 			assert_ok!(ParachainStaking::execute_delegation_request(
@@ -2230,7 +2279,12 @@ fn revoke_delegation_event_emits_correctly() {
 				2,
 				1
 			));
-			assert_event_emitted!(Event::DelegatorLeftCandidate(2, 1, 10, 30));
+			assert_event_emitted!(Event::DelegatorLeftCandidate {
+				delegator: 2,
+				candidate: 1,
+				unstaked_amount: 10,
+				total_candidate_staked: 30
+			});
 		});
 }
 
@@ -2443,9 +2497,12 @@ fn delegator_bond_more_updates_candidate_state_bottom_delegations() {
 				1,
 				5
 			));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::DelegationIncreased(
-				2, 1, 5, false
-			)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::DelegationIncreased {
+				delegator: 2,
+				candidate: 1,
+				amount: 5,
+				in_top: false
+			}));
 			assert_eq!(
 				ParachainStaking::bottom_delegations(1)
 					.expect("exists")
@@ -2517,7 +2574,12 @@ fn delegator_bond_less_event_emits_correctly() {
 				5
 			));
 			assert_last_event!(MetaEvent::ParachainStaking(
-				Event::DelegationDecreaseScheduled(2, 1, 5, 3,)
+				Event::DelegationDecreaseScheduled {
+					delegator: 2,
+					candidate: 1,
+					amount_to_decrease: 5,
+					execute_round: 3,
+				}
 			));
 		});
 }
@@ -2695,8 +2757,16 @@ fn execute_revoke_delegation_emits_exit_event_if_exit_happens() {
 				2,
 				1
 			));
-			assert_event_emitted!(Event::DelegatorLeftCandidate(2, 1, 10, 30));
-			assert_event_emitted!(Event::DelegatorLeft(2, 10));
+			assert_event_emitted!(Event::DelegatorLeftCandidate {
+				delegator: 2,
+				candidate: 1,
+				unstaked_amount: 10,
+				total_candidate_staked: 30
+			});
+			assert_event_emitted!(Event::DelegatorLeft {
+				delegator: 2,
+				unstaked_amount: 10
+			});
 		});
 }
 
@@ -2753,8 +2823,16 @@ fn revoke_delegation_executes_exit_if_last_delegation() {
 				2,
 				1
 			));
-			assert_event_emitted!(Event::DelegatorLeftCandidate(2, 1, 10, 30));
-			assert_event_emitted!(Event::DelegatorLeft(2, 10));
+			assert_event_emitted!(Event::DelegatorLeftCandidate {
+				delegator: 2,
+				candidate: 1,
+				unstaked_amount: 10,
+				total_candidate_staked: 30
+			});
+			assert_event_emitted!(Event::DelegatorLeft {
+				delegator: 2,
+				unstaked_amount: 10
+			});
 		});
 }
 
@@ -2776,7 +2854,12 @@ fn execute_revoke_delegation_emits_correct_event() {
 				2,
 				1
 			));
-			assert_event_emitted!(Event::DelegatorLeftCandidate(2, 1, 10, 30));
+			assert_event_emitted!(Event::DelegatorLeftCandidate {
+				delegator: 2,
+				candidate: 1,
+				unstaked_amount: 10,
+				total_candidate_staked: 30
+			});
 		});
 }
 
@@ -3035,7 +3118,12 @@ fn delegator_bond_less_after_revoke_delegation_does_not_effect_exit() {
 				1
 			));
 			assert_last_event!(MetaEvent::ParachainStaking(
-				Event::DelegationRevocationScheduled(1, 2, 1, 3,)
+				Event::DelegationRevocationScheduled {
+					round: 1,
+					delegator: 2,
+					candidate: 1,
+					scheduled_exit: 3,
+				}
 			));
 			assert_noop!(
 				ParachainStaking::schedule_delegator_bond_less(Origin::signed(2), 1, 2),
@@ -3057,9 +3145,12 @@ fn delegator_bond_less_after_revoke_delegation_does_not_effect_exit() {
 				2,
 				3
 			));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::DelegationDecreased(
-				2, 3, 2, true
-			)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::DelegationDecreased {
+				delegator: 2,
+				candidate: 3,
+				amount: 2,
+				in_top: true
+			}));
 			assert!(ParachainStaking::is_delegator(&2));
 			assert_eq!(Balances::reserved_balance(&2), 8);
 			assert_eq!(Balances::free_balance(&2), 22);
@@ -3409,15 +3500,15 @@ fn cancel_revoke_delegation_emits_correct_event() {
 				1
 			));
 			assert_last_event!(MetaEvent::ParachainStaking(
-				Event::CancelledDelegationRequest(
-					2,
-					DelegationRequest {
+				Event::CancelledDelegationRequest {
+					delegator: 2,
+					cancelled_request: DelegationRequest {
 						collator: 1,
 						amount: 10,
 						when_executable: 3,
 						action: DelegationChange::Revoke,
 					},
-				)
+				}
 			));
 		});
 }
@@ -3475,15 +3566,15 @@ fn cancel_delegator_bond_less_correct_event() {
 				1
 			));
 			assert_last_event!(MetaEvent::ParachainStaking(
-				Event::CancelledDelegationRequest(
-					2,
-					DelegationRequest {
+				Event::CancelledDelegationRequest {
+					delegator: 2,
+					cancelled_request: DelegationRequest {
 						collator: 1,
 						amount: 5,
 						when_executable: 3,
 						action: DelegationChange::Decrease,
 					},
-				)
+				}
 			));
 		});
 }
@@ -3636,13 +3727,38 @@ fn parachain_bond_inflation_reserve_matches_config() {
 			roll_to(8);
 			// chooses top TotalSelectedCandidates (5), in order
 			let mut expected = vec![
-				Event::ParachainBondAccountSet(0, 11),
-				Event::CollatorChosen(2, 1, 50),
-				Event::CollatorChosen(2, 2, 40),
-				Event::CollatorChosen(2, 3, 20),
-				Event::CollatorChosen(2, 4, 20),
-				Event::CollatorChosen(2, 5, 10),
-				Event::NewRound(5, 2, 5, 140),
+				Event::ParachainBondAccountSet { old: 0, new: 11 },
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 5,
+					round: 2,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
 			];
 			assert_eq_events!(expected.clone());
 			assert_eq!(Balances::free_balance(&11), 1);
@@ -3651,23 +3767,88 @@ fn parachain_bond_inflation_reserve_matches_config() {
 			roll_to(16);
 			// distribute total issuance to collator 1 and its delegators 6, 7, 19
 			let mut new = vec![
-				Event::CollatorChosen(3, 1, 50),
-				Event::CollatorChosen(3, 2, 40),
-				Event::CollatorChosen(3, 3, 20),
-				Event::CollatorChosen(3, 4, 20),
-				Event::CollatorChosen(3, 5, 10),
-				Event::NewRound(10, 3, 5, 140),
-				Event::ReservedForParachainBond(11, 15),
-				Event::CollatorChosen(4, 1, 50),
-				Event::CollatorChosen(4, 2, 40),
-				Event::CollatorChosen(4, 3, 20),
-				Event::CollatorChosen(4, 4, 20),
-				Event::CollatorChosen(4, 5, 10),
-				Event::NewRound(15, 4, 5, 140),
-				Event::Rewarded(1, 20),
-				Event::Rewarded(6, 5),
-				Event::Rewarded(7, 5),
-				Event::Rewarded(10, 5),
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 10,
+					round: 3,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::ReservedForParachainBond {
+					account: 11,
+					value: 15,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 15,
+					round: 4,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::Rewarded {
+					account: 1,
+					value: 20,
+				},
+				Event::Rewarded {
+					account: 6,
+					value: 5,
+				},
+				Event::Rewarded {
+					account: 7,
+					value: 5,
+				},
+				Event::Rewarded {
+					account: 10,
+					value: 5,
+				},
 			];
 			expected.append(&mut new);
 			assert_eq_events!(expected.clone());
@@ -3693,42 +3874,182 @@ fn parachain_bond_inflation_reserve_matches_config() {
 			));
 			roll_to(30);
 			let mut new2 = vec![
-				Event::DelegatorExitScheduled(4, 6, 6),
-				Event::ReservedForParachainBond(11, 16),
-				Event::CollatorChosen(5, 1, 50),
-				Event::CollatorChosen(5, 2, 40),
-				Event::CollatorChosen(5, 3, 20),
-				Event::CollatorChosen(5, 4, 20),
-				Event::CollatorChosen(5, 5, 10),
-				Event::NewRound(20, 5, 5, 140),
-				Event::Rewarded(1, 21),
-				Event::Rewarded(6, 5),
-				Event::Rewarded(7, 5),
-				Event::Rewarded(10, 5),
-				Event::ReservedForParachainBond(11, 16),
-				Event::CollatorChosen(6, 1, 50),
-				Event::CollatorChosen(6, 2, 40),
-				Event::CollatorChosen(6, 3, 20),
-				Event::CollatorChosen(6, 4, 20),
-				Event::CollatorChosen(6, 5, 10),
-				Event::NewRound(25, 6, 5, 140),
-				Event::Rewarded(1, 22),
-				Event::Rewarded(6, 6),
-				Event::Rewarded(7, 6),
-				Event::Rewarded(10, 6),
-				Event::DelegatorLeftCandidate(6, 1, 10, 40),
-				Event::DelegatorLeft(6, 10),
-				Event::ReservedForParachainBond(11, 17),
-				Event::CollatorChosen(7, 1, 40),
-				Event::CollatorChosen(7, 2, 40),
-				Event::CollatorChosen(7, 3, 20),
-				Event::CollatorChosen(7, 4, 20),
-				Event::CollatorChosen(7, 5, 10),
-				Event::NewRound(30, 7, 5, 130),
-				Event::Rewarded(1, 24),
-				Event::Rewarded(6, 6),
-				Event::Rewarded(7, 6),
-				Event::Rewarded(10, 6),
+				Event::DelegatorExitScheduled {
+					round: 4,
+					delegator: 6,
+					scheduled_exit: 6,
+				},
+				Event::ReservedForParachainBond {
+					account: 11,
+					value: 16,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 20,
+					round: 5,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::Rewarded {
+					account: 1,
+					value: 21,
+				},
+				(1, 21),
+				Event::Rewarded {
+					account: 6,
+					value: 5,
+				},
+				(6, 5),
+				Event::Rewarded {
+					account: 7,
+					value: 5,
+				},
+				(7, 5),
+				Event::Rewarded {
+					account: 10,
+					value: 5,
+				},
+				(10, 5),
+				Event::ReservedForParachainBond {
+					account: 11,
+					value: 16,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 25,
+					round: 6,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::Rewarded {
+					account: 1,
+					value: 22,
+				},
+				(1, 22),
+				Event::Rewarded {
+					account: 6,
+					value: 6,
+				},
+				(6, 6),
+				Event::Rewarded {
+					account: 7,
+					value: 6,
+				},
+				(7, 6),
+				Event::Rewarded {
+					account: 10,
+					value: 6,
+				},
+				(10, 6),
+				Event::DelegatorLeftCandidate {
+					delegator: 6,
+					candidate: 1,
+					unstaked_amount: 10,
+					total_candidate_staked: 40,
+				},
+				Event::DelegatorLeft {
+					delegator: 6,
+					unstaked_amount: 10,
+				},
+				Event::ReservedForParachainBond {
+					account: 11,
+					value: 17,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 1,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 30,
+					round: 7,
+					selected_collators_number: 5,
+					total_balance: 130,
+				},
+				Event::Rewarded {
+					account: 1,
+					value: 24,
+				},
+				Event::Rewarded {
+					account: 6,
+					value: 6,
+				},
+				Event::Rewarded {
+					account: 7,
+					value: 6,
+				},
+				Event::Rewarded {
+					account: 10,
+					value: 6,
+				},
 			];
 			expected.append(&mut new2);
 			assert_eq_events!(expected.clone());
@@ -3742,21 +4063,61 @@ fn parachain_bond_inflation_reserve_matches_config() {
 			roll_to(35);
 			// keep paying 6
 			let mut new3 = vec![
-				Event::ParachainBondReservePercentSet(
-					Percent::from_percent(30),
-					Percent::from_percent(50),
-				),
-				Event::ReservedForParachainBond(11, 30),
-				Event::CollatorChosen(8, 1, 40),
-				Event::CollatorChosen(8, 2, 40),
-				Event::CollatorChosen(8, 3, 20),
-				Event::CollatorChosen(8, 4, 20),
-				Event::CollatorChosen(8, 5, 10),
-				Event::NewRound(35, 8, 5, 130),
-				Event::Rewarded(1, 20),
-				Event::Rewarded(6, 4),
-				Event::Rewarded(7, 4),
-				Event::Rewarded(10, 4),
+				Event::ParachainBondReservePercentSet {
+					old: Percent::from_percent(30),
+					new: Percent::from_percent(50),
+				},
+				Event::ReservedForParachainBond {
+					account: 11,
+					value: 30,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 1,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 35,
+					round: 8,
+					selected_collators_number: 5,
+					total_balance: 130,
+				},
+				Event::Rewarded {
+					account: 1,
+					value: 20,
+				},
+				Event::Rewarded {
+					account: 6,
+					value: 4,
+				},
+				Event::Rewarded {
+					account: 7,
+					value: 4,
+				},
+				Event::Rewarded {
+					account: 10,
+					value: 4,
+				},
 			];
 			expected.append(&mut new3);
 			assert_eq_events!(expected.clone());
@@ -3765,16 +4126,53 @@ fn parachain_bond_inflation_reserve_matches_config() {
 			roll_to(40);
 			// no more paying 6
 			let mut new4 = vec![
-				Event::ReservedForParachainBond(11, 32),
-				Event::CollatorChosen(9, 1, 40),
-				Event::CollatorChosen(9, 2, 40),
-				Event::CollatorChosen(9, 3, 20),
-				Event::CollatorChosen(9, 4, 20),
-				Event::CollatorChosen(9, 5, 10),
-				Event::NewRound(40, 9, 5, 130),
-				Event::Rewarded(1, 22),
-				Event::Rewarded(7, 5),
-				Event::Rewarded(10, 5),
+				Event::ReservedForParachainBond {
+					account: 11,
+					value: 32,
+				},
+				Event::CollatorChosen {
+					round: 9,
+					collator_account: 1,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 9,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 9,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 9,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 9,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 40,
+					round: 9,
+					selected_collators_number: 5,
+					total_balance: 130,
+				},
+				Event::Rewarded {
+					account: 1,
+					value: 22,
+				},
+				Event::Rewarded {
+					account: 7,
+					value: 5,
+				},
+				Event::Rewarded {
+					account: 10,
+					value: 5,
+				},
 			];
 			expected.append(&mut new4);
 			assert_eq_events!(expected.clone());
@@ -3784,17 +4182,59 @@ fn parachain_bond_inflation_reserve_matches_config() {
 			roll_to(45);
 			// new delegation is not rewarded yet
 			let mut new5 = vec![
-				Event::Delegation(8, 10, 1, DelegatorAdded::AddedToTop { new_total: 50 }),
-				Event::ReservedForParachainBond(11, 33),
-				Event::CollatorChosen(10, 1, 50),
-				Event::CollatorChosen(10, 2, 40),
-				Event::CollatorChosen(10, 3, 20),
-				Event::CollatorChosen(10, 4, 20),
-				Event::CollatorChosen(10, 5, 10),
-				Event::NewRound(45, 10, 5, 140),
-				Event::Rewarded(1, 23),
-				Event::Rewarded(7, 5),
-				Event::Rewarded(10, 5),
+				Event::Delegation {
+					delegator: 8,
+					locked_amount: 10,
+					candidate: 1,
+					delegator_position: DelegatorAdded::AddedToTop { new_total: 50 },
+				},
+				Event::ReservedForParachainBond {
+					account: 11,
+					value: 33,
+				},
+				Event::CollatorChosen {
+					round: 10,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 10,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 10,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 10,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 10,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 45,
+					round: 10,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::Rewarded {
+					account: 1,
+					value: 23,
+				},
+				Event::Rewarded {
+					account: 7,
+					value: 5,
+				},
+				Event::Rewarded {
+					account: 10,
+					value: 5,
+				},
 			];
 			expected.append(&mut new5);
 			assert_eq_events!(expected.clone());
@@ -3804,16 +4244,53 @@ fn parachain_bond_inflation_reserve_matches_config() {
 			roll_to(50);
 			// new delegation is still not rewarded yet
 			let mut new6 = vec![
-				Event::ReservedForParachainBond(11, 35),
-				Event::CollatorChosen(11, 1, 50),
-				Event::CollatorChosen(11, 2, 40),
-				Event::CollatorChosen(11, 3, 20),
-				Event::CollatorChosen(11, 4, 20),
-				Event::CollatorChosen(11, 5, 10),
-				Event::NewRound(50, 11, 5, 140),
-				Event::Rewarded(1, 24),
-				Event::Rewarded(7, 5),
-				Event::Rewarded(10, 5),
+				Event::ReservedForParachainBond {
+					account: 11,
+					value: 35,
+				},
+				Event::CollatorChosen {
+					round: 11,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 11,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 11,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 11,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 11,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 50,
+					round: 11,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::Rewarded {
+					account: 1,
+					value: 24,
+				},
+				Event::Rewarded {
+					account: 7,
+					value: 5,
+				},
+				Event::Rewarded {
+					account: 10,
+					value: 5,
+				},
 			];
 			expected.append(&mut new6);
 			assert_eq_events!(expected.clone());
@@ -3821,17 +4298,57 @@ fn parachain_bond_inflation_reserve_matches_config() {
 			roll_to(55);
 			// new delegation is rewarded, 2 rounds after joining (`RewardPaymentDelay` is 2)
 			let mut new7 = vec![
-				Event::ReservedForParachainBond(11, 37),
-				Event::CollatorChosen(12, 1, 50),
-				Event::CollatorChosen(12, 2, 40),
-				Event::CollatorChosen(12, 3, 20),
-				Event::CollatorChosen(12, 4, 20),
-				Event::CollatorChosen(12, 5, 10),
-				Event::NewRound(55, 12, 5, 140),
-				Event::Rewarded(1, 24),
-				Event::Rewarded(7, 4),
-				Event::Rewarded(10, 4),
-				Event::Rewarded(8, 4),
+				Event::ReservedForParachainBond {
+					account: 11,
+					value: 37,
+				},
+				Event::CollatorChosen {
+					round: 12,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 12,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 12,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 12,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 12,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 55,
+					round: 12,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::Rewarded {
+					account: 1,
+					value: 24,
+				},
+				Event::Rewarded {
+					account: 7,
+					value: 4,
+				},
+				Event::Rewarded {
+					account: 10,
+					value: 4,
+				},
+				Event::Rewarded {
+					account: 8,
+					value: 4,
+				},
 			];
 			expected.append(&mut new7);
 			assert_eq_events!(expected);
@@ -3857,8 +4374,17 @@ fn paid_collator_commission_matches_config() {
 			roll_to(8);
 			// chooses top TotalSelectedCandidates (5), in order
 			let mut expected = vec![
-				Event::CollatorChosen(2, 1, 40),
-				Event::NewRound(5, 2, 1, 40),
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 1,
+					total_exposed_amount: 40,
+				},
+				Event::NewRound {
+					starting_block: 5,
+					round: 2,
+					selected_collators_number: 1,
+					total_balance: 40,
+				},
 			];
 			assert_eq_events!(expected.clone());
 			assert_ok!(ParachainStaking::join_candidates(
@@ -3867,19 +4393,50 @@ fn paid_collator_commission_matches_config() {
 				100u32
 			));
 			assert_last_event!(MetaEvent::ParachainStaking(
-				Event::JoinedCollatorCandidates(4, 20u128, 60u128,)
+				Event::JoinedCollatorCandidates {
+					account: 4,
+					amount_locked: 20u128,
+					new_total_amt_locked: 60u128,
+				}
 			));
 			roll_to(9);
 			assert_ok!(ParachainStaking::delegate(Origin::signed(5), 4, 10, 10, 10));
 			assert_ok!(ParachainStaking::delegate(Origin::signed(6), 4, 10, 10, 10));
 			roll_to(11);
 			let mut new = vec![
-				Event::JoinedCollatorCandidates(4, 20, 60),
-				Event::Delegation(5, 10, 4, DelegatorAdded::AddedToTop { new_total: 30 }),
-				Event::Delegation(6, 10, 4, DelegatorAdded::AddedToTop { new_total: 40 }),
-				Event::CollatorChosen(3, 1, 40),
-				Event::CollatorChosen(3, 4, 40),
-				Event::NewRound(10, 3, 2, 80),
+				Event::JoinedCollatorCandidates {
+					account: 4,
+					amount_locked: 20,
+					new_total_amt_locked: 60,
+				},
+				Event::Delegation {
+					delegator: 5,
+					locked_amount: 10,
+					candidate: 4,
+					delegator_position: DelegatorAdded::AddedToTop { new_total: 30 },
+				},
+				Event::Delegation {
+					delegator: 6,
+					locked_amount: 10,
+					candidate: 4,
+					delegator_position: DelegatorAdded::AddedToTop { new_total: 40 },
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 1,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 4,
+					total_exposed_amount: 40,
+				},
+				Event::NewRound {
+					starting_block: 10,
+					round: 3,
+					selected_collators_number: 2,
+					total_balance: 80,
+				},
 			];
 			expected.append(&mut new);
 			assert_eq_events!(expected.clone());
@@ -3889,15 +4446,50 @@ fn paid_collator_commission_matches_config() {
 			// 20% of 10 is commission + due_portion (0) = 2 + 4 = 6
 			// all delegator payouts are 10-2 = 8 * stake_pct
 			let mut new2 = vec![
-				Event::CollatorChosen(4, 1, 40),
-				Event::CollatorChosen(4, 4, 40),
-				Event::NewRound(15, 4, 2, 80),
-				Event::CollatorChosen(5, 1, 40),
-				Event::CollatorChosen(5, 4, 40),
-				Event::NewRound(20, 5, 2, 80),
-				Event::Rewarded(4, 18),
-				Event::Rewarded(5, 6),
-				Event::Rewarded(6, 6),
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 1,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 4,
+					total_exposed_amount: 40,
+				},
+				Event::NewRound {
+					starting_block: 15,
+					round: 4,
+					selected_collators_number: 2,
+					total_balance: 80,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 1,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 4,
+					total_exposed_amount: 40,
+				},
+				Event::NewRound {
+					starting_block: 20,
+					round: 5,
+					selected_collators_number: 2,
+					total_balance: 80,
+				},
+				Event::Rewarded {
+					account: 4,
+					value: 18,
+				},
+				Event::Rewarded {
+					account: 5,
+					value: 6,
+				},
+				Event::Rewarded {
+					account: 6,
+					value: 6,
+				},
 			];
 			expected.append(&mut new2);
 			assert_eq_events!(expected);
@@ -3939,18 +4531,70 @@ fn collator_exit_executes_after_delay() {
 			// holding them retroactively accountable for previous faults
 			// (within the last T::SlashingWindow blocks)
 			let expected = vec![
-				Event::CollatorChosen(2, 1, 700),
-				Event::CollatorChosen(2, 2, 400),
-				Event::NewRound(5, 2, 2, 1100),
-				Event::CollatorChosen(3, 1, 700),
-				Event::CollatorChosen(3, 2, 400),
-				Event::NewRound(10, 3, 2, 1100),
-				Event::CandidateScheduledExit(3, 2, 5),
-				Event::CollatorChosen(4, 1, 700),
-				Event::NewRound(15, 4, 1, 700),
-				Event::CollatorChosen(5, 1, 700),
-				Event::NewRound(20, 5, 1, 700),
-				Event::CandidateLeft(2, 400, 700),
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 1,
+					total_exposed_amount: 700,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 2,
+					total_exposed_amount: 400,
+				},
+				Event::NewRound {
+					starting_block: 5,
+					round: 2,
+					selected_collators_number: 2,
+					total_balance: 1100,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 1,
+					total_exposed_amount: 700,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 2,
+					total_exposed_amount: 400,
+				},
+				Event::NewRound {
+					starting_block: 10,
+					round: 3,
+					selected_collators_number: 2,
+					total_balance: 1100,
+				},
+				Event::CandidateScheduledExit {
+					exit_allowed_round: 3,
+					candidate: 2,
+					scheduled_exit: 5,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 1,
+					total_exposed_amount: 700,
+				},
+				Event::NewRound {
+					starting_block: 15,
+					round: 4,
+					selected_collators_number: 1,
+					total_balance: 700,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 1,
+					total_exposed_amount: 700,
+				},
+				Event::NewRound {
+					starting_block: 20,
+					round: 5,
+					selected_collators_number: 1,
+					total_balance: 700,
+				},
+				Event::CandidateLeft {
+					ex_candidate: 2,
+					unlocked_amount: 400,
+					new_total_amt_locked: 700,
+				},
 			];
 			assert_eq_events!(expected);
 		});
@@ -3976,21 +4620,48 @@ fn collator_selection_chooses_top_candidates() {
 			roll_to(8);
 			// should choose top TotalSelectedCandidates (5), in order
 			let expected = vec![
-				Event::CollatorChosen(2, 1, 100),
-				Event::CollatorChosen(2, 2, 90),
-				Event::CollatorChosen(2, 3, 80),
-				Event::CollatorChosen(2, 4, 70),
-				Event::CollatorChosen(2, 5, 60),
-				Event::NewRound(5, 2, 5, 400),
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 5,
+					total_exposed_amount: 60,
+				},
+				Event::NewRound {
+					starting_block: 5,
+					round: 2,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
 			];
 			assert_eq_events!(expected.clone());
 			assert_ok!(ParachainStaking::schedule_leave_candidates(
 				Origin::signed(6),
 				6
 			));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateScheduledExit(
-				2, 6, 4
-			)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateScheduledExit {
+				exit_allowed_round: 2,
+				candidate: 6,
+				scheduled_exit: 4
+			}));
 			roll_to(21);
 			assert_ok!(ParachainStaking::execute_leave_candidates(
 				Origin::signed(6),
@@ -4003,44 +4674,185 @@ fn collator_selection_chooses_top_candidates() {
 				100u32
 			));
 			assert_last_event!(MetaEvent::ParachainStaking(
-				Event::JoinedCollatorCandidates(6, 69u128, 469u128,)
+				Event::JoinedCollatorCandidates {
+					account: 6,
+					amount_locked: 69u128,
+					new_total_amt_locked: 469u128,
+				}
 			));
 			roll_to(27);
 			// should choose top TotalSelectedCandidates (5), in order
 			let expected = vec![
-				Event::CollatorChosen(2, 1, 100),
-				Event::CollatorChosen(2, 2, 90),
-				Event::CollatorChosen(2, 3, 80),
-				Event::CollatorChosen(2, 4, 70),
-				Event::CollatorChosen(2, 5, 60),
-				Event::NewRound(5, 2, 5, 400),
-				Event::CandidateScheduledExit(2, 6, 4),
-				Event::CollatorChosen(3, 1, 100),
-				Event::CollatorChosen(3, 2, 90),
-				Event::CollatorChosen(3, 3, 80),
-				Event::CollatorChosen(3, 4, 70),
-				Event::CollatorChosen(3, 5, 60),
-				Event::NewRound(10, 3, 5, 400),
-				Event::CollatorChosen(4, 1, 100),
-				Event::CollatorChosen(4, 2, 90),
-				Event::CollatorChosen(4, 3, 80),
-				Event::CollatorChosen(4, 4, 70),
-				Event::CollatorChosen(4, 5, 60),
-				Event::NewRound(15, 4, 5, 400),
-				Event::CollatorChosen(5, 1, 100),
-				Event::CollatorChosen(5, 2, 90),
-				Event::CollatorChosen(5, 3, 80),
-				Event::CollatorChosen(5, 4, 70),
-				Event::CollatorChosen(5, 5, 60),
-				Event::NewRound(20, 5, 5, 400),
-				Event::CandidateLeft(6, 50, 400),
-				Event::JoinedCollatorCandidates(6, 69, 469),
-				Event::CollatorChosen(6, 1, 100),
-				Event::CollatorChosen(6, 2, 90),
-				Event::CollatorChosen(6, 3, 80),
-				Event::CollatorChosen(6, 4, 70),
-				Event::CollatorChosen(6, 6, 69),
-				Event::NewRound(25, 6, 5, 409),
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 5,
+					total_exposed_amount: 60,
+				},
+				Event::NewRound {
+					starting_block: 5,
+					round: 2,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
+				Event::CandidateScheduledExit {
+					exit_allowed_round: 2,
+					candidate: 6,
+					scheduled_exit: 4,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 5,
+					total_exposed_amount: 60,
+				},
+				Event::NewRound {
+					starting_block: 10,
+					round: 3,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 5,
+					total_exposed_amount: 60,
+				},
+				Event::NewRound {
+					starting_block: 15,
+					round: 4,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 5,
+					total_exposed_amount: 60,
+				},
+				Event::NewRound {
+					starting_block: 20,
+					round: 5,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
+				Event::CandidateLeft {
+					ex_candidate: 6,
+					unlocked_amount: 50,
+					new_total_amt_locked: 400,
+				},
+				Event::JoinedCollatorCandidates {
+					account: 6,
+					amount_locked: 69,
+					new_total_amt_locked: 469,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 6,
+					total_exposed_amount: 69,
+				},
+				Event::NewRound {
+					starting_block: 25,
+					round: 6,
+					selected_collators_number: 5,
+					total_balance: 409,
+				},
 			];
 			assert_eq_events!(expected);
 		});
@@ -4066,12 +4878,37 @@ fn payout_distribution_to_solo_collators() {
 			roll_to(8);
 			// should choose top TotalCandidatesSelected (5), in order
 			let mut expected = vec![
-				Event::CollatorChosen(2, 1, 100),
-				Event::CollatorChosen(2, 2, 90),
-				Event::CollatorChosen(2, 3, 80),
-				Event::CollatorChosen(2, 4, 70),
-				Event::CollatorChosen(2, 5, 60),
-				Event::NewRound(5, 2, 5, 400),
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 5,
+					total_exposed_amount: 60,
+				},
+				Event::NewRound {
+					starting_block: 5,
+					round: 2,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
 			];
 			assert_eq_events!(expected.clone());
 			// ~ set block author as 1 for all blocks this round
@@ -4079,19 +4916,72 @@ fn payout_distribution_to_solo_collators() {
 			roll_to(16);
 			// pay total issuance to 1
 			let mut new = vec![
-				Event::CollatorChosen(3, 1, 100),
-				Event::CollatorChosen(3, 2, 90),
-				Event::CollatorChosen(3, 3, 80),
-				Event::CollatorChosen(3, 4, 70),
-				Event::CollatorChosen(3, 5, 60),
-				Event::NewRound(10, 3, 5, 400),
-				Event::CollatorChosen(4, 1, 100),
-				Event::CollatorChosen(4, 2, 90),
-				Event::CollatorChosen(4, 3, 80),
-				Event::CollatorChosen(4, 4, 70),
-				Event::CollatorChosen(4, 5, 60),
-				Event::NewRound(15, 4, 5, 400),
-				Event::Rewarded(1, 305),
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 5,
+					total_exposed_amount: 60,
+				},
+				Event::NewRound {
+					starting_block: 10,
+					round: 3,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 5,
+					total_exposed_amount: 60,
+				},
+				Event::NewRound {
+					starting_block: 15,
+					round: 4,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 305,
+				},
 			];
 			expected.append(&mut new);
 			assert_eq_events!(expected.clone());
@@ -4102,20 +4992,76 @@ fn payout_distribution_to_solo_collators() {
 			roll_to(26);
 			// pay 60% total issuance to 1 and 40% total issuance to 2
 			let mut new1 = vec![
-				Event::CollatorChosen(5, 1, 100),
-				Event::CollatorChosen(5, 2, 90),
-				Event::CollatorChosen(5, 3, 80),
-				Event::CollatorChosen(5, 4, 70),
-				Event::CollatorChosen(5, 5, 60),
-				Event::NewRound(20, 5, 5, 400),
-				Event::CollatorChosen(6, 1, 100),
-				Event::CollatorChosen(6, 2, 90),
-				Event::CollatorChosen(6, 3, 80),
-				Event::CollatorChosen(6, 4, 70),
-				Event::CollatorChosen(6, 5, 60),
-				Event::NewRound(25, 6, 5, 400),
-				Event::Rewarded(1, 192),
-				Event::Rewarded(2, 128),
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 5,
+					total_exposed_amount: 60,
+				},
+				Event::NewRound {
+					starting_block: 20,
+					round: 5,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 5,
+					total_exposed_amount: 60,
+				},
+				Event::NewRound {
+					starting_block: 25,
+					round: 6,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 192,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 128,
+				},
 			];
 			expected.append(&mut new1);
 			assert_eq_events!(expected.clone());
@@ -4128,23 +5074,88 @@ fn payout_distribution_to_solo_collators() {
 			roll_to(39);
 			// pay 20% issuance for all collators
 			let mut new2 = vec![
-				Event::CollatorChosen(7, 1, 100),
-				Event::CollatorChosen(7, 2, 90),
-				Event::CollatorChosen(7, 3, 80),
-				Event::CollatorChosen(7, 4, 70),
-				Event::CollatorChosen(7, 5, 60),
-				Event::NewRound(30, 7, 5, 400),
-				Event::CollatorChosen(8, 1, 100),
-				Event::CollatorChosen(8, 2, 90),
-				Event::CollatorChosen(8, 3, 80),
-				Event::CollatorChosen(8, 4, 70),
-				Event::CollatorChosen(8, 5, 60),
-				Event::NewRound(35, 8, 5, 400),
-				Event::Rewarded(5, 67),
-				Event::Rewarded(3, 67),
-				Event::Rewarded(4, 67),
-				Event::Rewarded(1, 67),
-				Event::Rewarded(2, 67),
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 5,
+					total_exposed_amount: 60,
+				},
+				Event::NewRound {
+					starting_block: 30,
+					round: 7,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 1,
+					total_exposed_amount: 100,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 2,
+					total_exposed_amount: 90,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 4,
+					total_exposed_amount: 70,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 5,
+					total_exposed_amount: 60,
+				},
+				Event::NewRound {
+					starting_block: 35,
+					round: 8,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
+				Event::Rewarded {
+					account: 5,
+					rewards: 67,
+				},
+				Event::Rewarded {
+					account: 3,
+					rewards: 67,
+				},
+				Event::Rewarded {
+					account: 4,
+					rewards: 67,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 67,
+				},
+				Event::Rewarded {
+					account: 2,
+					rewards: 67,
+				},
 			];
 			expected.append(&mut new2);
 			assert_eq_events!(expected);
@@ -4188,12 +5199,43 @@ fn multiple_delegations() {
 			roll_to(8);
 			// chooses top TotalSelectedCandidates (5), in order
 			let mut expected = vec![
-				Event::CollatorChosen(2, 1, 50),
-				Event::CollatorChosen(2, 2, 40),
-				Event::CollatorChosen(2, 3, 20),
-				Event::CollatorChosen(2, 4, 20),
-				Event::CollatorChosen(2, 5, 10),
-				Event::NewRound(5, 2, 5, 140),
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				(2, 1, 50),
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				(2, 2, 40),
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				(2, 3, 20),
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				(2, 4, 20),
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 3,
+					total_exposed_amount: 80,
+				},
+				(2, 5, 10),
+				Event::NewRound {
+					starting_block: 35,
+					round: 8,
+					selected_collators_number: 5,
+					total_balance: 400,
+				},
+				(5, 2, 5, 140),
 			];
 			assert_eq_events!(expected.clone());
 			assert_ok!(ParachainStaking::delegate(Origin::signed(6), 2, 10, 10, 10));
@@ -4201,21 +5243,86 @@ fn multiple_delegations() {
 			assert_ok!(ParachainStaking::delegate(Origin::signed(6), 4, 10, 10, 10));
 			roll_to(16);
 			let mut new = vec![
-				Event::Delegation(6, 10, 2, DelegatorAdded::AddedToTop { new_total: 50 }),
-				Event::Delegation(6, 10, 3, DelegatorAdded::AddedToTop { new_total: 30 }),
-				Event::Delegation(6, 10, 4, DelegatorAdded::AddedToTop { new_total: 30 }),
-				Event::CollatorChosen(3, 1, 50),
-				Event::CollatorChosen(3, 2, 50),
-				Event::CollatorChosen(3, 3, 30),
-				Event::CollatorChosen(3, 4, 30),
-				Event::CollatorChosen(3, 5, 10),
-				Event::NewRound(10, 3, 5, 170),
-				Event::CollatorChosen(4, 1, 50),
-				Event::CollatorChosen(4, 2, 50),
-				Event::CollatorChosen(4, 3, 30),
-				Event::CollatorChosen(4, 4, 30),
-				Event::CollatorChosen(4, 5, 10),
-				Event::NewRound(15, 4, 5, 170),
+				Event::Delegation {
+					delegator: 6,
+					locked_amount: 10,
+					candidate: 2,
+					delegator_position: DelegatorAdded::AddedToTop { new_total: 30 },
+				},
+				Event::Delegation {
+					delegator: 6,
+					locked_amount: 10,
+					candidate: 3,
+					delegator_position: DelegatorAdded::AddedToTop { new_total: 30 },
+				},
+				Event::Delegation {
+					delegator: 6,
+					locked_amount: 10,
+					candidate: 4,
+					delegator_position: DelegatorAdded::AddedToTop { new_total: 30 },
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 2,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 3,
+					total_exposed_amount: 30,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 4,
+					total_exposed_amount: 30,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 10,
+					round: 3,
+					selected_collators_number: 5,
+					total_balance: 170,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 2,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 3,
+					total_exposed_amount: 30,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 4,
+					total_exposed_amount: 30,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 15,
+					round: 4,
+					selected_collators_number: 5,
+					total_balance: 170,
+				},
 			];
 			expected.append(&mut new);
 			assert_eq_events!(expected.clone());
@@ -4230,20 +5337,80 @@ fn multiple_delegations() {
 			),);
 			roll_to(26);
 			let mut new2 = vec![
-				Event::CollatorChosen(5, 1, 50),
-				Event::CollatorChosen(5, 2, 50),
-				Event::CollatorChosen(5, 3, 30),
-				Event::CollatorChosen(5, 4, 30),
-				Event::CollatorChosen(5, 5, 10),
-				Event::NewRound(20, 5, 5, 170),
-				Event::Delegation(7, 80, 2, DelegatorAdded::AddedToTop { new_total: 130 }),
-				Event::Delegation(10, 10, 2, DelegatorAdded::AddedToBottom),
-				Event::CollatorChosen(6, 1, 50),
-				Event::CollatorChosen(6, 2, 130),
-				Event::CollatorChosen(6, 3, 30),
-				Event::CollatorChosen(6, 4, 30),
-				Event::CollatorChosen(6, 5, 10),
-				Event::NewRound(25, 6, 5, 250),
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 2,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 3,
+					total_exposed_amount: 30,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 4,
+					total_exposed_amount: 30,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 20,
+					round: 5,
+					selected_collators_number: 5,
+					total_balance: 170,
+				},
+				Event::Delegation {
+					delegator: 7,
+					locked_amount: 80,
+					candidate: 2,
+					delegator_position: DelegatorAdded::AddedToTop { new_total: 130 },
+				},
+				Event::Delegation {
+					delegator: 10,
+					locked_amount: 10,
+					candidate: 2,
+					delegator_position: DelegatorAdded::AddedToBottom,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 2,
+					total_exposed_amount: 130,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 3,
+					total_exposed_amount: 30,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 4,
+					total_exposed_amount: 30,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 25,
+					round: 6,
+					selected_collators_number: 5,
+					total_balance: 250,
+				},
 			];
 			expected.append(&mut new2);
 			assert_eq_events!(expected.clone());
@@ -4251,17 +5418,44 @@ fn multiple_delegations() {
 				Origin::signed(2),
 				5
 			));
-			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateScheduledExit(
-				6, 2, 8
-			)));
+			assert_last_event!(MetaEvent::ParachainStaking(Event::CandidateScheduledExit {
+				exit_allowed_round: 6,
+				candidate: 2,
+				scheduled_exit: 8
+			}));
 			roll_to(31);
 			let mut new3 = vec![
-				Event::CandidateScheduledExit(6, 2, 8),
-				Event::CollatorChosen(7, 1, 50),
-				Event::CollatorChosen(7, 3, 30),
-				Event::CollatorChosen(7, 4, 30),
-				Event::CollatorChosen(7, 5, 10),
-				Event::NewRound(30, 7, 4, 120),
+				Event::CandidateScheduledExit {
+					exit_allowed_round: 6,
+					candidate: 2,
+					scheduled_exit: 8,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 3,
+					total_exposed_amount: 30,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 4,
+					total_exposed_amount: 30,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 30,
+					round: 7,
+					selected_collators_number: 4,
+					total_balance: 120,
+				},
 			];
 			expected.append(&mut new3);
 			assert_eq_events!(expected);
@@ -4400,12 +5594,37 @@ fn payouts_follow_delegation_changes() {
 			roll_to(8);
 			// chooses top TotalSelectedCandidates (5), in order
 			let mut expected = vec![
-				Event::CollatorChosen(2, 1, 50),
-				Event::CollatorChosen(2, 2, 40),
-				Event::CollatorChosen(2, 3, 20),
-				Event::CollatorChosen(2, 4, 20),
-				Event::CollatorChosen(2, 5, 10),
-				Event::NewRound(5, 2, 5, 140),
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 5,
+					round: 2,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
 			];
 			assert_eq_events!(expected.clone());
 			// ~ set block author as 1 for all blocks this round
@@ -4413,22 +5632,84 @@ fn payouts_follow_delegation_changes() {
 			roll_to(16);
 			// distribute total issuance to collator 1 and its delegators 6, 7, 19
 			let mut new = vec![
-				Event::CollatorChosen(3, 1, 50),
-				Event::CollatorChosen(3, 2, 40),
-				Event::CollatorChosen(3, 3, 20),
-				Event::CollatorChosen(3, 4, 20),
-				Event::CollatorChosen(3, 5, 10),
-				Event::NewRound(10, 3, 5, 140),
-				Event::CollatorChosen(4, 1, 50),
-				Event::CollatorChosen(4, 2, 40),
-				Event::CollatorChosen(4, 3, 20),
-				Event::CollatorChosen(4, 4, 20),
-				Event::CollatorChosen(4, 5, 10),
-				Event::NewRound(15, 4, 5, 140),
-				Event::Rewarded(1, 26),
-				Event::Rewarded(6, 8),
-				Event::Rewarded(7, 8),
-				Event::Rewarded(10, 8),
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 10,
+					round: 3,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 4,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 15,
+					round: 4,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 26,
+				},
+				Event::Rewarded {
+					account: 6,
+					rewards: 8,
+				},
+				Event::Rewarded {
+					account: 7,
+					rewards: 8,
+				},
+				Event::Rewarded {
+					account: 10,
+					rewards: 8,
+				},
 			];
 			expected.append(&mut new);
 			assert_eq_events!(expected.clone());
@@ -4454,29 +5735,115 @@ fn payouts_follow_delegation_changes() {
 			));
 			// keep paying 6 (note: inflation is in terms of total issuance so that's why 1 is 21)
 			let mut new2 = vec![
-				Event::DelegatorExitScheduled(4, 6, 6),
-				Event::CollatorChosen(5, 1, 50),
-				Event::CollatorChosen(5, 2, 40),
-				Event::CollatorChosen(5, 3, 20),
-				Event::CollatorChosen(5, 4, 20),
-				Event::CollatorChosen(5, 5, 10),
-				Event::NewRound(20, 5, 5, 140),
-				Event::Rewarded(1, 27),
-				Event::Rewarded(6, 8),
-				Event::Rewarded(7, 8),
-				Event::Rewarded(10, 8),
-				Event::CollatorChosen(6, 1, 50),
-				Event::CollatorChosen(6, 2, 40),
-				Event::CollatorChosen(6, 3, 20),
-				Event::CollatorChosen(6, 4, 20),
-				Event::CollatorChosen(6, 5, 10),
-				Event::NewRound(25, 6, 5, 140),
-				Event::Rewarded(1, 29),
-				Event::Rewarded(6, 9),
-				Event::Rewarded(7, 9),
-				Event::Rewarded(10, 9),
-				Event::DelegatorLeftCandidate(6, 1, 10, 40),
-				Event::DelegatorLeft(6, 10),
+				Event::DelegatorExitScheduled {
+					round: 4,
+					delegator: 6,
+					scheduled_exit: 6,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 5,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 20,
+					round: 5,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 27,
+				},
+				Event::Rewarded {
+					account: 6,
+					rewards: 8,
+				},
+				Event::Rewarded {
+					account: 7,
+					rewards: 8,
+				},
+				Event::Rewarded {
+					account: 10,
+					rewards: 8,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 6,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 25,
+					round: 6,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 29,
+				},
+				Event::Rewarded {
+					account: 6,
+					rewards: 9,
+				},
+				Event::Rewarded {
+					account: 7,
+					rewards: 9,
+				},
+				Event::Rewarded {
+					account: 10,
+					rewards: 9,
+				},
+				Event::DelegatorLeftCandidate {
+					delegator: 6,
+					candidate: 1,
+					unstaked_amount: 10,
+					total_candidate_staked: 40,
+				},
+				Event::DelegatorLeft {
+					delegator: 6,
+					unstaked_amount: 10,
+				},
 			];
 			expected.append(&mut new2);
 			assert_eq_events!(expected.clone());
@@ -4485,26 +5852,100 @@ fn payouts_follow_delegation_changes() {
 			roll_to(35);
 			// keep paying 6
 			let mut new3 = vec![
-				Event::CollatorChosen(7, 1, 40),
-				Event::CollatorChosen(7, 2, 40),
-				Event::CollatorChosen(7, 3, 20),
-				Event::CollatorChosen(7, 4, 20),
-				Event::CollatorChosen(7, 5, 10),
-				Event::NewRound(30, 7, 5, 130),
-				Event::Rewarded(1, 30),
-				Event::Rewarded(6, 9),
-				Event::Rewarded(7, 9),
-				Event::Rewarded(10, 9),
-				Event::CollatorChosen(8, 1, 40),
-				Event::CollatorChosen(8, 2, 40),
-				Event::CollatorChosen(8, 3, 20),
-				Event::CollatorChosen(8, 4, 20),
-				Event::CollatorChosen(8, 5, 10),
-				Event::NewRound(35, 8, 5, 130),
-				Event::Rewarded(1, 32),
-				Event::Rewarded(6, 10),
-				Event::Rewarded(7, 10),
-				Event::Rewarded(10, 10),
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 1,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 7,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 30,
+					round: 7,
+					selected_collators_number: 5,
+					total_balance: 130,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 30,
+				},
+				Event::Rewarded {
+					account: 6,
+					rewards: 9,
+				},
+				Event::Rewarded {
+					account: 7,
+					rewards: 9,
+				},
+				Event::Rewarded {
+					account: 10,
+					rewards: 9,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 1,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 8,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 35,
+					round: 8,
+					selected_collators_number: 5,
+					total_balance: 130,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 32,
+				},
+				Event::Rewarded {
+					account: 6,
+					rewards: 10,
+				},
+				Event::Rewarded {
+					account: 7,
+					rewards: 10,
+				},
+				Event::Rewarded {
+					account: 10,
+					rewards: 10,
+				},
 			];
 			expected.append(&mut new3);
 			assert_eq_events!(expected.clone());
@@ -4512,15 +5953,49 @@ fn payouts_follow_delegation_changes() {
 			roll_to(40);
 			// no more paying 6
 			let mut new4 = vec![
-				Event::CollatorChosen(9, 1, 40),
-				Event::CollatorChosen(9, 2, 40),
-				Event::CollatorChosen(9, 3, 20),
-				Event::CollatorChosen(9, 4, 20),
-				Event::CollatorChosen(9, 5, 10),
-				Event::NewRound(40, 9, 5, 130),
-				Event::Rewarded(1, 38),
-				Event::Rewarded(7, 13),
-				Event::Rewarded(10, 13),
+				Event::CollatorChosen {
+					round: 9,
+					collator_account: 1,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 9,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 9,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 9,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 9,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 40,
+					round: 9,
+					selected_collators_number: 5,
+					total_balance: 130,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 38,
+				},
+				Event::Rewarded {
+					account: 7,
+					rewards: 13,
+				},
+				Event::Rewarded {
+					account: 10,
+					rewards: 13,
+				},
 			];
 			expected.append(&mut new4);
 			assert_eq_events!(expected.clone());
@@ -4529,16 +6004,55 @@ fn payouts_follow_delegation_changes() {
 			roll_to(45);
 			// new delegation is not rewarded yet
 			let mut new5 = vec![
-				Event::Delegation(8, 10, 1, DelegatorAdded::AddedToTop { new_total: 50 }),
-				Event::CollatorChosen(10, 1, 50),
-				Event::CollatorChosen(10, 2, 40),
-				Event::CollatorChosen(10, 3, 20),
-				Event::CollatorChosen(10, 4, 20),
-				Event::CollatorChosen(10, 5, 10),
-				Event::NewRound(45, 10, 5, 140),
-				Event::Rewarded(1, 40),
-				Event::Rewarded(7, 13),
-				Event::Rewarded(10, 13),
+				Event::Delegation {
+					delegator: 8,
+					locked_amount: 10,
+					candidate: 1,
+					delegator_position: DelegatorAdded::AddedToTop { new_total: 50 },
+				},
+				Event::CollatorChosen {
+					round: 10,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 10,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 10,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 10,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 10,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 45,
+					round: 10,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 40,
+				},
+				Event::Rewarded {
+					account: 7,
+					rewards: 13,
+				},
+				Event::Rewarded {
+					account: 10,
+					rewards: 13,
+				},
 			];
 			expected.append(&mut new5);
 			assert_eq_events!(expected.clone());
@@ -4546,15 +6060,52 @@ fn payouts_follow_delegation_changes() {
 			roll_to(50);
 			// new delegation not rewarded yet
 			let mut new6 = vec![
-				Event::CollatorChosen(11, 1, 50),
-				Event::CollatorChosen(11, 2, 40),
-				Event::CollatorChosen(11, 3, 20),
-				Event::CollatorChosen(11, 4, 20),
-				Event::CollatorChosen(11, 5, 10),
-				Event::NewRound(50, 11, 5, 140),
-				Event::Rewarded(1, 42),
-				Event::Rewarded(7, 14),
-				Event::Rewarded(10, 14),
+				Event::CollatorChosen {
+					round: 11,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 11,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 11,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 11,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 11,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 50,
+					round: 11,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 42,
+				},
+				(1, 42),
+				Event::Rewarded {
+					account: 7,
+					rewards: 14,
+				},
+				(7, 14),
+				Event::Rewarded {
+					account: 10,
+					rewards: 14,
+				},
+				(10, 14),
 			];
 			expected.append(&mut new6);
 			assert_eq_events!(expected.clone());
@@ -4562,16 +6113,53 @@ fn payouts_follow_delegation_changes() {
 			// new delegation is rewarded for first time
 			// 2 rounds after joining (`RewardPaymentDelay` = 2)
 			let mut new7 = vec![
-				Event::CollatorChosen(12, 1, 50),
-				Event::CollatorChosen(12, 2, 40),
-				Event::CollatorChosen(12, 3, 20),
-				Event::CollatorChosen(12, 4, 20),
-				Event::CollatorChosen(12, 5, 10),
-				Event::NewRound(55, 12, 5, 140),
-				Event::Rewarded(1, 39),
-				Event::Rewarded(7, 12),
-				Event::Rewarded(10, 12),
-				Event::Rewarded(8, 12),
+				Event::CollatorChosen {
+					round: 12,
+					collator_account: 1,
+					total_exposed_amount: 50,
+				},
+				Event::CollatorChosen {
+					round: 12,
+					collator_account: 2,
+					total_exposed_amount: 40,
+				},
+				Event::CollatorChosen {
+					round: 12,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 12,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 12,
+					collator_account: 5,
+					total_exposed_amount: 10,
+				},
+				Event::NewRound {
+					starting_block: 55,
+					round: 12,
+					selected_collators_number: 5,
+					total_balance: 140,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 39,
+				},
+				Event::Rewarded {
+					account: 7,
+					rewards: 12,
+				},
+				Event::Rewarded {
+					account: 10,
+					rewards: 12,
+				},
+				Event::Rewarded {
+					account: 8,
+					rewards: 12,
+				},
 			];
 			expected.append(&mut new7);
 			assert_eq_events!(expected);
@@ -4744,7 +6332,12 @@ fn only_top_collators_are_counted() {
 				1,
 				8
 			));
-			assert_event_emitted!(Event::DelegationIncreased(3, 1, 8, true));
+			assert_event_emitted!(Event::DelegationIncreased {
+				delegator: 3,
+				candidate: 1,
+				amount: 8,
+				in_top: true,
+			});
 			let collator_state = ParachainStaking::candidate_info(1).unwrap();
 			// 16 + 17 + 18 + 19 + 20 = 90 (top 4 + self bond)
 			assert_eq!(collator_state.total_counted, 90);
@@ -4754,7 +6347,12 @@ fn only_top_collators_are_counted() {
 				1,
 				8
 			));
-			assert_event_emitted!(Event::DelegationIncreased(4, 1, 8, true));
+			assert_event_emitted!(Event::DelegationIncreased {
+				delegator: 4,
+				candidate: 1,
+				amount: 8,
+				in_top: true,
+			});
 			let collator_state = ParachainStaking::candidate_info(1).unwrap();
 			// 17 + 18 + 19 + 20 + 20 = 94 (top 4 + self bond)
 			assert_eq!(collator_state.total_counted, 94);
@@ -4764,7 +6362,12 @@ fn only_top_collators_are_counted() {
 				1,
 				8
 			));
-			assert_event_emitted!(Event::DelegationIncreased(5, 1, 8, true));
+			assert_event_emitted!(Event::DelegationIncreased {
+				delegator: 5,
+				candidate: 1,
+				amount: 8,
+				in_top: true,
+			});
 			let collator_state = ParachainStaking::candidate_info(1).unwrap();
 			// 18 + 19 + 20 + 21 + 20 = 98 (top 4 + self bond)
 			assert_eq!(collator_state.total_counted, 98);
@@ -4774,7 +6377,12 @@ fn only_top_collators_are_counted() {
 				1,
 				8
 			));
-			assert_event_emitted!(Event::DelegationIncreased(6, 1, 8, true));
+			assert_event_emitted!(Event::DelegationIncreased {
+				delegator: 6,
+				candidate: 1,
+				amount: 8,
+				in_top: true,
+			});
 			let collator_state = ParachainStaking::candidate_info(1).unwrap();
 			// 19 + 20 + 21 + 22 + 20 = 102 (top 4 + self bond)
 			assert_eq!(collator_state.total_counted, 102);
@@ -4805,18 +6413,23 @@ fn delegation_events_convey_correct_position() {
 			assert_eq!(collator1_state.total_counted, 70);
 			// Top delegations are full, new highest delegation is made
 			assert_ok!(ParachainStaking::delegate(Origin::signed(7), 1, 15, 10, 10));
-			assert_event_emitted!(Event::Delegation(
-				7,
-				15,
-				1,
-				DelegatorAdded::AddedToTop { new_total: 74 },
-			));
+			assert_event_emitted!(Event::Delegation {
+				delegator: 7,
+				locked_amount: 15,
+				candidate: 1,
+				delegator_position: DelegatorAdded::AddedToTop { new_total: 74 },
+			});
 			let collator1_state = ParachainStaking::candidate_info(1).unwrap();
 			// 12 + 13 + 14 + 15 + 20 = 70 (top 4 + self bond)
 			assert_eq!(collator1_state.total_counted, 74);
 			// New delegation is added to the bottom
 			assert_ok!(ParachainStaking::delegate(Origin::signed(8), 1, 10, 10, 10));
-			assert_event_emitted!(Event::Delegation(8, 10, 1, DelegatorAdded::AddedToBottom));
+			assert_event_emitted!(Event::Delegation {
+				delegator: 8,
+				locked_amount: 10,
+				candidate: 1,
+				delegator_position: DelegatorAdded::AddedToBottom,
+			});
 			let collator1_state = ParachainStaking::candidate_info(1).unwrap();
 			// 12 + 13 + 14 + 15 + 20 = 70 (top 4 + self bond)
 			assert_eq!(collator1_state.total_counted, 74);
@@ -4826,7 +6439,12 @@ fn delegation_events_convey_correct_position() {
 				1,
 				3
 			));
-			assert_event_emitted!(Event::DelegationIncreased(8, 1, 3, true));
+			assert_event_emitted!(Event::DelegationIncreased {
+				delegator: 8,
+				candidate: 1,
+				amount: 3,
+				in_top: true,
+			});
 			let collator1_state = ParachainStaking::candidate_info(1).unwrap();
 			// 13 + 13 + 14 + 15 + 20 = 75 (top 4 + self bond)
 			assert_eq!(collator1_state.total_counted, 75);
@@ -4836,7 +6454,12 @@ fn delegation_events_convey_correct_position() {
 				1,
 				1
 			));
-			assert_event_emitted!(Event::DelegationIncreased(3, 1, 1, false));
+			assert_event_emitted!(Event::DelegationIncreased {
+				delegator: 3,
+				candidate: 1,
+				amount: 1,
+				in_top: false,
+			});
 			let collator1_state = ParachainStaking::candidate_info(1).unwrap();
 			// 13 + 13 + 14 + 15 + 20 = 75 (top 4 + self bond)
 			assert_eq!(collator1_state.total_counted, 75);
@@ -4846,14 +6469,24 @@ fn delegation_events_convey_correct_position() {
 				1,
 				2
 			));
-			assert_event_emitted!(Event::DelegationDecreaseScheduled(6, 1, 2, 3));
+			assert_event_emitted!(Event::DelegationDecreaseScheduled {
+				delegator: 6,
+				candidate: 1,
+				amount_to_decrease: 2,
+				execute_round: 3,
+			});
 			roll_to(30);
 			assert_ok!(ParachainStaking::execute_delegation_request(
 				Origin::signed(6),
 				6,
 				1
 			));
-			assert_event_emitted!(Event::DelegationDecreased(6, 1, 2, true));
+			assert_event_emitted!(Event::DelegationDecreased {
+				delegator: 6,
+				candidate: 1,
+				amount: 2,
+				in_top: true,
+			});
 			let collator1_state = ParachainStaking::candidate_info(1).unwrap();
 			// 12 + 13 + 13 + 15 + 20 = 73 (top 4 + self bond)ƒ
 			assert_eq!(collator1_state.total_counted, 73);
@@ -4863,14 +6496,24 @@ fn delegation_events_convey_correct_position() {
 				1,
 				1
 			));
-			assert_event_emitted!(Event::DelegationDecreaseScheduled(6, 1, 1, 9));
+			assert_event_emitted!(Event::DelegationDecreaseScheduled {
+				delegator: 6,
+				candidate: 1,
+				amount_to_decrease: 1,
+				execute_round: 9,
+			});
 			roll_to(40);
 			assert_ok!(ParachainStaking::execute_delegation_request(
 				Origin::signed(6),
 				6,
 				1
 			));
-			assert_event_emitted!(Event::DelegationDecreased(6, 1, 1, false));
+			assert_event_emitted!(Event::DelegationDecreased {
+				delegator: 6,
+				candidate: 1,
+				amount: 1,
+				in_top: false,
+			});
 			let collator1_state = ParachainStaking::candidate_info(1).unwrap();
 			// 12 + 13 + 13 + 15 + 20 = 73 (top 4 + self bond)
 			assert_eq!(collator1_state.total_counted, 73);
@@ -4892,38 +6535,92 @@ fn no_rewards_paid_until_after_reward_payment_delay() {
 			set_author(1, 4, 1);
 			set_author(1, 4, 1);
 			let mut expected = vec![
-				Event::CollatorChosen(2, 1, 20),
-				Event::CollatorChosen(2, 2, 20),
-				Event::CollatorChosen(2, 3, 20),
-				Event::CollatorChosen(2, 4, 20),
-				Event::NewRound(5, 2, 4, 80),
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 1,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 2,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 2,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::NewRound {
+					starting_block: 5,
+					round: 2,
+					selected_collators_number: 4,
+					total_balance: 80,
+				},
 			];
 			assert_eq_events!(expected);
 
 			roll_to_round_begin(3);
 			expected.append(&mut vec![
-				Event::CollatorChosen(3, 1, 20),
-				Event::CollatorChosen(3, 2, 20),
-				Event::CollatorChosen(3, 3, 20),
-				Event::CollatorChosen(3, 4, 20),
-				Event::NewRound(10, 3, 4, 80),
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 1,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 2,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 3,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: 3,
+					collator_account: 4,
+					total_exposed_amount: 20,
+				},
+				Event::NewRound {
+					starting_block: 10,
+					round: 3,
+					selected_collators_number: 4,
+					total_balance: 80,
+				},
 				// rewards will begin immediately following a NewRound
-				Event::Rewarded(3, 1),
+				Event::Rewarded {
+					account: 3,
+					rewards: 1,
+				},
 			]);
 			assert_eq_events!(expected);
 
 			// roll to the next block where we start round 3; we should have round change and first
 			// payout made.
 			roll_one_block();
-			expected.push(Event::Rewarded(4, 2));
+			expected.push(Event::Rewarded {
+				account: 4,
+				rewards: 2,
+			});
 			assert_eq_events!(expected);
 
 			roll_one_block();
-			expected.push(Event::Rewarded(1, 1));
+			expected.push(Event::Rewarded {
+				account: 1,
+				rewards: 2,
+			});
 			assert_eq_events!(expected);
 
 			roll_one_block();
-			expected.push(Event::Rewarded(2, 1));
+			expected.push(Event::Rewarded {
+				account: 2,
+				rewards: 1,
+			});
 			assert_eq_events!(expected);
 
 			// there should be no more payments in this round...
@@ -4956,9 +6653,22 @@ fn deferred_payment_storage_items_are_cleaned_up() {
 			round = 2;
 			roll_to_round_begin(round.into());
 			let mut expected = vec![
-				Event::CollatorChosen(round, 1, 20),
-				Event::CollatorChosen(round, 2, 20),
-				Event::NewRound(5, round, 2, 40),
+				Event::CollatorChosen {
+					round: round,
+					collator_account: 1,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: round,
+					collator_account: 2,
+					total_exposed_amount: 20,
+				},
+				Event::NewRound {
+					starting_block: 5,
+					round: round,
+					selected_collators_number: 2,
+					total_balance: 40,
+				},
 			];
 			assert_eq_events!(expected);
 
@@ -4995,10 +6705,26 @@ fn deferred_payment_storage_items_are_cleaned_up() {
 			round = 3;
 			roll_to_round_begin(round.into());
 			expected.append(&mut vec![
-				Event::CollatorChosen(round, 1, 20),
-				Event::CollatorChosen(round, 2, 20),
-				Event::NewRound(10, round, 2, 40),
-				Event::Rewarded(1, 1),
+				Event::CollatorChosen {
+					round: round,
+					collator_account: 1,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: round,
+					collator_account: 2,
+					total_exposed_amount: 20,
+				},
+				Event::NewRound {
+					starting_block: 10,
+					round: round,
+					selected_collators_number: 2,
+					total_balance: 40,
+				},
+				Event::Rewarded {
+					account: 1,
+					rewards: 1,
+				},
 			]);
 			assert_eq_events!(expected);
 
@@ -5043,10 +6769,26 @@ fn deferred_payment_storage_items_are_cleaned_up() {
 			round = 4;
 			roll_to_round_begin(round.into());
 			expected.append(&mut vec![
-				Event::Rewarded(2, 1), // from previous round
-				Event::CollatorChosen(round, 1, 20),
-				Event::CollatorChosen(round, 2, 20),
-				Event::NewRound(15, round, 2, 40),
+				Event::Rewarded {
+					account: 2,
+					rewards: 1,
+				}, // from previous round
+				Event::CollatorChosen {
+					round: round,
+					collator_account: 1,
+					total_exposed_amount: 20,
+				},
+				Event::CollatorChosen {
+					round: round,
+					collator_account: 2,
+					total_exposed_amount: 20,
+				},
+				Event::NewRound {
+					starting_block: 15,
+					round: round,
+					selected_collators_number: 2,
+					total_balance: 40,
+				},
 			]);
 			assert_eq_events!(expected);
 
@@ -5152,15 +6894,45 @@ fn deferred_payment_steady_state_event_flow() {
 				);
 
 				let expected = vec![
-					Event::CollatorChosen(round as u32, 1, 400),
-					Event::CollatorChosen(round as u32, 2, 400),
-					Event::CollatorChosen(round as u32, 3, 400),
-					Event::CollatorChosen(round as u32, 4, 400),
-					Event::NewRound((round - 1) * 5, round as u32, 4, 1600),
+					Event::CollatorChosen {
+						round: round as u32,
+						collator_account: 1,
+						total_exposed_amount: 400,
+					},
+					Event::CollatorChosen {
+						round: round as u32,
+						collator_account: 2,
+						total_exposed_amount: 400,
+					},
+					Event::CollatorChosen {
+						round: round as u32,
+						collator_account: 3,
+						total_exposed_amount: 400,
+					},
+					Event::CollatorChosen {
+						round: round as u32,
+						collator_account: 4,
+						total_exposed_amount: 400,
+					},
+					Event::NewRound {
+						starting_block: (round - 1) * 5,
+						round: round as u32,
+						selected_collators_number: 4,
+						total_balance: 1600,
+					},
 					// first payout should occur on round change
-					Event::Rewarded(3, 19),
-					Event::Rewarded(22, 6),
-					Event::Rewarded(33, 6),
+					Event::Rewarded {
+						account: 3,
+						rewards: 19,
+					},
+					Event::Rewarded {
+						account: 22,
+						rewards: 6,
+					},
+					Event::Rewarded {
+						account: 33,
+						rewards: 6,
+					},
 				];
 				assert_eq_last_events!(expected);
 
@@ -5168,32 +6940,63 @@ fn deferred_payment_steady_state_event_flow() {
 
 				roll_one_block();
 				let expected = vec![
-					Event::Rewarded(4, 19),
-					Event::Rewarded(33, 6),
-					Event::Rewarded(44, 6),
+					Event::Rewarded {
+						account: 4,
+						rewards: 19,
+					},
+					Event::Rewarded {
+						account: 33,
+						rewards: 6,
+					},
+					Event::Rewarded {
+						account: 44,
+						rewards: 6,
+					},
 				];
 				assert_eq_last_events!(expected);
 
 				roll_one_block();
 				let expected = vec![
-					Event::Rewarded(1, 19),
-					Event::Rewarded(11, 6),
-					Event::Rewarded(44, 6),
+					Event::Rewarded {
+						account: 1,
+						rewards: 19,
+					},
+					Event::Rewarded {
+						account: 11,
+						rewards: 6,
+					},
+					Event::Rewarded {
+						account: 44,
+						rewards: 6,
+					},
 				];
 				assert_eq_last_events!(expected);
 
 				roll_one_block();
 				let expected = vec![
-					Event::Rewarded(2, 19),
-					Event::Rewarded(11, 6),
-					Event::Rewarded(22, 6),
+					Event::Rewarded {
+						account: 2,
+						rewards: 19,
+					},
+					(2, 19),
+					Event::Rewarded {
+						account: 11,
+						rewards: 6,
+					},
+					Event::Rewarded {
+						account: 22,
+						rewards: 6,
+					},
 				];
 				assert_eq_last_events!(expected);
 
 				roll_one_block();
 				let expected = vec![
 					// we paid everyone out by now, should repeat last event
-					Event::Rewarded(22, 6),
+					Event::Rewarded {
+						account: 22,
+						rewards: 6,
+					},
 				];
 				assert_eq_last_events!(expected);
 
@@ -5411,12 +7214,34 @@ fn split_candidate_state_kicks_extra_bottom_delegators_to_exit() {
 			assert!(ParachainStaking::is_delegator(&11));
 			assert!(ParachainStaking::is_delegator(&12));
 			crate::migrations::SplitCandidateStateToDecreasePoV::<Test>::on_runtime_upgrade();
-			assert_event_emitted!(Event::DelegationKicked(11, 1, 11));
-			assert_event_emitted!(Event::DelegationKicked(11, 2, 11));
-			assert_event_emitted!(Event::DelegationKicked(12, 1, 10));
-			assert_event_emitted!(Event::DelegationKicked(12, 2, 10));
-			assert_event_emitted!(Event::DelegatorLeft(12, 10));
-			assert_event_emitted!(Event::DelegatorLeft(11, 11));
+			assert_event_emitted!(Event::DelegationKicked {
+				delegator: 11,
+				candidate: 1,
+				unstaked_amount: 11
+			});
+			assert_event_emitted!(Event::DelegationKicked {
+				delegator: 11,
+				candidate: 2,
+				unstaked_amount: 11
+			});
+			assert_event_emitted!(Event::DelegationKicked {
+				delegator: 12,
+				candidate: 1,
+				unstaked_amount: 10
+			});
+			assert_event_emitted!(Event::DelegationKicked {
+				delegator: 12,
+				candidate: 2,
+				unstaked_amount: 10
+			});
+			assert_event_emitted!(Event::DelegatorLeft {
+				delegator: 12,
+				unstaked_amount: 10
+			});
+			assert_event_emitted!(Event::DelegatorLeft {
+				delegator: 11,
+				unstaked_amount: 11
+			});
 			// kicked 11 and 12 and revoked them
 			assert_eq!(Balances::free_balance(&11), 22);
 			assert_eq!(Balances::free_balance(&12), 20);
@@ -5574,12 +7399,34 @@ fn split_candidate_state_kicks_extra_bottom_delegations_without_exit() {
 			assert!(ParachainStaking::is_delegator(&11));
 			assert!(ParachainStaking::is_delegator(&12));
 			crate::migrations::SplitCandidateStateToDecreasePoV::<Test>::on_runtime_upgrade();
-			assert_event_emitted!(Event::DelegationKicked(11, 1, 11));
-			assert_event_emitted!(Event::DelegationKicked(11, 2, 11));
-			assert_event_emitted!(Event::DelegationKicked(12, 1, 10));
-			assert_event_emitted!(Event::DelegationKicked(12, 2, 10));
-			assert_event_not_emitted!(Event::DelegatorLeft(12, 10));
-			assert_event_not_emitted!(Event::DelegatorLeft(11, 10));
+			assert_event_emitted!(Event::DelegationKicked {
+				delegator: 11,
+				candidate: 1,
+				unstaked_amount: 11,
+			});
+			assert_event_emitted!(Event::DelegationKicked {
+				delegator: 11,
+				candidate: 2,
+				unstaked_amount: 11,
+			});
+			assert_event_emitted!(Event::DelegationKicked {
+				delegator: 12,
+				candidate: 1,
+				unstaked_amount: 10,
+			});
+			assert_event_emitted!(Event::DelegationKicked {
+				delegator: 12,
+				candidate: 2,
+				unstaked_amount: 10,
+			});
+			assert_event_not_emitted!(Event::DelegatorLeft {
+				delegator: 12,
+				unstaked_amount: 10,
+			});
+			assert_event_not_emitted!(Event::DelegatorLeft {
+				delegator: 11,
+				unstaked_amount: 10,
+			});
 			// kicked 11 and 12 and revoked them
 			assert_eq!(Balances::free_balance(&11), 22);
 			assert_eq!(Balances::free_balance(&12), 20);

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -194,25 +194,25 @@ pub mod pallet {
 			account_id: T::AccountId,
 			dest: MultiLocation,
 			call: Vec<u8>,
-			index: u16
+			index: u16,
 		},
 		/// Transacted the call through the sovereign account in a destination chain.
 		TransactedSovereign {
 			fee_payer: T::AccountId,
 			dest: MultiLocation,
-			call: Vec<u8>
+			call: Vec<u8>,
 		},
 		/// Registered a derivative index for an account id.
 		RegisterdDerivative {
 			account_id: T::AccountId,
-			index: u16
+			index: u16,
 		},
 		/// Transact failed
 		TransactFailed { error: XcmError },
 		/// Changed the transact info of a location
 		TransactInfoChanged {
 			location: MultiLocation,
-			remote_info: RemoteTransactInfoWithMaxWeight
+			remote_info: RemoteTransactInfoWithMaxWeight,
 		},
 	}
 
@@ -238,9 +238,9 @@ pub mod pallet {
 			IndexToAccount::<T>::insert(&index, who.clone());
 
 			// Deposit event
-			Self::deposit_event(Event::<T>::RegisterdDerivative { 
-				account_id: who, 
-				index: index
+			Self::deposit_event(Event::<T>::RegisterdDerivative {
+				account_id: who,
+				index: index,
 			});
 
 			Ok(())
@@ -400,7 +400,11 @@ pub mod pallet {
 			)?;
 
 			// Deposit event
-			Self::deposit_event(Event::<T>::TransactedSovereign { fee_payer, dest, call });
+			Self::deposit_event(Event::<T>::TransactedSovereign {
+				fee_payer,
+				dest,
+				call,
+			});
 
 			Ok(())
 		}
@@ -425,7 +429,10 @@ pub mod pallet {
 
 			TransactInfoWithWeightLimit::<T>::insert(&location, &remote_info);
 
-			Self::deposit_event(Event::TransactInfoChanged { location, remote_info });
+			Self::deposit_event(Event::TransactInfoChanged {
+				location,
+				remote_info,
+			});
 			Ok(())
 		}
 	}

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -189,11 +189,31 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {
-		TransactedDerivative(T::AccountId, MultiLocation, Vec<u8>, u16),
-		TransactedSovereign(T::AccountId, MultiLocation, Vec<u8>),
-		RegisterdDerivative(T::AccountId, u16),
-		TransactFailed(XcmError),
-		TransactInfoChanged(MultiLocation, RemoteTransactInfoWithMaxWeight),
+		/// Transacted the inner call through a derivative account in a destination chain.
+		TransactedDerivative {
+			who: T::AccountId,
+			dest: MultiLocation,
+			call: Vec<u8>,
+			index: u16
+		},
+		/// Transacted the call through the sovereign account in a destination chain.
+		TransactedSovereign {
+			fee_payer: T::AccountId,
+			dest: MultiLocation,
+			call: Vec<u8>
+		},
+		/// Registered a derivative index for an account id.
+		RegisterdDerivative {
+			who: T::AccountId,
+			index: u16
+		},
+		/// Transact failed
+		TransactFailed { error: XcmError },
+		/// Changed the transact info of a location
+		TransactInfoChanged {
+			location: MultiLocation,
+			remote_info: RemoteTransactInfoWithMaxWeight
+		},
 	}
 
 	#[pallet::call]

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -191,7 +191,7 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		/// Transacted the inner call through a derivative account in a destination chain.
 		TransactedDerivative {
-			who: T::AccountId,
+			account_id: T::AccountId,
 			dest: MultiLocation,
 			call: Vec<u8>,
 			index: u16
@@ -204,7 +204,7 @@ pub mod pallet {
 		},
 		/// Registered a derivative index for an account id.
 		RegisterdDerivative {
-			who: T::AccountId,
+			account_id: T::AccountId,
 			index: u16
 		},
 		/// Transact failed
@@ -238,7 +238,10 @@ pub mod pallet {
 			IndexToAccount::<T>::insert(&index, who.clone());
 
 			// Deposit event
-			Self::deposit_event(Event::<T>::RegisterdDerivative(who, index));
+			Self::deposit_event(Event::<T>::RegisterdDerivative { 
+				account_id: who, 
+				index: index
+			});
 
 			Ok(())
 		}
@@ -292,9 +295,12 @@ pub mod pallet {
 			)?;
 
 			// Deposit event
-			Self::deposit_event(Event::<T>::TransactedDerivative(
-				who, dest, call_bytes, index,
-			));
+			Self::deposit_event(Event::<T>::TransactedDerivative {
+				account_id: who,
+				dest: dest,
+				call: call_bytes,
+				index: index,
+			});
 
 			Ok(())
 		}
@@ -348,9 +354,12 @@ pub mod pallet {
 				call_bytes.clone(),
 			)?;
 			// Deposit event
-			Self::deposit_event(Event::<T>::TransactedDerivative(
-				who, dest, call_bytes, index,
-			));
+			Self::deposit_event(Event::<T>::TransactedDerivative {
+				account_id: who,
+				dest: dest,
+				call: call_bytes,
+				index: index,
+			});
 
 			Ok(())
 		}
@@ -391,7 +400,7 @@ pub mod pallet {
 			)?;
 
 			// Deposit event
-			Self::deposit_event(Event::<T>::TransactedSovereign(fee_payer, dest, call));
+			Self::deposit_event(Event::<T>::TransactedSovereign { fee_payer, dest, call });
 
 			Ok(())
 		}
@@ -416,7 +425,7 @@ pub mod pallet {
 
 			TransactInfoWithWeightLimit::<T>::insert(&location, &remote_info);
 
-			Self::deposit_event(Event::TransactInfoChanged(location, remote_info));
+			Self::deposit_event(Event::TransactInfoChanged { location, remote_info });
 			Ok(())
 		}
 	}

--- a/pallets/xcm-transactor/src/tests.rs
+++ b/pallets/xcm-transactor/src/tests.rs
@@ -41,7 +41,10 @@ fn test_register_address() {
 
 			assert_eq!(XcmTransactor::index_to_account(&1).unwrap(), 1u64);
 
-			let expected = vec![crate::Event::RegisterdDerivative(1u64, 1)];
+			let expected = vec![crate::Event::RegisterdDerivative {
+				account_id: 1u64,
+				index: 1,
+			}];
 			assert_eq!(events(), expected);
 		})
 }
@@ -164,22 +167,25 @@ fn test_transact_through_derivative_multilocation_success() {
 				vec![1u8]
 			));
 			let expected = vec![
-				crate::Event::RegisterdDerivative(1u64, 1),
-				crate::Event::TransactInfoChanged(
-					MultiLocation::parent(),
-					RemoteTransactInfoWithMaxWeight {
+				crate::Event::RegisterdDerivative {
+					account_id: 1u64,
+					index: 1,
+				},
+				crate::Event::TransactInfoChanged {
+					location: MultiLocation::parent(),
+					remote_info: RemoteTransactInfoWithMaxWeight {
 						transact_extra_weight: 0,
 						fee_per_second: 1,
 						max_weight: 10000,
 					},
-				),
-				crate::Event::TransactedDerivative(
-					1u64,
-					MultiLocation::parent(),
-					Transactors::Relay
+				},
+				crate::Event::TransactedDerivative {
+					account_id: 1u64,
+					dest: MultiLocation::parent(),
+					call: Transactors::Relay
 						.encode_call(UtilityAvailableCalls::AsDerivative(1, vec![1u8])),
-					1,
-				),
+					index: 1,
+				},
 			];
 			assert_eq!(events(), expected);
 		})
@@ -213,22 +219,25 @@ fn test_transact_through_derivative_success() {
 				vec![1u8]
 			));
 			let expected = vec![
-				crate::Event::RegisterdDerivative(1u64, 1),
-				crate::Event::TransactInfoChanged(
-					MultiLocation::parent(),
-					RemoteTransactInfoWithMaxWeight {
+				crate::Event::RegisterdDerivative {
+					account_id: 1u64,
+					index: 1,
+				},
+				crate::Event::TransactInfoChanged {
+					location: MultiLocation::parent(),
+					remote_info: RemoteTransactInfoWithMaxWeight {
 						transact_extra_weight: 0,
 						fee_per_second: 1,
 						max_weight: 10000,
 					},
-				),
-				crate::Event::TransactedDerivative(
-					1u64,
-					MultiLocation::parent(),
-					Transactors::Relay
+				},
+				crate::Event::TransactedDerivative {
+					account_id: 1u64,
+					dest: MultiLocation::parent(),
+					call: Transactors::Relay
 						.encode_call(UtilityAvailableCalls::AsDerivative(1, vec![1u8])),
-					1,
-				),
+					index: 1,
+				},
 			];
 			assert_eq!(events(), expected);
 		})
@@ -273,15 +282,19 @@ fn test_root_can_transact_through_sovereign() {
 			));
 
 			let expected = vec![
-				crate::Event::TransactInfoChanged(
-					MultiLocation::parent(),
-					RemoteTransactInfoWithMaxWeight {
+				crate::Event::TransactInfoChanged {
+					location: MultiLocation::parent(),
+					remote_info: RemoteTransactInfoWithMaxWeight {
 						transact_extra_weight: 0,
 						fee_per_second: 1,
 						max_weight: 10000,
 					},
-				),
-				crate::Event::TransactedSovereign(1u64, MultiLocation::parent(), vec![1u8]),
+				},
+				crate::Event::TransactedSovereign {
+					fee_payer: 1u64,
+					dest: MultiLocation::parent(),
+					call: vec![1u8],
+				},
 			];
 			assert_eq!(events(), expected);
 		})

--- a/precompiles/author-mapping/src/tests.rs
+++ b/precompiles/author-mapping/src/tests.rs
@@ -121,9 +121,9 @@ fn add_association_works() {
 						amount: 10
 					}
 					.into(),
-					AuthorMappingEvent::AuthorRegistered { 
-						author_id: expected_nimbus_id, 
-						account_id: Alice 
+					AuthorMappingEvent::AuthorRegistered {
+						author_id: expected_nimbus_id,
+						account_id: Alice
 					}
 					.into(),
 					EvmEvent::Executed(Precompile.into()).into(),
@@ -165,13 +165,13 @@ fn update_association_works() {
 						amount: 10
 					}
 					.into(),
-					AuthorMappingEvent::AuthorRegistered { 
-						author_id: first_nimbus_id, 
-						account_id: Alice 
+					AuthorMappingEvent::AuthorRegistered {
+						author_id: first_nimbus_id,
+						account_id: Alice
 					}
 					.into(),
 					AuthorMappingEvent::AuthorRotated {
-						new_author_id: second_nimbus_id, 
+						new_author_id: second_nimbus_id,
 						account_id: Alice
 					}
 					.into(),
@@ -211,7 +211,7 @@ fn clear_association_works() {
 					}
 					.into(),
 					AuthorMappingEvent::AuthorRegistered {
-						author_id: nimbus_id.clone(), 
+						author_id: nimbus_id.clone(),
 						account_id: Alice
 					}
 					.into(),

--- a/precompiles/author-mapping/src/tests.rs
+++ b/precompiles/author-mapping/src/tests.rs
@@ -121,7 +121,11 @@ fn add_association_works() {
 						amount: 10
 					}
 					.into(),
-					AuthorMappingEvent::AuthorRegistered(expected_nimbus_id, Alice).into(),
+					AuthorMappingEvent::AuthorRegistered { 
+						author_id: expected_nimbus_id, 
+						account_id: Alice 
+					}
+					.into(),
 					EvmEvent::Executed(Precompile.into()).into(),
 				]
 			);
@@ -161,8 +165,16 @@ fn update_association_works() {
 						amount: 10
 					}
 					.into(),
-					AuthorMappingEvent::AuthorRegistered(first_nimbus_id, Alice).into(),
-					AuthorMappingEvent::AuthorRotated(second_nimbus_id, Alice).into(),
+					AuthorMappingEvent::AuthorRegistered { 
+						author_id: first_nimbus_id, 
+						account_id: Alice 
+					}
+					.into(),
+					AuthorMappingEvent::AuthorRotated {
+						new_author_id: second_nimbus_id, 
+						account_id: Alice
+					}
+					.into(),
 					EvmEvent::Executed(Precompile.into()).into(),
 				]
 			);
@@ -198,13 +210,20 @@ fn clear_association_works() {
 						amount: 10
 					}
 					.into(),
-					AuthorMappingEvent::AuthorRegistered(nimbus_id.clone(), Alice).into(),
+					AuthorMappingEvent::AuthorRegistered {
+						author_id: nimbus_id.clone(), 
+						account_id: Alice
+					}
+					.into(),
 					BalancesEvent::Unreserved {
 						who: Alice,
 						amount: 10
 					}
 					.into(),
-					AuthorMappingEvent::AuthorDeRegistered(nimbus_id).into(),
+					AuthorMappingEvent::AuthorDeRegistered {
+						author_id: nimbus_id
+					}
+					.into(),
 					EvmEvent::Executed(Precompile.into()).into(),
 				]
 			);

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -746,7 +746,12 @@ fn join_candidates_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::JoinedCollatorCandidates(TestAccount::Alice, 1000, 1000).into();
+				StakingEvent::JoinedCollatorCandidates {
+					account: TestAccount::Alice, 
+					amount_locked: 1000, 
+					new_total_amt_locked: 1000
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			println!("{:?}", events());
 			assert!(events().contains(&expected));
@@ -773,7 +778,12 @@ fn leave_candidates_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::CandidateScheduledExit(1, TestAccount::Alice, 3).into();
+				StakingEvent::CandidateScheduledExit {
+					exit_allowed_round: 1, 
+					candidate: TestAccount::Alice, 
+					scheduled_exit: 3
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -798,7 +808,12 @@ fn schedule_leave_candidates_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::CandidateScheduledExit(1, TestAccount::Alice, 3).into();
+				StakingEvent::CandidateScheduledExit {
+					exit_allowed_round: 1, 
+					candidate: TestAccount::Alice, 
+					scheduled_exit: 3
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -829,7 +844,12 @@ fn execute_leave_candidates_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::CandidateLeft(TestAccount::Alice, 1_000, 0).into();
+				StakingEvent::CandidateLeft {
+					ex_candidate: TestAccount::Alice, 
+					unlocked_amount: 1_000, 
+					new_total_amt_locked: 0
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -858,7 +878,7 @@ fn cancel_leave_candidates_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::CancelledCandidateExit(TestAccount::Alice).into();
+				StakingEvent::CancelledCandidateExit { candidate: TestAccount::Alice }.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -884,7 +904,7 @@ fn go_online_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::CandidateBackOnline(TestAccount::Alice).into();
+				StakingEvent::CandidateBackOnline { candidate: TestAccount::Alice }.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -907,7 +927,7 @@ fn go_offline_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::CandidateWentOffline(TestAccount::Alice).into();
+				StakingEvent::CandidateWentOffline { candidate: TestAccount::Alice }.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -932,7 +952,12 @@ fn candidate_bond_more_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::CandidateBondedMore(TestAccount::Alice, 500, 1500).into();
+				StakingEvent::CandidateBondedMore { 
+					candidate: TestAccount::Alice, 
+					amount: 500, 
+					new_total_bond: 1500
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -958,7 +983,12 @@ fn candidate_bond_less_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::CandidateBondLessRequested(TestAccount::Alice, 500, 3).into();
+				StakingEvent::CandidateBondLessRequested {
+					candidate: TestAccount::Alice, 
+					amount_to_decrease: 500, 
+					execute_round: 3
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -983,7 +1013,12 @@ fn schedule_candidate_bond_less_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::CandidateBondLessRequested(TestAccount::Alice, 500, 3).into();
+				StakingEvent::CandidateBondLessRequested {
+					candidate: TestAccount::Alice, 
+					amount_to_decrease: 500, 
+					execute_round: 3
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1013,7 +1048,11 @@ fn execute_candidate_bond_less_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::CandidateBondedLess(TestAccount::Alice, 500, 1000).into();
+				StakingEvent::CandidateBondedLess { 
+					candidate: TestAccount::Alice, 
+					amount: 500, 
+					new_bond: 1000
+				}.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1041,7 +1080,12 @@ fn cancel_candidate_bond_less_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::CancelledCandidateBondLess(TestAccount::Alice, 200, 3).into();
+				StakingEvent::CancelledCandidateBondLess {
+					candidate: TestAccount::Alice, 
+					amount: 200, 
+					execute_round: 3
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1073,12 +1117,12 @@ fn nominate_works() {
 
 			assert!(ParachainStaking::is_delegator(&TestAccount::Bob));
 
-			let expected: crate::mock::Event = StakingEvent::Delegation(
-				TestAccount::Bob,
-				1_000,
-				TestAccount::Alice,
-				parachain_staking::DelegatorAdded::AddedToTop { new_total: 2_000 },
-			)
+			let expected: crate::mock::Event = StakingEvent::Delegation {
+				delegator: TestAccount::Bob,
+				locked_amount: 1_000,
+				candidate: TestAccount::Alice,
+				delegator_position: parachain_staking::DelegatorAdded::AddedToTop { new_total: 2_000 },
+			}
 			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
@@ -1110,12 +1154,12 @@ fn delegate_works() {
 
 			assert!(ParachainStaking::is_delegator(&TestAccount::Bob));
 
-			let expected: crate::mock::Event = StakingEvent::Delegation(
-				TestAccount::Bob,
-				1_000,
-				TestAccount::Alice,
-				parachain_staking::DelegatorAdded::AddedToTop { new_total: 2_000 },
-			)
+			let expected: crate::mock::Event = StakingEvent::Delegation {
+				delegator: TestAccount::Bob,
+				locked_amount: 1_000,
+				candidate: TestAccount::Alice,
+				delegator_position: parachain_staking::DelegatorAdded::AddedToTop { new_total: 2_000 },
+			}
 			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
@@ -1143,7 +1187,12 @@ fn leave_nominators_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::DelegatorExitScheduled(1, TestAccount::Bob, 3).into();
+				StakingEvent::DelegatorExitScheduled {
+					round: 1, 
+					delegator: TestAccount::Bob, 
+					scheduled_exit: 3
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1167,7 +1216,12 @@ fn schedule_leave_delegators_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::DelegatorExitScheduled(1, TestAccount::Bob, 3).into();
+				StakingEvent::DelegatorExitScheduled {
+					round: 1, 
+					delegator: TestAccount::Bob, 
+					scheduled_exit: 3
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1198,7 +1252,11 @@ fn execute_leave_delegators_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::DelegatorLeft(TestAccount::Bob, 500).into();
+				StakingEvent::DelegatorLeft {
+					delegator: TestAccount::Bob, 
+					unstaked_amount: 500
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1225,7 +1283,7 @@ fn cancel_leave_delegators_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::DelegatorExitCancelled(TestAccount::Bob).into();
+				StakingEvent::DelegatorExitCancelled { delegator: TestAccount::Bob }.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1250,12 +1308,12 @@ fn revoke_nomination_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event = StakingEvent::DelegationRevocationScheduled(
-				1,
-				TestAccount::Bob,
-				TestAccount::Alice,
-				3,
-			)
+			let expected: crate::mock::Event = StakingEvent::DelegationRevocationScheduled {
+				round: 1,
+				delegator: TestAccount::Bob,
+				candidate: TestAccount::Alice,
+				scheduled_exit: 3,
+			}
 			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
@@ -1280,12 +1338,12 @@ fn schedule_revoke_delegation_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event = StakingEvent::DelegationRevocationScheduled(
-				1,
-				TestAccount::Bob,
-				TestAccount::Alice,
-				3,
-			)
+			let expected: crate::mock::Event = StakingEvent::DelegationRevocationScheduled {
+				round: 1,
+				delegator: TestAccount::Bob,
+				candidate: TestAccount::Alice,
+				scheduled_exit: 3,
+			}
 			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
@@ -1312,8 +1370,13 @@ fn nominator_bond_more_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::DelegationIncreased(TestAccount::Bob, TestAccount::Alice, 500, true)
-					.into();
+				StakingEvent::DelegationIncreased {
+					delegator: TestAccount::Bob, 
+					candidate: TestAccount::Alice, 
+					amount: 500, 
+					in_top: true
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1338,8 +1401,13 @@ fn delegator_bond_more_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::DelegationIncreased(TestAccount::Bob, TestAccount::Alice, 500, true)
-					.into();
+				StakingEvent::DelegationIncreased {
+					delegator: TestAccount::Bob, 
+					candidate: TestAccount::Alice, 
+					amount: 500, 
+					in_top: true
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1365,12 +1433,12 @@ fn nominator_bond_less_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
 			// Check for the right events.
-			let expected_event: crate::mock::Event = StakingEvent::DelegationDecreaseScheduled(
-				TestAccount::Bob,
-				TestAccount::Alice,
-				500,
-				3,
-			)
+			let expected_event: crate::mock::Event = StakingEvent::DelegationDecreaseScheduled {
+				delegator: TestAccount::Bob,
+				candidate: TestAccount::Alice,
+				amount_to_decrease: 500,
+				execute_round: 3,
+			}
 			.into();
 
 			assert!(events().contains(&expected_event));
@@ -1397,12 +1465,12 @@ fn schedule_delegator_bond_less_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
 			// Check for the right events.
-			let expected_event: crate::mock::Event = StakingEvent::DelegationDecreaseScheduled(
-				TestAccount::Bob,
-				TestAccount::Alice,
-				500,
-				3,
-			)
+			let expected_event: crate::mock::Event = StakingEvent::DelegationDecreaseScheduled {
+				delegator: TestAccount::Bob,
+				candidate: TestAccount::Alice,
+				amount_to_decrease: 500,
+				execute_round: 3,
+			}
 			.into();
 
 			assert!(events().contains(&expected_event));
@@ -1434,7 +1502,12 @@ fn execute_revoke_delegation_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::DelegationRevoked(TestAccount::Bob, TestAccount::Alice, 1_000).into();
+				StakingEvent::DelegationRevoked {
+					delegator: TestAccount::Bob, 
+					candidate: TestAccount::Alice, 
+					unstaked_amount: 1_000
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1466,8 +1539,13 @@ fn execute_delegator_bond_less_works() {
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
 			let expected: crate::mock::Event =
-				StakingEvent::DelegationDecreased(TestAccount::Bob, TestAccount::Alice, 500, true)
-					.into();
+				StakingEvent::DelegationDecreased {
+					delegator: TestAccount::Bob, 
+					candidate: TestAccount::Alice, 
+					amount: 500, 
+					in_top: true
+				}
+				.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1495,15 +1573,15 @@ fn cancel_revoke_delegation_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event = StakingEvent::CancelledDelegationRequest(
-				TestAccount::Bob,
-				parachain_staking::DelegationRequest {
+			let expected: crate::mock::Event = StakingEvent::CancelledDelegationRequest {
+				delegator: TestAccount::Bob,
+				cancelled_request: parachain_staking::DelegationRequest {
 					collator: TestAccount::Alice,
 					amount: 1_000,
 					when_executable: 3,
 					action: parachain_staking::DelegationChange::Revoke,
 				},
-			)
+			}
 			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
@@ -1533,15 +1611,15 @@ fn cancel_delegator_bonded_less_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event = StakingEvent::CancelledDelegationRequest(
-				TestAccount::Bob,
-				parachain_staking::DelegationRequest {
+			let expected: crate::mock::Event = StakingEvent::CancelledDelegationRequest {
+				delegator: TestAccount::Bob,
+				cancelled_request: parachain_staking::DelegationRequest {
 					collator: TestAccount::Alice,
 					amount: 500,
 					when_executable: 3,
 					action: parachain_staking::DelegationChange::Decrease,
 				},
-			)
+			}
 			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -745,13 +745,12 @@ fn join_candidates_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::JoinedCollatorCandidates {
-					account: TestAccount::Alice, 
-					amount_locked: 1000, 
-					new_total_amt_locked: 1000
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::JoinedCollatorCandidates {
+				account: TestAccount::Alice,
+				amount_locked: 1000,
+				new_total_amt_locked: 1000,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			println!("{:?}", events());
 			assert!(events().contains(&expected));
@@ -777,13 +776,12 @@ fn leave_candidates_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::CandidateScheduledExit {
-					exit_allowed_round: 1, 
-					candidate: TestAccount::Alice, 
-					scheduled_exit: 3
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::CandidateScheduledExit {
+				exit_allowed_round: 1,
+				candidate: TestAccount::Alice,
+				scheduled_exit: 3,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -807,13 +805,12 @@ fn schedule_leave_candidates_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::CandidateScheduledExit {
-					exit_allowed_round: 1, 
-					candidate: TestAccount::Alice, 
-					scheduled_exit: 3
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::CandidateScheduledExit {
+				exit_allowed_round: 1,
+				candidate: TestAccount::Alice,
+				scheduled_exit: 3,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -843,13 +840,12 @@ fn execute_leave_candidates_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::CandidateLeft {
-					ex_candidate: TestAccount::Alice, 
-					unlocked_amount: 1_000, 
-					new_total_amt_locked: 0
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::CandidateLeft {
+				ex_candidate: TestAccount::Alice,
+				unlocked_amount: 1_000,
+				new_total_amt_locked: 0,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -877,8 +873,10 @@ fn cancel_leave_candidates_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::CancelledCandidateExit { candidate: TestAccount::Alice }.into();
+			let expected: crate::mock::Event = StakingEvent::CancelledCandidateExit {
+				candidate: TestAccount::Alice,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -903,8 +901,10 @@ fn go_online_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::CandidateBackOnline { candidate: TestAccount::Alice }.into();
+			let expected: crate::mock::Event = StakingEvent::CandidateBackOnline {
+				candidate: TestAccount::Alice,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -926,8 +926,10 @@ fn go_offline_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::CandidateWentOffline { candidate: TestAccount::Alice }.into();
+			let expected: crate::mock::Event = StakingEvent::CandidateWentOffline {
+				candidate: TestAccount::Alice,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -951,13 +953,12 @@ fn candidate_bond_more_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::CandidateBondedMore { 
-					candidate: TestAccount::Alice, 
-					amount: 500, 
-					new_total_bond: 1500
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::CandidateBondedMore {
+				candidate: TestAccount::Alice,
+				amount: 500,
+				new_total_bond: 1500,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -982,13 +983,12 @@ fn candidate_bond_less_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::CandidateBondLessRequested {
-					candidate: TestAccount::Alice, 
-					amount_to_decrease: 500, 
-					execute_round: 3
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::CandidateBondLessRequested {
+				candidate: TestAccount::Alice,
+				amount_to_decrease: 500,
+				execute_round: 3,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1012,13 +1012,12 @@ fn schedule_candidate_bond_less_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::CandidateBondLessRequested {
-					candidate: TestAccount::Alice, 
-					amount_to_decrease: 500, 
-					execute_round: 3
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::CandidateBondLessRequested {
+				candidate: TestAccount::Alice,
+				amount_to_decrease: 500,
+				execute_round: 3,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1047,12 +1046,12 @@ fn execute_candidate_bond_less_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::CandidateBondedLess { 
-					candidate: TestAccount::Alice, 
-					amount: 500, 
-					new_bond: 1000
-				}.into();
+			let expected: crate::mock::Event = StakingEvent::CandidateBondedLess {
+				candidate: TestAccount::Alice,
+				amount: 500,
+				new_bond: 1000,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1079,13 +1078,12 @@ fn cancel_candidate_bond_less_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::CancelledCandidateBondLess {
-					candidate: TestAccount::Alice, 
-					amount: 200, 
-					execute_round: 3
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::CancelledCandidateBondLess {
+				candidate: TestAccount::Alice,
+				amount: 200,
+				execute_round: 3,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1121,7 +1119,9 @@ fn nominate_works() {
 				delegator: TestAccount::Bob,
 				locked_amount: 1_000,
 				candidate: TestAccount::Alice,
-				delegator_position: parachain_staking::DelegatorAdded::AddedToTop { new_total: 2_000 },
+				delegator_position: parachain_staking::DelegatorAdded::AddedToTop {
+					new_total: 2_000,
+				},
 			}
 			.into();
 			// Assert that the events vector contains the one expected
@@ -1158,7 +1158,9 @@ fn delegate_works() {
 				delegator: TestAccount::Bob,
 				locked_amount: 1_000,
 				candidate: TestAccount::Alice,
-				delegator_position: parachain_staking::DelegatorAdded::AddedToTop { new_total: 2_000 },
+				delegator_position: parachain_staking::DelegatorAdded::AddedToTop {
+					new_total: 2_000,
+				},
 			}
 			.into();
 			// Assert that the events vector contains the one expected
@@ -1186,13 +1188,12 @@ fn leave_nominators_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::DelegatorExitScheduled {
-					round: 1, 
-					delegator: TestAccount::Bob, 
-					scheduled_exit: 3
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::DelegatorExitScheduled {
+				round: 1,
+				delegator: TestAccount::Bob,
+				scheduled_exit: 3,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1215,13 +1216,12 @@ fn schedule_leave_delegators_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::DelegatorExitScheduled {
-					round: 1, 
-					delegator: TestAccount::Bob, 
-					scheduled_exit: 3
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::DelegatorExitScheduled {
+				round: 1,
+				delegator: TestAccount::Bob,
+				scheduled_exit: 3,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1251,12 +1251,11 @@ fn execute_leave_delegators_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::DelegatorLeft {
-					delegator: TestAccount::Bob, 
-					unstaked_amount: 500
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::DelegatorLeft {
+				delegator: TestAccount::Bob,
+				unstaked_amount: 500,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1282,8 +1281,10 @@ fn cancel_leave_delegators_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::DelegatorExitCancelled { delegator: TestAccount::Bob }.into();
+			let expected: crate::mock::Event = StakingEvent::DelegatorExitCancelled {
+				delegator: TestAccount::Bob,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1369,14 +1370,13 @@ fn nominator_bond_more_works() {
 
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::DelegationIncreased {
-					delegator: TestAccount::Bob, 
-					candidate: TestAccount::Alice, 
-					amount: 500, 
-					in_top: true
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::DelegationIncreased {
+				delegator: TestAccount::Bob,
+				candidate: TestAccount::Alice,
+				amount: 500,
+				in_top: true,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1400,14 +1400,13 @@ fn delegator_bond_more_works() {
 
 			assert_ok!(Call::Evm(evm_call(TestAccount::Bob, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::DelegationIncreased {
-					delegator: TestAccount::Bob, 
-					candidate: TestAccount::Alice, 
-					amount: 500, 
-					in_top: true
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::DelegationIncreased {
+				delegator: TestAccount::Bob,
+				candidate: TestAccount::Alice,
+				amount: 500,
+				in_top: true,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1501,13 +1500,12 @@ fn execute_revoke_delegation_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::DelegationRevoked {
-					delegator: TestAccount::Bob, 
-					candidate: TestAccount::Alice, 
-					unstaked_amount: 1_000
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::DelegationRevoked {
+				delegator: TestAccount::Bob,
+				candidate: TestAccount::Alice,
+				unstaked_amount: 1_000,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});
@@ -1538,14 +1536,13 @@ fn execute_delegator_bond_less_works() {
 			// Make sure the call goes through successfully
 			assert_ok!(Call::Evm(evm_call(TestAccount::Alice, input_data)).dispatch(Origin::root()));
 
-			let expected: crate::mock::Event =
-				StakingEvent::DelegationDecreased {
-					delegator: TestAccount::Bob, 
-					candidate: TestAccount::Alice, 
-					amount: 500, 
-					in_top: true
-				}
-				.into();
+			let expected: crate::mock::Event = StakingEvent::DelegationDecreased {
+				delegator: TestAccount::Bob,
+				candidate: TestAccount::Alice,
+				amount: 500,
+				in_top: true,
+			}
+			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
 		});

--- a/precompiles/xcm_transactor/src/tests.rs
+++ b/precompiles/xcm_transactor/src/tests.rs
@@ -161,15 +161,13 @@ fn take_transact_info() {
 			);
 
 			// Root can set transact info
-			assert_ok!(
-				XcmTransactor::set_transact_info(
-					Origin::root(),
-					Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
-					0,
-					1,
-					10000,
-				)
-			);
+			assert_ok!(XcmTransactor::set_transact_info(
+				Origin::root(),
+				Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
+				0,
+				1,
+				10000,
+			));
 
 			// Expected result is zero
 			let expected_result = Some(Ok(PrecompileOutput {

--- a/precompiles/xcm_transactor/src/tests.rs
+++ b/precompiles/xcm_transactor/src/tests.rs
@@ -161,13 +161,15 @@ fn take_transact_info() {
 			);
 
 			// Root can set transact info
-			assert_ok!(XcmTransactor::set_transact_info(
-				Origin::root(),
-				Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
-				0,
-				1,
-				10000
-			));
+			assert_ok!(
+				XcmTransactor::set_transact_info(
+					Origin::root(),
+					Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
+					0,
+					1,
+					10000,
+				)
+			);
 
 			// Expected result is zero
 			let expected_result = Some(Ok(PrecompileOutput {

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -931,18 +931,16 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => {
-				matches!(
-					c,
-					Call::System(..)
-						| Call::Timestamp(..) | Call::ParachainStaking(..)
-						| Call::Democracy(..) | Call::CouncilCollective(..)
-						| Call::Identity(..) | Call::TechCommitteeCollective(..)
-						| Call::Utility(..) | Call::Proxy(..)
-						| Call::AuthorMapping(..)
-						| Call::CrowdloanRewards(pallet_crowdloan_rewards::Call::claim { .. })
-				)
-			}
+			ProxyType::NonTransfer => matches!(
+				c,
+				Call::System(..)
+					| Call::Timestamp(..) | Call::ParachainStaking(..)
+					| Call::Democracy(..) | Call::CouncilCollective(..)
+					| Call::Identity(..) | Call::TechCommitteeCollective(..)
+					| Call::Utility(..) | Call::Proxy(..)
+					| Call::AuthorMapping(..)
+					| Call::CrowdloanRewards(pallet_crowdloan_rewards::Call::claim { .. })
+			),
 			ProxyType::Governance => matches!(
 				c,
 				Call::Democracy(..)
@@ -954,18 +952,12 @@ impl InstanceFilter<Call> for ProxyType {
 				c,
 				Call::ParachainStaking(..) | Call::Utility(..) | Call::AuthorMapping(..)
 			),
-			ProxyType::CancelProxy => {
-				matches!(
-					c,
-					Call::Proxy(pallet_proxy::Call::reject_announcement { .. })
-				)
-			}
-			ProxyType::Balances => {
-				matches!(c, Call::Balances(..) | Call::Utility(..))
-			}
-			ProxyType::AuthorMapping => {
-				matches!(c, Call::AuthorMapping(..))
-			}
+			ProxyType::CancelProxy => matches!(
+				c,
+				Call::Proxy(pallet_proxy::Call::reject_announcement { .. })
+			),
+			ProxyType::Balances => matches!(c, Call::Balances(..) | Call::Utility(..)),
+			ProxyType::AuthorMapping => matches!(c, Call::AuthorMapping(..)),
 		}
 	}
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -931,16 +931,18 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => matches!(
-				c,
-				Call::System(..)
-					| Call::Timestamp(..) | Call::ParachainStaking(..)
-					| Call::Democracy(..) | Call::CouncilCollective(..)
-					| Call::Identity(..) | Call::TechCommitteeCollective(..)
-					| Call::Utility(..) | Call::Proxy(..)
-					| Call::AuthorMapping(..)
-					| Call::CrowdloanRewards(pallet_crowdloan_rewards::Call::claim { .. })
-			),
+			ProxyType::NonTransfer => {
+				matches!(
+					c,
+					Call::System(..)
+						| Call::Timestamp(..) | Call::ParachainStaking(..)
+						| Call::Democracy(..) | Call::CouncilCollective(..)
+						| Call::Identity(..) | Call::TechCommitteeCollective(..)
+						| Call::Utility(..) | Call::Proxy(..)
+						| Call::AuthorMapping(..)
+						| Call::CrowdloanRewards(pallet_crowdloan_rewards::Call::claim { .. })
+				)
+			}
 			ProxyType::Governance => matches!(
 				c,
 				Call::Democracy(..)

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -302,11 +302,11 @@ fn join_collator_candidates() {
 			));
 			assert_eq!(
 				last_event(),
-				Event::ParachainStaking(parachain_staking::Event::JoinedCollatorCandidates(
-					AccountId::from(DAVE),
-					1_000 * UNIT,
-					3_100 * UNIT
-				))
+				Event::ParachainStaking(parachain_staking::Event::JoinedCollatorCandidates {
+					account: AccountId::from(DAVE),
+					amount_locked: 1_000 * UNIT,
+					new_total_amt_locked: 3_100 * UNIT
+				})
 			);
 			let candidates = ParachainStaking::candidate_pool();
 			assert_eq!(candidates.0[0].owner, AccountId::from(ALICE));
@@ -1770,10 +1770,10 @@ fn author_mapping_precompile_associate_update_and_clear() {
 			);
 
 			let expected_associate_event =
-				Event::AuthorMapping(pallet_author_mapping::Event::AuthorRegistered(
-					first_nimbus_id.clone(),
-					AccountId::from(ALICE),
-				));
+				Event::AuthorMapping(pallet_author_mapping::Event::AuthorRegistered {
+					author_id: first_nimbus_id.clone(),
+					account_id: AccountId::from(ALICE),
+				});
 			assert_eq!(last_event(), expected_associate_event);
 
 			let update_expected_result = Some(Ok(PrecompileOutput {
@@ -1803,10 +1803,10 @@ fn author_mapping_precompile_associate_update_and_clear() {
 			);
 
 			let expected_update_event =
-				Event::AuthorMapping(pallet_author_mapping::Event::AuthorRotated(
-					second_nimbus_id.clone(),
-					AccountId::from(ALICE),
-				));
+				Event::AuthorMapping(pallet_author_mapping::Event::AuthorRotated {
+					new_author_id: second_nimbus_id.clone(),
+					account_id: AccountId::from(ALICE),
+				});
 			assert_eq!(last_event(), expected_update_event);
 
 			let clear_expected_result = Some(Ok(PrecompileOutput {
@@ -1834,9 +1834,10 @@ fn author_mapping_precompile_associate_update_and_clear() {
 				clear_expected_result
 			);
 
-			let expected_clear_event = Event::AuthorMapping(
-				pallet_author_mapping::Event::AuthorDeRegistered(second_nimbus_id.clone()),
-			);
+			let expected_clear_event =
+				Event::AuthorMapping(pallet_author_mapping::Event::AuthorDeRegistered {
+					author_id: second_nimbus_id.clone(),
+				});
 			assert_eq!(last_event(), expected_clear_event);
 		});
 }

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -865,18 +865,16 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => {
-				matches!(
-					c,
-					Call::System(..)
-						| Call::Timestamp(..) | Call::ParachainStaking(..)
-						| Call::Democracy(..) | Call::CouncilCollective(..)
-						| Call::Identity(..) | Call::TechCommitteeCollective(..)
-						| Call::Utility(..) | Call::Proxy(..)
-						| Call::AuthorMapping(..)
-						| Call::CrowdloanRewards(pallet_crowdloan_rewards::Call::claim { .. })
-				)
-			}
+			ProxyType::NonTransfer => matches!(
+				c,
+				Call::System(..)
+					| Call::Timestamp(..) | Call::ParachainStaking(..)
+					| Call::Democracy(..) | Call::CouncilCollective(..)
+					| Call::Identity(..) | Call::TechCommitteeCollective(..)
+					| Call::Utility(..) | Call::Proxy(..)
+					| Call::AuthorMapping(..)
+					| Call::CrowdloanRewards(pallet_crowdloan_rewards::Call::claim { .. })
+			),
 			ProxyType::Governance => matches!(
 				c,
 				Call::Democracy(..)
@@ -888,18 +886,12 @@ impl InstanceFilter<Call> for ProxyType {
 				c,
 				Call::ParachainStaking(..) | Call::Utility(..) | Call::AuthorMapping(..)
 			),
-			ProxyType::CancelProxy => {
-				matches!(
-					c,
-					Call::Proxy(pallet_proxy::Call::reject_announcement { .. })
-				)
-			}
-			ProxyType::Balances => {
-				matches!(c, Call::Balances(..) | Call::Utility(..))
-			}
-			ProxyType::AuthorMapping => {
-				matches!(c, Call::AuthorMapping(..))
-			}
+			ProxyType::CancelProxy => matches!(
+				c,
+				Call::Proxy(pallet_proxy::Call::reject_announcement { .. })
+			),
+			ProxyType::Balances => matches!(c, Call::Balances(..) | Call::Utility(..)),
+			ProxyType::AuthorMapping => matches!(c, Call::AuthorMapping(..)),
 		}
 	}
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -865,16 +865,18 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => matches!(
-				c,
-				Call::System(..)
-					| Call::Timestamp(..) | Call::ParachainStaking(..)
-					| Call::Democracy(..) | Call::CouncilCollective(..)
-					| Call::Identity(..) | Call::TechCommitteeCollective(..)
-					| Call::Utility(..) | Call::Proxy(..)
-					| Call::AuthorMapping(..)
-					| Call::CrowdloanRewards(pallet_crowdloan_rewards::Call::claim { .. })
-			),
+			ProxyType::NonTransfer => {
+				matches!(
+					c,
+					Call::System(..)
+						| Call::Timestamp(..) | Call::ParachainStaking(..)
+						| Call::Democracy(..) | Call::CouncilCollective(..)
+						| Call::Identity(..) | Call::TechCommitteeCollective(..)
+						| Call::Utility(..) | Call::Proxy(..)
+						| Call::AuthorMapping(..)
+						| Call::CrowdloanRewards(pallet_crowdloan_rewards::Call::claim { .. })
+				)
+			}
 			ProxyType::Governance => matches!(
 				c,
 				Call::Democracy(..)

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -304,11 +304,11 @@ fn join_collator_candidates() {
 			));
 			assert_eq!(
 				last_event(),
-				Event::ParachainStaking(parachain_staking::Event::JoinedCollatorCandidates(
-					AccountId::from(DAVE),
-					100_000 * GLMR,
-					310_000 * GLMR
-				))
+				Event::ParachainStaking(parachain_staking::Event::JoinedCollatorCandidates {
+					account: AccountId::from(DAVE),
+					amount_locked: 100_000 * GLMR,
+					new_total_amt_locked: 310_000 * GLMR
+				})
 			);
 			let candidates = ParachainStaking::candidate_pool();
 			assert_eq!(candidates.0[0].owner, AccountId::from(ALICE));

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -864,18 +864,16 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => {
-				matches!(
-					c,
-					Call::System(..)
-						| Call::Timestamp(..) | Call::ParachainStaking(..)
-						| Call::Democracy(..) | Call::CouncilCollective(..)
-						| Call::Identity(..) | Call::TechCommitteeCollective(..)
-						| Call::Utility(..) | Call::Proxy(..)
-						| Call::AuthorMapping(..)
-						| Call::CrowdloanRewards(pallet_crowdloan_rewards::Call::claim { .. })
-				)
-			}
+			ProxyType::NonTransfer => matches!(
+				c,
+				Call::System(..)
+					| Call::Timestamp(..) | Call::ParachainStaking(..)
+					| Call::Democracy(..) | Call::CouncilCollective(..)
+					| Call::Identity(..) | Call::TechCommitteeCollective(..)
+					| Call::Utility(..) | Call::Proxy(..)
+					| Call::AuthorMapping(..)
+					| Call::CrowdloanRewards(pallet_crowdloan_rewards::Call::claim { .. })
+			),
 			ProxyType::Governance => matches!(
 				c,
 				Call::Democracy(..)
@@ -887,18 +885,12 @@ impl InstanceFilter<Call> for ProxyType {
 				c,
 				Call::ParachainStaking(..) | Call::Utility(..) | Call::AuthorMapping(..)
 			),
-			ProxyType::CancelProxy => {
-				matches!(
-					c,
-					Call::Proxy(pallet_proxy::Call::reject_announcement { .. })
-				)
-			}
-			ProxyType::Balances => {
-				matches!(c, Call::Balances(..) | Call::Utility(..))
-			}
-			ProxyType::AuthorMapping => {
-				matches!(c, Call::AuthorMapping(..))
-			}
+			ProxyType::CancelProxy => matches!(
+				c,
+				Call::Proxy(pallet_proxy::Call::reject_announcement { .. })
+			),
+			ProxyType::Balances => matches!(c, Call::Balances(..) | Call::Utility(..)),
+			ProxyType::AuthorMapping => matches!(c, Call::AuthorMapping(..)),
 		}
 	}
 

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -864,16 +864,18 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => matches!(
-				c,
-				Call::System(..)
-					| Call::Timestamp(..) | Call::ParachainStaking(..)
-					| Call::Democracy(..) | Call::CouncilCollective(..)
-					| Call::Identity(..) | Call::TechCommitteeCollective(..)
-					| Call::Utility(..) | Call::Proxy(..)
-					| Call::AuthorMapping(..)
-					| Call::CrowdloanRewards(pallet_crowdloan_rewards::Call::claim { .. })
-			),
+			ProxyType::NonTransfer => {
+				matches!(
+					c,
+					Call::System(..)
+						| Call::Timestamp(..) | Call::ParachainStaking(..)
+						| Call::Democracy(..) | Call::CouncilCollective(..)
+						| Call::Identity(..) | Call::TechCommitteeCollective(..)
+						| Call::Utility(..) | Call::Proxy(..)
+						| Call::AuthorMapping(..)
+						| Call::CrowdloanRewards(pallet_crowdloan_rewards::Call::claim { .. })
+				)
+			}
 			ProxyType::Governance => matches!(
 				c,
 				Call::Democracy(..)

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -299,11 +299,11 @@ fn join_collator_candidates() {
 			));
 			assert_eq!(
 				last_event(),
-				Event::ParachainStaking(parachain_staking::Event::JoinedCollatorCandidates(
-					AccountId::from(DAVE),
-					1_000 * MOVR,
-					3_100 * MOVR
-				))
+				Event::ParachainStaking(parachain_staking::Event::JoinedCollatorCandidates {
+					account: AccountId::from(DAVE),
+					amount_locked: 1_000 * MOVR,
+					new_total_amt_locked: 3_100 * MOVR
+				})
 			);
 			let candidates = ParachainStaking::candidate_pool();
 			assert_eq!(candidates.0[0].owner, AccountId::from(ALICE));


### PR DESCRIPTION
### Description
This PR changes/added:
 - pallet events variants from tuples to structs with named fields;
 - descriptions for some events.

After [PR#9896](https://github.com/paritytech/substrate/pull/9896) was merged events can now be described with field names.

These field names and their respective comments are in turn reflected in the metadata for a better client experience.