### PR TITLE
{suspend, resume} xcm execution when {enter, exit}ing maintenance-mode

### DIFF
--- a/pallets/maintenance-mode/src/lib.rs
+++ b/pallets/maintenance-mode/src/lib.rs
@@ -54,18 +54,12 @@ pub use pallet::*;
 
 #[pallet]
 pub mod pallet {
-	#[cfg(feature = "xcm-support")]
-	use cumulus_primitives_core::{
-		relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, XcmpMessageHandler,
-	};
 	use frame_support::pallet_prelude::*;
 	use frame_support::traits::{
 		Contains, EnsureOrigin, OffchainWorker, OnFinalize, OnIdle, OnInitialize, OnRuntimeUpgrade,
 	};
 	use frame_system::pallet_prelude::*;
 	use sp_runtime::DispatchResult;
-	#[cfg(feature = "xcm-support")]
-	use sp_std::vec::Vec;
 	/// Pallet for migrations
 	#[pallet::pallet]
 	#[pallet::without_storage_info]
@@ -106,18 +100,6 @@ pub mod pallet {
 		/// Handler to suspend and resume XCM execution
 		#[cfg(feature = "xcm-support")]
 		type XcmExecutionManager: PauseXcmExecution;
-		/// The DMP handler to be used in normal operating mode
-		#[cfg(feature = "xcm-support")]
-		type NormalDmpHandler: DmpMessageHandler;
-		/// The DMP handler to be used in maintenance mode
-		#[cfg(feature = "xcm-support")]
-		type MaintenanceDmpHandler: DmpMessageHandler;
-		/// The XCMP handler to be used in normal operating mode
-		#[cfg(feature = "xcm-support")]
-		type NormalXcmpHandler: XcmpMessageHandler;
-		/// The XCMP handler to be used in maintenance mode
-		#[cfg(feature = "xcm-support")]
-		type MaintenanceXcmpHandler: XcmpMessageHandler;
 		/// The executive hooks that will be used in normal operating mode
 		/// Important: Use AllPalletsReversedWithSystemFirst here if you dont want to modify the
 		/// hooks behaviour
@@ -251,33 +233,6 @@ pub mod pallet {
 				T::MaintenanceCallFilter::contains(call)
 			} else {
 				T::NormalCallFilter::contains(call)
-			}
-		}
-	}
-	#[cfg(feature = "xcm-support")]
-	impl<T: Config> DmpMessageHandler for Pallet<T> {
-		fn handle_dmp_messages(
-			iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
-			limit: Weight,
-		) -> Weight {
-			if MaintenanceMode::<T>::get() {
-				T::MaintenanceDmpHandler::handle_dmp_messages(iter, limit)
-			} else {
-				T::NormalDmpHandler::handle_dmp_messages(iter, limit)
-			}
-		}
-	}
-
-	#[cfg(feature = "xcm-support")]
-	impl<T: Config> XcmpMessageHandler for Pallet<T> {
-		fn handle_xcmp_messages<'a, I: Iterator<Item = (ParaId, RelayBlockNumber, &'a [u8])>>(
-			iter: I,
-			limit: Weight,
-		) -> Weight {
-			if MaintenanceMode::<T>::get() {
-				T::MaintenanceXcmpHandler::handle_xcmp_messages(iter, limit)
-			} else {
-				T::NormalXcmpHandler::handle_xcmp_messages(iter, limit)
 			}
 		}
 	}

--- a/pallets/maintenance-mode/src/lib.rs
+++ b/pallets/maintenance-mode/src/lib.rs
@@ -58,14 +58,14 @@ pub mod pallet {
 	use cumulus_primitives_core::{
 		relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, XcmpMessageHandler,
 	};
-	#[cfg(feature = "xcm-support")]
-	use sp_std::vec::Vec;
-
 	use frame_support::pallet_prelude::*;
 	use frame_support::traits::{
 		Contains, EnsureOrigin, OffchainWorker, OnFinalize, OnIdle, OnInitialize, OnRuntimeUpgrade,
 	};
 	use frame_system::pallet_prelude::*;
+	use sp_runtime::DispatchResult;
+	#[cfg(feature = "xcm-support")]
+	use sp_std::vec::Vec;
 	/// Pallet for migrations
 	#[pallet::pallet]
 	#[pallet::without_storage_info]
@@ -143,10 +143,10 @@ pub mod pallet {
 		EnteredMaintenanceMode,
 		/// The chain returned to its normal operating state
 		NormalOperationResumed,
-		/// The call to suspend XCM execution failed with inner error
-		FailedToSuspendXcmExecution { error: DispatchError },
-		/// The call to resume XCM execution failed with inner error
-		FailedToResumeXcmExecution { error: DispatchError },
+		/// The call to suspend on_idle XCM execution failed with inner error
+		FailedToSuspendIdleXcmExecution { error: DispatchError },
+		/// The call to resume on_idle XCM execution failed with inner error
+		FailedToResumeIdleXcmExecution { error: DispatchError },
 	}
 
 	/// An error that can occur while executing this pallet's extrinsics.
@@ -187,7 +187,7 @@ pub mod pallet {
 			MaintenanceMode::<T>::put(true);
 			// Suspend XCM execution
 			if let Err(error) = T::XcmExecutionManager::suspend_xcm_execution() {
-				<Pallet<T>>::deposit_event(Event::FailedToSuspendXcmExecution { error });
+				<Pallet<T>>::deposit_event(Event::FailedToSuspendIdleXcmExecution { error });
 			}
 
 			// Event
@@ -218,7 +218,7 @@ pub mod pallet {
 			MaintenanceMode::<T>::put(false);
 			// Resume XCM execution
 			if let Err(error) = T::XcmExecutionManager::resume_xcm_execution() {
-				<Pallet<T>>::deposit_event(Event::FailedToResumeXcmExecution { error });
+				<Pallet<T>>::deposit_event(Event::FailedToResumeIdleXcmExecution { error });
 			}
 
 			// Event

--- a/pallets/maintenance-mode/src/lib.rs
+++ b/pallets/maintenance-mode/src/lib.rs
@@ -169,8 +169,8 @@ pub mod pallet {
 		///
 		/// Weight cost is:
 		/// * One DB read to ensure we're not already in maintenance mode
-		/// * Two DB writes - 1 for the mode and 1 for the event
-		#[pallet::weight(T::DbWeight::get().read + 2 * T::DbWeight::get().write)]
+		/// * Three DB writes - 1 for the mode, 1 for suspending xcm execution, 1 for the event
+		#[pallet::weight(T::DbWeight::get().read + 3 * T::DbWeight::get().write)]
 		pub fn enter_maintenance_mode(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			// Ensure Origin
 			T::MaintenanceOrigin::ensure_origin(origin)?;
@@ -200,8 +200,8 @@ pub mod pallet {
 		///
 		/// Weight cost is:
 		/// * One DB read to ensure we're in maintenance mode
-		/// * Two DB writes - 1 for the mode and 1 for the event
-		#[pallet::weight(T::DbWeight::get().read + 2 * T::DbWeight::get().write)]
+		/// * Three DB writes - 1 for the mode, 1 for resuming xcm execution, 1 for the event
+		#[pallet::weight(T::DbWeight::get().read + 3 * T::DbWeight::get().write)]
 		pub fn resume_normal_operation(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			// Ensure Origin
 			T::MaintenanceOrigin::ensure_origin(origin)?;

--- a/pallets/maintenance-mode/src/lib.rs
+++ b/pallets/maintenance-mode/src/lib.rs
@@ -107,9 +107,11 @@ pub mod pallet {
 		#[cfg(feature = "xcm-support")]
 		type XcmExecutionManager: PauseXcmExecution;
 		/// The DMP handler to be used in normal operating mode
+		/// TODO: remove once https://github.com/paritytech/polkadot/pull/5035 is merged
 		#[cfg(feature = "xcm-support")]
 		type NormalDmpHandler: DmpMessageHandler;
 		/// The DMP handler to be used in maintenance mode
+		/// TODO: remove once https://github.com/paritytech/polkadot/pull/5035 is merged
 		#[cfg(feature = "xcm-support")]
 		type MaintenanceDmpHandler: DmpMessageHandler;
 		/// The executive hooks that will be used in normal operating mode

--- a/pallets/maintenance-mode/src/mock.rs
+++ b/pallets/maintenance-mode/src/mock.rs
@@ -17,9 +17,7 @@
 //! A minimal runtime including the maintenance-mode pallet
 use super::*;
 use crate as pallet_maintenance_mode;
-use cumulus_primitives_core::{
-	relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, XcmpMessageHandler,
-};
+use cumulus_primitives_core::relay_chain::BlockNumber as RelayBlockNumber;
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{
@@ -95,58 +93,6 @@ pub struct MaintenanceCallFilter;
 impl Contains<Call> for MaintenanceCallFilter {
 	fn contains(_: &Call) -> bool {
 		false
-	}
-}
-
-pub struct MaintenanceXcmpHandler;
-#[cfg(feature = "xcm-support")]
-impl XcmpMessageHandler for MaintenanceXcmpHandler {
-	// This implementation makes messages be queued
-	// Since the limit is 0, messages are queued for next iteration
-	fn handle_xcmp_messages<'a, I: Iterator<Item = (ParaId, RelayBlockNumber, &'a [u8])>>(
-		_iter: I,
-		_limit: Weight,
-	) -> Weight {
-		return 1;
-	}
-}
-
-pub struct NormalXcmpHandler;
-#[cfg(feature = "xcm-support")]
-impl XcmpMessageHandler for NormalXcmpHandler {
-	// This implementation makes messages be queued
-	// Since the limit is 0, messages are queued for next iteration
-	fn handle_xcmp_messages<'a, I: Iterator<Item = (ParaId, RelayBlockNumber, &'a [u8])>>(
-		_iter: I,
-		_limit: Weight,
-	) -> Weight {
-		return 0;
-	}
-}
-
-pub struct MaintenanceDmpHandler;
-#[cfg(feature = "xcm-support")]
-impl DmpMessageHandler for MaintenanceDmpHandler {
-	// This implementation makes messages be queued
-	// Since the limit is 0, messages are queued for next iteration
-	fn handle_dmp_messages(
-		_iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
-		_limit: Weight,
-	) -> Weight {
-		return 1;
-	}
-}
-
-pub struct NormalDmpHandler;
-#[cfg(feature = "xcm-support")]
-impl DmpMessageHandler for NormalDmpHandler {
-	// This implementation makes messages be queued
-	// Since the limit is 0, messages are queued for next iteration
-	fn handle_dmp_messages(
-		_iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
-		_limit: Weight,
-	) -> Weight {
-		return 0;
 	}
 }
 
@@ -285,14 +231,6 @@ impl Config for Test {
 	type MaintenanceOrigin = EnsureRoot<AccountId>;
 	#[cfg(feature = "xcm-support")]
 	type XcmExecutionManager = ();
-	#[cfg(feature = "xcm-support")]
-	type NormalDmpHandler = NormalDmpHandler;
-	#[cfg(feature = "xcm-support")]
-	type MaintenanceDmpHandler = MaintenanceDmpHandler;
-	#[cfg(feature = "xcm-support")]
-	type NormalXcmpHandler = NormalXcmpHandler;
-	#[cfg(feature = "xcm-support")]
-	type MaintenanceXcmpHandler = MaintenanceXcmpHandler;
 	type NormalExecutiveHooks = NormalHooks;
 	type MaitenanceExecutiveHooks = MaintenanceHooks;
 }

--- a/pallets/maintenance-mode/src/mock.rs
+++ b/pallets/maintenance-mode/src/mock.rs
@@ -17,6 +17,7 @@
 //! A minimal runtime including the maintenance-mode pallet
 use super::*;
 use crate as pallet_maintenance_mode;
+use cumulus_primitives_core::{relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler};
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{
@@ -92,6 +93,32 @@ pub struct MaintenanceCallFilter;
 impl Contains<Call> for MaintenanceCallFilter {
 	fn contains(_: &Call) -> bool {
 		false
+	}
+}
+
+pub struct MaintenanceDmpHandler;
+#[cfg(feature = "xcm-support")]
+impl DmpMessageHandler for MaintenanceDmpHandler {
+	// This implementation makes messages be queued
+	// Since the limit is 0, messages are queued for next iteration
+	fn handle_dmp_messages(
+		_iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
+		_limit: Weight,
+	) -> Weight {
+		return 1;
+	}
+}
+
+pub struct NormalDmpHandler;
+#[cfg(feature = "xcm-support")]
+impl DmpMessageHandler for NormalDmpHandler {
+	// This implementation makes messages be queued
+	// Since the limit is 0, messages are queued for next iteration
+	fn handle_dmp_messages(
+		_iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
+		_limit: Weight,
+	) -> Weight {
+		return 0;
 	}
 }
 
@@ -230,6 +257,10 @@ impl Config for Test {
 	type MaintenanceOrigin = EnsureRoot<AccountId>;
 	#[cfg(feature = "xcm-support")]
 	type XcmExecutionManager = ();
+	#[cfg(feature = "xcm-support")]
+	type NormalDmpHandler = NormalDmpHandler;
+	#[cfg(feature = "xcm-support")]
+	type MaintenanceDmpHandler = MaintenanceDmpHandler;
 	type NormalExecutiveHooks = NormalHooks;
 	type MaitenanceExecutiveHooks = MaintenanceHooks;
 }

--- a/pallets/maintenance-mode/src/mock.rs
+++ b/pallets/maintenance-mode/src/mock.rs
@@ -284,6 +284,8 @@ impl Config for Test {
 	type MaintenanceCallFilter = MaintenanceCallFilter;
 	type MaintenanceOrigin = EnsureRoot<AccountId>;
 	#[cfg(feature = "xcm-support")]
+	type XcmExecutionManager = ();
+	#[cfg(feature = "xcm-support")]
 	type NormalDmpHandler = NormalDmpHandler;
 	#[cfg(feature = "xcm-support")]
 	type MaintenanceDmpHandler = MaintenanceDmpHandler;

--- a/pallets/maintenance-mode/src/mock.rs
+++ b/pallets/maintenance-mode/src/mock.rs
@@ -17,7 +17,6 @@
 //! A minimal runtime including the maintenance-mode pallet
 use super::*;
 use crate as pallet_maintenance_mode;
-use cumulus_primitives_core::relay_chain::BlockNumber as RelayBlockNumber;
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{

--- a/pallets/maintenance-mode/src/tests.rs
+++ b/pallets/maintenance-mode/src/tests.rs
@@ -15,9 +15,7 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Unit testing
-use crate::mock::{
-	events, mock_events, Call as OuterCall, ExtBuilder, MaintenanceMode, Origin, Test,
-};
+use crate::mock::{events, mock_events, Call as OuterCall, ExtBuilder, Origin, Test};
 use crate::{Call, Error, Event, ExecutiveHooks};
 use frame_support::{
 	assert_noop, assert_ok,

--- a/pallets/maintenance-mode/src/tests.rs
+++ b/pallets/maintenance-mode/src/tests.rs
@@ -19,7 +19,6 @@ use crate::mock::{
 	events, mock_events, Call as OuterCall, ExtBuilder, MaintenanceMode, Origin, Test,
 };
 use crate::{Call, Error, Event, ExecutiveHooks};
-use cumulus_primitives_core::{DmpMessageHandler, XcmpMessageHandler};
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::Dispatchable,
@@ -122,42 +121,6 @@ fn cannot_resume_normal_operation_while_already_operating_normally() {
 			Error::<Test>::NotInMaintenanceMode
 		);
 	})
-}
-
-#[cfg(feature = "xcm-support")]
-#[test]
-fn normal_dmp_and_xcmp_in_non_maintenance() {
-	ExtBuilder::default()
-		.with_maintenance_mode(false)
-		.build()
-		.execute_with(|| {
-			assert_eq!(
-				MaintenanceMode::handle_dmp_messages(vec![].into_iter(), 1),
-				0
-			);
-			assert_eq!(
-				MaintenanceMode::handle_xcmp_messages(vec![].into_iter(), 1),
-				0
-			);
-		})
-}
-
-#[cfg(feature = "xcm-support")]
-#[test]
-fn maintenance_dmp_and_xcmp_in_maintenance() {
-	ExtBuilder::default()
-		.with_maintenance_mode(true)
-		.build()
-		.execute_with(|| {
-			assert_eq!(
-				MaintenanceMode::handle_dmp_messages(vec![].into_iter(), 1),
-				1
-			);
-			assert_eq!(
-				MaintenanceMode::handle_xcmp_messages(vec![].into_iter(), 1),
-				1
-			);
-		})
 }
 
 #[test]

--- a/pallets/maintenance-mode/src/tests.rs
+++ b/pallets/maintenance-mode/src/tests.rs
@@ -15,8 +15,11 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Unit testing
-use crate::mock::{events, mock_events, Call as OuterCall, ExtBuilder, Origin, Test};
+use crate::mock::{
+	events, mock_events, Call as OuterCall, ExtBuilder, MaintenanceMode, Origin, Test,
+};
 use crate::{Call, Error, Event, ExecutiveHooks};
+use cumulus_primitives_core::DmpMessageHandler;
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::Dispatchable,
@@ -119,6 +122,34 @@ fn cannot_resume_normal_operation_while_already_operating_normally() {
 			Error::<Test>::NotInMaintenanceMode
 		);
 	})
+}
+
+#[cfg(feature = "xcm-support")]
+#[test]
+fn normal_dmp_in_non_maintenance() {
+	ExtBuilder::default()
+		.with_maintenance_mode(false)
+		.build()
+		.execute_with(|| {
+			assert_eq!(
+				MaintenanceMode::handle_dmp_messages(vec![].into_iter(), 1),
+				0
+			);
+		})
+}
+
+#[cfg(feature = "xcm-support")]
+#[test]
+fn maintenance_dmp_in_maintenance() {
+	ExtBuilder::default()
+		.with_maintenance_mode(true)
+		.build()
+		.execute_with(|| {
+			assert_eq!(
+				MaintenanceMode::handle_dmp_messages(vec![].into_iter(), 1),
+				1
+			);
+		})
 }
 
 #[test]

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1132,7 +1132,8 @@ impl pallet_maintenance_mode::Config for Runtime {
 	type MaintenanceOrigin =
 		pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, TechCommitteeInstance>;
 	type XcmExecutionManager = XcmExecutionManager;
-	type DmpMessageHandler = MaintenanceDmpHandler;
+	type NormalDmpHandler = DmpQueue;
+	type MaintenanceDmpHandler = MaintenanceDmpHandler;
 	// We use AllPalletsReversedWithSystemFirst because we dont want to change the hooks in normal
 	// operation
 	type NormalExecutiveHooks = AllPalletsReversedWithSystemFirst;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1051,9 +1051,7 @@ impl Contains<Call> for NormalFilter {
 	}
 }
 
-use cumulus_primitives_core::{
-	relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, XcmpMessageHandler,
-};
+use cumulus_primitives_core::{relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler};
 
 pub struct XcmExecutionManager;
 impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1051,10 +1051,6 @@ impl Contains<Call> for NormalFilter {
 	}
 }
 
-use cumulus_primitives_core::{
-	relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, XcmpMessageHandler,
-};
-
 pub struct XcmExecutionManager;
 impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
 	fn suspend_xcm_execution() -> DispatchResult {

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -694,7 +694,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type Event = Event;
 	type OnSystemEvent = ();
 	type SelfParaId = ParachainInfo;
-	type DmpMessageHandler = DmpQueue;
+	type DmpMessageHandler = MaintenanceMode;
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type OutboundXcmpMessageSource = XcmpQueue;
 	type XcmpMessageHandler = XcmpQueue;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1143,10 +1143,10 @@ use cumulus_primitives_core::{
 pub struct XcmExecutionManager;
 impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
 	fn suspend_xcm_execution() {
-		XcmpQueue::suspend_xcm_execution(Origin::root());
+		XcmpQueue::suspend_xcm_execution(Origin::root()).expect("ControllerOrigin = EnsureRoot ");
 	}
 	fn resume_xcm_execution() {
-		XcmpQueue::resume_xcm_execution(Origin::root());
+		XcmpQueue::resume_xcm_execution(Origin::root()).expect("ControllerOrigin = EnsureRoot");
 	}
 }
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1139,6 +1139,17 @@ impl Contains<Call> for NormalFilter {
 use cumulus_primitives_core::{
 	relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, XcmpMessageHandler,
 };
+
+pub struct XcmExecutionManager;
+impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
+	fn suspend_xcm_execution() {
+		XcmpQueue::suspend_xcm_execution(Origin::root());
+	}
+	fn resume_xcm_execution() {
+		XcmpQueue::resume_xcm_execution(Origin::root());
+	}
+}
+
 pub struct MaintenanceDmpHandler;
 impl DmpMessageHandler for MaintenanceDmpHandler {
 	// This implementation makes messages be queued
@@ -1217,6 +1228,7 @@ impl pallet_maintenance_mode::Config for Runtime {
 	type MaintenanceCallFilter = MaintenanceFilter;
 	type MaintenanceOrigin =
 		pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, TechCommitteeInstance>;
+	type XcmExecutionManager = XcmExecutionManager;
 	type NormalDmpHandler = DmpQueue;
 	type MaintenanceDmpHandler = MaintenanceDmpHandler;
 	type NormalXcmpHandler = XcmpQueue;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -745,10 +745,10 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type Event = Event;
 	type OnSystemEvent = ();
 	type SelfParaId = ParachainInfo;
-	type DmpMessageHandler = MaintenanceMode;
+	type DmpMessageHandler = DmpQueue;
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type OutboundXcmpMessageSource = XcmpQueue;
-	type XcmpMessageHandler = MaintenanceMode;
+	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
 }
 
@@ -1150,30 +1150,6 @@ impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
 	}
 }
 
-pub struct MaintenanceDmpHandler;
-impl DmpMessageHandler for MaintenanceDmpHandler {
-	// This implementation makes messages be queued
-	// Since the limit is 0, messages are queued for next iteration
-	fn handle_dmp_messages(
-		iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
-		_limit: Weight,
-	) -> Weight {
-		DmpQueue::handle_dmp_messages(iter, 0)
-	}
-}
-
-pub struct MaintenanceXcmpHandler;
-impl XcmpMessageHandler for MaintenanceXcmpHandler {
-	// This implementation makes messages be queued
-	// Since the limit is 0, messages are queued for next iteration
-	fn handle_xcmp_messages<'a, I: Iterator<Item = (ParaId, RelayBlockNumber, &'a [u8])>>(
-		iter: I,
-		_limit: Weight,
-	) -> Weight {
-		XcmpQueue::handle_xcmp_messages(iter, 0)
-	}
-}
-
 /// The hooks we wnat to run in Maintenance Mode
 pub struct MaintenanceHooks;
 
@@ -1229,10 +1205,6 @@ impl pallet_maintenance_mode::Config for Runtime {
 	type MaintenanceOrigin =
 		pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, TechCommitteeInstance>;
 	type XcmExecutionManager = XcmExecutionManager;
-	type NormalDmpHandler = DmpQueue;
-	type MaintenanceDmpHandler = MaintenanceDmpHandler;
-	type NormalXcmpHandler = XcmpQueue;
-	type MaintenanceXcmpHandler = MaintenanceXcmpHandler;
 	// We use AllPalletsReversedWithSystemFirst because we dont want to change the hooks in normal
 	// operation
 	type NormalExecutiveHooks = AllPalletsReversedWithSystemFirst;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1142,11 +1142,11 @@ use cumulus_primitives_core::{
 
 pub struct XcmExecutionManager;
 impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
-	fn suspend_xcm_execution() {
-		XcmpQueue::suspend_xcm_execution(Origin::root()).expect("ControllerOrigin = EnsureRoot ");
+	fn suspend_xcm_execution() -> DispatchResult {
+		XcmpQueue::suspend_xcm_execution(Origin::root())
 	}
-	fn resume_xcm_execution() {
-		XcmpQueue::resume_xcm_execution(Origin::root()).expect("ControllerOrigin = EnsureRoot");
+	fn resume_xcm_execution() -> DispatchResult {
+		XcmpQueue::resume_xcm_execution(Origin::root())
 	}
 }
 

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -25,7 +25,7 @@ use fp_evm::{Context, ExitSucceed, PrecompileOutput};
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::Dispatchable,
-	traits::{fungible::Inspect, PalletInfo, StorageInfo, StorageInfoTrait},
+	traits::{fungible::Inspect, EnsureOrigin, PalletInfo, StorageInfo, StorageInfoTrait},
 	weights::{DispatchClass, Weight},
 	StorageHasher, Twox128,
 };
@@ -52,6 +52,16 @@ use sp_runtime::{
 	DispatchError, ModuleError,
 };
 use xcm::latest::prelude::*;
+
+#[test]
+fn xcmp_queue_controller_origin_is_root() {
+	// important for the XcmExecutionManager impl of PauseExecution which uses root origin
+	// to suspend/resume XCM execution in xcmp_queue::on_idle
+	assert_ok!(
+		<moonbase_runtime::Runtime as cumulus_pallet_xcmp_queue::Config
+		>::ControllerOrigin::ensure_origin(root_origin())
+	);
+}
 
 #[test]
 fn fast_track_available() {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1089,10 +1089,10 @@ impl Contains<Call> for NormalFilter {
 pub struct XcmExecutionManager;
 impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
 	fn suspend_xcm_execution() {
-		XcmpQueue::suspend_xcm_execution(Origin::root());
+		XcmpQueue::suspend_xcm_execution(Origin::root()).expect("ControllerOrigin = EnsureRoot ");
 	}
 	fn resume_xcm_execution() {
-		XcmpQueue::resume_xcm_execution(Origin::root());
+		XcmpQueue::resume_xcm_execution(Origin::root()).expect("ControllerOrigin = EnsureRoot");
 	}
 }
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -83,9 +83,7 @@ use pallet_evm_precompile_assets_erc20::AccountIdAssetIdConversion;
 
 use xcm::latest::prelude::*;
 
-use cumulus_primitives_core::{
-	relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, XcmpMessageHandler,
-};
+use cumulus_primitives_core::{relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler};
 
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -83,10 +83,6 @@ use pallet_evm_precompile_assets_erc20::AccountIdAssetIdConversion;
 
 use xcm::latest::prelude::*;
 
-use cumulus_primitives_core::{
-	relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, XcmpMessageHandler,
-};
-
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1073,7 +1073,8 @@ impl pallet_maintenance_mode::Config for Runtime {
 	type MaintenanceOrigin =
 		pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, TechCommitteeInstance>;
 	type XcmExecutionManager = XcmExecutionManager;
-	type DmpMessageHandler = MaintenanceDmpHandler;
+	type NormalDmpHandler = DmpQueue;
+	type MaintenanceDmpHandler = MaintenanceDmpHandler;
 	// We use AllPalletsReversedWithSystemFirst because we dont want to change the hooks in normal
 	// operation
 	type NormalExecutiveHooks = AllPalletsReversedWithSystemFirst;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1086,6 +1086,16 @@ impl Contains<Call> for NormalFilter {
 	}
 }
 
+pub struct XcmExecutionManager;
+impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
+	fn suspend_xcm_execution() {
+		XcmpQueue::suspend_xcm_execution(Origin::root());
+	}
+	fn resume_xcm_execution() {
+		XcmpQueue::resume_xcm_execution(Origin::root());
+	}
+}
+
 pub struct MaintenanceDmpHandler;
 impl DmpMessageHandler for MaintenanceDmpHandler {
 	// This implementation makes messages be queued
@@ -1164,6 +1174,7 @@ impl pallet_maintenance_mode::Config for Runtime {
 	type MaintenanceCallFilter = MaintenanceFilter;
 	type MaintenanceOrigin =
 		pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, TechCommitteeInstance>;
+	type XcmExecutionManager = XcmExecutionManager;
 	type NormalDmpHandler = DmpQueue;
 	type MaintenanceDmpHandler = MaintenanceDmpHandler;
 	type NormalXcmpHandler = XcmpQueue;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1088,11 +1088,11 @@ impl Contains<Call> for NormalFilter {
 
 pub struct XcmExecutionManager;
 impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
-	fn suspend_xcm_execution() {
-		XcmpQueue::suspend_xcm_execution(Origin::root()).expect("ControllerOrigin = EnsureRoot ");
+	fn suspend_xcm_execution() -> DispatchResult {
+		XcmpQueue::suspend_xcm_execution(Origin::root())
 	}
-	fn resume_xcm_execution() {
-		XcmpQueue::resume_xcm_execution(Origin::root()).expect("ControllerOrigin = EnsureRoot");
+	fn resume_xcm_execution() -> DispatchResult {
+		XcmpQueue::resume_xcm_execution(Origin::root())
 	}
 }
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -621,7 +621,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type Event = Event;
 	type OnSystemEvent = ();
 	type SelfParaId = ParachainInfo;
-	type DmpMessageHandler = DmpQueue;
+	type DmpMessageHandler = MaintenanceMode;
 	type ReservedDmpWeight = ConstU64<{ MAXIMUM_BLOCK_WEIGHT / 4 }>;
 	type OutboundXcmpMessageSource = XcmpQueue;
 	type XcmpMessageHandler = XcmpQueue;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -83,6 +83,10 @@ use pallet_evm_precompile_assets_erc20::AccountIdAssetIdConversion;
 
 use xcm::latest::prelude::*;
 
+use cumulus_primitives_core::{
+	relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, XcmpMessageHandler,
+};
+
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
@@ -1002,6 +1006,18 @@ impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
 	}
 }
 
+pub struct MaintenanceDmpHandler;
+impl DmpMessageHandler for MaintenanceDmpHandler {
+	// This implementation makes messages be queued
+	// Since the limit is 0, messages are queued for next iteration
+	fn handle_dmp_messages(
+		iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
+		_limit: Weight,
+	) -> Weight {
+		DmpQueue::handle_dmp_messages(iter, 0)
+	}
+}
+
 /// The hooks we want to run in Maintenance Mode
 pub struct MaintenanceHooks;
 
@@ -1057,6 +1073,7 @@ impl pallet_maintenance_mode::Config for Runtime {
 	type MaintenanceOrigin =
 		pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, TechCommitteeInstance>;
 	type XcmExecutionManager = XcmExecutionManager;
+	type DmpMessageHandler = MaintenanceDmpHandler;
 	// We use AllPalletsReversedWithSystemFirst because we dont want to change the hooks in normal
 	// operation
 	type NormalExecutiveHooks = AllPalletsReversedWithSystemFirst;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -679,10 +679,10 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type Event = Event;
 	type OnSystemEvent = ();
 	type SelfParaId = ParachainInfo;
-	type DmpMessageHandler = MaintenanceMode;
+	type DmpMessageHandler = DmpQueue;
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type OutboundXcmpMessageSource = XcmpQueue;
-	type XcmpMessageHandler = MaintenanceMode;
+	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
 }
 impl parachain_info::Config for Runtime {}
@@ -1096,30 +1096,6 @@ impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
 	}
 }
 
-pub struct MaintenanceDmpHandler;
-impl DmpMessageHandler for MaintenanceDmpHandler {
-	// This implementation makes messages be queued
-	// Since the limit is 0, messages are queued for next iteration
-	fn handle_dmp_messages(
-		iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
-		_limit: Weight,
-	) -> Weight {
-		DmpQueue::handle_dmp_messages(iter, 0)
-	}
-}
-
-pub struct MaintenanceXcmpHandler;
-impl XcmpMessageHandler for MaintenanceXcmpHandler {
-	// This implementation makes messages be queued
-	// Since the limit is 0, messages are queued for next iteration
-	fn handle_xcmp_messages<'a, I: Iterator<Item = (ParaId, RelayBlockNumber, &'a [u8])>>(
-		iter: I,
-		_limit: Weight,
-	) -> Weight {
-		XcmpQueue::handle_xcmp_messages(iter, 0)
-	}
-}
-
 /// The hooks we want to run in Maintenance Mode
 pub struct MaintenanceHooks;
 
@@ -1175,10 +1151,6 @@ impl pallet_maintenance_mode::Config for Runtime {
 	type MaintenanceOrigin =
 		pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, TechCommitteeInstance>;
 	type XcmExecutionManager = XcmExecutionManager;
-	type NormalDmpHandler = DmpQueue;
-	type MaintenanceDmpHandler = MaintenanceDmpHandler;
-	type NormalXcmpHandler = XcmpQueue;
-	type MaintenanceXcmpHandler = MaintenanceXcmpHandler;
 	// We use AllPalletsReversedWithSystemFirst because we dont want to change the hooks in normal
 	// operation
 	type NormalExecutiveHooks = AllPalletsReversedWithSystemFirst;

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -25,7 +25,7 @@ use fp_evm::{Context, ExitSucceed, PrecompileOutput};
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::Dispatchable,
-	traits::{fungible::Inspect, PalletInfo, StorageInfo, StorageInfoTrait},
+	traits::{fungible::Inspect, EnsureOrigin, PalletInfo, StorageInfo, StorageInfoTrait},
 	weights::{DispatchClass, Weight},
 	StorageHasher, Twox128,
 };
@@ -51,6 +51,16 @@ use sp_runtime::{
 use xcm::latest::prelude::*;
 use xcm::{VersionedMultiAsset, VersionedMultiAssets, VersionedMultiLocation};
 use xtokens_precompiles::Action as XtokensAction;
+
+#[test]
+fn xcmp_queue_controller_origin_is_root() {
+	// important for the XcmExecutionManager impl of PauseExecution which uses root origin
+	// to suspend/resume XCM execution in xcmp_queue::on_idle
+	assert_ok!(
+		<moonbeam_runtime::Runtime as cumulus_pallet_xcmp_queue::Config
+		>::ControllerOrigin::ensure_origin(root_origin())
+	);
+}
 
 #[test]
 fn fast_track_available() {

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1119,10 +1119,10 @@ impl Contains<Call> for NormalFilter {
 pub struct XcmExecutionManager;
 impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
 	fn suspend_xcm_execution() {
-		XcmpQueue::suspend_xcm_execution(Origin::root());
+		XcmpQueue::suspend_xcm_execution(Origin::root()).expect("ControllerOrigin = EnsureRoot ");
 	}
 	fn resume_xcm_execution() {
-		XcmpQueue::resume_xcm_execution(Origin::root());
+		XcmpQueue::resume_xcm_execution(Origin::root()).expect("ControllerOrigin = EnsureRoot");
 	}
 }
 

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -701,10 +701,10 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type Event = Event;
 	type OnSystemEvent = ();
 	type SelfParaId = ParachainInfo;
-	type DmpMessageHandler = MaintenanceMode;
+	type DmpMessageHandler = DmpQueue;
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type OutboundXcmpMessageSource = XcmpQueue;
-	type XcmpMessageHandler = MaintenanceMode;
+	type XcmpMessageHandler = XcmpQueue;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
 }
 
@@ -1126,30 +1126,6 @@ impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
 	}
 }
 
-pub struct MaintenanceDmpHandler;
-impl DmpMessageHandler for MaintenanceDmpHandler {
-	// This implementation makes messages be queued
-	// Since the limit is 0, messages are queued for next iteration
-	fn handle_dmp_messages(
-		iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
-		_limit: Weight,
-	) -> Weight {
-		DmpQueue::handle_dmp_messages(iter, 0)
-	}
-}
-
-pub struct MaintenanceXcmpHandler;
-impl XcmpMessageHandler for MaintenanceXcmpHandler {
-	// This implementation makes messages be queued
-	// Since the limit is 0, messages are queued for next iteration
-	fn handle_xcmp_messages<'a, I: Iterator<Item = (ParaId, RelayBlockNumber, &'a [u8])>>(
-		iter: I,
-		_limit: Weight,
-	) -> Weight {
-		XcmpQueue::handle_xcmp_messages(iter, 0)
-	}
-}
-
 /// The hooks we wantt to run in Maintenance Mode
 pub struct MaintenanceHooks;
 
@@ -1205,10 +1181,6 @@ impl pallet_maintenance_mode::Config for Runtime {
 	type MaintenanceOrigin =
 		pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, TechCommitteeInstance>;
 	type XcmExecutionManager = XcmExecutionManager;
-	type NormalDmpHandler = DmpQueue;
-	type MaintenanceDmpHandler = MaintenanceDmpHandler;
-	type NormalXcmpHandler = XcmpQueue;
-	type MaintenanceXcmpHandler = MaintenanceXcmpHandler;
 	// We use AllPalletsReversedWithSystemFirst because we dont want to change the hooks in normal
 	// operation
 	type NormalExecutiveHooks = AllPalletsReversedWithSystemFirst;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1108,7 +1108,8 @@ impl pallet_maintenance_mode::Config for Runtime {
 	type MaintenanceOrigin =
 		pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, TechCommitteeInstance>;
 	type XcmExecutionManager = XcmExecutionManager;
-	type DmpMessageHandler = MaintenanceDmpHandler;
+	type NormalDmpHandler = DmpQueue;
+	type MaintenanceDmpHandler = MaintenanceDmpHandler;
 	// We use AllPalletsReversedWithSystemFirst because we dont want to change the hooks in normal
 	// operation
 	type NormalExecutiveHooks = AllPalletsReversedWithSystemFirst;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -81,9 +81,6 @@ use sp_runtime::{
 };
 use sp_std::{convert::TryFrom, prelude::*};
 
-use cumulus_primitives_core::{
-	relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, XcmpMessageHandler,
-};
 use smallvec::smallvec;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -648,7 +648,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type Event = Event;
 	type OnSystemEvent = ();
 	type SelfParaId = ParachainInfo;
-	type DmpMessageHandler = DmpQueue;
+	type DmpMessageHandler = MaintenanceMode;
 	type ReservedDmpWeight = ReservedDmpWeight;
 	type OutboundXcmpMessageSource = XcmpQueue;
 	type XcmpMessageHandler = XcmpQueue;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1118,11 +1118,11 @@ impl Contains<Call> for NormalFilter {
 
 pub struct XcmExecutionManager;
 impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
-	fn suspend_xcm_execution() {
-		XcmpQueue::suspend_xcm_execution(Origin::root()).expect("ControllerOrigin = EnsureRoot ");
+	fn suspend_xcm_execution() -> DispatchResult {
+		XcmpQueue::suspend_xcm_execution(Origin::root())
 	}
-	fn resume_xcm_execution() {
-		XcmpQueue::resume_xcm_execution(Origin::root()).expect("ControllerOrigin = EnsureRoot");
+	fn resume_xcm_execution() -> DispatchResult {
+		XcmpQueue::resume_xcm_execution(Origin::root())
 	}
 }
 

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1116,6 +1116,16 @@ impl Contains<Call> for NormalFilter {
 	}
 }
 
+pub struct XcmExecutionManager;
+impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
+	fn suspend_xcm_execution() {
+		XcmpQueue::suspend_xcm_execution(Origin::root());
+	}
+	fn resume_xcm_execution() {
+		XcmpQueue::resume_xcm_execution(Origin::root());
+	}
+}
+
 pub struct MaintenanceDmpHandler;
 impl DmpMessageHandler for MaintenanceDmpHandler {
 	// This implementation makes messages be queued
@@ -1194,6 +1204,7 @@ impl pallet_maintenance_mode::Config for Runtime {
 	type MaintenanceCallFilter = MaintenanceFilter;
 	type MaintenanceOrigin =
 		pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, TechCommitteeInstance>;
+	type XcmExecutionManager = XcmExecutionManager;
 	type NormalDmpHandler = DmpQueue;
 	type MaintenanceDmpHandler = MaintenanceDmpHandler;
 	type NormalXcmpHandler = XcmpQueue;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -81,9 +81,7 @@ use sp_runtime::{
 };
 use sp_std::{convert::TryFrom, prelude::*};
 
-use cumulus_primitives_core::{
-	relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, XcmpMessageHandler,
-};
+use cumulus_primitives_core::{relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler};
 use smallvec::smallvec;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -81,6 +81,9 @@ use sp_runtime::{
 };
 use sp_std::{convert::TryFrom, prelude::*};
 
+use cumulus_primitives_core::{
+	relay_chain::BlockNumber as RelayBlockNumber, DmpMessageHandler, ParaId, XcmpMessageHandler,
+};
 use smallvec::smallvec;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
@@ -1038,6 +1041,18 @@ impl pallet_maintenance_mode::PauseXcmExecution for XcmExecutionManager {
 	}
 }
 
+pub struct MaintenanceDmpHandler;
+impl DmpMessageHandler for MaintenanceDmpHandler {
+	// This implementation makes messages be queued
+	// Since the limit is 0, messages are queued for next iteration
+	fn handle_dmp_messages(
+		iter: impl Iterator<Item = (RelayBlockNumber, Vec<u8>)>,
+		_limit: Weight,
+	) -> Weight {
+		DmpQueue::handle_dmp_messages(iter, 0)
+	}
+}
+
 /// The hooks we wantt to run in Maintenance Mode
 pub struct MaintenanceHooks;
 
@@ -1093,6 +1108,7 @@ impl pallet_maintenance_mode::Config for Runtime {
 	type MaintenanceOrigin =
 		pallet_collective::EnsureProportionAtLeast<_2, _3, AccountId, TechCommitteeInstance>;
 	type XcmExecutionManager = XcmExecutionManager;
+	type DmpMessageHandler = MaintenanceDmpHandler;
 	// We use AllPalletsReversedWithSystemFirst because we dont want to change the hooks in normal
 	// operation
 	type NormalExecutiveHooks = AllPalletsReversedWithSystemFirst;

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -25,7 +25,7 @@ use fp_evm::{Context, ExitSucceed, PrecompileOutput};
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::Dispatchable,
-	traits::{fungible::Inspect, PalletInfo, StorageInfo, StorageInfoTrait},
+	traits::{fungible::Inspect, EnsureOrigin, PalletInfo, StorageInfo, StorageInfoTrait},
 	weights::{DispatchClass, Weight},
 	StorageHasher, Twox128,
 };
@@ -49,6 +49,16 @@ use sp_runtime::{
 use xcm::latest::prelude::*;
 use xcm::{VersionedMultiAssets, VersionedMultiLocation};
 use xtokens_precompiles::Action as XtokensAction;
+
+#[test]
+fn xcmp_queue_controller_origin_is_root() {
+	// important for the XcmExecutionManager impl of PauseExecution which uses root origin
+	// to suspend/resume XCM execution in xcmp_queue::on_idle
+	assert_ok!(
+		<moonriver_runtime::Runtime as cumulus_pallet_xcmp_queue::Config
+		>::ControllerOrigin::ensure_origin(root_origin())
+	);
+}
 
 #[test]
 fn fast_track_available() {


### PR DESCRIPTION
MOON-1483

Suspends xcm execution of messages in xcmp_queue::on_idle when entering maintenance-mode

Resumes xcm execution of messages in xcmp_queue::on_idle when exiting maintenance-mode

Removes the XcmpHandler associated types from pallet maintenance mode

Relevant:
* https://github.com/paritytech/cumulus/commit/77491879cd5af1717c459e7b980b7e9a270617c6
* https://github.com/AcalaNetwork/Acala/pull/1737#issuecomment-1006609731