### PR TITLE
Add link to rustdocs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ The following pallets are stored in `pallets/`. They are designed for Moonbeam's
 - _Author Inherent_: Allows block authors to include their identity in a block via an inherent
 - _Parachain Staking_: Minimal staking pallet that selects collators by total amount at stake
 
+## Rustdocs
+
+Rustdocs for the Moonbeam codebase are automatically generated and published
+[here](https://purestake.github.io/moonbeam/moonbeam_runtime/index.html).
+
 ## Contribute
 
 Moonbeam is open source under the terms of the GPL3. We welcome contributions. Please review our


### PR DESCRIPTION
### What does it do?

Adds a link to our generated rustdocs in the main readme.