### PR TITLE
Ability to destroy asset through asset-manager

### DIFF
--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -169,6 +169,11 @@ pub mod pallet {
 		},
 		/// Supported asset type for fee payment removed
 		SupportedAssetRemoved { asset_type: T::AssetType },
+		/// Removed all information related to an assetId and destroyed asset
+		AssetDestroyed {
+			asset_id: T::AssetId,
+			asset_type: T::AssetType,
+		},
 	}
 
 	/// Mapping from an asset id to asset type.
@@ -442,7 +447,7 @@ pub mod pallet {
 			// Insert
 			SupportedFeePaymentAssets::<T>::put(supported_assets);
 
-			Self::deposit_event(Event::AssetRemoved {
+			Self::deposit_event(Event::AssetDestroyed {
 				asset_id,
 				asset_type,
 			});

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -49,7 +49,7 @@ pub mod weights;
 pub mod pallet {
 
 	use crate::weights::WeightInfo;
-	use frame_support::{pallet_prelude::*, weights::DispatchInfo, PalletId};
+	use frame_support::{pallet_prelude::*, PalletId};
 	use frame_system::pallet_prelude::*;
 	use parity_scale_codec::HasCompact;
 	use sp_runtime::traits::{AccountIdConversion, AtLeast32BitUnsigned};
@@ -74,16 +74,13 @@ pub mod pallet {
 		) -> DispatchResult;
 
 		// How to destroy an asset
-		fn destroy_asset(
-			asset: T::AssetId,
-			witness: T::AssetDestroyWitness,
-		) -> DispatchResultWithPostInfo;
+		fn destroy_asset(asset: T::AssetId, witness: T::AssetDestroyWitness) -> DispatchResult;
 
 		// Get destroy asset dispatch info
-		fn destroy_asset_dispatch_info(
+		fn destroy_asset_dispatch_info_weight(
 			asset: T::AssetId,
 			witness: T::AssetDestroyWitness,
-		) -> DispatchInfo;
+		) -> Weight;
 	}
 
 	// We implement this trait to be able to get the AssetType and units per second registered
@@ -404,9 +401,9 @@ pub mod pallet {
 
 		/// Destroy a given assetId
 		#[pallet::weight({
-			let dispatch_info = T::AssetRegistrar::destroy_asset_dispatch_info(*asset_id, destroy_asset_witness.clone());
+			let dispatch_info_weight = T::AssetRegistrar::destroy_asset_dispatch_info_weight(*asset_id, destroy_asset_witness.clone());
 			T::WeightInfo::remove_supported_asset(*num_assets_weight_hint)
-			.saturating_add(dispatch_info.weight)
+			.saturating_add(dispatch_info_weight)
 		})]
 		pub fn destroy_asset(
 			origin: OriginFor<T>,

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -406,7 +406,9 @@ pub mod pallet {
 
 		/// Destroy a given assetId
 		#[pallet::weight({
-			let dispatch_info_weight = T::AssetRegistrar::destroy_asset_dispatch_info_weight(*asset_id, destroy_asset_witness.clone());
+			let dispatch_info_weight = T::AssetRegistrar::destroy_asset_dispatch_info_weight(
+				*asset_id, destroy_asset_witness.clone()
+			);
 			T::WeightInfo::remove_supported_asset(*num_assets_weight_hint)
 			.saturating_add(dispatch_info_weight)
 		})]

--- a/pallets/asset-manager/src/mock.rs
+++ b/pallets/asset-manager/src/mock.rs
@@ -18,7 +18,9 @@ use super::*;
 use crate as pallet_asset_manager;
 use parity_scale_codec::{Decode, Encode};
 
-use frame_support::{construct_runtime, parameter_types, traits::Everything, RuntimeDebug};
+use frame_support::{
+	construct_runtime, parameter_types, traits::Everything, weights::Weight, RuntimeDebug,
+};
 use frame_system::EnsureRoot;
 use scale_info::TypeInfo;
 use sp_core::H256;
@@ -157,6 +159,14 @@ impl AssetRegistrar<Test> for MockAssetPalletRegistrar {
 	) -> Result<(), DispatchError> {
 		Ok(())
 	}
+
+	fn destroy_asset(_asset: u32, _witness: u32) -> Result<(), DispatchError> {
+		Ok(())
+	}
+
+	fn destroy_asset_dispatch_info_weight(_asset: u32, _witness: u32) -> Weight {
+		0
+	}
 }
 
 impl Config for Test {
@@ -167,6 +177,7 @@ impl Config for Test {
 	type AssetType = MockAssetType;
 	type AssetRegistrar = MockAssetPalletRegistrar;
 	type AssetModifierOrigin = EnsureRoot<u64>;
+	type AssetDestroyWitness = u32;
 	type WeightInfo = ();
 }
 

--- a/pallets/asset-manager/src/tests.rs
+++ b/pallets/asset-manager/src/tests.rs
@@ -730,3 +730,37 @@ fn test_removing_without_asset_units_per_second_does_not_panic() {
 		])
 	});
 }
+
+#[test]
+fn test_destroy_asset_also_removes_everything() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(AssetManager::register_asset(
+			Origin::root(),
+			MockAssetType::MockAsset(1),
+			0u32.into(),
+			1u32.into(),
+			true
+		));
+
+		assert_ok!(AssetManager::destroy_asset(Origin::root(), 1, 0, 1));
+
+		// Mappings are deleted
+		assert!(AssetManager::asset_type_id(MockAssetType::MockAsset(1)).is_none());
+		assert!(AssetManager::asset_id_type(1).is_none());
+
+		// Units per second removed
+		assert!(AssetManager::asset_type_units_per_second(MockAssetType::MockAsset(1)).is_none());
+
+		expect_events(vec![
+			crate::Event::AssetRegistered {
+				asset_id: 1,
+				asset: MockAssetType::MockAsset(1),
+				metadata: 0,
+			},
+			crate::Event::AssetDestroyed {
+				asset_id: 1,
+				asset_type: MockAssetType::MockAsset(1),
+			},
+		])
+	});
+}

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -43,7 +43,7 @@ use frame_support::{
 	},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_PER_SECOND},
-		DispatchClass, DispatchInfo, GetDispatchInfo, IdentityFee, Weight, WeightToFeeCoefficient,
+		DispatchClass, GetDispatchInfo, IdentityFee, Weight, WeightToFeeCoefficient,
 		WeightToFeeCoefficients, WeightToFeePolynomial,
 	},
 	PalletId,
@@ -1030,10 +1030,7 @@ impl pallet_assets::Config for Runtime {
 // We instruct how to register the Assets
 // In this case, we tell it to Create an Asset in pallet-assets
 pub struct AssetRegistrar;
-use frame_support::{
-	pallet_prelude::{DispatchResult, DispatchResultWithPostInfo},
-	transactional,
-};
+use frame_support::{pallet_prelude::DispatchResult, transactional};
 
 impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	#[transactional]
@@ -1071,30 +1068,31 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		)
 	}
 
+	#[transactional]
 	fn destroy_asset(
 		asset: AssetId,
 		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchResultWithPostInfo {
-		Assets::destroy(Origin::root(), asset, asset_destroy_witness)
+	) -> DispatchResult {
+		// First destroy the asset
+		Assets::destroy(Origin::root(), asset, asset_destroy_witness).map_err(|info| info.error)?;
 
-		// TODO uncomment when we feel comfortable
-		/*
-		// Shall we indeed remove it here?
-		let precompile_address = Runtime::asset_id_to_account(asset);
-		pallet_evm::AccountCodes::<Runtime>::remove(
-			precompile_address,
-		);*/
+		// We remove the EVM revert code
+		let precompile_address: H160 = Runtime::asset_id_to_account(asset).into();
+		pallet_evm::AccountCodes::<Runtime>::remove(precompile_address);
+		Ok(())
 	}
 
-	fn destroy_asset_dispatch_info(
+	fn destroy_asset_dispatch_info_weight(
 		asset: AssetId,
 		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchInfo {
+	) -> Weight {
 		let call = Call::Assets(pallet_assets::Call::<Runtime>::destroy {
 			id: asset,
 			witness: asset_destroy_witness,
 		});
 		call.get_dispatch_info()
+			.weight
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 }
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -43,7 +43,7 @@ use frame_support::{
 	},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_PER_SECOND},
-		DispatchClass, GetDispatchInfo, IdentityFee, Weight, WeightToFeeCoefficient,
+		DispatchClass, DispatchInfo, GetDispatchInfo, IdentityFee, Weight, WeightToFeeCoefficient,
 		WeightToFeeCoefficients, WeightToFeePolynomial,
 	},
 	PalletId,
@@ -1030,7 +1030,10 @@ impl pallet_assets::Config for Runtime {
 // We instruct how to register the Assets
 // In this case, we tell it to Create an Asset in pallet-assets
 pub struct AssetRegistrar;
-use frame_support::{pallet_prelude::DispatchResult, transactional};
+use frame_support::{
+	pallet_prelude::{DispatchResult, DispatchResultWithPostInfo},
+	transactional,
+};
 
 impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	#[transactional]
@@ -1067,6 +1070,32 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 			metadata.is_frozen,
 		)
 	}
+
+	fn destroy_asset(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> DispatchResultWithPostInfo {
+		Assets::destroy(Origin::root(), asset, asset_destroy_witness)
+
+		// TODO uncomment when we feel comfortable
+		/*
+		// Shall we indeed remove it here?
+		let precompile_address = Runtime::asset_id_to_account(asset);
+		pallet_evm::AccountCodes::<Runtime>::remove(
+			precompile_address,
+		);*/
+	}
+
+	fn destroy_asset_dispatch_info(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> DispatchInfo {
+		let call = Call::Assets(pallet_assets::Call::<Runtime>::destroy {
+			id: asset,
+			witness: asset_destroy_witness,
+		});
+		call.get_dispatch_info()
+	}
 }
 
 #[derive(Clone, Default, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -1085,6 +1114,7 @@ impl pallet_asset_manager::Config for Runtime {
 	type AssetType = xcm_config::AssetType;
 	type AssetRegistrar = AssetRegistrar;
 	type AssetModifierOrigin = EnsureRoot<AccountId>;
+	type AssetDestroyWitness = pallet_assets::DestroyWitness;
 	type WeightInfo = pallet_asset_manager::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -19,7 +19,7 @@
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Get, Nothing, PalletInfoAccess},
-	weights::Weight,
+	weights::{Weight, GetDispatchInfo},
 	PalletId,
 };
 
@@ -706,6 +706,27 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 			false,
 		)
 	}
+	fn destroy_asset(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> DispatchResult {
+		// First destroy the asset
+		Assets::destroy(Origin::root(), asset, asset_destroy_witness).map_err(|info| info.error)?;
+
+		Ok(())
+	}
+
+	fn destroy_asset_dispatch_info_weight(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> Weight {
+		let call = Call::Assets(pallet_assets::Call::<Runtime>::destroy {
+			id: asset,
+			witness: asset_destroy_witness,
+		});
+		call.get_dispatch_info()
+			.weight
+	}
 }
 
 #[derive(Clone, Default, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -723,6 +744,7 @@ impl pallet_asset_manager::Config for Runtime {
 	type AssetType = AssetType;
 	type AssetRegistrar = AssetRegistrar;
 	type AssetModifierOrigin = EnsureRoot<AccountId>;
+	type AssetDestroyWitness = pallet_assets::DestroyWitness;
 	type WeightInfo = ();
 }
 
@@ -843,7 +865,7 @@ construct_runtime!(
 		XcmVersioner: mock_version_changer::{Pallet, Storage, Event<T>},
 
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
-		Assets: pallet_assets::{Pallet, Storage, Event<T>},
+		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>},
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin},
 		XTokens: orml_xtokens::{Pallet, Call, Storage, Event<T>},
 		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>},

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -19,7 +19,7 @@
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Get, Nothing, PalletInfoAccess},
-	weights::{Weight, GetDispatchInfo},
+	weights::{GetDispatchInfo, Weight},
 	PalletId,
 };
 
@@ -724,8 +724,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 			id: asset,
 			witness: asset_destroy_witness,
 		});
-		call.get_dispatch_info()
-			.weight
+		call.get_dispatch_info().weight
 	}
 }
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -39,7 +39,7 @@ use frame_support::{
 	},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_PER_SECOND},
-		DispatchClass, GetDispatchInfo, IdentityFee, Weight,
+		DispatchClass, DispatchInfo, GetDispatchInfo, IdentityFee, Weight,
 	},
 	PalletId,
 };
@@ -953,7 +953,10 @@ impl pallet_assets::Config for Runtime {
 // We instruct how to register the Assets
 // In this case, we tell it to Create an Asset in pallet-assets
 pub struct AssetRegistrar;
-use frame_support::{pallet_prelude::DispatchResult, transactional};
+use frame_support::{
+	pallet_prelude::{DispatchResult, DispatchResultWithPostInfo},
+	transactional,
+};
 
 impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	#[transactional]
@@ -990,6 +993,32 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 			metadata.is_frozen,
 		)
 	}
+
+	fn destroy_asset(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> DispatchResultWithPostInfo {
+		Assets::destroy(Origin::root(), asset, asset_destroy_witness)
+
+		// TODO uncomment when we feel comfortable
+		/*
+		// Shall we indeed remove it here?
+		let precompile_address = Runtime::asset_id_to_account(asset);
+		pallet_evm::AccountCodes::<Runtime>::remove(
+			precompile_address,
+		);*/
+	}
+
+	fn destroy_asset_dispatch_info(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> DispatchInfo {
+		let call = Call::Assets(pallet_assets::Call::<Runtime>::destroy {
+			id: asset,
+			witness: asset_destroy_witness,
+		});
+		call.get_dispatch_info()
+	}
 }
 
 #[derive(Clone, Default, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -1008,6 +1037,7 @@ impl pallet_asset_manager::Config for Runtime {
 	type AssetType = xcm_config::AssetType;
 	type AssetRegistrar = AssetRegistrar;
 	type AssetModifierOrigin = EnsureRoot<AccountId>;
+	type AssetDestroyWitness = pallet_assets::DestroyWitness;
 	type WeightInfo = pallet_asset_manager::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -19,7 +19,7 @@
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Get, Nothing, PalletInfoAccess},
-	weights::{Weight, GetDispatchInfo},
+	weights::{GetDispatchInfo, Weight},
 	PalletId,
 };
 
@@ -668,8 +668,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 			id: asset,
 			witness: asset_destroy_witness,
 		});
-		call.get_dispatch_info()
-			.weight
+		call.get_dispatch_info().weight
 	}
 }
 

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -19,7 +19,7 @@
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Get, Nothing, PalletInfoAccess},
-	weights::Weight,
+	weights::{Weight, GetDispatchInfo},
 	PalletId,
 };
 
@@ -650,6 +650,27 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 			false,
 		)
 	}
+	fn destroy_asset(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> DispatchResult {
+		// First destroy the asset
+		Assets::destroy(Origin::root(), asset, asset_destroy_witness).map_err(|info| info.error)?;
+
+		Ok(())
+	}
+
+	fn destroy_asset_dispatch_info_weight(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> Weight {
+		let call = Call::Assets(pallet_assets::Call::<Runtime>::destroy {
+			id: asset,
+			witness: asset_destroy_witness,
+		});
+		call.get_dispatch_info()
+			.weight
+	}
 }
 
 #[derive(Clone, Default, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -667,6 +688,7 @@ impl pallet_asset_manager::Config for Runtime {
 	type AssetType = AssetType;
 	type AssetRegistrar = AssetRegistrar;
 	type AssetModifierOrigin = EnsureRoot<AccountId>;
+	type AssetDestroyWitness = pallet_assets::DestroyWitness;
 	type WeightInfo = ();
 }
 
@@ -787,7 +809,7 @@ construct_runtime!(
 		XcmVersioner: mock_version_changer::{Pallet, Storage, Event<T>},
 
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
-		Assets: pallet_assets::{Pallet, Storage, Event<T>},
+		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>},
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin},
 		XTokens: orml_xtokens::{Pallet, Call, Storage, Event<T>},
 		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>},

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -39,7 +39,7 @@ use frame_support::{
 	},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_PER_SECOND},
-		DispatchClass, GetDispatchInfo, IdentityFee, Weight, WeightToFeeCoefficient,
+		DispatchClass, DispatchInfo, GetDispatchInfo, IdentityFee, Weight, WeightToFeeCoefficient,
 		WeightToFeeCoefficients, WeightToFeePolynomial,
 	},
 	PalletId,
@@ -983,7 +983,10 @@ impl pallet_assets::Config for Runtime {
 // We instruct how to register the Assets
 // In this case, we tell it to Create an Asset in pallet-assets
 pub struct AssetRegistrar;
-use frame_support::{pallet_prelude::DispatchResult, transactional};
+use frame_support::{
+	pallet_prelude::{DispatchResult, DispatchResultWithPostInfo},
+	transactional,
+};
 
 impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	#[transactional]
@@ -1020,6 +1023,32 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 			metadata.is_frozen,
 		)
 	}
+
+	fn destroy_asset(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> DispatchResultWithPostInfo {
+		Assets::destroy(Origin::root(), asset, asset_destroy_witness)
+
+		// TODO uncomment when we feel comfortable
+		/*
+		// Shall we indeed remove it here?
+		let precompile_address = Runtime::asset_id_to_account(asset);
+		pallet_evm::AccountCodes::<Runtime>::remove(
+			precompile_address,
+		);*/
+	}
+
+	fn destroy_asset_dispatch_info(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> DispatchInfo {
+		let call = Call::Assets(pallet_assets::Call::<Runtime>::destroy {
+			id: asset,
+			witness: asset_destroy_witness,
+		});
+		call.get_dispatch_info()
+	}
 }
 
 #[derive(Clone, Default, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -1038,6 +1067,7 @@ impl pallet_asset_manager::Config for Runtime {
 	type AssetType = xcm_config::AssetType;
 	type AssetRegistrar = AssetRegistrar;
 	type AssetModifierOrigin = EnsureRoot<AccountId>;
+	type AssetDestroyWitness = pallet_assets::DestroyWitness;
 	type WeightInfo = pallet_asset_manager::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -39,7 +39,7 @@ use frame_support::{
 	},
 	weights::{
 		constants::{RocksDbWeight, WEIGHT_PER_SECOND},
-		DispatchClass, DispatchInfo, GetDispatchInfo, IdentityFee, Weight, WeightToFeeCoefficient,
+		DispatchClass, GetDispatchInfo, IdentityFee, Weight, WeightToFeeCoefficient,
 		WeightToFeeCoefficients, WeightToFeePolynomial,
 	},
 	PalletId,
@@ -983,10 +983,7 @@ impl pallet_assets::Config for Runtime {
 // We instruct how to register the Assets
 // In this case, we tell it to Create an Asset in pallet-assets
 pub struct AssetRegistrar;
-use frame_support::{
-	pallet_prelude::{DispatchResult, DispatchResultWithPostInfo},
-	transactional,
-};
+use frame_support::{pallet_prelude::DispatchResult, transactional};
 
 impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	#[transactional]
@@ -1024,30 +1021,31 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		)
 	}
 
+	#[transactional]
 	fn destroy_asset(
 		asset: AssetId,
 		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchResultWithPostInfo {
-		Assets::destroy(Origin::root(), asset, asset_destroy_witness)
+	) -> DispatchResult {
+		// First destroy the asset
+		Assets::destroy(Origin::root(), asset, asset_destroy_witness).map_err(|info| info.error)?;
 
-		// TODO uncomment when we feel comfortable
-		/*
-		// Shall we indeed remove it here?
-		let precompile_address = Runtime::asset_id_to_account(asset);
-		pallet_evm::AccountCodes::<Runtime>::remove(
-			precompile_address,
-		);*/
+		// We remove the EVM revert code
+		let precompile_address: H160 = Runtime::asset_id_to_account(asset).into();
+		pallet_evm::AccountCodes::<Runtime>::remove(precompile_address);
+		Ok(())
 	}
 
-	fn destroy_asset_dispatch_info(
+	fn destroy_asset_dispatch_info_weight(
 		asset: AssetId,
 		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchInfo {
+	) -> Weight {
 		let call = Call::Assets(pallet_assets::Call::<Runtime>::destroy {
 			id: asset,
 			witness: asset_destroy_witness,
 		});
 		call.get_dispatch_info()
+			.weight
+			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
 	}
 }
 

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -19,7 +19,7 @@
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Get, Nothing, PalletInfo as PalletInfoTrait, PalletInfoAccess},
-	weights::{Weight, GetDispatchInfo},
+	weights::{GetDispatchInfo, Weight},
 	PalletId,
 };
 
@@ -727,8 +727,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 			id: asset,
 			witness: asset_destroy_witness,
 		});
-		call.get_dispatch_info()
-			.weight
+		call.get_dispatch_info().weight
 	}
 }
 

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -19,7 +19,7 @@
 use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{Everything, Get, Nothing, PalletInfo as PalletInfoTrait, PalletInfoAccess},
-	weights::Weight,
+	weights::{Weight, GetDispatchInfo},
 	PalletId,
 };
 
@@ -709,6 +709,27 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 			false,
 		)
 	}
+	fn destroy_asset(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> DispatchResult {
+		// First destroy the asset
+		Assets::destroy(Origin::root(), asset, asset_destroy_witness).map_err(|info| info.error)?;
+
+		Ok(())
+	}
+
+	fn destroy_asset_dispatch_info_weight(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> Weight {
+		let call = Call::Assets(pallet_assets::Call::<Runtime>::destroy {
+			id: asset,
+			witness: asset_destroy_witness,
+		});
+		call.get_dispatch_info()
+			.weight
+	}
 }
 
 #[derive(Clone, Default, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -726,6 +747,7 @@ impl pallet_asset_manager::Config for Runtime {
 	type AssetType = AssetType;
 	type AssetRegistrar = AssetRegistrar;
 	type AssetModifierOrigin = EnsureRoot<AccountId>;
+	type AssetDestroyWitness = pallet_assets::DestroyWitness;
 	type WeightInfo = ();
 }
 
@@ -846,7 +868,7 @@ construct_runtime!(
 		XcmVersioner: mock_version_changer::{Pallet, Storage, Event<T>},
 
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
-		Assets: pallet_assets::{Pallet, Storage, Event<T>},
+		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>},
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin},
 		XTokens: orml_xtokens::{Pallet, Call, Storage, Event<T>},
 		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>},

--- a/tests/tests/test-asset-manager.ts
+++ b/tests/tests/test-asset-manager.ts
@@ -258,7 +258,7 @@ describeDevMoonbeam("XCM - asset manager - register asset", (context) => {
     const assetDestroyWitness = context.polkadotApi.createType("PalletAssetsDestroyWitness", {
       accounts: 0,
       sufficients: 0,
-      approvals: 0
+      approvals: 0,
     });
 
     // ChangeAssetType
@@ -271,8 +271,7 @@ describeDevMoonbeam("XCM - asset manager - register asset", (context) => {
     );
 
     // assetId
-    let id = 
-      (await context.polkadotApi.query.assetManager.assetTypeId(sourceLocation)) as any;
+    let id = (await context.polkadotApi.query.assetManager.assetTypeId(sourceLocation)) as any;
 
     // asset units per second removed
     let assetUnitsPerSecond = (await context.polkadotApi.query.assetManager.assetTypeUnitsPerSecond(
@@ -284,8 +283,7 @@ describeDevMoonbeam("XCM - asset manager - register asset", (context) => {
       (await context.polkadotApi.query.assetManager.supportedFeePaymentAssets()) as any;
 
     // assetDetails should have dissapeared
-    let assetDetails =
-        (await context.polkadotApi.query.assets.asset(assetId)) as any;
+    let assetDetails = (await context.polkadotApi.query.assets.asset(assetId)) as any;
 
     expect(assetUnitsPerSecond.isNone).to.eq(true);
     expect(id.isNone).to.eq(true);

--- a/tests/tests/test-asset-manager.ts
+++ b/tests/tests/test-asset-manager.ts
@@ -283,8 +283,13 @@ describeDevMoonbeam("XCM - asset manager - register asset", (context) => {
     let supportedAssets =
       (await context.polkadotApi.query.assetManager.supportedFeePaymentAssets()) as any;
 
+    // assetDetails should have dissapeared
+    let assetDetails =
+        (await context.polkadotApi.query.assets.asset(assetId)) as any;
+
     expect(assetUnitsPerSecond.isNone).to.eq(true);
     expect(id.isNone).to.eq(true);
+    expect(assetDetails.isNone).to.eq(true);
     // the asset should not be supported
     expect(supportedAssets.length).to.eq(0);
   });


### PR DESCRIPTION
### What does it do?
It adds the possibility to destroy an asset in the asset-manager by cleaning up everything realted to it, which for now its:
- All elements associated with an assetID in pallet-asset-manager
- All elements associated with an assetId in pallet-assets
- EVM revert code erasure for precompile address

### What important points reviewers should know?
This would have been hard to benchmark as it involves benchmarking another pallet like pallet-assets, which has some private struct fields that I dont have access to from outside the crate. Instead what I did is gather the weight information of the `destroy` extrinsic in pallet-assets and pass it through a trait when you call it through pallet-asset-manager
### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
