### PR TITLE
Girazoki pending delegation request precompile

### DIFF
--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -103,6 +103,16 @@ interface ParachainStaking {
     /// @return The selected candidate accounts
     function selected_candidates() external view returns (address[] memory);
 
+    /// @dev Whether there exists a pending request for a delegation made by a delegator
+    /// Selector: 192e1db3
+    /// @param candidate the candidate for which the delegation was made
+    /// @param delegator the delegator that made the delegation
+    /// @return Whether a pending request exist for such delegation
+    function delegation_request_is_pending(address candidate, address delegator)
+        external
+        view
+        returns (bool);
+
     /// @dev Join the set of collator candidates
     /// Selector: 0a1bff60
     /// @param amount The amount self-bonded by the caller to become a collator candidate

--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -105,10 +105,10 @@ interface ParachainStaking {
 
     /// @dev Whether there exists a pending request for a delegation made by a delegator
     /// Selector: 192e1db3
-    /// @param candidate the candidate for which the delegation was made
     /// @param delegator the delegator that made the delegation
+    /// @param candidate the candidate for which the delegation was made
     /// @return Whether a pending request exist for such delegation
-    function delegation_request_is_pending(address candidate, address delegator)
+    function delegation_request_is_pending(address delegator, address candidate)
         external
         view
         returns (bool);

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -60,6 +60,7 @@ enum Action {
 	IsDelegator = "is_delegator(address)",
 	IsCandidate = "is_candidate(address)",
 	IsSelectedCandidate = "is_selected_candidate(address)",
+	DelegationRequestIsPending = "delegation_request_is_pending(address,address)",
 	JoinCandidates = "join_candidates(uint256,uint256)",
 	// DEPRECATED
 	LeaveCandidates = "leave_candidates(uint256)",
@@ -173,6 +174,9 @@ where
 			Action::IsDelegator => return Self::is_delegator(input, gasometer),
 			Action::IsCandidate => return Self::is_candidate(input, gasometer),
 			Action::IsSelectedCandidate => return Self::is_selected_candidate(input, gasometer),
+			Action::DelegationRequestIsPending => {
+				return Self::delegation_request_is_pending(input, gasometer)
+			}
 			// runtime methods (dispatchables)
 			Action::JoinCandidates => Self::join_candidates(input, gasometer, context)?,
 			// DEPRECATED
@@ -472,6 +476,48 @@ where
 			exit_status: ExitSucceed::Returned,
 			cost: gasometer.used_gas(),
 			output: EvmDataWriter::new().write(is_selected).build(),
+			logs: vec![],
+		})
+	}
+
+	fn delegation_request_is_pending(
+		input: &mut EvmDataReader,
+		gasometer: &mut Gasometer,
+	) -> EvmResult<PrecompileOutput> {
+		// Read input.
+		input.expect_arguments(gasometer, 2)?;
+
+		// First argument is candidate
+		let candidate =
+			Runtime::AddressMapping::into_account_id(input.read::<Address>(gasometer)?.0);
+
+		// Second argument is delegator
+		let delegator =
+			Runtime::AddressMapping::into_account_id(input.read::<Address>(gasometer)?.0);
+
+		// Fetch info.
+		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		// If we are not able to get delegator state, we return false
+		// TODO: evaluate whether we should early-return instead of returning false
+		let pending = if let Some(state) =
+			<parachain_staking::Pallet<Runtime>>::delegator_state(&delegator)
+		{
+			state.requests.requests.contains_key(&candidate)
+		} else {
+			log::trace!(
+				target: "staking-precompile",
+				"Delegation for {:?} not found, so pending requests is false",
+				candidate
+			);
+			false
+		};
+
+		// Build output.
+		Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			cost: gasometer.used_gas(),
+			output: EvmDataWriter::new().write(pending).build(),
 			logs: vec![],
 		})
 	}

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -487,12 +487,12 @@ where
 		// Read input.
 		input.expect_arguments(gasometer, 2)?;
 
-		// First argument is candidate
-		let candidate =
+		// First argument is delegator
+		let delegator =
 			Runtime::AddressMapping::into_account_id(input.read::<Address>(gasometer)?.0);
 
-		// Second argument is delegator
-		let delegator =
+		// Second argument is candidate
+		let candidate =
 			Runtime::AddressMapping::into_account_id(input.read::<Address>(gasometer)?.0);
 
 		// Fetch info.

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -790,8 +790,8 @@ fn delegation_request_is_pending_works() {
 				precompiles().execute(
 					precompile_address(),
 					&EvmDataWriter::new_with_selector(Action::DelegationRequestIsPending)
-						.write(Address(TestAccount::Alice.into()))
 						.write(Address(TestAccount::Charlie.into()))
+						.write(Address(TestAccount::Alice.into()))
 						.build(),
 					None,
 					&evm_test_context(),
@@ -835,8 +835,8 @@ fn delegation_request_is_pending_works() {
 				precompiles().execute(
 					precompile_address(),
 					&EvmDataWriter::new_with_selector(Action::DelegationRequestIsPending)
-						.write(Address(TestAccount::Alice.into()))
 						.write(Address(TestAccount::Charlie.into()))
+						.write(Address(TestAccount::Alice.into()))
 						.build(),
 					None,
 					&evm_test_context(),
@@ -871,8 +871,8 @@ fn delegation_request_is_pending_returns_false_for_non_existing_del() {
 				precompiles().execute(
 					precompile_address(),
 					&EvmDataWriter::new_with_selector(Action::DelegationRequestIsPending)
-						.write(Address(TestAccount::Alice.into()))
 						.write(Address(TestAccount::Bob.into()))
+						.write(Address(TestAccount::Alice.into()))
 						.build(),
 					None,
 					&evm_test_context(),

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -63,6 +63,7 @@ fn selectors() {
 	assert_eq!(Action::NominatorNominationCount as u32, 0xdae5659b);
 	assert_eq!(Action::DelegatorDelegationCount as u32, 0xfbc51bca);
 	assert_eq!(Action::SelectedCandidates as u32, 0x89f47a21);
+	assert_eq!(Action::DelegationRequestIsPending as u32, 0x192e1db3);
 	assert_eq!(Action::JoinCandidates as u32, 0x0a1bff60);
 	// DEPRECATED
 	assert_eq!(Action::LeaveCandidates as u32, 0x72b02a31);

--- a/tests/tests/test-precompile/test-precompile-staking.ts
+++ b/tests/tests/test-precompile/test-precompile-staking.ts
@@ -77,7 +77,7 @@ async function delegationRequestIsPending(
     ADDRESS_STAKING,
     SELECTORS,
     "delegation_request_is_pending",
-    [collatorAddress, delegatorAddress]
+    [delegatorAddress, collatorAddress]
   );
 }
 

--- a/tests/tests/test-precompile/test-precompile-staking.ts
+++ b/tests/tests/test-precompile/test-precompile-staking.ts
@@ -69,8 +69,8 @@ async function candidateCount(context: DevTestContext) {
 
 async function delegationRequestIsPending(
   context: DevTestContext,
-  collatorAddress: string,
-  delegatorAddress: string
+  delegatorAddress: string,
+  collatorAddress: string
 ) {
   return await callPrecompile(
     context,
@@ -165,7 +165,7 @@ describeDevMoonbeamAllEthTxTypes("Staking - Join Delegators", (context) => {
   });
 
   it("should return false for pending requests", async function () {
-    expect(Number((await delegationRequestIsPending(context, ALITH, ETHAN)).result)).to.equal(0);
+    expect(Number((await delegationRequestIsPending(context, ETHAN, ALITH)).result)).to.equal(0);
 
     // Schedule Revoke
     await context.polkadotApi.tx.parachainStaking
@@ -174,6 +174,6 @@ describeDevMoonbeamAllEthTxTypes("Staking - Join Delegators", (context) => {
     await context.createBlock();
 
     // Check that there exists a pending request
-    expect(Number((await delegationRequestIsPending(context, ALITH, ETHAN)).result)).to.equal(1);
+    expect(Number((await delegationRequestIsPending(context, ETHAN, ALITH)).result)).to.equal(1);
   });
 });


### PR DESCRIPTION
### What does it do?
It adds a new precompile called `delegation_request_is_pending` that accepts a `candidate` and a `delegator` as an argument and verifies whether there exists a pending request for such delegation. Motivated by the discussion in https://github.com/PureStake/moonbeam/issues/1128.

For now we did not see necessary to return the request type, as there can be only one request per delegation and the SC can perfectly know which request this is. If there exists any motivation to return the request type, please let me know
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
