### PR TITLE
fix: client build use production profile

### DIFF
--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -34,12 +34,12 @@ jobs:
         if: ${{ matrix.cpu == '' }}
         run: |
           mkdir -p build
-          cp target/release/moonbeam build/moonbeam
+          cp target/production/moonbeam build/moonbeam
       - name: Save parachain custom binary
         if: ${{ matrix.cpu != '' }}
         run: |
           mkdir -p build
-          cp target/release/moonbeam build/moonbeam-${{matrix.cpu}}
+          cp target/production/moonbeam build/moonbeam-${{matrix.cpu}}
       - name: Upload binary
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
### What does it do?

"production" profile usage implies that the binary is now in `target/production` and not in `target/release`

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
