### PR TITLE
Add support for optimized binaries in Docker image

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -29,6 +29,8 @@ jobs:
 
           mkdir -p build 
           wget https://github.com/PureStake/moonbeam/releases/download/$VERSION/moonbeam -O build/moonbeam
+          wget https://github.com/PureStake/moonbeam/releases/download/$VERSION/moonbeam-skylake -O build/moonbeam-skylake
+          wget https://github.com/PureStake/moonbeam/releases/download/$VERSION/moonbeam-znver3 -O build/moonbeam-znver3
 
           echo building "${DOCKER_IMAGE}:${VERSION}"
           docker build \

--- a/docker/moonbeam-release.Dockerfile
+++ b/docker/moonbeam-release.Dockerfile
@@ -5,5 +5,5 @@ ARG SHA
 FROM "$DOCKER_IMAGE:$SHA"
 USER moonbeam
 
-COPY --chown=moonbeam build/moonbeam /moonbeam/moonbeam
-RUN chmod uog+x /moonbeam/moonbeam
+COPY --chown=moonbeam build/* /moonbeam
+RUN chmod uog+x /moonbeam/moonbeam*


### PR DESCRIPTION
### What does it do?
This PR is destined to add support for the optimized binaries (skylake and znver3) in the Docker image.
### What important points reviewers should know?
alan@purestake.com
### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
Simply allows people that are using the Docker images provided by Purestake to have a choice regarding their preferred binary (i.e. people using newer generation Intel Xeon can use the moonbeam-skylake binary, while people using newer generation AMD processors can use the moonbeam-znver3 binary)