### PR TITLE
Create a new cli option for statuses cache size & adapt default size to the new unit (bytes instead of blocks)

### DIFF
--- a/node/cli-opt/src/lib.rs
+++ b/node/cli-opt/src/lib.rs
@@ -75,6 +75,7 @@ pub struct RpcConfig {
 	pub ethapi_trace_max_count: u32,
 	pub ethapi_trace_cache_duration: u64,
 	pub eth_log_block_cache: usize,
+	pub eth_statuses_cache: usize,
 	pub max_past_logs: u32,
 	pub fee_history_limit: u64,
 }

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -176,9 +176,13 @@ pub struct RunCmd {
 	#[clap(long, default_value = "300")]
 	pub ethapi_trace_cache_duration: u64,
 
-	/// Size of the LRU cache for block data and their transaction statuses.
-	#[clap(long, default_value = "3000")]
+	/// Size in bytes of the LRU cache for block data.
+	#[clap(long, default_value = "300000000")]
 	pub eth_log_block_cache: usize,
+
+	/// Size in bytes of the LRU cache for transactions statuses data.
+	#[clap(long, default_value = "300000000")]
+	pub eth_statuses_cache: usize,
 
 	/// Maximum number of logs in a query.
 	#[clap(long, default_value = "10000")]

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -596,6 +596,7 @@ pub fn run() -> Result<()> {
 					ethapi_trace_max_count: cli.run.ethapi_trace_max_count,
 					ethapi_trace_cache_duration: cli.run.ethapi_trace_cache_duration,
 					eth_log_block_cache: cli.run.eth_log_block_cache,
+					eth_statuses_cache: cli.run.eth_statuses_cache,
 					max_past_logs: cli.run.max_past_logs,
 					fee_history_limit: cli.run.fee_history_limit,
 				};

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -545,7 +545,7 @@ where
 		task_manager.spawn_handle(),
 		overrides.clone(),
 		rpc_config.eth_log_block_cache as u64,
-		rpc_config.eth_log_block_cache as u64,
+		rpc_config.eth_statuses_cache as u64,
 		prometheus_registry.clone(),
 	));
 
@@ -954,7 +954,7 @@ where
 		task_manager.spawn_handle(),
 		overrides.clone(),
 		rpc_config.eth_log_block_cache as u64,
-		rpc_config.eth_log_block_cache as u64,
+		rpc_config.eth_statuses_cache as u64,
 		prometheus_registry,
 	));
 


### PR DESCRIPTION
### What does it do?

Create a new cli option `--eth-statuses-cache` for statuses cache size & adapt default size to the new unit (bytes instead of blocks)

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
