### PR TITLE
[Staking] Fix benchmarks (and update weights) for pay_one_collator_reward and round_transition_on_initialize

### DIFF
--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -873,10 +873,10 @@ benchmarks! {
 			max: Perbill::one(),
 		};
 		Pallet::<T>::set_inflation(RawOrigin::Root.into(), high_inflation.clone())?;
-		// To set total selected to 28, must first increase round length to at least 28
+		// To set total selected to 40, must first increase round length to at least 40
 		// to avoid hitting RoundLengthMustBeAtLeastTotalSelectedCollators
-		Pallet::<T>::set_blocks_per_round(RawOrigin::Root.into(), 28u32)?;
-		Pallet::<T>::set_total_selected(RawOrigin::Root.into(), 28u32)?;
+		Pallet::<T>::set_blocks_per_round(RawOrigin::Root.into(), 40u32)?;
+		Pallet::<T>::set_total_selected(RawOrigin::Root.into(), 40u32)?;
 		// INITIALIZE COLLATOR STATE
 		let mut collators: Vec<T::AccountId> = Vec::new();
 		let mut collator_count = 1u32;

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -859,7 +859,7 @@ benchmarks! {
 	round_transition_on_initialize {
 		// TOTAL SELECTED COLLATORS PER ROUND
 		let x in 8..100;
-		// DELEGATIONS PER CANDIDATE
+		// DELEGATIONS
 		let y in 0..(<<T as Config>::MaxTopDelegationsPerCandidate as Get<u32>>::get() * 100);
 		let max_delegators_per_collator =
 			<<T as Config>::MaxTopDelegationsPerCandidate as Get<u32>>::get();

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -858,7 +858,7 @@ benchmarks! {
 
 	round_transition_on_initialize {
 		// TOTAL SELECTED COLLATORS PER ROUND
-		let x in 1..28;
+		let x in 8..40;
 		// DELEGATIONS
 		let y in 0..(<<T as Config>::MaxTopDelegationsPerCandidate as Get<u32>>::get() * 28);
 		let max_delegators_per_collator =

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -873,6 +873,9 @@ benchmarks! {
 			max: Perbill::one(),
 		};
 		Pallet::<T>::set_inflation(RawOrigin::Root.into(), high_inflation.clone())?;
+		// To set total selected to 28, must first increase round length to at least 28
+		// to avoid hitting RoundLengthMustBeAtLeastTotalSelectedCollators
+		Pallet::<T>::set_blocks_per_round(RawOrigin::Root.into(), 28u32)?;
 		Pallet::<T>::set_total_selected(RawOrigin::Root.into(), 28u32)?;
 		// INITIALIZE COLLATOR STATE
 		let mut collators: Vec<T::AccountId> = Vec::new();
@@ -1002,12 +1005,8 @@ benchmarks! {
 	}
 
 	pay_one_collator_reward {
-		// y controls number of delegators
-		// TODO: mock.rs sets MaxTopDelegationsPerCandidate to 4, which is too low for this test to be
-		// meaningful. we use a higher value here, which works so long as we don't invoke any of
-		// pallet_staking's logic which uses MaxTopDelegationsPerCandidate as a constraint. this is
-		// brittle, to say the least...
-		let y in 0..2000;
+		// y controls number of delegations, its maximum per collator is the max top delegations
+		let y in 0..<<T as Config>::MaxTopDelegationsPerCandidate as Get<u32>>::get();
 
 		// must come after 'let foo in 0..` statements for macro
 		use crate::{

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -858,9 +858,9 @@ benchmarks! {
 
 	round_transition_on_initialize {
 		// TOTAL SELECTED COLLATORS PER ROUND
-		let x in 8..40;
-		// DELEGATIONS
-		let y in 0..(<<T as Config>::MaxTopDelegationsPerCandidate as Get<u32>>::get() * 28);
+		let x in 8..100;
+		// DELEGATIONS PER CANDIDATE
+		let y in 0..(<<T as Config>::MaxTopDelegationsPerCandidate as Get<u32>>::get() * 100);
 		let max_delegators_per_collator =
 			<<T as Config>::MaxTopDelegationsPerCandidate as Get<u32>>::get();
 		let max_delegations = x * max_delegators_per_collator;
@@ -875,8 +875,8 @@ benchmarks! {
 		Pallet::<T>::set_inflation(RawOrigin::Root.into(), high_inflation.clone())?;
 		// To set total selected to 40, must first increase round length to at least 40
 		// to avoid hitting RoundLengthMustBeAtLeastTotalSelectedCollators
-		Pallet::<T>::set_blocks_per_round(RawOrigin::Root.into(), 40u32)?;
-		Pallet::<T>::set_total_selected(RawOrigin::Root.into(), 40u32)?;
+		Pallet::<T>::set_blocks_per_round(RawOrigin::Root.into(), 100u32)?;
+		Pallet::<T>::set_total_selected(RawOrigin::Root.into(), 100u32)?;
 		// INITIALIZE COLLATOR STATE
 		let mut collators: Vec<T::AccountId> = Vec::new();
 		let mut collator_count = 1u32;

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -253,11 +253,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
 	fn round_transition_on_initialize(x: u32, y: u32) -> Weight {
-		(0 as Weight) // Standard Error: 2_524_000
-			.saturating_add((21_321_000 as Weight).saturating_mul(x as Weight))
+		(0 as Weight) // Standard Error: 2_467_000
+			.saturating_add((29_501_000 as Weight).saturating_mul(x as Weight))
 			// Standard Error: 9_000
-			.saturating_add((919_000 as Weight).saturating_mul(y as Weight))
+			.saturating_add((904_000 as Weight).saturating_mul(y as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(x as Weight)))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(x as Weight)))
 	}
 	fn base_on_initialize() -> Weight {
 		(4_913_000 as Weight).saturating_add(T::DbWeight::get().reads(1 as Weight))
@@ -438,11 +439,12 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
 	}
 	fn round_transition_on_initialize(x: u32, y: u32) -> Weight {
-		(0 as Weight) // Standard Error: 2_524_000
-			.saturating_add((21_321_000 as Weight).saturating_mul(x as Weight))
+		(0 as Weight) // Standard Error: 2_467_000
+			.saturating_add((29_501_000 as Weight).saturating_mul(x as Weight))
 			// Standard Error: 9_000
-			.saturating_add((919_000 as Weight).saturating_mul(y as Weight))
+			.saturating_add((904_000 as Weight).saturating_mul(y as Weight))
 			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(x as Weight)))
+			.saturating_add(RocksDbWeight::get().writes((1 as Weight).saturating_mul(x as Weight)))
 	}
 	fn base_on_initialize() -> Weight {
 		(4_913_000 as Weight).saturating_add(RocksDbWeight::get().reads(1 as Weight))

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -264,9 +264,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		(4_913_000 as Weight).saturating_add(T::DbWeight::get().reads(1 as Weight))
 	}
 	fn pay_one_collator_reward(y: u32) -> Weight {
-		(0 as Weight)
-			// Standard Error: 6_000
-			.saturating_add((23_284_000 as Weight).saturating_mul(y as Weight))
+		(44_854_000 as Weight) // Standard Error: 4_000
+			.saturating_add((16_772_000 as Weight).saturating_mul(y as Weight))
 			.saturating_add(T::DbWeight::get().reads(11 as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(y as Weight)))
 			.saturating_add(T::DbWeight::get().writes(6 as Weight))
@@ -451,9 +450,8 @@ impl WeightInfo for () {
 		(4_913_000 as Weight).saturating_add(RocksDbWeight::get().reads(1 as Weight))
 	}
 	fn pay_one_collator_reward(y: u32) -> Weight {
-		(0 as Weight)
-			// Standard Error: 6_000
-			.saturating_add((23_284_000 as Weight).saturating_mul(y as Weight))
+		(44_854_000 as Weight) // Standard Error: 4_000
+			.saturating_add((16_772_000 as Weight).saturating_mul(y as Weight))
 			.saturating_add(RocksDbWeight::get().reads(11 as Weight))
 			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(y as Weight)))
 			.saturating_add(RocksDbWeight::get().writes(6 as Weight))

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -253,12 +253,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
 	fn round_transition_on_initialize(x: u32, y: u32) -> Weight {
-		(0 as Weight) // Standard Error: 4_087_000
-			// Standard Error: 12_000
-			.saturating_add((100_164_000 as Weight).saturating_mul(x as Weight))
-			.saturating_add((1_202_000 as Weight).saturating_mul(y as Weight))
-			.saturating_add(T::DbWeight::get().reads((4 as Weight).saturating_mul(x as Weight)))
-			.saturating_add(T::DbWeight::get().writes((3 as Weight).saturating_mul(x as Weight)))
+		(0 as Weight) // Standard Error: 2_524_000
+			.saturating_add((21_321_000 as Weight).saturating_mul(x as Weight))
+			// Standard Error: 9_000
+			.saturating_add((919_000 as Weight).saturating_mul(y as Weight))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(x as Weight)))
 	}
 	fn base_on_initialize() -> Weight {
 		(4_913_000 as Weight).saturating_add(T::DbWeight::get().reads(1 as Weight))
@@ -439,12 +438,11 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
 	}
 	fn round_transition_on_initialize(x: u32, y: u32) -> Weight {
-		(0 as Weight) // Standard Error: 4_087_000
-			// Standard Error: 12_000
-			.saturating_add((100_164_000 as Weight).saturating_mul(x as Weight))
-			.saturating_add((1_202_000 as Weight).saturating_mul(y as Weight))
-			.saturating_add(RocksDbWeight::get().reads((4 as Weight).saturating_mul(x as Weight)))
-			.saturating_add(RocksDbWeight::get().writes((3 as Weight).saturating_mul(x as Weight)))
+		(0 as Weight) // Standard Error: 2_524_000
+			.saturating_add((21_321_000 as Weight).saturating_mul(x as Weight))
+			// Standard Error: 9_000
+			.saturating_add((919_000 as Weight).saturating_mul(y as Weight))
+			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(x as Weight)))
 	}
 	fn base_on_initialize() -> Weight {
 		(4_913_000 as Weight).saturating_add(RocksDbWeight::get().reads(1 as Weight))

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -253,11 +253,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
 	fn round_transition_on_initialize(x: u32, y: u32) -> Weight {
-		(0 as Weight) // Standard Error: 2_467_000
-			.saturating_add((29_501_000 as Weight).saturating_mul(x as Weight))
-			// Standard Error: 9_000
-			.saturating_add((904_000 as Weight).saturating_mul(y as Weight))
-			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(x as Weight)))
+		(0 as Weight) // Standard Error: 1_560_000
+			.saturating_add((62_210_000 as Weight).saturating_mul(x as Weight))
+			// Standard Error: 4_000
+			.saturating_add((208_000 as Weight).saturating_mul(y as Weight))
+			.saturating_add(T::DbWeight::get().reads(168 as Weight))
+			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(x as Weight)))
+			.saturating_add(T::DbWeight::get().writes(159 as Weight))
 			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(x as Weight)))
 	}
 	fn base_on_initialize() -> Weight {
@@ -439,11 +441,13 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
 	}
 	fn round_transition_on_initialize(x: u32, y: u32) -> Weight {
-		(0 as Weight) // Standard Error: 2_467_000
-			.saturating_add((29_501_000 as Weight).saturating_mul(x as Weight))
-			// Standard Error: 9_000
-			.saturating_add((904_000 as Weight).saturating_mul(y as Weight))
-			.saturating_add(RocksDbWeight::get().reads((1 as Weight).saturating_mul(x as Weight)))
+		(0 as Weight) // Standard Error: 1_560_000
+			.saturating_add((62_210_000 as Weight).saturating_mul(x as Weight))
+			// Standard Error: 4_000
+			.saturating_add((208_000 as Weight).saturating_mul(y as Weight))
+			.saturating_add(RocksDbWeight::get().reads(168 as Weight))
+			.saturating_add(RocksDbWeight::get().reads((2 as Weight).saturating_mul(x as Weight)))
+			.saturating_add(RocksDbWeight::get().writes(159 as Weight))
 			.saturating_add(RocksDbWeight::get().writes((1 as Weight).saturating_mul(x as Weight)))
 	}
 	fn base_on_initialize() -> Weight {


### PR DESCRIPTION
Reported by @notlesh 

Benchmarking for the following extrinsics is broken in master:
1. `pay_one_collator_reward` broke in #1117 when we bound delegations
2. `round_transition_on_initialize` broke in #1035 when we introduced the `RoundLengthMustBeAtLeastTotalSelectedCollators` constraint

Neither of these benchmarks have been updated since they were broken in the respective PRs so the weights needed to be updated.

For (1), fixes the CandidateExists error in pay one collator reward benchmark by bounding delegations to the maximum total counted delegations per collator.

For (2), fixes the current error `RoundLengthMustBeAtLeastTotalSelectedCollators` by setting blocks per round to 40 before setting total selected to this number. Also resets the upper bound on total selected per round to 40 because this is what it is on production networks. The lower bound has always been 8 so this is also set.
