### PR TITLE
Remove some unused crates from perf-test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,26 +2054,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darwin-libproc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb90051930c9a0f09e585762152048e23ac74d20c10590ef7cf01c0343c3046"
-dependencies = [
- "darwin-libproc-sys",
- "libc",
- "memchr",
-]
-
-[[package]]
-name = "darwin-libproc-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cebb5bde66eecdd30ddc4b9cd208238b15db4982ccc72db59d699ea10867c1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5656,7 +5636,7 @@ dependencies = [
  "hex",
  "moonbeam-cli",
  "moonbeam-service",
- "nix 0.17.0",
+ "nix",
  "pallet-xcm",
  "serde",
  "serde_json",
@@ -6135,7 +6115,7 @@ dependencies = [
  "moonriver-runtime",
  "nimbus-consensus",
  "nimbus-primitives",
- "nix 0.17.0",
+ "nix",
  "pallet-author-inherent",
  "pallet-ethereum",
  "pallet-sudo",
@@ -6537,19 +6517,6 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "void",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -8420,10 +8387,7 @@ dependencies = [
  "moonbeam-cli-opt",
  "moonbeam-service",
  "nimbus-primitives",
- "num_cpus",
  "pallet-ethereum",
- "psutil",
- "raw-cpuid",
  "rlp",
  "sc-basic-authorship",
  "sc-cli",
@@ -9930,25 +9894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psutil"
-version = "3.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f866af2b0f8e4b0d2d00aad8a9c5fc48fad33466cd99a64cbb3a4c1505f1a62d"
-dependencies = [
- "cfg-if 1.0.0",
- "darwin-libproc",
- "derive_more",
- "glob",
- "mach",
- "nix 0.23.1",
- "num_cpus",
- "once_cell",
- "platforms",
- "thiserror",
- "unescape",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10181,15 +10126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "10.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738bc47119e3eeccc7e94c4a506901aea5e7b4944ecd0829cbebf4af04ceda12"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -13899,12 +13835,6 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
-
-[[package]]
-name = "unescape"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
 
 [[package]]
 name = "unicase"

--- a/node/perf-test/Cargo.toml
+++ b/node/perf-test/Cargo.toml
@@ -13,9 +13,6 @@ futures = { version = "0.3.1", features = [ "compat" ] }
 hex = "0.4.3"
 libsecp256k1 = { version = "0.5" }
 log = "0.4.8"
-num_cpus = "1.13.0"
-psutil = "3.2.1"
-raw-cpuid = "10.2.0"
 rlp = { version = "0.5" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"


### PR DESCRIPTION
### What does it do?

Removes some deps that are no longer needed in `perf-test`.

This may fix #930 