### PR TITLE
[Staking] More saturating ops

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -3007,7 +3007,7 @@ pub mod pallet {
 			} else {
 				amount
 			};
-			let new_total_locked = <Total<T>>::get() + net_total_increase;
+			let new_total_locked = <Total<T>>::get().saturating_add(net_total_increase);
 			<Total<T>>::put(new_total_locked);
 			<CandidateInfo<T>>::insert(&candidate, state);
 			<DelegatorState<T>>::insert(&delegator, delegator_state);


### PR DESCRIPTION
Adds saturating ops missed in #1222 

They were missed because we only replaced `+=` and `-=` in that PR so forgot about just strict addition and subtraction.