### PR TITLE
[Staking] Patch delegations total mismatch

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -536,6 +536,9 @@ pub mod pallet {
 			self.top_capacity = top_delegations.top_capacity::<T>();
 			let old_total_counted = self.total_counted;
 			self.total_counted = self.bond + top_delegations.total.into();
+			// CandidatePool value for candidate always changes if top delegations total changes
+			// so we moved the update into this function to deduplicate code and patch a bug that
+			// forgot to apply the update when increasing top delegation
 			if old_total_counted != self.total_counted && self.is_active() {
 				Pallet::<T>::update_active(candidate, self.total_counted.into());
 			}

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -880,6 +880,7 @@ pub mod pallet {
 				})
 				.collect();
 			ensure!(in_top, Error::<T>::DelegationDNE);
+			top_delegations.total = top_delegations.total.saturating_add(more);
 			top_delegations.sort_greatest_to_least();
 			self.reset_top_data::<T>(&top_delegations);
 			<TopDelegations<T>>::insert(candidate, top_delegations);
@@ -960,6 +961,7 @@ pub mod pallet {
 						})
 						.collect();
 					ensure!(in_bottom, Error::<T>::DelegationDNE);
+					bottom_delegations.total = bottom_delegations.total.saturating_add(more);
 					bottom_delegations.sort_greatest_to_least();
 					false
 				};

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -37,6 +37,99 @@ use frame_support::{
 use sp_runtime::traits::Zero;
 use sp_std::{convert::TryInto, vec::Vec};
 
+/// Migration to patch the incorrect delegations sums for all candidates
+pub struct PatchIncorrectDelegationSums<T>(PhantomData<T>);
+impl<T: Config> OnRuntimeUpgrade for PatchIncorrectDelegationSums<T> {
+	fn on_runtime_upgrade() -> Weight {
+		let pallet_prefix: &[u8] = b"ParachainStaking";
+		let top_delegations_prefix: &[u8] = b"TopDelegations";
+		let bottom_delegations_prefix: &[u8] = b"BottomDelegations";
+		// Read all the data into memory.
+		// https://crates.parity.io/frame_support/storage/migration/fn.storage_key_iter.html
+		let stored_top_delegations: Vec<_> = storage_key_iter::<
+			T::AccountId,
+			Delegations<T::AccountId, BalanceOf<T>>,
+			Twox64Concat,
+		>(pallet_prefix, top_delegations_prefix)
+		.collect();
+		let migrated_candidates_top_count: Weight = stored_top_delegations
+			.len()
+			.try_into()
+			.expect("There are between 0 and 2**64 mappings stored.");
+		let stored_bottom_delegations: Vec<_> = storage_key_iter::<
+			T::AccountId,
+			Delegations<T::AccountId, BalanceOf<T>>,
+			Twox64Concat,
+		>(pallet_prefix, bottom_delegations_prefix)
+		.collect();
+		let migrated_candidates_bottom_count: Weight = stored_bottom_delegations
+			.len()
+			.try_into()
+			.expect("There are between 0 and 2**64 mappings stored.");
+		fn fix_delegations<T: Config>(
+			delegations: Delegations<T::AccountId, BalanceOf<T>>,
+		) -> Delegations<T::AccountId, BalanceOf<T>> {
+			let correct_total = delegations
+				.delegations
+				.iter()
+				.fold(BalanceOf::<T>::zero(), |acc, b| acc + b.amount);
+			// TODO print both as debug output
+			// let _potentially_incorrect_total = delegations.total;
+			Delegations {
+				delegations: delegations.delegations,
+				total: correct_total,
+			}
+		}
+		for (account, old_top_delegations) in stored_top_delegations {
+			let new_top_delegations = fix_delegations::<T>(old_top_delegations);
+			let mut candidate_info = <CandidateInfo<T>>::get(&account)
+				.expect("TopDelegations exists => CandidateInfo exists");
+			candidate_info.total_counted = candidate_info.bond + new_top_delegations.total;
+			if candidate_info.is_active() {
+				Pallet::<T>::update_active(account.clone(), candidate_info.total_counted);
+			}
+			<CandidateInfo<T>>::insert(&account, candidate_info);
+			<TopDelegations<T>>::insert(&account, new_top_delegations);
+		}
+		for (account, old_bottom_delegations) in stored_bottom_delegations {
+			let new_bottom_delegations = fix_delegations::<T>(old_bottom_delegations);
+			<BottomDelegations<T>>::insert(&account, new_bottom_delegations);
+		}
+		let weight = T::DbWeight::get();
+		let top = migrated_candidates_top_count.saturating_mul(3 * weight.write + 3 * weight.read);
+		let bottom = migrated_candidates_bottom_count.saturating_mul(weight.write + weight.read);
+		// 20% max block weight as margin for error
+		top + bottom + 100_000_000_000
+	}
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		// get delegation count for all candidates to check consistency
+		// for (account, state) in <CandidateState<T>>::iter() {
+		// 	// insert top + bottom into some temp map?
+		// 	let total_delegation_count =
+		// 		state.top_delegations.len() as u32 + state.bottom_delegations.len() as u32;
+		// 	Self::set_temp_storage(
+		// 		total_delegation_count,
+		// 		&format!("Candidate{}DelegationCount", account)[..],
+		// 	);
+		// }
+		Ok(())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		// check that top + bottom are the same as the expected (stored in temp)
+		// for (account, state) in <CandidateInfo<T>>::iter() {
+		// 	let expected_count: u32 =
+		// 		Self::get_temp_storage(&format!("Candidate{}DelegationCount", account)[..])
+		// 			.expect("qed");
+		// 	let actual_count = state.delegation_count;
+		// 	assert_eq!(expected_count, actual_count);
+		// }
+		Ok(())
+	}
+}
+
 /// Migration to split CandidateState and minimize unnecessary storage reads
 /// for PoV optimization
 /// This assumes Config::MaxTopDelegationsPerCandidate == OldConfig::MaxDelegatorsPerCandidate

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -295,7 +295,7 @@ impl<T: Config> OnRuntimeUpgrade for SplitCandidateStateToDecreasePoV<T> {
 				state.top_delegations.len() as u32 + state.bottom_delegations.len() as u32;
 			Self::set_temp_storage(
 				total_delegation_count,
-				&format!("Candidate{}DelegationCount", account)[..],
+				&format!("Candidate{:?}DelegationCount", account)[..],
 			);
 		}
 		Ok(())
@@ -306,7 +306,7 @@ impl<T: Config> OnRuntimeUpgrade for SplitCandidateStateToDecreasePoV<T> {
 		// check that top + bottom are the same as the expected (stored in temp)
 		for (account, state) in <CandidateInfo<T>>::iter() {
 			let expected_count: u32 =
-				Self::get_temp_storage(&format!("Candidate{}DelegationCount", account)[..])
+				Self::get_temp_storage(&format!("Candidate{:?}DelegationCount", account)[..])
 					.expect("qed");
 			let actual_count = state.delegation_count;
 			assert_eq!(expected_count, actual_count);

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -2440,6 +2440,7 @@ fn delegator_bond_more_updates_candidate_state_bottom_delegations() {
 					.amount,
 				10
 			);
+			assert_eq!(ParachainStaking::bottom_delegations(1).unwrap().total, 10);
 			assert_ok!(ParachainStaking::delegator_bond_more(
 				Origin::signed(2),
 				1,
@@ -2462,6 +2463,7 @@ fn delegator_bond_more_updates_candidate_state_bottom_delegations() {
 					.amount,
 				15
 			);
+			assert_eq!(ParachainStaking::bottom_delegations(1).unwrap().total, 15);
 		});
 }
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -2394,6 +2394,7 @@ fn delegator_bond_more_updates_candidate_state_top_delegations() {
 				ParachainStaking::top_delegations(1).unwrap().delegations[0].amount,
 				10
 			);
+			assert_eq!(ParachainStaking::top_delegations(1).unwrap().total, 10);
 			assert_ok!(ParachainStaking::delegator_bond_more(
 				Origin::signed(2),
 				1,
@@ -2407,6 +2408,7 @@ fn delegator_bond_more_updates_candidate_state_top_delegations() {
 				ParachainStaking::top_delegations(1).unwrap().delegations[0].amount,
 				15
 			);
+			assert_eq!(ParachainStaking::top_delegations(1).unwrap().total, 15);
 		});
 }
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -28,10 +28,10 @@ use crate::mock::{
 use crate::{
 	assert_eq_events, assert_eq_last_events, assert_event_emitted, assert_event_not_emitted,
 	assert_last_event, assert_tail_eq, pallet::CapacityStatus, set::OrderedSet, BalanceOf, Bond,
-	BottomDelegations, CandidateInfo, CandidatePool, CandidateState, CollatorCandidate,
-	CollatorStatus, Config, DelegationChange, DelegationRequest, Delegator, DelegatorAdded,
-	DelegatorState, DelegatorStatus, Error, Event, PendingDelegationRequests, Range,
-	TopDelegations, Total,
+	BottomDelegations, CandidateInfo, CandidateMetadata, CandidatePool, CandidateState,
+	CollatorCandidate, CollatorStatus, Config, DelegationChange, DelegationRequest, Delegations,
+	Delegator, DelegatorAdded, DelegatorState, DelegatorStatus, Error, Event,
+	PendingDelegationRequests, Range, TopDelegations, Total,
 };
 use frame_support::{assert_noop, assert_ok, traits::ReservableCurrency};
 use sp_runtime::{traits::Zero, DispatchError, Perbill, Percent};
@@ -5323,6 +5323,92 @@ fn hotfix_update_candidate_pool_value_updates_candidate_pool() {
 
 // MIGRATION UNIT TESTS
 use frame_support::traits::OnRuntimeUpgrade;
+
+#[test]
+fn patch_incorrect_delegations_sums() {
+	ExtBuilder::default()
+		.with_balances(vec![(11, 22), (12, 20)])
+		.build()
+		.execute_with(|| {
+			// corrupt top and bottom delegations so totals are incorrect
+			let old_top_delegations = Delegations {
+				delegations: vec![
+					Bond {
+						owner: 2,
+						amount: 103,
+					},
+					Bond {
+						owner: 3,
+						amount: 102,
+					},
+					Bond {
+						owner: 4,
+						amount: 101,
+					},
+					Bond {
+						owner: 5,
+						amount: 100,
+					},
+				],
+				// should be 406
+				total: 453,
+			};
+			<TopDelegations<Test>>::insert(&1, old_top_delegations);
+			let old_bottom_delegations = Delegations {
+				delegations: vec![
+					Bond {
+						owner: 6,
+						amount: 25,
+					},
+					Bond {
+						owner: 7,
+						amount: 24,
+					},
+					Bond {
+						owner: 8,
+						amount: 23,
+					},
+					Bond {
+						owner: 9,
+						amount: 22,
+					},
+				],
+				// should be 94
+				total: 222,
+			};
+			<BottomDelegations<Test>>::insert(&1, old_bottom_delegations);
+			<CandidateInfo<Test>>::insert(
+				&1,
+				CandidateMetadata {
+					bond: 25,
+					delegation_count: 8,
+					// 25 + 453 (incorrect), should be 25 + 406 after upgrade
+					total_counted: 478,
+					lowest_top_delegation_amount: 100,
+					highest_bottom_delegation_amount: 25,
+					lowest_bottom_delegation_amount: 22,
+					top_capacity: CapacityStatus::Full,
+					bottom_capacity: CapacityStatus::Full,
+					request: None,
+					status: CollatorStatus::Active,
+				},
+			);
+			<CandidatePool<Test>>::put(OrderedSet::from(vec![Bond {
+				owner: 1,
+				amount: 478,
+			}]));
+			crate::migrations::PatchIncorrectDelegationSums::<Test>::on_runtime_upgrade();
+			let top = <TopDelegations<Test>>::get(&1).expect("just updated so exists");
+			assert_eq!(top.total, 406);
+			let bottom = <BottomDelegations<Test>>::get(&1).expect("just updated so exists");
+			assert_eq!(bottom.total, 94);
+			let info = <CandidateInfo<Test>>::get(&1).expect("just updated so exists");
+			assert_eq!(info.total_counted, 431);
+			let only_bond = <CandidatePool<Test>>::get().0[0].clone();
+			assert_eq!(only_bond.owner, 1);
+			assert_eq!(only_bond.amount, 431);
+		});
+}
 
 #[test]
 /// Kicks extra bottom delegations to force leave delegators if last delegation

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -411,9 +411,6 @@ where
 	}
 }
 
-//TODO: Once the statemine prefix migration is applied,
-// we can remove StatemineParaIdInfo and StatemineAssetsInstanceInfo
-// but for now we need a way to pass these parameters, which are distinct for each of the runtimes
 #[cfg(feature = "xcm-support")]
 pub struct XcmMigrations<Runtime, StatemineParaIdInfo, StatemineAssetsInstanceInfo>(
 	PhantomData<(Runtime, StatemineParaIdInfo, StatemineAssetsInstanceInfo)>,
@@ -424,35 +421,37 @@ impl<Runtime, StatemineParaIdInfo, StatemineAssetsInstanceInfo> GetMigrations
 	for XcmMigrations<Runtime, StatemineParaIdInfo, StatemineAssetsInstanceInfo>
 where
 	Runtime: xcm_transactor::Config + pallet_migrations::Config + pallet_asset_manager::Config,
-	StatemineParaIdInfo: Get<u32> + 'static,
-	StatemineAssetsInstanceInfo: Get<u8> + 'static,
 	<Runtime as pallet_asset_manager::Config>::AssetType:
 		Into<Option<MultiLocation>> + From<MultiLocation>,
 {
 	fn get_migrations() -> Vec<Box<dyn Migration>> {
-		let xcm_transactor_max_weight =
-			XcmTransactorMaxTransactWeight::<Runtime>(Default::default());
+		// let xcm_transactor_max_weight =
+		// 	XcmTransactorMaxTransactWeight::<Runtime>(Default::default());
 
-		let asset_manager_units_with_asset_type =
-			AssetManagerUnitsWithAssetType::<Runtime>(Default::default());
+		// let asset_manager_units_with_asset_type =
+		// 	AssetManagerUnitsWithAssetType::<Runtime>(Default::default());
 
-		let asset_manager_populate_asset_type_id_storage =
-			AssetManagerPopulateAssetTypeIdStorage::<Runtime>(Default::default());
+		// let asset_manager_populate_asset_type_id_storage =
+		// 	AssetManagerPopulateAssetTypeIdStorage::<Runtime>(Default::default());
 
-		let asset_manager_change_statemine_prefixes = AssetManagerChangeStateminePrefixes::<
-			Runtime,
-			StatemineParaIdInfo,
-			StatemineAssetsInstanceInfo,
-		>(Default::default());
+		// let asset_manager_change_statemine_prefixes = AssetManagerChangeStateminePrefixes::<
+		// 	Runtime,
+		// 	StatemineParaIdInfo,
+		// 	StatemineAssetsInstanceInfo,
+		// >(Default::default());
 
 		// TODO: this is a lot of allocation to do upon every get() call. this *should* be avoided
 		// except when pallet_migrations undergoes a runtime upgrade -- but TODO: review
 
 		vec![
-			Box::new(xcm_transactor_max_weight),
-			Box::new(asset_manager_units_with_asset_type),
-			Box::new(asset_manager_change_statemine_prefixes),
-			Box::new(asset_manager_populate_asset_type_id_storage),
+			// completed in runtime 1201
+			// Box::new(xcm_transactor_max_weight),
+			// completed in runtime 1201
+			// Box::new(asset_manager_units_with_asset_type),
+			// completed in runtime 1201
+			// Box::new(asset_manager_change_statemine_prefixes),
+			// completed in runtime 1201
+			// Box::new(asset_manager_populate_asset_type_id_storage),
 		]
 	}
 }


### PR DESCRIPTION
### What does it do?

MOON-1517

- [x] unit tests that fail before changes and pass after
- [x]  migration to fix incorrect state (by resumming all the delegations for all candidates)
- [x] unit test for migration
- [x] add migration to migrations config

#### Summary of Bug

The totalTopDelegations value was not updated after delegator_bond_more which means that total_counted = collator_bond + totalTopDelegations was not correctly updated and total_counted is used to determine which candidates are chosen in the active set.

#### Consequences

This bug does not enable abuse AFAICT. It does mean some data is incorrect, but the runtime migration fixes it.

It will understate the total_counted for collators that have delegations which were increased via `delegator_bond_more`. Moreover, it will overestimate each delegation share when paying out rewards leading to increased inflation rewards. Likewise, the patch needs to be applied ASAP to minimize the impact on reward payouts.