### PR TITLE
[MOON-1460] add migration for author-slot-filter EligibleRatioToEligiblityCount

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6472,7 +6472,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#14215b0053fb516e142e77fe26d3e26b1e3fb8f1"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#f65fafba3ece36a24588709bdbef4ffce7f74a01"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -6503,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#14215b0053fb516e142e77fe26d3e26b1e3fb8f1"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#f65fafba3ece36a24588709bdbef4ffce7f74a01"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -6903,7 +6903,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#14215b0053fb516e142e77fe26d3e26b1e3fb8f1"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#f65fafba3ece36a24588709bdbef4ffce7f74a01"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6968,7 +6968,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#14215b0053fb516e142e77fe26d3e26b1e3fb8f1"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#f65fafba3ece36a24588709bdbef4ffce7f74a01"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6472,7 +6472,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#50b9cfeca9609dcd1b5fd835c1f23bfaaef831cb"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#14215b0053fb516e142e77fe26d3e26b1e3fb8f1"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -6503,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#50b9cfeca9609dcd1b5fd835c1f23bfaaef831cb"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#14215b0053fb516e142e77fe26d3e26b1e3fb8f1"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -6903,7 +6903,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#50b9cfeca9609dcd1b5fd835c1f23bfaaef831cb"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#14215b0053fb516e142e77fe26d3e26b1e3fb8f1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6968,7 +6968,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#50b9cfeca9609dcd1b5fd835c1f23bfaaef831cb"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#14215b0053fb516e142e77fe26d3e26b1e3fb8f1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5212,15 +5212,6 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard 1.1.0",
-]
-
-[[package]]
-name = "lock_api"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
@@ -6481,7 +6472,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#d68bf7409768927870f2315fe185c9e95777d5fc"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#50b9cfeca9609dcd1b5fd835c1f23bfaaef831cb"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -6491,7 +6482,7 @@ dependencies = [
  "log",
  "nimbus-primitives",
  "parity-scale-codec",
- "parking_lot 0.9.0",
+ "parking_lot 0.12.0",
  "polkadot-client",
  "sc-client-api",
  "sc-consensus",
@@ -6512,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#d68bf7409768927870f2315fe185c9e95777d5fc"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#50b9cfeca9609dcd1b5fd835c1f23bfaaef831cb"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -6912,7 +6903,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#d68bf7409768927870f2315fe185c9e95777d5fc"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#50b9cfeca9609dcd1b5fd835c1f23bfaaef831cb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6977,7 +6968,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#d68bf7409768927870f2315fe185c9e95777d5fc"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.18#50b9cfeca9609dcd1b5fd835c1f23bfaaef831cb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8272,17 +8263,6 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.6.2",
- "rustc_version 0.2.3",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
@@ -8317,21 +8297,6 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "rustc_version 0.2.3",
- "smallvec 0.6.14",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "parking_lot_core"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
@@ -8339,7 +8304,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.12",
+ "redox_syscall",
  "smallvec 1.8.0",
  "winapi 0.3.9",
 ]
@@ -8352,7 +8317,7 @@ checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.12",
+ "redox_syscall",
  "smallvec 1.8.0",
  "windows-sys",
 ]
@@ -10234,12 +10199,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
@@ -10254,7 +10213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7776223e2696f1aa4c6b0170e83212f47296a00424305117d013dfe86fb0fe55"
 dependencies = [
  "getrandom 0.2.6",
- "redox_syscall 0.2.12",
+ "redox_syscall",
  "thiserror",
 ]
 
@@ -10571,6 +10530,7 @@ dependencies = [
  "log",
  "pallet-asset-manager",
  "pallet-author-mapping",
+ "pallet-author-slot-filter",
  "pallet-base-fee",
  "pallet-collective",
  "pallet-evm",
@@ -13379,7 +13339,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "libc",
- "redox_syscall 0.2.12",
+ "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
 ]

--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -286,7 +286,7 @@ pub fn testnet_genesis(
 			members: tech_comittee_members,
 		},
 		author_filter: AuthorFilterConfig {
-			eligible_count: EligibilityValue::default(),
+			eligible_count: EligibilityValue::new_unchecked(50),
 		},
 		author_mapping: AuthorMappingConfig {
 			mappings: candidates

--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -29,7 +29,8 @@ use moonbase_runtime::{
 	BaseFeeConfig, CouncilCollectiveConfig, CrowdloanRewardsConfig, DemocracyConfig, EVMConfig,
 	EthereumChainIdConfig, EthereumConfig, GenesisAccount, GenesisConfig, InflationInfo,
 	MaintenanceModeConfig, ParachainInfoConfig, ParachainStakingConfig, PolkadotXcmConfig,
-	Precompiles, Range, SudoConfig, SystemConfig, TechCommitteeCollectiveConfig, WASM_BINARY,
+	Precompiles, Range, SudoConfig, SystemConfig, TechCommitteeCollectiveConfig,
+	DEFAULT_TOTAL_ELIGIBLE_AUTHORS, WASM_BINARY,
 };
 use nimbus_primitives::NimbusId;
 use sc_service::ChainType;
@@ -285,7 +286,7 @@ pub fn testnet_genesis(
 			members: tech_comittee_members,
 		},
 		author_filter: AuthorFilterConfig {
-			eligible_ratio: sp_runtime::Percent::from_percent(50),
+			eligible_count: DEFAULT_TOTAL_ELIGIBLE_AUTHORS,
 		},
 		author_mapping: AuthorMappingConfig {
 			mappings: candidates

--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -27,10 +27,10 @@ use hex_literal::hex;
 use moonbase_runtime::{
 	currency::UNIT, AccountId, AuthorFilterConfig, AuthorMappingConfig, Balance, BalancesConfig,
 	BaseFeeConfig, CouncilCollectiveConfig, CrowdloanRewardsConfig, DemocracyConfig, EVMConfig,
-	EthereumChainIdConfig, EthereumConfig, GenesisAccount, GenesisConfig, InflationInfo,
-	MaintenanceModeConfig, ParachainInfoConfig, ParachainStakingConfig, PolkadotXcmConfig,
-	Precompiles, Range, SudoConfig, SystemConfig, TechCommitteeCollectiveConfig,
-	DEFAULT_TOTAL_ELIGIBLE_AUTHORS, WASM_BINARY,
+	EligibilityValue, EthereumChainIdConfig, EthereumConfig, GenesisAccount, GenesisConfig,
+	InflationInfo, MaintenanceModeConfig, ParachainInfoConfig, ParachainStakingConfig,
+	PolkadotXcmConfig, Precompiles, Range, SudoConfig, SystemConfig, TechCommitteeCollectiveConfig,
+	WASM_BINARY,
 };
 use nimbus_primitives::NimbusId;
 use sc_service::ChainType;
@@ -286,7 +286,7 @@ pub fn testnet_genesis(
 			members: tech_comittee_members,
 		},
 		author_filter: AuthorFilterConfig {
-			eligible_count: DEFAULT_TOTAL_ELIGIBLE_AUTHORS,
+			eligible_count: EligibilityValue::default(),
 		},
 		author_mapping: AuthorMappingConfig {
 			mappings: candidates

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -24,6 +24,7 @@ use crate::chain_spec::{derive_bip44_pairs_from_mnemonic, get_account_id_from_pa
 use crate::chain_spec::{generate_accounts, get_from_seed, Extensions};
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
+use moonbase_runtime::DEFAULT_TOTAL_ELIGIBLE_AUTHORS;
 use moonbeam_runtime::{
 	currency::GLMR, currency::SUPPLY_FACTOR, get, AccountId, AuthorFilterConfig,
 	AuthorMappingConfig, Balance, BalancesConfig, CouncilCollectiveConfig, CrowdloanRewardsConfig,
@@ -270,7 +271,7 @@ pub fn testnet_genesis(
 			members: tech_comittee_members,
 		},
 		author_filter: AuthorFilterConfig {
-			eligible_ratio: sp_runtime::Percent::from_percent(50),
+			eligible_count: DEFAULT_TOTAL_ELIGIBLE_AUTHORS,
 		},
 		author_mapping: AuthorMappingConfig {
 			mappings: candidates

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -24,7 +24,7 @@ use crate::chain_spec::{derive_bip44_pairs_from_mnemonic, get_account_id_from_pa
 use crate::chain_spec::{generate_accounts, get_from_seed, Extensions};
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
-use moonbase_runtime::DEFAULT_TOTAL_ELIGIBLE_AUTHORS;
+use moonbase_runtime::EligibilityValue;
 use moonbeam_runtime::{
 	currency::GLMR, currency::SUPPLY_FACTOR, get, AccountId, AuthorFilterConfig,
 	AuthorMappingConfig, Balance, BalancesConfig, CouncilCollectiveConfig, CrowdloanRewardsConfig,
@@ -271,7 +271,7 @@ pub fn testnet_genesis(
 			members: tech_comittee_members,
 		},
 		author_filter: AuthorFilterConfig {
-			eligible_count: DEFAULT_TOTAL_ELIGIBLE_AUTHORS,
+			eligible_count: EligibilityValue::default(),
 		},
 		author_mapping: AuthorMappingConfig {
 			mappings: candidates

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -271,7 +271,7 @@ pub fn testnet_genesis(
 			members: tech_comittee_members,
 		},
 		author_filter: AuthorFilterConfig {
-			eligible_count: EligibilityValue::default(),
+			eligible_count: EligibilityValue::new_unchecked(50),
 		},
 		author_mapping: AuthorMappingConfig {
 			mappings: candidates

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -273,7 +273,7 @@ pub fn testnet_genesis(
 			members: tech_comittee_members,
 		},
 		author_filter: AuthorFilterConfig {
-			eligible_count: EligibilityValue::default(),
+			eligible_count: EligibilityValue::new_unchecked(50),
 		},
 		author_mapping: AuthorMappingConfig {
 			mappings: candidates

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -24,6 +24,7 @@ use crate::chain_spec::{derive_bip44_pairs_from_mnemonic, get_account_id_from_pa
 use crate::chain_spec::{generate_accounts, get_from_seed, Extensions};
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
+use moonbase_runtime::DEFAULT_TOTAL_ELIGIBLE_AUTHORS;
 use moonriver_runtime::{
 	currency::MOVR, AccountId, AuthorFilterConfig, AuthorMappingConfig, Balance, BalancesConfig,
 	CouncilCollectiveConfig, CrowdloanRewardsConfig, DemocracyConfig, EVMConfig,
@@ -272,7 +273,7 @@ pub fn testnet_genesis(
 			members: tech_comittee_members,
 		},
 		author_filter: AuthorFilterConfig {
-			eligible_ratio: sp_runtime::Percent::from_percent(50),
+			eligible_count: DEFAULT_TOTAL_ELIGIBLE_AUTHORS,
 		},
 		author_mapping: AuthorMappingConfig {
 			mappings: candidates

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -24,7 +24,7 @@ use crate::chain_spec::{derive_bip44_pairs_from_mnemonic, get_account_id_from_pa
 use crate::chain_spec::{generate_accounts, get_from_seed, Extensions};
 use cumulus_primitives_core::ParaId;
 use hex_literal::hex;
-use moonbase_runtime::DEFAULT_TOTAL_ELIGIBLE_AUTHORS;
+use moonbase_runtime::EligibilityValue;
 use moonriver_runtime::{
 	currency::MOVR, AccountId, AuthorFilterConfig, AuthorMappingConfig, Balance, BalancesConfig,
 	CouncilCollectiveConfig, CrowdloanRewardsConfig, DemocracyConfig, EVMConfig,
@@ -273,7 +273,7 @@ pub fn testnet_genesis(
 			members: tech_comittee_members,
 		},
 		author_filter: AuthorFilterConfig {
-			eligible_count: DEFAULT_TOTAL_ELIGIBLE_AUTHORS,
+			eligible_count: EligibilityValue::default(),
 		},
 		author_mapping: AuthorMappingConfig {
 			mappings: candidates

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -31,6 +31,9 @@ sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-po
 pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
 
+# Nimbus
+pallet-author-slot-filter = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+
 # Polkadot
 xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.18", optional = true, default-features = false }
 

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -270,6 +270,7 @@ try-runtime = [
 	"frame-try-runtime",
 	"pallet-asset-manager/try-runtime",
 	"pallet-author-mapping/try-runtime",
+	"pallet-author-slot-filter/try-runtime",
 	"pallet-balances/try-runtime",
 	"pallet-collective/try-runtime",
 	"pallet-maintenance-mode/try-runtime",

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -33,8 +33,6 @@ use fp_rpc::TransactionStatus;
 
 use account::AccountId20;
 
-pub use pallet_author_slot_filter::DEFAULT_TOTAL_ELIGIBLE_AUTHORS;
-
 // Re-export required by get! macro.
 pub use frame_support::traits::Get;
 use frame_support::{
@@ -61,6 +59,7 @@ pub use moonbeam_core_primitives::{
 	Index, Signature,
 };
 use moonbeam_rpc_primitives_txpool::TxPoolResponse;
+pub use pallet_author_slot_filter::EligibilityValue;
 use pallet_balances::NegativeImbalance;
 use pallet_ethereum::Call::transact;
 use pallet_ethereum::Transaction as EthereumTransaction;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -33,6 +33,8 @@ use fp_rpc::TransactionStatus;
 
 use account::AccountId20;
 
+pub use pallet_author_slot_filter::DEFAULT_TOTAL_ELIGIBLE_AUTHORS;
+
 // Re-export required by get! macro.
 pub use frame_support::traits::Get;
 use frame_support::{

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -262,6 +262,7 @@ try-runtime = [
 	"frame-try-runtime",
 	"pallet-asset-manager/try-runtime",
 	"pallet-author-mapping/try-runtime",
+	"pallet-author-slot-filter/try-runtime",
 	"pallet-balances/try-runtime",
 	"pallet-collective/try-runtime",
 	"pallet-maintenance-mode/try-runtime",

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -264,6 +264,7 @@ try-runtime = [
 	"frame-try-runtime",
 	"pallet-asset-manager/try-runtime",
 	"pallet-author-mapping/try-runtime",
+	"pallet-author-slot-filter/try-runtime",
 	"pallet-balances/try-runtime",
 	"pallet-collective/try-runtime",
 	"pallet-maintenance-mode/try-runtime",


### PR DESCRIPTION
### What does it do?
Adds the migration defined in https://github.com/PureStake/nimbus/pull/45

### What important points reviewers should know?
* The migration was run with `try-runtime` and passed without failures but it _always_ passes without failures.
* The migration might not need to be enabled right now (maybe needs to be commented out?)
* The migration will insert a new storage item, also when the previous storage item was missing.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?
https://github.com/PureStake/nimbus/pull/45

### What value does it bring to the blockchain users?
Instead of using a percentage value, which makes it hard to represent some numbers (based on fixed precision) for large values of author count, we instead use an integer (`NonZeroU32`).