### PR TITLE
Use release binary instead of debug binary in benchamark script

### DIFF
--- a/scripts/benchmarking.sh
+++ b/scripts/benchmarking.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-BINARY="./target/debug/moonbeam"
+BINARY="./target/release/moonbeam"
 STEPS=50
 REPEAT=20
 


### PR DESCRIPTION
### What does it do?

Updates @nbaztec 's benchmark script to use the `release` binary instead of the `debug` one.