### PR TITLE
eth blocks cache: add prometheus metrics & replace blocks size by bytes size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5817,7 +5817,7 @@ dependencies = [
  "pallet-transaction-payment-rpc-runtime-api",
  "parachain-staking",
  "parity-scale-codec",
- "parking_lot 0.9.0",
+ "parking_lot 0.12.0",
  "polkadot-cli",
  "polkadot-parachain",
  "polkadot-primitives",
@@ -6154,7 +6154,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.17#7dcc2821b860722b524819dc558837016da66c70"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.17#8c7008666d0407b4536c7cf21c835e9ecc426774"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -6165,7 +6165,7 @@ dependencies = [
  "log",
  "nimbus-primitives",
  "parity-scale-codec",
- "parking_lot 0.9.0",
+ "parking_lot 0.12.0",
  "polkadot-client",
  "sc-client-api",
  "sc-consensus",
@@ -6186,7 +6186,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.17#7dcc2821b860722b524819dc558837016da66c70"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.17#8c7008666d0407b4536c7cf21c835e9ecc426774"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -6566,7 +6566,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.17#7dcc2821b860722b524819dc558837016da66c70"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.17#8c7008666d0407b4536c7cf21c835e9ecc426774"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6631,7 +6631,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.17#7dcc2821b860722b524819dc558837016da66c70"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.17#8c7008666d0407b4536c7cf21c835e9ecc426774"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7926,17 +7926,6 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.6.2",
- "rustc_version 0.2.3",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
@@ -7974,21 +7963,6 @@ checksum = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 dependencies = [
  "libc",
  "rand 0.6.5",
- "rustc_version 0.2.3",
- "smallvec 0.6.14",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
  "rustc_version 0.2.3",
  "smallvec 0.6.14",
  "winapi 0.3.9",
@@ -13289,7 +13263,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.7.1",
+ "parking_lot 0.10.2",
  "regex",
  "serde",
  "serde_json",
@@ -13436,7 +13410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.6.5",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "async-trait",
  "fc-db",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "fp-storage",
  "kvdb-rocksdb",
@@ -2508,7 +2508,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "fc-db",
  "fp-consensus",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2544,6 +2544,7 @@ dependencies = [
  "lru 0.6.6",
  "pallet-ethereum",
  "parity-scale-codec",
+ "prometheus",
  "rand 0.8.5",
  "rlp",
  "sc-client-api",
@@ -2559,13 +2560,14 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-storage",
+ "substrate-prometheus-endpoint 0.10.0-dev (git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.17)",
  "tokio",
 ]
 
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2685,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2697,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "evm",
  "parity-scale-codec",
@@ -2709,7 +2711,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2726,7 +2728,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -2742,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -6732,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6989,7 +6991,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -7029,7 +7031,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "evm",
  "fp-evm",
@@ -7107,7 +7109,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "fp-evm",
 ]
@@ -7115,7 +7117,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7125,7 +7127,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7135,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "fp-evm",
  "num",
@@ -7144,7 +7146,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -7153,7 +7155,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#e37f7d97b55bfa22aa055a4d348baeeadb35e348"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.17#2832fe84a0b90e228ec1c2404eb979ed9dbbf090"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -13287,7 +13289,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.11.2",
+ "parking_lot 0.7.1",
  "regex",
  "serde",
  "serde_json",
@@ -13434,7 +13436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
  "cfg-if 1.0.0",
- "rand 0.8.5",
+ "rand 0.6.5",
  "static_assertions",
 ]
 

--- a/node/perf-test/src/command.rs
+++ b/node/perf-test/src/command.rs
@@ -203,11 +203,12 @@ where
 
 		let command_sink_for_deps = Some(command_sink.clone());
 
-		let block_data_cache = Arc::new(fc_rpc::EthBlockDataCache::new(
+		let block_data_cache = Arc::new(fc_rpc::EthBlockDataCacheTask::new(
 			task_manager.spawn_handle(),
 			overrides.clone(),
 			3000,
 			3000,
+			prometheus_registry,
 		));
 
 		let rpc_extensions_builder = {

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -20,7 +20,7 @@ jsonrpc-pubsub = "18.0.0"
 libsecp256k1 = { version = "0.6", features = [ "hmac" ] }
 log = "0.4"
 maplit = "1.0.2"
-parking_lot = "0.9.0"
+parking_lot = "0.12.0"
 serde = { version = "1.0.101", features = [ "derive" ] }
 serde_json = "1.0"
 sha3 = { version = "0.9", default-features = false }

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -541,11 +541,12 @@ where
 			}
 		};
 
-	let block_data_cache = Arc::new(fc_rpc::EthBlockDataCache::new(
+	let block_data_cache = Arc::new(fc_rpc::EthBlockDataCacheTask::new(
 		task_manager.spawn_handle(),
 		overrides.clone(),
-		rpc_config.eth_log_block_cache,
-		rpc_config.eth_log_block_cache,
+		rpc_config.eth_log_block_cache as u64,
+		rpc_config.eth_log_block_cache as u64,
+		prometheus_registry.clone(),
 	));
 
 	let rpc_extensions_builder = {
@@ -949,11 +950,12 @@ where
 			}
 		};
 
-	let block_data_cache = Arc::new(fc_rpc::EthBlockDataCache::new(
+	let block_data_cache = Arc::new(fc_rpc::EthBlockDataCacheTask::new(
 		task_manager.spawn_handle(),
 		overrides.clone(),
-		rpc_config.eth_log_block_cache,
-		rpc_config.eth_log_block_cache,
+		rpc_config.eth_log_block_cache as u64,
+		rpc_config.eth_log_block_cache as u64,
+		prometheus_registry,
 	));
 
 	let rpc_extensions_builder = {

--- a/node/service/src/rpc.rs
+++ b/node/service/src/rpc.rs
@@ -28,7 +28,7 @@ use cli_opt::EthApi as EthApiCmd;
 use cumulus_primitives_core::ParaId;
 use fc_mapping_sync::{MappingSyncWorker, SyncStrategy};
 use fc_rpc::{
-	EthApi, EthApiServer, EthBlockDataCache, EthFilterApi, EthFilterApiServer, EthPubSubApi,
+	EthApi, EthApiServer, EthBlockDataCacheTask, EthFilterApi, EthFilterApiServer, EthPubSubApi,
 	EthPubSubApiServer, EthTask, HexEncodedIdProvider, NetApi, NetApiServer, OverrideHandle,
 	RuntimeApiStorageOverride, SchemaV1Override, SchemaV2Override, SchemaV3Override,
 	StorageOverride, Web3Api, Web3ApiServer,
@@ -98,7 +98,7 @@ pub struct FullDeps<C, P, A: ChainApi, BE> {
 	/// Ethereum data access overrides.
 	pub overrides: Arc<OverrideHandle<Block>>,
 	/// Cache for Ethereum block data.
-	pub block_data_cache: Arc<EthBlockDataCache<Block>>,
+	pub block_data_cache: Arc<EthBlockDataCacheTask<Block>>,
 }
 
 pub fn overrides_handle<C, BE>(client: Arc<C>) -> Arc<OverrideHandle<Block>>


### PR DESCRIPTION
### What does it do?

It's a moonbeam companion for this PR: https://github.com/PureStake/frontier/pull/53

Add 6 prometheus metrics: 

- `frontier_eth_blocks_cache_size`: size of the blocks cache in bytes
- `frontier_eth_blocks_cache_hits`: hits of the blocks cache since the node starting
- `frontier_eth_blocks_cache_miss`: miss of the blocks cache since the node starting
- `frontier_eth_statuses_cache_size`: size of the statuses cache in bytes
- `frontier_eth_statuses_cache_hits`: hits of the statuses cache since the node starting
- `frontier_eth_statuses_cache_miss`: miss of the blocks statuses since the node starting

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
