### PR TITLE
Add local assets to Moonbeam, without them being transferrable through xcm

### DIFF
--- a/runtime/moonbase/src/asset_config.rs
+++ b/runtime/moonbase/src/asset_config.rs
@@ -43,6 +43,7 @@ use sp_std::{
 	prelude::*,
 };
 
+// Not to disrupt the previous asset instance, we assign () to Foreign
 pub type ForeignAssetInstance = ();
 pub type LocalAssetInstance = pallet_assets::Instance1;
 

--- a/runtime/moonbase/src/asset_config.rs
+++ b/runtime/moonbase/src/asset_config.rs
@@ -43,8 +43,8 @@ use sp_std::{
 	prelude::*,
 };
 
-type ForeignAssetInstance = pallet_assets::Instance1;
-type LocalAssetInstance = pallet_assets::Instance2;
+pub type ForeignAssetInstance = ();
+pub type LocalAssetInstance = pallet_assets::Instance1;
 
 // For foreign assets, these parameters dont matter much
 // as this will only be called by root with the forced arguments

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1102,14 +1102,14 @@ construct_runtime! {
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 26,
 		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 27,
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Storage, Event<T>, Origin, Config} = 28,
-		Assets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>} = 29,
+		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 29,
 		XTokens: orml_xtokens::{Pallet, Call, Storage, Event<T>} = 30,
 		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>} = 31,
 		Migrations: pallet_migrations::{Pallet, Storage, Config, Event<T>} = 32,
 		XcmTransactor: xcm_transactor::{Pallet, Call, Storage, Event<T>} = 33,
 		ProxyGenesisCompanion: pallet_proxy_genesis_companion::{Pallet, Config<T>} = 34,
 		BaseFee: pallet_base_fee::{Pallet, Call, Storage, Config<T>, Event} = 35,
-		LocalAssets: pallet_assets::<Instance2>::{Pallet, Call, Storage, Event<T>} = 36,
+		LocalAssets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>} = 36,
 
 	}
 }

--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::asset_config::{ForeignAssetInstance, LocalAssetInstance};
 use crowdloan_rewards_precompiles::CrowdloanRewardsWrapper;
 use fp_evm::Context;
 use moonbeam_relay_encoder::westend::WestendEncoder;
@@ -103,8 +104,8 @@ where
 	Erc20BalancesPrecompile<R, NativeErc20Metadata>: Precompile,
 	// We require PrecompileSet here because indeed we are dealing with a set of precompiles
 	// This precompile set does additional checks, e.g., total supply not being 0
-	Erc20AssetsPrecompileSet<R, IsForeign, pallet_assets::Instance1>: PrecompileSet,
-	Erc20AssetsPrecompileSet<R, IsLocal, pallet_assets::Instance2>: PrecompileSet,
+	Erc20AssetsPrecompileSet<R, IsForeign, ForeignAssetInstance>: PrecompileSet,
+	Erc20AssetsPrecompileSet<R, IsLocal, LocalAssetInstance>: PrecompileSet,
 	DemocracyWrapper<R>: Precompile,
 	XtokensWrapper<R>: Precompile,
 	RelayEncoderWrapper<R, WestendEncoder>: Precompile,
@@ -170,12 +171,12 @@ where
 			)),
 			// If the address matches asset prefix, the we route through the asset precompile set
 			a if &a.to_fixed_bytes()[0..4] == FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX => {
-				Erc20AssetsPrecompileSet::<R, IsForeign, pallet_assets::Instance1>::new()
+				Erc20AssetsPrecompileSet::<R, IsForeign, ForeignAssetInstance>::new()
 					.execute(address, input, target_gas, context, is_static)
 			}
 			// If the address matches asset prefix, the we route through the asset precompile set
 			a if &a.to_fixed_bytes()[0..4] == LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX => {
-				Erc20AssetsPrecompileSet::<R, IsLocal, pallet_assets::Instance2>::new()
+				Erc20AssetsPrecompileSet::<R, IsLocal, LocalAssetInstance>::new()
 					.execute(address, input, target_gas, context, is_static)
 			}
 			_ => None,
@@ -183,9 +184,9 @@ where
 	}
 	fn is_precompile(&self, address: H160) -> bool {
 		Self::used_addresses().any(|x| x == R::AddressMapping::into_account_id(address))
-			|| Erc20AssetsPrecompileSet::<R, IsForeign, pallet_assets::Instance1>::new()
+			|| Erc20AssetsPrecompileSet::<R, IsForeign, ForeignAssetInstance>::new()
 				.is_precompile(address)
-			|| Erc20AssetsPrecompileSet::<R, IsLocal, pallet_assets::Instance2>::new()
+			|| Erc20AssetsPrecompileSet::<R, IsLocal, LocalAssetInstance>::new()
 				.is_precompile(address)
 	}
 }

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -33,10 +33,11 @@ use frame_support::{
 	StorageHasher, Twox128,
 };
 use moonbase_runtime::{
-	asset_config::AssetRegistrarMetadata, currency::UNIT, get, xcm_config::AssetType, AccountId,
-	AssetId, AssetManager, Assets, Balances, BaseFee, BlockWeights, Call, CrowdloanRewards, Event,
-	LocalAssets, ParachainStaking, PolkadotXcm, Precompiles, Runtime, System, XTokens,
-	XcmTransactor, FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX, LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX,
+	asset_config::AssetRegistrarMetadata, asset_config::LocalAssetInstance, currency::UNIT, get,
+	xcm_config::AssetType, AccountId, AssetId, AssetManager, Assets, Balances, BaseFee,
+	BlockWeights, Call, CrowdloanRewards, Event, LocalAssets, ParachainStaking, PolkadotXcm,
+	Precompiles, Runtime, System, XTokens, XcmTransactor, FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX,
+	LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX,
 };
 
 use nimbus_primitives::NimbusId;
@@ -1098,13 +1099,11 @@ fn local_assets_cannot_be_create_by_signed_origins() {
 		.build()
 		.execute_with(|| {
 			assert_noop!(
-				Call::LocalAssets(
-					pallet_assets::Call::<Runtime, pallet_assets::Instance2>::create {
-						id: 11u128,
-						admin: AccountId::from(ALICE),
-						min_balance: 1u128
-					}
-				)
+				Call::LocalAssets(pallet_assets::Call::<Runtime, LocalAssetInstance>::create {
+					id: 11u128,
+					admin: AccountId::from(ALICE),
+					min_balance: 1u128
+				})
 				.dispatch(<Runtime as frame_system::Config>::Origin::signed(
 					AccountId::from(ALICE)
 				)),

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -1089,6 +1089,31 @@ fn asset_can_be_registered() {
 }
 
 #[test]
+fn local_assets_cannot_be_create_by_signed_origins() {
+	ExtBuilder::default()
+		.with_balances(vec![
+			(AccountId::from(ALICE), 2_000 * UNIT * SUPPLY_FACTOR),
+			(AccountId::from(BOB), 1_000 * UNIT * SUPPLY_FACTOR),
+		])
+		.build()
+		.execute_with(|| {
+			assert_noop!(
+				Call::LocalAssets(
+					pallet_assets::Call::<Runtime, pallet_assets::Instance2>::create {
+						id: 11u128,
+						admin: AccountId::from(ALICE),
+						min_balance: 1u128
+					}
+				)
+				.dispatch(<Runtime as frame_system::Config>::Origin::signed(
+					AccountId::from(ALICE)
+				)),
+				frame_system::Error::<Runtime>::CallFiltered
+			);
+		});
+}
+
+#[test]
 fn asset_erc20_precompiles_supply_and_balance() {
 	ExtBuilder::default()
 		.with_local_assets(vec![(

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -111,8 +111,8 @@ impl pallet_balances::Config for Runtime {
 	type ReserveIdentifier = [u8; 8];
 }
 
-pub type ForeignAssetInstance = pallet_assets::Instance1;
-pub type LocalAssetInstance = pallet_assets::Instance2;
+pub type ForeignAssetInstance = ();
+pub type LocalAssetInstance = pallet_assets::Instance1;
 
 parameter_types! {
 	pub const AssetDeposit: Balance = 10; // Does not really matter as this will be only called by root
@@ -1019,13 +1019,13 @@ construct_runtime!(
 		XcmVersioner: mock_version_changer::{Pallet, Storage, Event<T>},
 
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
-		Assets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>},
+		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>},
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin},
 		XTokens: orml_xtokens::{Pallet, Call, Storage, Event<T>},
 		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>},
 		XcmTransactor: xcm_transactor::{Pallet, Call, Storage, Event<T>},
 		Treasury: pallet_treasury::{Pallet, Storage, Config, Event<T>, Call},
-		LocalAssets: pallet_assets::<Instance2>::{Pallet, Call, Storage, Event<T>},
+		LocalAssets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>},
 
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage},
 		EVM: pallet_evm::{Pallet, Call, Storage, Config, Event<T>},

--- a/runtime/moonbeam/src/asset_config.rs
+++ b/runtime/moonbeam/src/asset_config.rs
@@ -42,8 +42,8 @@ use sp_std::{
 	convert::{From, Into},
 	prelude::*,
 };
-type ForeignAssetInstance = pallet_assets::Instance1;
-type LocalAssetInstance = pallet_assets::Instance2;
+pub type ForeignAssetInstance = ();
+pub type LocalAssetInstance = pallet_assets::Instance1;
 
 // For foreign assets, these parameters dont matter much
 // as this will only be called by root with the forced arguments

--- a/runtime/moonbeam/src/asset_config.rs
+++ b/runtime/moonbeam/src/asset_config.rs
@@ -42,6 +42,8 @@ use sp_std::{
 	convert::{From, Into},
 	prelude::*,
 };
+
+// Not to disrupt the previous asset instance, we assign () to Foreign
 pub type ForeignAssetInstance = ();
 pub type LocalAssetInstance = pallet_assets::Instance1;
 

--- a/runtime/moonbeam/src/asset_config.rs
+++ b/runtime/moonbeam/src/asset_config.rs
@@ -156,7 +156,6 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 
 		// No metadata needs to be set, as this can be set through regular calls
 
-		// TODO: should we put the revert code?
 		// The asset has been created. Let's put the revert code in the precompile address
 		let precompile_address: H160 =
 			Runtime::asset_id_to_account(LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX, asset).into();

--- a/runtime/moonbeam/src/asset_config.rs
+++ b/runtime/moonbeam/src/asset_config.rs
@@ -19,7 +19,8 @@
 
 use super::{
 	currency, xcm_config, AccountId, AssetId, AssetManager, Assets, Balance, Balances, Call,
-	CouncilInstance, Event, Origin, Runtime, ASSET_PRECOMPILE_ADDRESS_PREFIX,
+	CouncilInstance, Event, LocalAssets, Origin, Runtime, FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX,
+	LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX,
 };
 
 use pallet_evm_precompile_assets_erc20::AccountIdAssetIdConversion;
@@ -41,6 +42,8 @@ use sp_std::{
 	convert::{From, Into},
 	prelude::*,
 };
+type ForeignAssetInstance = pallet_assets::Instance1;
+type LocalAssetInstance = pallet_assets::Instance2;
 
 // For foreign assets, these parameters dont matter much
 // as this will only be called by root with the forced arguments
@@ -61,7 +64,26 @@ pub type AssetsForceOrigin = EnsureOneOf<
 	pallet_collective::EnsureProportionMoreThan<AccountId, CouncilInstance, 1, 2>,
 >;
 
-impl pallet_assets::Config for Runtime {
+// Foreign assets
+impl pallet_assets::Config<ForeignAssetInstance> for Runtime {
+	type Event = Event;
+	type Balance = Balance;
+	type AssetId = AssetId;
+	type Currency = Balances;
+	type ForceOrigin = AssetsForceOrigin;
+	type AssetDeposit = AssetDeposit;
+	type MetadataDepositBase = MetadataDepositBase;
+	type MetadataDepositPerByte = MetadataDepositPerByte;
+	type ApprovalDeposit = ApprovalDeposit;
+	type StringLimit = AssetsStringLimit;
+	type Freezer = ();
+	type Extra = ();
+	type AssetAccountDeposit = ConstU128<{ currency::deposit(1, 18) }>;
+	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+}
+
+// Local assets
+impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type Event = Event;
 	type Balance = Balance;
 	type AssetId = AssetId;
@@ -102,7 +124,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// TODO uncomment when we feel comfortable
 		/*
 		// The asset has been created. Let's put the revert code in the precompile address
-		let precompile_address = Runtime::asset_id_to_account(asset);
+		let precompile_address = Runtime::asset_id_to_account(ASSET_PRECOMPILE_ADDRESS_PREFIX, asset);
 		pallet_evm::AccountCodes::<Runtime>::insert(
 			precompile_address,
 			vec![0x60, 0x00, 0x60, 0x00, 0xfd],
@@ -120,6 +142,32 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	}
 
 	#[transactional]
+	fn create_local_asset(
+		asset: AssetId,
+		_creator: AccountId,
+		min_balance: Balance,
+		is_sufficient: bool,
+		owner: AccountId,
+	) -> DispatchResult {
+		// We create with root, because we need to decide whether we want to create the asset
+		// as sufficient. Take into account this does not hold any reserved amount
+		// in pallet-assets
+		LocalAssets::force_create(Origin::root(), asset, owner, is_sufficient, min_balance)?;
+
+		// No metadata needs to be set, as this can be set through regular calls
+
+		// TODO: should we put the revert code?
+		// The asset has been created. Let's put the revert code in the precompile address
+		let precompile_address: H160 =
+			Runtime::asset_id_to_account(LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX, asset).into();
+		pallet_evm::AccountCodes::<Runtime>::insert(
+			precompile_address,
+			vec![0x60, 0x00, 0x60, 0x00, 0xfd],
+		);
+		Ok(())
+	}
+
+	#[transactional]
 	fn destroy_foreign_asset(
 		asset: AssetId,
 		asset_destroy_witness: pallet_assets::DestroyWitness,
@@ -130,7 +178,24 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// We remove the EVM revert code
 		// This does not panick even if there is no code in the address
 		let precompile_address: H160 =
-			Runtime::asset_id_to_account(ASSET_PRECOMPILE_ADDRESS_PREFIX, asset).into();
+			Runtime::asset_id_to_account(FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX, asset).into();
+		pallet_evm::AccountCodes::<Runtime>::remove(precompile_address);
+		Ok(())
+	}
+
+	#[transactional]
+	fn destroy_local_asset(
+		asset: AssetId,
+		asset_destroy_witness: pallet_assets::DestroyWitness,
+	) -> DispatchResult {
+		// First destroy the asset
+		LocalAssets::destroy(Origin::root(), asset, asset_destroy_witness)
+			.map_err(|info| info.error)?;
+
+		// We remove the EVM revert code
+		// This does not panick even if there is no code in the address
+		let precompile_address: H160 =
+			Runtime::asset_id_to_account(LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX, asset).into();
 		pallet_evm::AccountCodes::<Runtime>::remove(precompile_address);
 		Ok(())
 	}
@@ -147,10 +212,12 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// EVM
 
 		// This is the dispatch info of destroy
-		let call = Call::Assets(pallet_assets::Call::<Runtime>::destroy {
-			id: asset,
-			witness: asset_destroy_witness,
-		});
+		let call = Call::Assets(
+			pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy {
+				id: asset,
+				witness: asset_destroy_witness,
+			},
+		);
 
 		// This is the db write
 		call.get_dispatch_info()
@@ -205,7 +272,9 @@ impl AccountIdAssetIdConversion<AccountId, AssetId> for Runtime {
 		let h160_account: H160 = account.into();
 		let mut data = [0u8; 16];
 		let (prefix_part, id_part) = h160_account.as_fixed_bytes().split_at(4);
-		if prefix_part == ASSET_PRECOMPILE_ADDRESS_PREFIX {
+		if prefix_part == FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX
+			|| prefix_part == LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX
+		{
 			data.copy_from_slice(id_part);
 			let asset_id: AssetId = u128::from_be_bytes(data).into();
 			Some((prefix_part.to_vec(), asset_id))

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1040,11 +1040,11 @@ construct_runtime! {
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 101,
 		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 102,
 		PolkadotXcm: pallet_xcm::{Pallet, Storage, Call, Event<T>, Origin, Config} = 103,
-		Assets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>} = 104,
+		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 104,
 		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>} = 105,
 		XTokens: orml_xtokens::{Pallet, Call, Storage, Event<T>} = 106,
 		XcmTransactor: xcm_transactor::{Pallet, Call, Storage, Event<T>} = 107,
-		LocalAssets: pallet_assets::<Instance2>::{Pallet, Call, Storage, Event<T>} = 108,
+		LocalAssets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>} = 108,
 	}
 }
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -90,7 +90,10 @@ use sp_version::RuntimeVersion;
 use nimbus_primitives::{CanAuthor, NimbusId};
 
 mod precompiles;
-pub use precompiles::{MoonbeamPrecompiles, ASSET_PRECOMPILE_ADDRESS_PREFIX};
+pub use precompiles::{
+	MoonbeamPrecompiles, FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX,
+	LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX,
+};
 
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
@@ -833,6 +836,7 @@ impl Contains<Call> for MaintenanceFilter {
 	fn contains(c: &Call) -> bool {
 		match c {
 			Call::Assets(_) => false,
+			Call::LocalAssets(_) => false,
 			Call::Balances(_) => false,
 			Call::CrowdloanRewards(_) => false,
 			Call::Ethereum(_) => false,
@@ -864,6 +868,16 @@ impl Contains<Call> for NormalFilter {
 				pallet_assets::Call::transfer_approved { .. } => true,
 				pallet_assets::Call::cancel_approval { .. } => true,
 				_ => false,
+			},
+			// We want to disable create, as we dont want users to be choosing the
+			// assetId of their choice
+			// We also disable destroy, as we want to route destroy through the
+			// asset-manager, which guarantees the removal both at the EVM and
+			// substrate side of things
+			Call::LocalAssets(method) => match method {
+				pallet_assets::Call::create { .. } => false,
+				pallet_assets::Call::destroy { .. } => false,
+				_ => true,
 			},
 			// We just want to enable this in case of live chains, since the default version
 			// is populated at genesis
@@ -1026,10 +1040,11 @@ construct_runtime! {
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 101,
 		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 102,
 		PolkadotXcm: pallet_xcm::{Pallet, Storage, Call, Event<T>, Origin, Config} = 103,
-		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 104,
+		Assets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>} = 104,
 		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>} = 105,
 		XTokens: orml_xtokens::{Pallet, Call, Storage, Event<T>} = 106,
 		XcmTransactor: xcm_transactor::{Pallet, Call, Storage, Event<T>} = 107,
+		LocalAssets: pallet_assets::<Instance2>::{Pallet, Call, Storage, Event<T>} = 108,
 	}
 }
 

--- a/runtime/moonbeam/src/precompiles.rs
+++ b/runtime/moonbeam/src/precompiles.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::asset_config::{ForeignAssetInstance, LocalAssetInstance};
 use crowdloan_rewards_precompiles::CrowdloanRewardsWrapper;
 use fp_evm::Context;
 use moonbeam_relay_encoder::polkadot::PolkadotEncoder;
@@ -103,8 +104,8 @@ where
 	ParachainStakingWrapper<R>: Precompile,
 	CrowdloanRewardsWrapper<R>: Precompile,
 	Erc20BalancesPrecompile<R, NativeErc20Metadata>: Precompile,
-	Erc20AssetsPrecompileSet<R, IsForeign, pallet_assets::Instance1>: PrecompileSet,
-	Erc20AssetsPrecompileSet<R, IsLocal, pallet_assets::Instance2>: PrecompileSet,
+	Erc20AssetsPrecompileSet<R, IsForeign, ForeignAssetInstance>: PrecompileSet,
+	Erc20AssetsPrecompileSet<R, IsLocal, LocalAssetInstance>: PrecompileSet,
 	XtokensWrapper<R>: Precompile,
 	RelayEncoderWrapper<R, PolkadotEncoder>: Precompile,
 	XcmTransactorWrapper<R>: Precompile,
@@ -170,12 +171,12 @@ where
 			)),
 			// If the address matches asset prefix, the we route through the asset precompile set
 			a if &a.to_fixed_bytes()[0..4] == FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX => {
-				Erc20AssetsPrecompileSet::<R, IsForeign, pallet_assets::Instance1>::new()
+				Erc20AssetsPrecompileSet::<R, IsForeign, ForeignAssetInstance>::new()
 					.execute(address, input, target_gas, context, is_static)
 			}
 			// If the address matches asset prefix, the we route through the asset precompile set
 			a if &a.to_fixed_bytes()[0..4] == LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX => {
-				Erc20AssetsPrecompileSet::<R, IsLocal, pallet_assets::Instance2>::new()
+				Erc20AssetsPrecompileSet::<R, IsLocal, LocalAssetInstance>::new()
 					.execute(address, input, target_gas, context, is_static)
 			}
 			_ => None,
@@ -183,9 +184,9 @@ where
 	}
 	fn is_precompile(&self, address: H160) -> bool {
 		Self::used_addresses().any(|x| x == R::AddressMapping::into_account_id(address))
-			|| Erc20AssetsPrecompileSet::<R, IsForeign, pallet_assets::Instance1>::new()
+			|| Erc20AssetsPrecompileSet::<R, IsForeign, ForeignAssetInstance>::new()
 				.is_precompile(address)
-			|| Erc20AssetsPrecompileSet::<R, IsLocal, pallet_assets::Instance2>::new()
+			|| Erc20AssetsPrecompileSet::<R, IsLocal, LocalAssetInstance>::new()
 				.is_precompile(address)
 	}
 }

--- a/runtime/moonbeam/src/precompiles.rs
+++ b/runtime/moonbeam/src/precompiles.rs
@@ -20,7 +20,7 @@ use moonbeam_relay_encoder::polkadot::PolkadotEncoder;
 use pallet_author_mapping_precompiles::AuthorMappingWrapper;
 use pallet_democracy_precompiles::DemocracyWrapper;
 use pallet_evm::{AddressMapping, Precompile, PrecompileResult, PrecompileSet};
-use pallet_evm_precompile_assets_erc20::{Erc20AssetsPrecompileSet, IsForeign};
+use pallet_evm_precompile_assets_erc20::{Erc20AssetsPrecompileSet, IsForeign, IsLocal};
 use pallet_evm_precompile_balances_erc20::{Erc20BalancesPrecompile, Erc20Metadata};
 use pallet_evm_precompile_blake2::Blake2F;
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
@@ -90,7 +90,8 @@ where
 
 /// The asset precompile address prefix. Addresses that match against this prefix will be routed
 /// to Erc20AssetsPrecompileSet
-pub const ASSET_PRECOMPILE_ADDRESS_PREFIX: &[u8] = &[255u8; 4];
+pub const FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX: &[u8] = &[255u8; 4];
+pub const LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX: &[u8] = &[255u8, 255u8, 255u8, 254u8];
 
 /// The following distribution has been decided for the precompiles
 /// 0-1023: Ethereum Mainnet Precompiles
@@ -101,8 +102,9 @@ where
 	Dispatch<R>: Precompile,
 	ParachainStakingWrapper<R>: Precompile,
 	CrowdloanRewardsWrapper<R>: Precompile,
-	Erc20AssetsPrecompileSet<R, IsForeign>: PrecompileSet,
 	Erc20BalancesPrecompile<R, NativeErc20Metadata>: Precompile,
+	Erc20AssetsPrecompileSet<R, IsForeign, pallet_assets::Instance1>: PrecompileSet,
+	Erc20AssetsPrecompileSet<R, IsLocal, pallet_assets::Instance2>: PrecompileSet,
 	XtokensWrapper<R>: Precompile,
 	RelayEncoderWrapper<R, PolkadotEncoder>: Precompile,
 	XcmTransactorWrapper<R>: Precompile,
@@ -139,8 +141,8 @@ where
 			a if a == hash(1026) => Some(ECRecoverPublicKey::execute(
 				input, target_gas, context, is_static,
 			)),
-			// Moonbeam specific precompiles :
 			a if a == hash(2048) => Some(ParachainStakingWrapper::<R>::execute(
+				// Moonbeam specific precompiles :
 				input, target_gas, context, is_static,
 			)),
 			a if a == hash(2049) => Some(CrowdloanRewardsWrapper::<R>::execute(
@@ -167,8 +169,13 @@ where
 				input, target_gas, context, is_static,
 			)),
 			// If the address matches asset prefix, the we route through the asset precompile set
-			a if &a.to_fixed_bytes()[0..4] == ASSET_PRECOMPILE_ADDRESS_PREFIX => {
-				Erc20AssetsPrecompileSet::<R, IsForeign>::new()
+			a if &a.to_fixed_bytes()[0..4] == FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX => {
+				Erc20AssetsPrecompileSet::<R, IsForeign, pallet_assets::Instance1>::new()
+					.execute(address, input, target_gas, context, is_static)
+			}
+			// If the address matches asset prefix, the we route through the asset precompile set
+			a if &a.to_fixed_bytes()[0..4] == LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX => {
+				Erc20AssetsPrecompileSet::<R, IsLocal, pallet_assets::Instance2>::new()
 					.execute(address, input, target_gas, context, is_static)
 			}
 			_ => None,
@@ -176,7 +183,10 @@ where
 	}
 	fn is_precompile(&self, address: H160) -> bool {
 		Self::used_addresses().any(|x| x == R::AddressMapping::into_account_id(address))
-			|| Erc20AssetsPrecompileSet::<R, IsForeign>::new().is_precompile(address)
+			|| Erc20AssetsPrecompileSet::<R, IsForeign, pallet_assets::Instance1>::new()
+				.is_precompile(address)
+			|| Erc20AssetsPrecompileSet::<R, IsLocal, pallet_assets::Instance2>::new()
+				.is_precompile(address)
 	}
 }
 

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -18,9 +18,9 @@
 //!
 
 use super::{
-	AccountId, AssetId, AssetManager, Assets, Balance, Balances, Call, Event, Origin,
+	AccountId, AssetId, AssetManager, Assets, Balance, Balances, Call, Event, LocalAssets, Origin,
 	ParachainInfo, ParachainSystem, PolkadotXcm, Runtime, Treasury, XcmpQueue,
-	MAXIMUM_BLOCK_WEIGHT,
+	FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX, MAXIMUM_BLOCK_WEIGHT,
 };
 
 use pallet_evm_precompile_assets_erc20::AccountIdAssetIdConversion;
@@ -78,6 +78,31 @@ parameter_types! {
 			PalletInstance(<Balances as PalletInfoAccess>::index() as u8)
 		)
 	};
+
+	// Old reanchor logic location for pallet assets
+	// We need to support both in case we talk to a chain not in 0.9.16
+	// Or until we import https://github.com/open-web3-stack/open-runtime-module-library/pull/708
+	// We will be able to remove this once we import the aforementioned change
+	// Indentified by thix prefix + generalIndex(assetId)
+	pub LocalAssetsPalletLocationOldReanchor: MultiLocation = MultiLocation {
+		parents:1,
+		interior: Junctions::X2(
+			Parachain(ParachainInfo::parachain_id().into()),
+			PalletInstance(<LocalAssets as PalletInfoAccess>::index() as u8)
+		)
+	};
+
+	// New reanchor logic location for pallet assets
+	// This is the relative view of our local assets. This is the representation that will
+	// be considered canonical after we import
+	// https://github.com/open-web3-stack/open-runtime-module-library/pull/708
+	// Indentified by thix prefix + generalIndex(assetId)
+	pub LocalAssetsPalletLocationNewReanchor: MultiLocation = MultiLocation {
+		parents:0,
+		interior: Junctions::X1(
+			PalletInstance(<LocalAssets as PalletInfoAccess>::index() as u8)
+		)
+	};
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -119,6 +144,7 @@ pub type FungiblesTransactor = FungiblesAdapter<
 // We use only fungiblesAdapter transactor for now
 // The idea is that we only accept the relay token, hence no need to handle the local token
 // As long as this does not contain the local transactor, we are good
+// LocalAssets are also not enabled
 pub type AssetTransactors = FungiblesTransactor;
 
 /// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
@@ -331,6 +357,8 @@ impl From<AssetType> for AssetId {
 pub enum CurrencyId {
 	SelfReserve,
 	ForeignAsset(AssetId),
+	// Our local assets
+	LocalAssetReserve(AssetId),
 }
 
 impl AccountIdToCurrencyId<AccountId, CurrencyId> for Runtime {
@@ -339,8 +367,13 @@ impl AccountIdToCurrencyId<AccountId, CurrencyId> for Runtime {
 			// the self-reserve currency is identified by the pallet-balances address
 			a if a == H160::from_low_u64_be(2050).into() => Some(CurrencyId::SelfReserve),
 			// the rest of the currencies, by their corresponding erc20 address
-			_ => Runtime::account_to_asset_id(account)
-				.map(|(_, asset_id)| CurrencyId::ForeignAsset(asset_id)),
+			_ => Runtime::account_to_asset_id(account).map(|(prefix, asset_id)| {
+				if prefix == FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX.to_vec() {
+					CurrencyId::ForeignAsset(asset_id)
+				} else {
+					CurrencyId::LocalAssetReserve(asset_id)
+				}
+			}),
 		}
 	}
 }
@@ -354,11 +387,22 @@ where
 {
 	fn convert(currency: CurrencyId) -> Option<MultiLocation> {
 		match currency {
+			// For now and until Xtokens is adapted to handle 0.9.16 version we use
+			// the old anchoring here
+			// This is not a problem in either cases, since the view of the destination
+			// chain does not change
+			// TODO! change this to NewAnchoringSelfReserve once xtokens is adapted for it
 			CurrencyId::SelfReserve => {
 				let multi: MultiLocation = SelfReserve::get();
 				Some(multi)
 			}
 			CurrencyId::ForeignAsset(asset) => AssetXConverter::reverse_ref(asset).ok(),
+			// No transactor matches this yet, so even if we have this enum variant the transfer will fail
+			CurrencyId::LocalAssetReserve(asset) => {
+				let mut location = LocalAssetsPalletLocationOldReanchor::get();
+				location.push_interior(Junction::GeneralIndex(asset)).ok();
+				Some(location)
+			}
 		}
 	}
 }

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -387,11 +387,6 @@ where
 {
 	fn convert(currency: CurrencyId) -> Option<MultiLocation> {
 		match currency {
-			// For now and until Xtokens is adapted to handle 0.9.16 version we use
-			// the old anchoring here
-			// This is not a problem in either cases, since the view of the destination
-			// chain does not change
-			// TODO! change this to NewAnchoringSelfReserve once xtokens is adapted for it
 			CurrencyId::SelfReserve => {
 				let multi: MultiLocation = SelfReserve::get();
 				Some(multi)

--- a/runtime/moonbeam/tests/common/mod.rs
+++ b/runtime/moonbeam/tests/common/mod.rs
@@ -27,8 +27,8 @@ pub use moonbeam_runtime::{
 	currency::{GIGAWEI, GLMR, SUPPLY_FACTOR, WEI},
 	xcm_config::AssetType,
 	AccountId, AssetId, AssetManager, Assets, AuthorInherent, Balance, Balances, Call,
-	CrowdloanRewards, Ethereum, Event, Executive, FixedGasPrice, InflationInfo, ParachainStaking,
-	Range, Runtime, System, TransactionConverter, UncheckedExtrinsic, WEEKS,
+	CrowdloanRewards, Ethereum, Event, Executive, FixedGasPrice, InflationInfo, LocalAssets,
+	ParachainStaking, Range, Runtime, System, TransactionConverter, UncheckedExtrinsic, WEEKS,
 };
 use nimbus_primitives::{NimbusId, NIMBUS_ENGINE_ID};
 use pallet_evm::GenesisAccount;
@@ -109,8 +109,8 @@ pub struct XcmAssetInitialization {
 }
 
 pub struct ExtBuilder {
-	// [asset, Vec<Account, Balance>]
-	assets: Vec<(AssetId, Vec<(AccountId, Balance)>)>,
+	// [asset, Vec<Account, Balance>, owner]
+	local_assets: Vec<(AssetId, Vec<(AccountId, Balance)>, AccountId)>,
 	// endowed accounts with balances
 	balances: Vec<(AccountId, Balance)>,
 	// [collator, amount]
@@ -135,7 +135,7 @@ pub struct ExtBuilder {
 impl Default for ExtBuilder {
 	fn default() -> ExtBuilder {
 		ExtBuilder {
-			assets: vec![],
+			local_assets: vec![],
 			balances: vec![],
 			delegations: vec![],
 			collators: vec![],
@@ -199,8 +199,11 @@ impl ExtBuilder {
 		self
 	}
 
-	pub fn with_assets(mut self, assets: Vec<(AssetId, Vec<(AccountId, Balance)>)>) -> Self {
-		self.assets = assets;
+	pub fn with_local_assets(
+		mut self,
+		local_assets: Vec<(AssetId, Vec<(AccountId, Balance)>, AccountId)>,
+	) -> Self {
+		self.local_assets = local_assets;
 		self
 	}
 
@@ -288,14 +291,14 @@ impl ExtBuilder {
 		.unwrap();
 
 		let mut ext = sp_io::TestExternalities::new(t);
-		let assets = self.assets.clone();
+		let local_assets = self.local_assets.clone();
 		let xcm_assets = self.xcm_assets.clone();
 		ext.execute_with(|| {
-			// If any assets specified, we create them here
-			for (asset_id, balances) in assets.clone() {
-				Assets::force_create(root_origin(), asset_id, ALICE.into(), true, 1).unwrap();
+			// If any local assets specified, we create them here
+			for (asset_id, balances, owner) in local_assets.clone() {
+				LocalAssets::force_create(root_origin(), asset_id, owner, true, 1).unwrap();
 				for (account, balance) in balances {
-					Assets::mint(origin_of(ALICE.into()), asset_id, account, balance).unwrap();
+					LocalAssets::mint(origin_of(owner.into()), asset_id, account, balance).unwrap();
 				}
 			}
 			// If any xcm assets specified, we register them here

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -33,9 +33,10 @@ use frame_support::{
 	StorageHasher, Twox128,
 };
 use moonbeam_runtime::{
-	currency::GLMR, xcm_config::CurrencyId, AccountId, Balances, BaseFee, BlockWeights, Call,
-	CrowdloanRewards, Event, ParachainStaking, PolkadotXcm, Precompiles, Runtime, System, XTokens,
-	XcmTransactor, FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX, LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX,
+	asset_config::LocalAssetInstance, currency::GLMR, xcm_config::CurrencyId, AccountId, Balances,
+	BaseFee, BlockWeights, Call, CrowdloanRewards, Event, ParachainStaking, PolkadotXcm,
+	Precompiles, Runtime, System, XTokens, XcmTransactor, FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX,
+	LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX,
 };
 use nimbus_primitives::NimbusId;
 use pallet_evm::PrecompileSet;
@@ -1345,13 +1346,11 @@ fn local_assets_cannot_be_create_by_signed_origins() {
 		.build()
 		.execute_with(|| {
 			assert_noop!(
-				Call::LocalAssets(
-					pallet_assets::Call::<Runtime, pallet_assets::Instance2>::create {
-						id: 11u128,
-						admin: AccountId::from(ALICE),
-						min_balance: 1u128
-					}
-				)
+				Call::LocalAssets(pallet_assets::Call::<Runtime, LocalAssetInstance>::create {
+					id: 11u128,
+					admin: AccountId::from(ALICE),
+					min_balance: 1u128
+				})
 				.dispatch(<Runtime as frame_system::Config>::Origin::signed(
 					AccountId::from(ALICE)
 				)),

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -25,14 +25,17 @@ use fp_evm::{Context, ExitSucceed, PrecompileOutput};
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::Dispatchable,
-	traits::{fungible::Inspect, EnsureOrigin, PalletInfo, StorageInfo, StorageInfoTrait},
+	traits::{
+		fungible::Inspect, fungibles::Inspect as FungiblesInspect, EnsureOrigin, PalletInfo,
+		StorageInfo, StorageInfoTrait,
+	},
 	weights::{DispatchClass, Weight},
 	StorageHasher, Twox128,
 };
 use moonbeam_runtime::{
 	currency::GLMR, xcm_config::CurrencyId, AccountId, Balances, BaseFee, BlockWeights, Call,
 	CrowdloanRewards, Event, ParachainStaking, PolkadotXcm, Precompiles, Runtime, System, XTokens,
-	XcmTransactor, ASSET_PRECOMPILE_ADDRESS_PREFIX,
+	XcmTransactor, FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX, LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX,
 };
 use nimbus_primitives::NimbusId;
 use pallet_evm::PrecompileSet;
@@ -46,7 +49,7 @@ use sha3::{Digest, Keccak256};
 use sp_core::{ByteArray, Pair, H160, U256};
 use sp_runtime::{
 	traits::{Convert, One},
-	DispatchError, ModuleError,
+	DispatchError, ModuleError, TokenError,
 };
 use xcm::latest::prelude::*;
 use xcm::{VersionedMultiAsset, VersionedMultiAssets, VersionedMultiLocation};
@@ -1333,17 +1336,46 @@ fn asset_can_be_registered() {
 }
 
 #[test]
+fn local_assets_cannot_be_create_by_signed_origins() {
+	ExtBuilder::default()
+		.with_balances(vec![
+			(AccountId::from(ALICE), 2_000 * GLMR * SUPPLY_FACTOR),
+			(AccountId::from(BOB), 1_000 * GLMR * SUPPLY_FACTOR),
+		])
+		.build()
+		.execute_with(|| {
+			assert_noop!(
+				Call::LocalAssets(
+					pallet_assets::Call::<Runtime, pallet_assets::Instance2>::create {
+						id: 11u128,
+						admin: AccountId::from(ALICE),
+						min_balance: 1u128
+					}
+				)
+				.dispatch(<Runtime as frame_system::Config>::Origin::signed(
+					AccountId::from(ALICE)
+				)),
+				frame_system::Error::<Runtime>::CallFiltered
+			);
+		});
+}
+
+#[test]
 fn asset_erc20_precompiles_supply_and_balance() {
 	ExtBuilder::default()
-		.with_assets(vec![(0u128, vec![(AccountId::from(ALICE), 1_000 * GLMR)])])
+		.with_local_assets(vec![(
+			0u128,
+			vec![(AccountId::from(ALICE), 1_000 * GLMR)],
+			AccountId::from(ALICE),
+		)])
 		.build()
 		.execute_with(|| {
 			// Assert the asset has been created with the correct supply
-			assert_eq!(Assets::total_supply(0u128), 1_000 * GLMR);
+			assert_eq!(LocalAssets::total_supply(0u128), 1_000 * GLMR);
 
 			// Convert the assetId to its corresponding precompile address
 			let asset_precompile_address =
-				Runtime::asset_id_to_account(ASSET_PRECOMPILE_ADDRESS_PREFIX, 0u128).into();
+				Runtime::asset_id_to_account(LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX, 0u128).into();
 
 			// The expected result for both total supply and balance of is the same, as only Alice
 			// holds balance
@@ -1393,7 +1425,11 @@ fn asset_erc20_precompiles_supply_and_balance() {
 #[test]
 fn asset_erc20_precompiles_transfer() {
 	ExtBuilder::default()
-		.with_assets(vec![(0u128, vec![(AccountId::from(ALICE), 1_000 * GLMR)])])
+		.with_local_assets(vec![(
+			0u128,
+			vec![(AccountId::from(ALICE), 1_000 * GLMR)],
+			AccountId::from(ALICE),
+		)])
 		.with_balances(vec![
 			(AccountId::from(ALICE), 2_000 * GLMR),
 			(AccountId::from(BOB), 1_000 * GLMR),
@@ -1401,7 +1437,7 @@ fn asset_erc20_precompiles_transfer() {
 		.build()
 		.execute_with(|| {
 			let asset_precompile_address =
-				Runtime::asset_id_to_account(ASSET_PRECOMPILE_ADDRESS_PREFIX, 0u128).into();
+				Runtime::asset_id_to_account(LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX, 0u128).into();
 
 			// Expected result for a transfer
 			let expected_result = Some(Ok(PrecompileOutput {
@@ -1468,7 +1504,11 @@ fn asset_erc20_precompiles_transfer() {
 #[test]
 fn asset_erc20_precompiles_approve() {
 	ExtBuilder::default()
-		.with_assets(vec![(0u128, vec![(AccountId::from(ALICE), 1_000 * GLMR)])])
+		.with_local_assets(vec![(
+			0u128,
+			vec![(AccountId::from(ALICE), 1_000 * GLMR)],
+			AccountId::from(ALICE),
+		)])
 		.with_balances(vec![
 			(AccountId::from(ALICE), 2_000 * GLMR),
 			(AccountId::from(BOB), 1_000 * GLMR),
@@ -1476,7 +1516,686 @@ fn asset_erc20_precompiles_approve() {
 		.build()
 		.execute_with(|| {
 			let asset_precompile_address =
-				Runtime::asset_id_to_account(ASSET_PRECOMPILE_ADDRESS_PREFIX, 0u128).into();
+				Runtime::asset_id_to_account(LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX, 0u128).into();
+
+			// Expected result for approve
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: 13989u64,
+				logs: LogsBuilder::new(asset_precompile_address)
+					.log3(
+						SELECTOR_LOG_APPROVAL,
+						H160::from(ALICE),
+						H160::from(BOB),
+						EvmDataWriter::new().write(U256::from(400 * GLMR)).build(),
+					)
+					.build(),
+			}));
+
+			// Aprove Bob for spending 400 GLMR from Alice
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::Approve)
+						.write(EvmAddress(BOB.into()))
+						.write(U256::from(400 * GLMR))
+						.build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: ALICE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+
+			// Expected result for transfer_from
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: 29006u64,
+				logs: LogsBuilder::new(asset_precompile_address)
+					.log3(
+						SELECTOR_LOG_TRANSFER,
+						H160::from(ALICE),
+						H160::from(CHARLIE),
+						EvmDataWriter::new().write(U256::from(400 * GLMR)).build(),
+					)
+					.build(),
+			}));
+
+			// Transfer tokens from Alice to Charlie by using BOB as origin
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::TransferFrom)
+						.write(EvmAddress(ALICE.into()))
+						.write(EvmAddress(CHARLIE.into()))
+						.write(U256::from(400 * GLMR))
+						.build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: BOB.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+
+			// Expected result for balance of CHARLIE
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(U256::from(400 * GLMR)).build(),
+				cost: 1000,
+				logs: Default::default(),
+			}));
+
+			// Make sure CHARLIE has 400 GLMR
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
+						.write(EvmAddress(CHARLIE.into()))
+						.build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: CHARLIE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+		});
+}
+
+#[test]
+fn asset_erc20_precompiles_mint_burn() {
+	ExtBuilder::default()
+		.with_local_assets(vec![(
+			0u128,
+			vec![(AccountId::from(ALICE), 1_000 * GLMR)],
+			AccountId::from(ALICE),
+		)])
+		.with_balances(vec![
+			(AccountId::from(ALICE), 2_000 * GLMR),
+			(AccountId::from(BOB), 1_000 * GLMR),
+		])
+		.build()
+		.execute_with(|| {
+			let asset_precompile_address =
+				Runtime::asset_id_to_account(LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX, 0u128).into();
+
+			// Expected result for approve
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: 12821u64,
+				logs: LogsBuilder::new(asset_precompile_address)
+					.log3(
+						SELECTOR_LOG_TRANSFER,
+						H160::default(),
+						H160::from(BOB),
+						EvmDataWriter::new().write(U256::from(1000 * GLMR)).build(),
+					)
+					.build(),
+			}));
+
+			// Mint 1000 GLMRS to BOB
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::Mint)
+						.write(EvmAddress(BOB.into()))
+						.write(U256::from(1000 * GLMR))
+						.build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: ALICE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+
+			// Assert the asset has been minted
+			assert_eq!(LocalAssets::total_supply(0u128), 2_000 * GLMR);
+			assert_eq!(
+				LocalAssets::balance(0u128, AccountId::from(BOB)),
+				1_000 * GLMR
+			);
+
+			// Expected result for burn
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: 12957u64,
+				logs: LogsBuilder::new(asset_precompile_address)
+					.log3(
+						SELECTOR_LOG_TRANSFER,
+						H160::from(BOB),
+						H160::default(),
+						EvmDataWriter::new().write(U256::from(500 * GLMR)).build(),
+					)
+					.build(),
+			}));
+
+			// Transfer tokens from Alice to Charlie by using BOB as origin
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::Burn)
+						.write(EvmAddress(BOB.into()))
+						.write(U256::from(500 * GLMR))
+						.build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: ALICE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+
+			// Assert the asset has been burnt
+			assert_eq!(LocalAssets::total_supply(0u128), 1_500 * GLMR);
+			assert_eq!(
+				LocalAssets::balance(0u128, AccountId::from(BOB)),
+				500 * GLMR
+			);
+		});
+}
+
+#[test]
+fn asset_erc20_precompiles_freeze_thaw_account() {
+	ExtBuilder::default()
+		.with_local_assets(vec![(
+			0u128,
+			vec![(AccountId::from(ALICE), 1_000 * GLMR)],
+			AccountId::from(ALICE),
+		)])
+		.with_balances(vec![
+			(AccountId::from(ALICE), 2_000 * GLMR),
+			(AccountId::from(BOB), 1_000 * GLMR),
+		])
+		.build()
+		.execute_with(|| {
+			let asset_precompile_address =
+				Runtime::asset_id_to_account(LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX, 0u128).into();
+
+			// Expected result for approve
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: 6732u64,
+				logs: Default::default(),
+			}));
+
+			// Freeze Account
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::Freeze)
+						.write(EvmAddress(ALICE.into()))
+						.build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: ALICE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+
+			// Assert account is frozen
+			assert_eq!(
+				LocalAssets::can_withdraw(0u128, &AccountId::from(ALICE), 1).into_result(),
+				Err(TokenError::Frozen.into())
+			);
+
+			// Expected result for burn
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: 6731u64,
+				logs: Default::default(),
+			}));
+
+			// Thaw Account
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::Thaw)
+						.write(EvmAddress(ALICE.into()))
+						.build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: ALICE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+
+			// Assert account is not frozen
+			assert!(LocalAssets::can_withdraw(0u128, &AccountId::from(ALICE), 1)
+				.into_result()
+				.is_ok());
+		});
+}
+
+#[test]
+fn asset_erc20_precompiles_freeze_thaw_asset() {
+	ExtBuilder::default()
+		.with_local_assets(vec![(
+			0u128,
+			vec![(AccountId::from(ALICE), 1_000 * GLMR)],
+			AccountId::from(ALICE),
+		)])
+		.with_balances(vec![
+			(AccountId::from(ALICE), 2_000 * GLMR),
+			(AccountId::from(BOB), 1_000 * GLMR),
+		])
+		.build()
+		.execute_with(|| {
+			let asset_precompile_address =
+				Runtime::asset_id_to_account(LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX, 0u128).into();
+
+			// Expected result for approve
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: 5589u64,
+				logs: Default::default(),
+			}));
+
+			// Freeze Asset
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::FreezeAsset).build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: ALICE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+
+			// Assert account is frozen
+			assert_eq!(
+				LocalAssets::can_withdraw(0u128, &AccountId::from(ALICE), 1).into_result(),
+				Err(TokenError::Frozen.into())
+			);
+
+			// Expected result for burn
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: 5593u64,
+				logs: Default::default(),
+			}));
+
+			// Thaw Asset
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::ThawAsset).build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: ALICE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+
+			// Assert account is not frozen
+			assert!(LocalAssets::can_withdraw(0u128, &AccountId::from(ALICE), 1)
+				.into_result()
+				.is_ok());
+		});
+}
+
+#[test]
+fn asset_erc20_precompiles_freeze_transfer_ownership() {
+	ExtBuilder::default()
+		.with_local_assets(vec![(
+			0u128,
+			vec![(AccountId::from(ALICE), 1_000 * GLMR)],
+			AccountId::from(ALICE),
+		)])
+		.with_balances(vec![
+			(AccountId::from(ALICE), 2_000 * GLMR),
+			(AccountId::from(BOB), 1_000 * GLMR),
+		])
+		.build()
+		.execute_with(|| {
+			let asset_precompile_address =
+				Runtime::asset_id_to_account(LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX, 0u128).into();
+
+			// Expected result for approve
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: 6666u64,
+				logs: Default::default(),
+			}));
+
+			// Transfer ownerhsip of an asset
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::TransferOwnership)
+						.write(EvmAddress(BOB.into()))
+						.build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: ALICE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+
+			// No clear way of testing BOB is new owner, other than doing a priviledged function
+			// e.g., transfer_ownership again
+			assert_ok!(LocalAssets::transfer_ownership(
+				origin_of(AccountId::from(BOB)),
+				0u128,
+				AccountId::from(ALICE)
+			));
+		});
+}
+
+#[test]
+fn asset_erc20_precompiles_freeze_set_team() {
+	ExtBuilder::default()
+		.with_local_assets(vec![(
+			0u128,
+			vec![(AccountId::from(ALICE), 1_000 * GLMR)],
+			AccountId::from(ALICE),
+		)])
+		.with_balances(vec![
+			(AccountId::from(ALICE), 2_000 * GLMR),
+			(AccountId::from(BOB), 1_000 * GLMR),
+		])
+		.build()
+		.execute_with(|| {
+			let asset_precompile_address =
+				Runtime::asset_id_to_account(LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX, 0u128).into();
+
+			// Expected result for approve
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: 5614u64,
+				logs: Default::default(),
+			}));
+
+			// Set Bob as issuer, admin and freezer
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::SetTeam)
+						.write(EvmAddress(BOB.into()))
+						.write(EvmAddress(BOB.into()))
+						.write(EvmAddress(BOB.into()))
+						.build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: ALICE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+
+			// Bob should be able to mint, freeze, and thaw
+			assert_ok!(LocalAssets::mint(
+				origin_of(AccountId::from(BOB)),
+				0u128,
+				AccountId::from(BOB),
+				1_000 * GLMR
+			));
+			assert_ok!(LocalAssets::freeze(
+				origin_of(AccountId::from(BOB)),
+				0u128,
+				AccountId::from(ALICE)
+			));
+			assert_ok!(LocalAssets::thaw(
+				origin_of(AccountId::from(BOB)),
+				0u128,
+				AccountId::from(ALICE)
+			));
+		});
+}
+
+#[test]
+fn xcm_asset_erc20_precompiles_supply_and_balance() {
+	ExtBuilder::default()
+		.with_xcm_assets(vec![XcmAssetInitialization {
+			asset_type: AssetType::Xcm(MultiLocation::parent()),
+			metadata: AssetRegistrarMetadata {
+				name: b"RelayToken".to_vec(),
+				symbol: b"Relay".to_vec(),
+				decimals: 12,
+				is_frozen: false,
+			},
+			balances: vec![(AccountId::from(ALICE), 1_000 * GLMR)],
+			is_sufficient: true,
+		}])
+		.with_balances(vec![
+			(AccountId::from(ALICE), 2_000 * GLMR),
+			(AccountId::from(BOB), 1_000 * GLMR),
+		])
+		.build()
+		.execute_with(|| {
+			// We have the assetId that corresponds to the relay chain registered
+			let relay_asset_id: moonbeam_runtime::AssetId =
+				AssetType::Xcm(MultiLocation::parent()).into();
+
+			// Its address is
+			let asset_precompile_address = Runtime::asset_id_to_account(
+				FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX,
+				relay_asset_id,
+			)
+			.into();
+
+			// Assert the asset has been created with the correct supply
+			assert_eq!(Assets::total_supply(relay_asset_id), 1_000 * GLMR);
+
+			// The expected result for both total supply and balance of is the same, as only Alice
+			// holds balance
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(U256::from(1000 * GLMR)).build(),
+				cost: 1000,
+				logs: Default::default(),
+			}));
+
+			// Access totalSupply through precompile. Important that the context is correct
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::TotalSupply).build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: ALICE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+
+			// Access balanceOf through precompile
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
+						.write(EvmAddress(ALICE.into()))
+						.build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: ALICE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+		});
+}
+
+#[test]
+fn xcm_asset_erc20_precompiles_transfer() {
+	ExtBuilder::default()
+		.with_xcm_assets(vec![XcmAssetInitialization {
+			asset_type: AssetType::Xcm(MultiLocation::parent()),
+			metadata: AssetRegistrarMetadata {
+				name: b"RelayToken".to_vec(),
+				symbol: b"Relay".to_vec(),
+				decimals: 12,
+				is_frozen: false,
+			},
+			balances: vec![(AccountId::from(ALICE), 1_000 * GLMR)],
+			is_sufficient: true,
+		}])
+		.with_balances(vec![
+			(AccountId::from(ALICE), 2_000 * GLMR),
+			(AccountId::from(BOB), 1_000 * GLMR),
+		])
+		.build()
+		.execute_with(|| {
+			// We have the assetId that corresponds to the relay chain registered
+			let relay_asset_id: moonbeam_runtime::AssetId =
+				AssetType::Xcm(MultiLocation::parent()).into();
+
+			// Its address is
+			let asset_precompile_address = Runtime::asset_id_to_account(
+				FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX,
+				relay_asset_id,
+			)
+			.into();
+
+			// Expected result for a transfer
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: 23516u64,
+				logs: LogsBuilder::new(asset_precompile_address)
+					.log3(
+						SELECTOR_LOG_TRANSFER,
+						H160::from(ALICE),
+						H160::from(BOB),
+						EvmDataWriter::new().write(U256::from(400 * GLMR)).build(),
+					)
+					.build(),
+			}));
+
+			// Transfer tokens from Aice to Bob, 400 GLMR.
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::Transfer)
+						.write(EvmAddress(BOB.into()))
+						.write(U256::from(400 * GLMR))
+						.build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: ALICE.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+
+			// Expected result for balanceOf BOB
+			let expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(U256::from(400 * GLMR)).build(),
+				cost: 1000,
+				logs: Default::default(),
+			}));
+
+			// Make sure BOB has 400 GLMR
+			assert_eq!(
+				Precompiles::new().execute(
+					asset_precompile_address,
+					&EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
+						.write(EvmAddress(BOB.into()))
+						.build(),
+					None,
+					&Context {
+						address: asset_precompile_address,
+						caller: BOB.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				expected_result
+			);
+		});
+}
+
+#[test]
+fn xcm_asset_erc20_precompiles_approve() {
+	ExtBuilder::default()
+		.with_xcm_assets(vec![XcmAssetInitialization {
+			asset_type: AssetType::Xcm(MultiLocation::parent()),
+			metadata: AssetRegistrarMetadata {
+				name: b"RelayToken".to_vec(),
+				symbol: b"Relay".to_vec(),
+				decimals: 12,
+				is_frozen: false,
+			},
+			balances: vec![(AccountId::from(ALICE), 1_000 * GLMR)],
+			is_sufficient: true,
+		}])
+		.with_balances(vec![
+			(AccountId::from(ALICE), 2_000 * GLMR),
+			(AccountId::from(BOB), 1_000 * GLMR),
+		])
+		.build()
+		.execute_with(|| {
+			// We have the assetId that corresponds to the relay chain registered
+			let relay_asset_id: moonbeam_runtime::AssetId =
+				AssetType::Xcm(MultiLocation::parent()).into();
+
+			// Its address is
+			let asset_precompile_address = Runtime::asset_id_to_account(
+				FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX,
+				relay_asset_id,
+			)
+			.into();
 
 			// Expected result for approve
 			let expected_result = Some(Ok(PrecompileOutput {
@@ -1603,9 +2322,11 @@ fn xtokens_precompiles_transfer() {
 				AssetType::Xcm(MultiLocation::parent()).into();
 
 			// Its address is
-			let asset_precompile_address =
-				Runtime::asset_id_to_account(ASSET_PRECOMPILE_ADDRESS_PREFIX, relay_asset_id)
-					.into();
+			let asset_precompile_address = Runtime::asset_id_to_account(
+				FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX,
+				relay_asset_id,
+			)
+			.into();
 
 			// Alice has 1000 tokens. She should be able to send through precompile
 			let destination = MultiLocation::new(

--- a/runtime/moonbeam/tests/xcm_mock/mod.rs
+++ b/runtime/moonbeam/tests/xcm_mock/mod.rs
@@ -186,7 +186,8 @@ pub type StatemintBalances = pallet_balances::Pallet<statemint_like::Runtime>;
 pub type StatemintChainPalletXcm = pallet_xcm::Pallet<statemint_like::Runtime>;
 pub type StatemintAssets = pallet_assets::Pallet<statemint_like::Runtime>;
 
-pub type Assets = pallet_assets::Pallet<parachain::Runtime>;
+pub type Assets = pallet_assets::Pallet<parachain::Runtime, parachain::ForeignAssetInstance>;
+pub type LocalAssets = pallet_assets::Pallet<parachain::Runtime, parachain::LocalAssetInstance>;
 pub type Treasury = pallet_treasury::Pallet<parachain::Runtime>;
 pub type AssetManager = pallet_asset_manager::Pallet<parachain::Runtime>;
 pub type XTokens = orml_xtokens::Pallet<parachain::Runtime>;

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -328,11 +328,6 @@ where
 	fn convert(currency: CurrencyId) -> Option<MultiLocation> {
 		match currency {
 			CurrencyId::SelfReserve => {
-				// For now and until Xtokens is adapted to handle 0.9.16 version we use
-				// the old anchoring here
-				// This is not a problem in either cases, since the view of the destination
-				// chain does not change
-				// TODO! change this to NewAnchoringSelfReserve once xtokens is adapted for it
 				let multi: MultiLocation = SelfReserve::get();
 				Some(multi)
 			}

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -110,8 +110,8 @@ impl pallet_balances::Config for Runtime {
 	type ReserveIdentifier = [u8; 8];
 }
 
-pub type ForeignAssetInstance = pallet_assets::Instance1;
-pub type LocalAssetInstance = pallet_assets::Instance2;
+pub type ForeignAssetInstance = ();
+pub type LocalAssetInstance = pallet_assets::Instance1;
 
 parameter_types! {
 	pub const AssetDeposit: Balance = 1; // Does not really matter as this will be only called by root
@@ -913,13 +913,13 @@ construct_runtime!(
 		XcmVersioner: mock_version_changer::{Pallet, Storage, Event<T>},
 
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
-		Assets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>},
+		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>},
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin},
 		XTokens: orml_xtokens::{Pallet, Call, Storage, Event<T>},
 		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>},
 		XcmTransactor: xcm_transactor::{Pallet, Call, Storage, Event<T>},
 		Treasury: pallet_treasury::{Pallet, Storage, Config, Event<T>, Call},
-		LocalAssets: pallet_assets::<Instance2>::{Pallet, Call, Storage, Event<T>},
+		LocalAssets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>},
 
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage},
 		EVM: pallet_evm::{Pallet, Call, Storage, Config, Event<T>},

--- a/runtime/moonbeam/tests/xcm_tests.rs
+++ b/runtime/moonbeam/tests/xcm_tests.rs
@@ -28,12 +28,8 @@ use xcm_mock::relay_chain;
 use xcm_mock::*;
 use xcm_primitives::UtilityEncodeCall;
 
-use xcm::latest::prelude::QueryResponse;
-use xcm::latest::{
-	Junction::{self, AccountId32, AccountKey20, PalletInstance, Parachain},
-	Junctions::*,
-	MultiLocation, NetworkId, OriginKind, Response, Xcm,
-};
+use pallet_asset_manager::LocalAssetIdCreator;
+use xcm::latest::prelude::*;
 use xcm_executor::traits::Convert;
 use xcm_simulator::TestExt;
 
@@ -1624,6 +1620,82 @@ fn test_statemint_like_prefix_change() {
 	// Make sure that balance increases, as both prefixes are supported
 	ParaA::execute_with(|| {
 		assert_eq!(Assets::balance(source_id, &PARAALICE.into()), 246);
+	});
+}
+
+#[test]
+fn send_para_a_local_asset_to_para_b() {
+	MockNet::reset();
+
+	let asset_id = parachain::LocalAssetIdCreator::create_asset_id_from_metadata(0);
+	let para_a_local_asset = MultiLocation::new(
+		1,
+		X3(Parachain(1), PalletInstance(11u8), GeneralIndex(asset_id)),
+	);
+	let source_location = parachain::AssetType::Xcm(para_a_local_asset);
+
+	let asset_metadata = parachain::AssetMetadata {
+		name: b"ParaALocalAsset".to_vec(),
+		symbol: b"ParaALocalAsset".to_vec(),
+		decimals: 12,
+	};
+
+	ParaA::execute_with(|| {
+		assert_ok!(AssetManager::register_local_asset(
+			parachain::Origin::root(),
+			PARAALICE.into(),
+			PARAALICE.into(),
+			true,
+			1
+		));
+
+		assert_ok!(LocalAssets::mint(
+			parachain::Origin::signed(PARAALICE.into()),
+			asset_id,
+			PARAALICE.into(),
+			300000000000000
+		));
+	});
+
+	ParaB::execute_with(|| {
+		assert_ok!(AssetManager::register_foreign_asset(
+			parachain::Origin::root(),
+			source_location.clone(),
+			asset_metadata,
+			1u128,
+			true
+		));
+		assert_ok!(AssetManager::set_asset_units_per_second(
+			parachain::Origin::root(),
+			source_location,
+			0u128,
+			0
+		));
+	});
+
+	let dest = MultiLocation {
+		parents: 1,
+		interior: X2(
+			Parachain(2),
+			AccountKey20 {
+				network: NetworkId::Any,
+				key: PARAALICE.into(),
+			},
+		),
+	};
+
+	ParaA::execute_with(|| {
+		// Transactor not installed, fails
+		assert_noop!(
+			XTokens::transfer(
+				parachain::Origin::signed(PARAALICE.into()),
+				parachain::CurrencyId::LocalAssetReserve(asset_id),
+				100,
+				Box::new(VersionedMultiLocation::V1(dest)),
+				800000
+			),
+			orml_xtokens::Error::<parachain::Runtime>::XcmExecutionFailed
+		);
 	});
 }
 

--- a/runtime/moonriver/src/asset_config.rs
+++ b/runtime/moonriver/src/asset_config.rs
@@ -42,8 +42,8 @@ use sp_std::{
 	convert::{From, Into},
 	prelude::*,
 };
-type ForeignAssetInstance = pallet_assets::Instance1;
-type LocalAssetInstance = pallet_assets::Instance2;
+pub type ForeignAssetInstance = ();
+pub type LocalAssetInstance = pallet_assets::Instance1;
 
 // For foreign assets, these parameters dont matter much
 // as this will only be called by root with the forced arguments

--- a/runtime/moonriver/src/asset_config.rs
+++ b/runtime/moonriver/src/asset_config.rs
@@ -42,6 +42,8 @@ use sp_std::{
 	convert::{From, Into},
 	prelude::*,
 };
+
+// Not to disrupt the previous asset instance, we assign () to Foreign
 pub type ForeignAssetInstance = ();
 pub type LocalAssetInstance = pallet_assets::Instance1;
 

--- a/runtime/moonriver/src/asset_config.rs
+++ b/runtime/moonriver/src/asset_config.rs
@@ -124,7 +124,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// TODO uncomment when we feel comfortable
 		/*
 		// The asset has been created. Let's put the revert code in the precompile address
-		let precompile_address = Runtime::asset_id_to_account(ASSET_PRECOMPILE_ADDRESS_PREFIX, asset);
+		let precompile_address = Runtime::asset_id_to_account(asset);
 		pallet_evm::AccountCodes::<Runtime>::insert(
 			precompile_address,
 			vec![0x60, 0x00, 0x60, 0x00, 0xfd],

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1076,11 +1076,11 @@ construct_runtime! {
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 101,
 		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 102,
 		PolkadotXcm: pallet_xcm::{Pallet, Storage, Call, Event<T>, Origin, Config} = 103,
-		Assets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>} = 104,
+		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>} = 104,
 		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>} = 105,
 		XTokens: orml_xtokens::{Pallet, Call, Storage, Event<T>} = 106,
 		XcmTransactor: xcm_transactor::{Pallet, Call, Storage, Event<T>} = 107,
-		LocalAssets: pallet_assets::<Instance2>::{Pallet, Call, Storage, Event<T>} = 108,
+		LocalAssets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>} = 108,
 	}
 }
 

--- a/runtime/moonriver/src/precompiles.rs
+++ b/runtime/moonriver/src/precompiles.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::asset_config::{ForeignAssetInstance, LocalAssetInstance};
 use crowdloan_rewards_precompiles::CrowdloanRewardsWrapper;
 use fp_evm::Context;
 use moonbeam_relay_encoder::kusama::KusamaEncoder;
@@ -103,8 +104,8 @@ where
 	ParachainStakingWrapper<R>: Precompile,
 	CrowdloanRewardsWrapper<R>: Precompile,
 	Erc20BalancesPrecompile<R, NativeErc20Metadata>: Precompile,
-	Erc20AssetsPrecompileSet<R, IsForeign, pallet_assets::Instance1>: PrecompileSet,
-	Erc20AssetsPrecompileSet<R, IsLocal, pallet_assets::Instance2>: PrecompileSet,
+	Erc20AssetsPrecompileSet<R, IsForeign, ForeignAssetInstance>: PrecompileSet,
+	Erc20AssetsPrecompileSet<R, IsLocal, LocalAssetInstance>: PrecompileSet,
 	XtokensWrapper<R>: Precompile,
 	RelayEncoderWrapper<R, KusamaEncoder>: Precompile,
 	XcmTransactorWrapper<R>: Precompile,
@@ -170,12 +171,12 @@ where
 			)),
 			// If the address matches asset prefix, the we route through the asset precompile set
 			a if &a.to_fixed_bytes()[0..4] == FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX => {
-				Erc20AssetsPrecompileSet::<R, IsForeign, pallet_assets::Instance1>::new()
+				Erc20AssetsPrecompileSet::<R, IsForeign, ForeignAssetInstance>::new()
 					.execute(address, input, target_gas, context, is_static)
 			}
 			// If the address matches asset prefix, the we route through the asset precompile set
 			a if &a.to_fixed_bytes()[0..4] == LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX => {
-				Erc20AssetsPrecompileSet::<R, IsLocal, pallet_assets::Instance2>::new()
+				Erc20AssetsPrecompileSet::<R, IsLocal, LocalAssetInstance>::new()
 					.execute(address, input, target_gas, context, is_static)
 			}
 			_ => None,
@@ -183,9 +184,9 @@ where
 	}
 	fn is_precompile(&self, address: H160) -> bool {
 		Self::used_addresses().any(|x| x == R::AddressMapping::into_account_id(address))
-			|| Erc20AssetsPrecompileSet::<R, IsForeign, pallet_assets::Instance1>::new()
+			|| Erc20AssetsPrecompileSet::<R, IsForeign, ForeignAssetInstance>::new()
 				.is_precompile(address)
-			|| Erc20AssetsPrecompileSet::<R, IsLocal, pallet_assets::Instance2>::new()
+			|| Erc20AssetsPrecompileSet::<R, IsLocal, LocalAssetInstance>::new()
 				.is_precompile(address)
 	}
 }

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -1325,6 +1325,31 @@ fn asset_can_be_registered() {
 }
 
 #[test]
+fn local_assets_cannot_be_create_by_signed_origins() {
+	ExtBuilder::default()
+		.with_balances(vec![
+			(AccountId::from(ALICE), 2_000 * MOVR * SUPPLY_FACTOR),
+			(AccountId::from(BOB), 1_000 * MOVR * SUPPLY_FACTOR),
+		])
+		.build()
+		.execute_with(|| {
+			assert_noop!(
+				Call::LocalAssets(
+					pallet_assets::Call::<Runtime, pallet_assets::Instance2>::create {
+						id: 11u128,
+						admin: AccountId::from(ALICE),
+						min_balance: 1u128
+					}
+				)
+				.dispatch(<Runtime as frame_system::Config>::Origin::signed(
+					AccountId::from(ALICE)
+				)),
+				frame_system::Error::<Runtime>::CallFiltered
+			);
+		});
+}
+
+#[test]
 fn asset_erc20_precompiles_supply_and_balance() {
 	ExtBuilder::default()
 		.with_local_assets(vec![(

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -33,9 +33,9 @@ use frame_support::{
 	StorageHasher, Twox128,
 };
 use moonriver_runtime::{
-	xcm_config::CurrencyId, AssetId, BaseFee, BlockWeights, LocalAssets, PolkadotXcm, Precompiles,
-	XTokens, XcmTransactor, FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX,
-	LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX,
+	asset_config::LocalAssetInstance, xcm_config::CurrencyId, AssetId, BaseFee, BlockWeights,
+	LocalAssets, PolkadotXcm, Precompiles, XTokens, XcmTransactor,
+	FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX, LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX,
 };
 use nimbus_primitives::NimbusId;
 use pallet_evm::PrecompileSet;
@@ -1334,13 +1334,11 @@ fn local_assets_cannot_be_create_by_signed_origins() {
 		.build()
 		.execute_with(|| {
 			assert_noop!(
-				Call::LocalAssets(
-					pallet_assets::Call::<Runtime, pallet_assets::Instance2>::create {
-						id: 11u128,
-						admin: AccountId::from(ALICE),
-						min_balance: 1u128
-					}
-				)
+				Call::LocalAssets(pallet_assets::Call::<Runtime, LocalAssetInstance>::create {
+					id: 11u128,
+					admin: AccountId::from(ALICE),
+					min_balance: 1u128
+				})
 				.dispatch(<Runtime as frame_system::Config>::Origin::signed(
 					AccountId::from(ALICE)
 				)),

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -441,6 +441,7 @@ where
 				Some(multi)
 			}
 			CurrencyId::ForeignAsset(asset) => AssetXConverter::reverse_ref(asset).ok(),
+			// Even if we instruct how to convert, the transactor is not enabled
 			CurrencyId::LocalAssetReserve(asset) => {
 				let mut location = LocalAssetsPalletLocationOldReanchor::get();
 				location.push_interior(Junction::GeneralIndex(asset)).ok();

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -441,7 +441,6 @@ where
 				Some(multi)
 			}
 			CurrencyId::ForeignAsset(asset) => AssetXConverter::reverse_ref(asset).ok(),
-			// Even if we instruct how to convert, the transactor is not enabled
 			CurrencyId::LocalAssetReserve(asset) => {
 				let mut location = LocalAssetsPalletLocationOldReanchor::get();
 				location.push_interior(Junction::GeneralIndex(asset)).ok();

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -111,8 +111,8 @@ impl pallet_balances::Config for Runtime {
 	type ReserveIdentifier = [u8; 8];
 }
 
-pub type ForeignAssetInstance = pallet_assets::Instance1;
-pub type LocalAssetInstance = pallet_assets::Instance2;
+pub type ForeignAssetInstance = ();
+pub type LocalAssetInstance = pallet_assets::Instance1;
 
 parameter_types! {
 	pub const AssetDeposit: Balance = 1; // Does not really matter as this will be only called by root
@@ -1019,13 +1019,13 @@ construct_runtime!(
 		XcmVersioner: mock_version_changer::{Pallet, Storage, Event<T>},
 
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin},
-		Assets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>},
+		Assets: pallet_assets::{Pallet, Call, Storage, Event<T>},
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin},
 		XTokens: orml_xtokens::{Pallet, Call, Storage, Event<T>},
 		AssetManager: pallet_asset_manager::{Pallet, Call, Storage, Event<T>},
 		XcmTransactor: xcm_transactor::{Pallet, Call, Storage, Event<T>},
 		Treasury: pallet_treasury::{Pallet, Storage, Config, Event<T>, Call},
-		LocalAssets: pallet_assets::<Instance2>::{Pallet, Call, Storage, Event<T>},
+		LocalAssets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>},
 
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage},
 		EVM: pallet_evm::{Pallet, Call, Storage, Config, Event<T>},


### PR DESCRIPTION
### What does it do?
Enable local assets in Moonbeam, but without them beign transferrable through XCM

Particularly this is guaranteed as long as `pub type AssetTransactors = FungiblesTransactor`, only foreign assets are transferrable through xcm

For safety purposes we also change `AssetInstance1` for` () `and `AssetInstance2` for `AssetInstance1`. We know storage should not be affected but just in case, @nanocryk suggested to not change the instance name of the already existing assets 
### What important points reviewers should know?
The following changes have been made:

- An integration test has been added to all runtime verifying local assets are not creatable through signed origins
- Local assets have been added to Moonbeam runtime
- All xcm-related stuff for local assets has been added **except for the transactor. This is the key component preventing local assets from being transferred**
- Local asset tests in Moonbeam 
- `AssetInstance1` renamed to `()` and `assetInstance2` for `AssetInstance2` in all runtimes


### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
