### PR TITLE
Make AuthorMapping instantiable

### DIFF
--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -293,6 +293,7 @@ pub fn testnet_genesis(
 				.cloned()
 				.map(|(account_id, author_id, _)| (author_id, account_id))
 				.collect(),
+			phantom: Default::default(),
 		},
 		proxy_genesis_companion: Default::default(),
 		treasury: Default::default(),

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -278,6 +278,7 @@ pub fn testnet_genesis(
 				.cloned()
 				.map(|(account_id, author_id, _)| (author_id, account_id))
 				.collect(),
+			phantom: Default::default(),
 		},
 		proxy_genesis_companion: Default::default(),
 		treasury: Default::default(),

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -280,6 +280,7 @@ pub fn testnet_genesis(
 				.cloned()
 				.map(|(account_id, author_id, _)| (author_id, account_id))
 				.collect(),
+			phantom: Default::default(),
 		},
 		proxy_genesis_companion: Default::default(),
 		treasury: Default::default(),

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -14,12 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Maps Author Ids as used in nimbus consensus layer to account ids as used i nthe runtime.
+//! Maps Author Ids as used in nimbus consensus layer to account ids as used in the runtime.
 //! This should likely be moved to nimbus eventually.
 //!
 //! This pallet maps NimbusId => AccountId which is most useful when using propositional style
 //! queries. This mapping will likely need to go the other way if using exhaustive authority sets.
-//! That could either be a seperate pallet, or this pallet could implement a two-way mapping. But
+//! That could either be a separate pallet, or this pallet could implement a two-way mapping. But
 //! for now it it one-way
 
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -61,9 +61,7 @@ pub mod pallet {
 	#[pallet::without_storage_info]
 	pub struct Pallet<T, I = ()>(PhantomData<(T, I)>);
 
-	/// Configuration trait of this pallet. We tightly couple to Parachain Staking in order to
-	/// ensure that only staked accounts can create registrations in the first place. This could be
-	/// generalized.
+	/// Configuration trait of this pallet.
 	#[pallet::config]
 	pub trait Config<I: 'static = ()>: frame_system::Config {
 		/// Overarching event type

--- a/pallets/author-mapping/src/mock.rs
+++ b/pallets/author-mapping/src/mock.rs
@@ -176,6 +176,7 @@ impl ExtBuilder {
 
 		pallet_author_mapping::GenesisConfig::<Runtime> {
 			mappings: self.mappings,
+			phantom: Default::default(),
 		}
 		.assimilate_storage(&mut t)
 		.expect("Pallet author mapping's storage can be assimilated");

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -175,26 +175,26 @@ impl<T: ParachainStakingConfig> Migration for ParachainStakingPurgeStaleStorage<
 }
 
 /// A moonbeam migration wrapping the similarly named migration in pallet-author-mapping
-pub struct AuthorMappingTwoXToBlake<T>(PhantomData<T>);
-impl<T: AuthorMappingConfig> Migration for AuthorMappingTwoXToBlake<T> {
+pub struct AuthorMappingTwoXToBlake<T, I: 'static>(PhantomData<(T, I)>);
+impl<T: AuthorMappingConfig, I: 'static> Migration for AuthorMappingTwoXToBlake<T, I> {
 	fn friendly_name(&self) -> &str {
 		"MM_Author_Mapping_TwoXToBlake"
 	}
 
 	fn migrate(&self, _available_weight: Weight) -> Weight {
-		TwoXToBlake::<T>::on_runtime_upgrade()
+		TwoXToBlake::<T, I>::on_runtime_upgrade()
 	}
 
 	/// Run a standard pre-runtime test. This works the same way as in a normal runtime upgrade.
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade(&self) -> Result<(), &'static str> {
-		TwoXToBlake::<T>::pre_upgrade()
+		TwoXToBlake::<T, I>::pre_upgrade()
 	}
 
 	/// Run a standard post-runtime test. This works the same way as in a normal runtime upgrade.
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(&self) -> Result<(), &'static str> {
-		TwoXToBlake::<T>::post_upgrade()
+		TwoXToBlake::<T, I>::post_upgrade()
 	}
 }
 

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -176,7 +176,7 @@ impl<T: ParachainStakingConfig> Migration for ParachainStakingPurgeStaleStorage<
 
 /// A moonbeam migration wrapping the similarly named migration in pallet-author-mapping
 pub struct AuthorMappingTwoXToBlake<T, I: 'static>(PhantomData<(T, I)>);
-impl<T: AuthorMappingConfig, I: 'static> Migration for AuthorMappingTwoXToBlake<T, I> {
+impl<T: AuthorMappingConfig<I>, I: 'static> Migration for AuthorMappingTwoXToBlake<T, I> {
 	fn friendly_name(&self) -> &str {
 		"MM_Author_Mapping_TwoXToBlake"
 	}

--- a/runtime/moonbase/tests/common/mod.rs
+++ b/runtime/moonbase/tests/common/mod.rs
@@ -246,6 +246,7 @@ impl ExtBuilder {
 
 		pallet_author_mapping::GenesisConfig::<Runtime> {
 			mappings: self.mappings,
+			phantom: Default::default(),
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();

--- a/runtime/moonbeam/tests/common/mod.rs
+++ b/runtime/moonbeam/tests/common/mod.rs
@@ -246,6 +246,7 @@ impl ExtBuilder {
 
 		pallet_author_mapping::GenesisConfig::<Runtime> {
 			mappings: self.mappings,
+			phantom: Default::default(),
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();

--- a/runtime/moonriver/tests/common/mod.rs
+++ b/runtime/moonriver/tests/common/mod.rs
@@ -246,6 +246,7 @@ impl ExtBuilder {
 
 		pallet_author_mapping::GenesisConfig::<Runtime> {
 			mappings: self.mappings,
+			phantom: Default::default(),
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();


### PR DESCRIPTION
### What does it do?
Make author-mapping pallet instantiable so that a second instance can be instantiated for the per-block VRF keys #1376 

Also need
- [ ] impl Convert<AccountId, NimbusId> for the pallet, which motivates adding a storage map the other way (this is required because we need AuthorityId in the VRF pallet to make the VRF transcript which is written to storage)
- [ ] make NimbusId an associated type instead so the pallet can be used with a different key type

Also considering:
- [ ] moving DepositAmount to storage and adding root extrinsic to set it
