### PR TITLE
Revert back wrong hasher introduced for AssetTypeUnitsPerSecond

### DIFF
--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -282,7 +282,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn asset_type_units_per_second)]
 	pub type AssetTypeUnitsPerSecond<T: Config> =
-		StorageMap<_, Twox64Concat, T::ForeignAssetType, u128>;
+		StorageMap<_, Blake2_128Concat, T::ForeignAssetType, u128>;
 
 	/// Stores the counter of the number of local assets that have been
 	/// created so far


### PR DESCRIPTION
### What does it do?
Reverts back a mistakenly changed hasher
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
