### PR TITLE
plumb cli option  `--relay-chain-rpc-url`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5706,6 +5706,7 @@ dependencies = [
  "sp-runtime",
  "tiny-bip39",
  "tiny-hderive",
+ "url 2.2.2",
 ]
 
 [[package]]

--- a/node/cli-opt/Cargo.toml
+++ b/node/cli-opt/Cargo.toml
@@ -13,6 +13,7 @@ primitive-types = "0.11.0"
 sha3 = "0.9"
 tiny-bip39 = "0.8"
 tiny-hderive = "0.3.0"
+url = "2.2.2"
 
 # Moonbeam
 account = { path = "../../primitives/account" }

--- a/node/cli-opt/src/lib.rs
+++ b/node/cli-opt/src/lib.rs
@@ -76,6 +76,7 @@ pub struct RpcConfig {
 	pub ethapi_trace_cache_duration: u64,
 	pub eth_log_block_cache: usize,
 	pub eth_statuses_cache: usize,
-	pub max_past_logs: u32,
 	pub fee_history_limit: u64,
+	pub max_past_logs: u32,
+	pub relay_chain_rpc_url: Option<url::Url>,
 }

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -596,8 +596,9 @@ pub fn run() -> Result<()> {
 					ethapi_trace_cache_duration: cli.run.ethapi_trace_cache_duration,
 					eth_log_block_cache: cli.run.eth_log_block_cache,
 					eth_statuses_cache: cli.run.eth_statuses_cache,
-					max_past_logs: cli.run.max_past_logs,
 					fee_history_limit: cli.run.fee_history_limit,
+					max_past_logs: cli.run.max_past_logs,
+					relay_chain_rpc_url: cli.run.base.relay_chain_rpc_url,
 				};
 
 				// If dev service was requested, start up manual or instant seal.

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -554,6 +554,10 @@ where
 		prometheus_registry.clone(),
 	));
 
+	// variable `rpc_config` will be moved in next code block, to we need to
+	// save param `relay_chain_rpc_url` to be able to use it later.
+	let relay_chain_rpc_url = rpc_config.relay_chain_rpc_url.clone();
+
 	let rpc_extensions_builder = {
 		let client = client.clone();
 		let pool = transaction_pool.clone();
@@ -662,9 +666,8 @@ where
 			relay_chain_interface,
 			relay_chain_slot_duration,
 			import_queue,
-			// TODO: plumb this through CLI properly
 			collator_options: CollatorOptions {
-				relay_chain_rpc_url: Default::default(),
+				relay_chain_rpc_url,
 			},
 		};
 


### PR DESCRIPTION
### What does it do?

Polkadot 0.9.18 introduce a new cli option `--relay-chain-rpc-url`, but before this PR our codebase didn't map this new option.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
