### PR TITLE
Add session keys to author mapping pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6903,6 +6903,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "session-keys-primitives",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -11873,6 +11874,10 @@ checksum = "e44969a61f5d316be20a42ff97816efb3b407a924d06824c3d8a49fa8450de0e"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "session-keys-primitives"
+version = "0.1.0"
 
 [[package]]
 name = "sha-1"

--- a/pallets/author-mapping/Cargo.toml
+++ b/pallets/author-mapping/Cargo.toml
@@ -21,6 +21,8 @@ sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-po
 # Nimbus
 nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
 
+session-keys-primitives = { path = "../../primitives/session-keys", default-features = false }
+
 [dev-dependencies]
 pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18" }
 sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.18" }
@@ -37,6 +39,7 @@ std = [
 	"parity-scale-codec/std",
 	"scale-info/std",
 	"serde",
+	"session-keys-primitives/std",
 	"sp-runtime/std",
 	"sp-std/std",
 ]

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -14,12 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Maps Author Ids as used in nimbus consensus layer to account ids as used i nthe runtime.
+//! Maps Author Ids as used in nimbus consensus layer to account ids as used in the runtime.
 //! This should likely be moved to nimbus eventually.
 //!
 //! This pallet maps NimbusId => AccountId which is most useful when using propositional style
 //! queries. This mapping will likely need to go the other way if using exhaustive authority sets.
-//! That could either be a seperate pallet, or this pallet could implement a two-way mapping. But
+//! That could either be a separate pallet, or this pallet could implement a two-way mapping. But
 //! for now it it one-way
 
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -46,24 +46,25 @@ pub mod pallet {
 	use frame_support::traits::{Currency, ReservableCurrency};
 	use frame_system::pallet_prelude::*;
 	use nimbus_primitives::{AccountLookup, NimbusId};
+	use session_keys_primitives::KeysLookup;
 
 	pub type BalanceOf<T> = <<T as Config>::DepositCurrency as Currency<
 		<T as frame_system::Config>::AccountId,
 	>>::Balance;
 
 	#[derive(Encode, Decode, PartialEq, Eq, Debug, scale_info::TypeInfo)]
-	pub struct RegistrationInfo<AccountId, Balance> {
-		account: AccountId,
-		deposit: Balance,
+	#[scale_info(skip_type_params(T))]
+	pub struct RegistrationInfo<T: Config> {
+		pub(crate) account: T::AccountId,
+		pub(crate) deposit: BalanceOf<T>,
+		pub(crate) keys: T::Keys,
 	}
 
 	#[pallet::pallet]
 	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 
-	/// Configuration trait of this pallet. We tightly couple to Parachain Staking in order to
-	/// ensure that only staked accounts can create registrations in the first place. This could be
-	/// generalized.
+	/// Configuration trait of this pallet
 	#[pallet::config]
 	pub trait Config: frame_system::Config {
 		/// Overarching event type
@@ -72,6 +73,10 @@ pub mod pallet {
 		type DepositCurrency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
 		/// The amount that should be taken as a security deposit when registering a NimbusId.
 		type DepositAmount: Get<<Self::DepositCurrency as Currency<Self::AccountId>>::Balance>;
+		/// Additional keys
+		/// Convertible From<NimbusId> to get default keys for each mapping (for the migration)
+		/// TODO: add lookup trait bound to find key in keys, see sp_runtime::traits::OpaqueKeys
+		type Keys: Parameter + Member + MaybeSerializeDeserialize + From<NimbusId>;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 	}
@@ -96,19 +101,19 @@ pub mod pallet {
 		AuthorRegistered {
 			author_id: NimbusId,
 			account_id: T::AccountId,
+			keys: T::Keys,
 		},
 		/// An NimbusId has been de-registered, and its AccountId mapping removed.
-		AuthorDeRegistered { author_id: NimbusId },
-		/// An NimbusId has been registered, replacing a previous registration and its mapping.
-		AuthorRotated {
-			new_author_id: NimbusId,
-			account_id: T::AccountId,
-		},
-		/// An NimbusId has been forcibly deregistered after not being rotated or cleaned up.
-		/// The reporteing account has been rewarded accordingly.
-		DefunctAuthorBusted {
+		AuthorDeRegistered {
 			author_id: NimbusId,
 			account_id: T::AccountId,
+			keys: T::Keys,
+		},
+		/// An NimbusId has been registered, replacing a previous registration and its mapping.
+		KeysRotated {
+			new_author_id: NimbusId,
+			account_id: T::AccountId,
+			new_keys: T::Keys,
 		},
 	}
 
@@ -127,11 +132,80 @@ pub mod pallet {
 				Error::<T>::AlreadyAssociated
 			);
 
-			Self::enact_registration(&author_id, &account_id)?;
+			Self::enact_registration(&author_id, &account_id, author_id.clone().into())?;
+
+			<Pallet<T>>::deposit_event(Event::AuthorRegistered {
+				author_id: author_id.clone(),
+				account_id,
+				keys: author_id.into(),
+			});
+
+			Ok(())
+		}
+
+		#[pallet::weight(<T as Config>::WeightInfo::add_association())] // TODO update weight
+		pub fn add_full_association(
+			origin: OriginFor<T>,
+			author_id: NimbusId,
+			keys: T::Keys,
+		) -> DispatchResult {
+			let account_id = ensure_signed(origin)?;
+
+			ensure!(
+				MappingWithDeposit::<T>::get(&author_id).is_none(),
+				Error::<T>::AlreadyAssociated
+			);
+
+			Self::enact_registration(&author_id, &account_id, keys.clone())?;
 
 			<Pallet<T>>::deposit_event(Event::AuthorRegistered {
 				author_id,
 				account_id,
+				keys,
+			});
+
+			Ok(())
+		}
+
+		/// Change your keys
+		///
+		/// This is useful for key rotation to update Nimbus and VRF keys in one call.
+		/// No new security deposit is required. Will replace `update_association` which is kept
+		/// now for backwards compatibility reasons.
+		#[pallet::weight(0)] // TODO: update weights
+		pub fn set_keys(
+			origin: OriginFor<T>,
+			old_author_id: NimbusId,
+			new_author_id: NimbusId,
+			new_keys: T::Keys,
+		) -> DispatchResult {
+			let account_id = ensure_signed(origin)?;
+
+			let stored_info = MappingWithDeposit::<T>::try_get(&old_author_id)
+				.map_err(|_| Error::<T>::AssociationNotFound)?;
+
+			ensure!(
+				account_id == stored_info.account,
+				Error::<T>::NotYourAssociation
+			);
+			ensure!(
+				MappingWithDeposit::<T>::get(&new_author_id).is_none(),
+				Error::<T>::AlreadyAssociated
+			);
+
+			MappingWithDeposit::<T>::remove(&old_author_id);
+			MappingWithDeposit::<T>::insert(
+				&new_author_id,
+				&RegistrationInfo {
+					keys: new_keys.clone(),
+					..stored_info
+				},
+			);
+
+			<Pallet<T>>::deposit_event(Event::KeysRotated {
+				new_author_id,
+				account_id,
+				new_keys,
 			});
 
 			Ok(())
@@ -140,7 +214,8 @@ pub mod pallet {
 		/// Change your Mapping.
 		///
 		/// This is useful for normal key rotation or for when switching from one physical collator
-		/// machine to another. No new security deposit is required.
+		/// machine to another. No new security deposit is required. This will not change the
+		/// additional keys associated.
 		#[pallet::weight(<T as Config>::WeightInfo::update_association())]
 		pub fn update_association(
 			origin: OriginFor<T>,
@@ -164,9 +239,10 @@ pub mod pallet {
 			MappingWithDeposit::<T>::remove(&old_author_id);
 			MappingWithDeposit::<T>::insert(&new_author_id, &stored_info);
 
-			<Pallet<T>>::deposit_event(Event::AuthorRotated {
+			<Pallet<T>>::deposit_event(Event::KeysRotated {
 				new_author_id: new_author_id,
 				account_id: stored_info.account,
+				new_keys: stored_info.keys,
 			});
 
 			Ok(())
@@ -195,7 +271,11 @@ pub mod pallet {
 
 			T::DepositCurrency::unreserve(&account_id, stored_info.deposit);
 
-			<Pallet<T>>::deposit_event(Event::AuthorDeRegistered { author_id });
+			<Pallet<T>>::deposit_event(Event::AuthorDeRegistered {
+				author_id,
+				account_id,
+				keys: stored_info.keys,
+			});
 
 			Ok(().into())
 		}
@@ -205,6 +285,7 @@ pub mod pallet {
 		pub fn enact_registration(
 			author_id: &NimbusId,
 			account_id: &T::AccountId,
+			keys: T::Keys,
 		) -> DispatchResult {
 			let deposit = T::DepositAmount::get();
 
@@ -214,6 +295,7 @@ pub mod pallet {
 			let info = RegistrationInfo {
 				account: account_id.clone(),
 				deposit,
+				keys,
 			};
 
 			MappingWithDeposit::<T>::insert(&author_id, &info);
@@ -225,14 +307,9 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn account_and_deposit_of)]
 	/// We maintain a mapping from the NimbusIds used in the consensus layer
-	/// to the AccountIds runtime (including this staking pallet).
-	pub type MappingWithDeposit<T: Config> = StorageMap<
-		_,
-		Blake2_128Concat,
-		NimbusId,
-		RegistrationInfo<T::AccountId, BalanceOf<T>>,
-		OptionQuery,
-	>;
+	/// to the AccountIds runtime.
+	pub type MappingWithDeposit<T: Config> =
+		StorageMap<_, Blake2_128Concat, NimbusId, RegistrationInfo<T>, OptionQuery>;
 
 	#[pallet::genesis_config]
 	/// Genesis config for author mapping pallet
@@ -252,7 +329,11 @@ pub mod pallet {
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
 			for (author_id, account_id) in &self.mappings {
-				if let Err(e) = Pallet::<T>::enact_registration(&author_id, &account_id) {
+				if let Err(e) = Pallet::<T>::enact_registration(
+					&author_id,
+					&account_id,
+					author_id.clone().into(),
+				) {
 					log::warn!("Error with genesis author mapping registration: {:?}", e);
 				}
 			}
@@ -265,11 +346,21 @@ pub mod pallet {
 		}
 	}
 
+	impl<T: Config> KeysLookup<NimbusId, T::Keys> for Pallet<T> {
+		fn lookup_keys(author: &NimbusId) -> Option<T::Keys> {
+			Self::keys_of(author)
+		}
+	}
+
 	impl<T: Config> Pallet<T> {
 		/// A helper function to lookup the account id associated with the given author id. This is
 		/// the primary lookup that this pallet is responsible for.
 		pub fn account_id_of(author_id: &NimbusId) -> Option<T::AccountId> {
 			Self::account_and_deposit_of(author_id).map(|info| info.account)
+		}
+		/// A helper function to lookup the keys associated with the given author id.
+		pub fn keys_of(author_id: &NimbusId) -> Option<T::Keys> {
+			Self::account_and_deposit_of(author_id).map(|info| info.keys)
 		}
 	}
 }

--- a/pallets/author-mapping/src/migrations.rs
+++ b/pallets/author-mapping/src/migrations.rs
@@ -23,10 +23,94 @@ use frame_support::{
 	Twox64Concat,
 };
 use nimbus_primitives::NimbusId;
-
+use parity_scale_codec::{Decode, Encode};
 use sp_std::convert::TryInto;
 //TODO sometimes this is unused, sometimes its necessary
 use sp_std::vec::Vec;
+
+/// Migrates MappingWithDeposit map value from RegistrationInfo to RegistrationInformation,
+/// thereby adding a keys: T::Keys field to the value to support VRF keys that can be looked up
+/// via NimbusId.
+pub struct AddKeysToRegistrationInfo<T>(PhantomData<T>);
+#[derive(Encode, Decode, PartialEq, Eq, Debug, scale_info::TypeInfo)]
+struct OldRegistrationInfo<AccountId, Balance> {
+	account: AccountId,
+	deposit: Balance,
+}
+fn migrate_registration_info<T: Config>(
+	nimbus_id: NimbusId,
+	old: OldRegistrationInfo<T::AccountId, BalanceOf<T>>,
+) -> RegistrationInfo<T> {
+	RegistrationInfo {
+		account: old.account,
+		deposit: old.deposit,
+		keys: nimbus_id.into(),
+	}
+}
+impl<T: Config> OnRuntimeUpgrade for AddKeysToRegistrationInfo<T> {
+	fn on_runtime_upgrade() -> Weight {
+		log::info!(target: "AddKeysToRegistrationInfo", "running migration");
+
+		let mut read_write_count = 0u64;
+		<MappingWithDeposit<T>>::translate(
+			|nimbus_id, old_registration_info: OldRegistrationInfo<T::AccountId, BalanceOf<T>>| {
+				read_write_count = read_write_count.saturating_add(1u64);
+				Some(migrate_registration_info(nimbus_id, old_registration_info))
+			},
+		);
+		// return weight
+		read_write_count.saturating_mul(T::DbWeight::get().read + T::DbWeight::get().write)
+	}
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		use frame_support::traits::OnRuntimeUpgradeHelpersExt;
+		// get total deposited and account for all nimbus_keys
+		for (nimbus_id, info) in <MappingWithDeposit<T>>::iter() {
+			Self::set_temp_storage(
+				info.account,
+				&format!("MappingWithDeposit{:?}Account", nimbus_id)[..],
+			);
+			Self::set_temp_storage(
+				info.deposit,
+				&format!("MappingWithDeposit{:?}Deposit", nimbus_id)[..],
+			);
+		}
+		Ok(())
+	}
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		use frame_support::traits::OnRuntimeUpgradeHelpersExt;
+		// ensure new deposit and account are the same as the old ones
+		// ensure new keys are equal to nimbus_id
+		for (nimbus_id, info) in <MappingWithDeposit<T>>::iter() {
+			let old_account: T::AccountId =
+				Self::get_temp_storage(&format!("MappingWithDeposit{:?}Account", nimbus_id)[..])
+					.expect("qed");
+			let new_account = info.account;
+			assert_eq!(
+				old_account, new_account,
+				"Old Account {:?} dne New Account {:?} for NimbusID {:?}",
+				old_account, new_account, nimbus_id
+			);
+			let old_deposit: BalanceOf<T> =
+				Self::get_temp_storage(&format!("MappingWithDeposit{:?}Deposit", nimbus_id)[..])
+					.expect("qed");
+			let new_deposit = info.deposit;
+			assert_eq!(
+				old_deposit, new_deposit,
+				"Old Deposit {:?} dne New Deposit {:?} for NimbusID {:?}",
+				old_deposit, new_deposit, nimbus_id
+			);
+			let nimbus_id_as_keys: T::Keys = nimbus_id.into();
+			assert_eq!(
+				nimbus_id_as_keys, info.keys,
+				"Old NimbusID {:?} dne New Keys {:?}",
+				nimbus_id_as_keys, info.keys,
+			);
+		}
+		Ok(())
+	}
+}
 
 /// Migrates the AuthorMapping's storage map fro mthe insecure Twox64 hasher to the secure
 /// BlakeTwo hasher.
@@ -39,11 +123,10 @@ impl<T: Config> OnRuntimeUpgrade for TwoXToBlake<T> {
 
 		// Read all the data into memory.
 		// https://crates.parity.io/frame_support/storage/migration/fn.storage_key_iter.html
-		let stored_data: Vec<_> = storage_key_iter::<
-			NimbusId,
-			RegistrationInfo<T::AccountId, BalanceOf<T>>,
-			Twox64Concat,
-		>(pallet_prefix, storage_item_prefix)
+		let stored_data: Vec<_> = storage_key_iter::<NimbusId, RegistrationInfo<T>, Twox64Concat>(
+			pallet_prefix,
+			storage_item_prefix,
+		)
 		.collect();
 
 		let migrated_count: Weight = stored_data
@@ -56,13 +139,14 @@ impl<T: Config> OnRuntimeUpgrade for TwoXToBlake<T> {
 		remove_storage_prefix(pallet_prefix, storage_item_prefix, &[]);
 
 		// Assert that old storage is empty
-		assert!(storage_key_iter::<
-			NimbusId,
-			RegistrationInfo<T::AccountId, BalanceOf<T>>,
-			Twox64Concat,
-		>(pallet_prefix, storage_item_prefix)
-		.next()
-		.is_none());
+		assert!(
+			storage_key_iter::<NimbusId, RegistrationInfo<T>, Twox64Concat>(
+				pallet_prefix,
+				storage_item_prefix
+			)
+			.next()
+			.is_none()
+		);
 
 		// Write the mappings back to storage with the new secure hasher
 		for (author_id, account_id) in stored_data {
@@ -97,20 +181,16 @@ impl<T: Config> OnRuntimeUpgrade for TwoXToBlake<T> {
 		assert!(MappingWithDeposit::<T>::iter().next().is_none());
 
 		// Check number of entries, and set it aside in temp storage
-		let mapping_count = storage_iter::<RegistrationInfo<T::AccountId, BalanceOf<T>>>(
-			pallet_prefix,
-			storage_item_prefix,
-		)
-		.count() as u64;
+		let mapping_count =
+			storage_iter::<RegistrationInfo<T>>(pallet_prefix, storage_item_prefix).count() as u64;
 		Self::set_temp_storage(mapping_count, "mapping_count");
 
 		// Read an example pair from old storage and set it aside in temp storage
 		if mapping_count > 0 {
-			let example_pair = storage_key_iter::<
-				NimbusId,
-				RegistrationInfo<T::AccountId, BalanceOf<T>>,
-				Twox64Concat,
-			>(pallet_prefix, storage_item_prefix)
+			let example_pair = storage_key_iter::<NimbusId, RegistrationInfo<T>, Twox64Concat>(
+				pallet_prefix,
+				storage_item_prefix,
+			)
 			.next()
 			.expect("We already confirmed that there was at least one item stored");
 
@@ -132,7 +212,7 @@ impl<T: Config> OnRuntimeUpgrade for TwoXToBlake<T> {
 
 		// Check that our example pair is still well-mapped after the migration
 		if new_mapping_count > 0 {
-			let (account, original_info): (NimbusId, RegistrationInfo<T::AccountId, BalanceOf<T>>) =
+			let (account, original_info): (NimbusId, RegistrationInfo<T>) =
 				Self::get_temp_storage("example_pair").expect("qed");
 			let migrated_info = MappingWithDeposit::<T>::get(account).expect("qed");
 			assert_eq!(original_info, migrated_info);

--- a/pallets/author-mapping/src/mock.rs
+++ b/pallets/author-mapping/src/mock.rs
@@ -131,6 +131,7 @@ impl pallet_author_mapping::Config for Runtime {
 	type Event = Event;
 	type DepositCurrency = Balances;
 	type DepositAmount = DepositAmount;
+	type Keys = NimbusId;
 	type WeightInfo = ();
 }
 

--- a/pallets/author-mapping/src/tests.rs
+++ b/pallets/author-mapping/src/tests.rs
@@ -62,14 +62,15 @@ fn eligible_account_can_register() {
 				last_event(),
 				MetaEvent::AuthorMapping(Event::AuthorRegistered {
 					author_id: TestAuthor::Bob.into(),
-					account_id: 2
+					account_id: 2,
+					keys: TestAuthor::Bob.into(),
 				})
 			);
 		})
 }
 
 #[test]
-fn cannot_register_without_deposit() {
+fn cannot_add_association_without_deposit() {
 	ExtBuilder::default()
 		.with_balances(vec![(2, 10)])
 		.build()
@@ -110,7 +111,8 @@ fn double_registration_costs_twice_as_much() {
 				last_event(),
 				MetaEvent::AuthorMapping(Event::AuthorRegistered {
 					author_id: TestAuthor::Bob.into(),
-					account_id: 2
+					account_id: 2,
+					keys: TestAuthor::Bob.into(),
 				})
 			);
 
@@ -131,7 +133,8 @@ fn double_registration_costs_twice_as_much() {
 				last_event(),
 				MetaEvent::AuthorMapping(Event::AuthorRegistered {
 					author_id: TestAuthor::Alice.into(),
-					account_id: 2
+					account_id: 2,
+					keys: TestAuthor::Alice.into(),
 				})
 			);
 
@@ -165,7 +168,9 @@ fn registered_account_can_clear() {
 			assert_eq!(
 				last_event(),
 				MetaEvent::AuthorMapping(Event::AuthorDeRegistered {
-					author_id: TestAuthor::Alice.into()
+					author_id: TestAuthor::Alice.into(),
+					account_id: 1,
+					keys: TestAuthor::Alice.into(),
 				})
 			);
 		})
@@ -228,7 +233,7 @@ fn registered_can_rotate() {
 				Some(2)
 			);
 
-			// Should still only ahve paid a single security deposit
+			// Should still only have paid a single security deposit
 			assert_eq!(Balances::free_balance(&2), 900);
 			assert_eq!(Balances::reserved_balance(&2), 100);
 		})
@@ -278,6 +283,219 @@ fn rotating_to_the_same_author_id_leaves_registration_in_tact() {
 					Origin::signed(1),
 					TestAuthor::Alice.into(),
 					TestAuthor::Alice.into()
+				),
+				Error::<Runtime>::AlreadyAssociated
+			);
+		})
+}
+
+#[test]
+fn eligible_account_can_full_register() {
+	ExtBuilder::default()
+		.with_balances(vec![(2, 1000)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(AuthorMapping::add_full_association(
+				Origin::signed(2),
+				TestAuthor::Bob.into(),
+				TestAuthor::Alice.into(),
+			));
+
+			assert_eq!(Balances::free_balance(&2), 900);
+			assert_eq!(Balances::reserved_balance(&2), 100);
+			assert_eq!(
+				AuthorMapping::account_id_of(&TestAuthor::Bob.into()),
+				Some(2)
+			);
+
+			assert_eq!(
+				last_event(),
+				MetaEvent::AuthorMapping(Event::AuthorRegistered {
+					author_id: TestAuthor::Bob.into(),
+					account_id: 2,
+					keys: TestAuthor::Alice.into(),
+				})
+			);
+		})
+}
+
+#[test]
+fn cannot_add_full_association_without_deposit() {
+	ExtBuilder::default()
+		.with_balances(vec![(2, 10)])
+		.build()
+		.execute_with(|| {
+			assert_noop!(
+				AuthorMapping::add_full_association(
+					Origin::signed(2),
+					TestAuthor::Alice.into(),
+					TestAuthor::Bob.into(),
+				),
+				Error::<Runtime>::CannotAffordSecurityDeposit
+			);
+
+			assert_eq!(Balances::free_balance(&2), 10);
+			assert_eq!(AuthorMapping::keys_of(&TestAuthor::Alice.into()), None);
+		})
+}
+
+#[test]
+fn double_full_registration_counts_twice_as_much() {
+	ExtBuilder::default()
+		.with_balances(vec![(2, 1000)])
+		.build()
+		.execute_with(|| {
+			// Register once as Bob
+			assert_ok!(AuthorMapping::add_full_association(
+				Origin::signed(2),
+				TestAuthor::Bob.into(),
+				TestAuthor::Charlie.into(),
+			));
+
+			assert_eq!(Balances::free_balance(&2), 900);
+			assert_eq!(Balances::reserved_balance(&2), 100);
+			assert_eq!(
+				AuthorMapping::account_id_of(&TestAuthor::Bob.into()),
+				Some(2)
+			);
+
+			assert_eq!(
+				last_event(),
+				MetaEvent::AuthorMapping(Event::AuthorRegistered {
+					author_id: TestAuthor::Bob.into(),
+					account_id: 2,
+					keys: TestAuthor::Charlie.into(),
+				})
+			);
+
+			// Register again as Alice
+			assert_ok!(AuthorMapping::add_full_association(
+				Origin::signed(2),
+				TestAuthor::Alice.into(),
+				TestAuthor::Bob.into(),
+			));
+
+			assert_eq!(Balances::free_balance(&2), 800);
+			assert_eq!(Balances::reserved_balance(&2), 200);
+			assert_eq!(
+				AuthorMapping::account_id_of(&TestAuthor::Alice.into()),
+				Some(2)
+			);
+
+			assert_eq!(
+				last_event(),
+				MetaEvent::AuthorMapping(Event::AuthorRegistered {
+					author_id: TestAuthor::Alice.into(),
+					account_id: 2,
+					keys: TestAuthor::Bob.into(),
+				})
+			);
+
+			// Should still be registered as Bob as well
+			assert_eq!(
+				AuthorMapping::account_id_of(&TestAuthor::Bob.into()),
+				Some(2)
+			);
+		})
+}
+
+#[test]
+fn full_registered_author_cannot_be_overwritten() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 1000)])
+		.with_mappings(vec![(TestAuthor::Alice.into(), 1)])
+		.build()
+		.execute_with(|| {
+			assert_noop!(
+				AuthorMapping::add_full_association(
+					Origin::signed(2),
+					TestAuthor::Alice.into(),
+					TestAuthor::Bob.into()
+				),
+				Error::<Runtime>::AlreadyAssociated
+			);
+		})
+}
+
+// TODO: all the rotated ones but for set_keys instead
+
+#[test]
+fn registered_can_full_rotate() {
+	ExtBuilder::default()
+		.with_balances(vec![(2, 1000)])
+		.with_mappings(vec![(TestAuthor::Bob.into(), 2)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(AuthorMapping::set_keys(
+				Origin::signed(2),
+				TestAuthor::Bob.into(),
+				TestAuthor::Charlie.into(),
+				TestAuthor::Charlie.into(),
+			));
+
+			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Bob.into()), None);
+			assert_eq!(
+				AuthorMapping::account_id_of(&TestAuthor::Charlie.into()),
+				Some(2)
+			);
+			assert_eq!(
+				AuthorMapping::keys_of(&TestAuthor::Charlie.into()),
+				Some(TestAuthor::Charlie.into())
+			);
+
+			// Should still only have paid a single security deposit
+			assert_eq!(Balances::free_balance(&2), 900);
+			assert_eq!(Balances::reserved_balance(&2), 100);
+		})
+}
+
+#[test]
+fn unregistered_author_cannot_be_full_rotated() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_noop!(
+			AuthorMapping::set_keys(
+				Origin::signed(2),
+				TestAuthor::Alice.into(),
+				TestAuthor::Bob.into(),
+				TestAuthor::Bob.into(),
+			),
+			Error::<Runtime>::AssociationNotFound
+		);
+	})
+}
+
+#[test]
+fn registered_author_cannot_be_full_rotated_by_non_owner() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 1000)])
+		.with_mappings(vec![(TestAuthor::Alice.into(), 1)])
+		.build()
+		.execute_with(|| {
+			assert_noop!(
+				AuthorMapping::set_keys(
+					Origin::signed(2),
+					TestAuthor::Alice.into(),
+					TestAuthor::Bob.into(),
+					TestAuthor::Bob.into(),
+				),
+				Error::<Runtime>::NotYourAssociation
+			);
+		})
+}
+
+#[test]
+fn full_rotating_to_the_same_author_id_leaves_registration_in_tact() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 1000)])
+		.with_mappings(vec![(TestAuthor::Alice.into(), 1)])
+		.build()
+		.execute_with(|| {
+			assert_noop!(
+				AuthorMapping::set_keys(
+					Origin::signed(1),
+					TestAuthor::Alice.into(),
+					TestAuthor::Alice.into(),
+					TestAuthor::Alice.into(),
 				),
 				Error::<Runtime>::AlreadyAssociated
 			);

--- a/precompiles/author-mapping/AuthorMappingInterface.sol
+++ b/precompiles/author-mapping/AuthorMappingInterface.sol
@@ -11,7 +11,7 @@ pragma solidity >=0.8.0;
 interface AuthorMapping {
     /**
      * Add association
-     * Selector: aa5ac585   
+     * Selector: aa5ac585
      *
      * @param nimbus_id The nimbusId to be associated
      */
@@ -24,13 +24,37 @@ interface AuthorMapping {
      * @param old_nimbus_id The old nimbusId to be replaced
      * @param new_nimbus_id The new nimbusId to be associated
      */
-    function update_association(bytes32 old_nimbus_id, bytes32 new_nimbus_id) external;
+    function update_association(bytes32 old_nimbus_id, bytes32 new_nimbus_id)
+        external;
 
-     /**
+    /**
      * Clear existing associationg
      * Selector: 7354c91d
      *
      * @param nimbus_id The nimbusId to be cleared
      */
     function clear_association(bytes32 nimbus_id) external;
+
+    /**
+     * Add full association
+     * Selector: fa331c88
+     *
+     * @param author_id The new author id registered
+     * @param keys The session keys
+     */
+    function add_full_association(bytes32 author_id, bytes32 keys) external;
+
+    /**
+     * Set keys
+     * Selector: a8259c85
+     *
+     * @param old_author_id The old nimbusId to be replaced
+     * @param new_author_id The new nimbusId to be associated
+     * @param new_keys The new session keys
+     */
+    function set_keys(
+        bytes32 old_author_id,
+        bytes32 new_author_id,
+        bytes32 new_keys
+    ) external;
 }

--- a/precompiles/author-mapping/Cargo.toml
+++ b/precompiles/author-mapping/Cargo.toml
@@ -25,11 +25,12 @@ sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-po
 # Frontier
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
 
+# Nimbus
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.18", default-features = false }
+
 [dev-dependencies]
 derive_more = "0.99"
 hex-literal = "0.3.4"
-# Nimbus
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.18" }
 serde = "1.0.100"
 
 # Substrate
@@ -46,6 +47,7 @@ std = [
 	"fp-evm/std",
 	"frame-support/std",
 	"frame-system/std",
+	"nimbus-primitives/std",
 	"pallet-author-mapping/std",
 	"pallet-evm/std",
 	"precompile-utils/std",

--- a/precompiles/author-mapping/src/lib.rs
+++ b/precompiles/author-mapping/src/lib.rs
@@ -21,6 +21,7 @@
 
 use fp_evm::{Context, ExitSucceed, PrecompileOutput};
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
+use nimbus_primitives::NimbusId;
 use pallet_author_mapping::Call as AuthorMappingCall;
 use pallet_evm::AddressMapping;
 use pallet_evm::Precompile;
@@ -40,6 +41,8 @@ pub enum Action {
 	AddAssociation = "add_association(bytes32)",
 	UpdateAssociation = "update_association(bytes32,bytes32)",
 	ClearAssociation = "clear_association(bytes32)",
+	AddFullAssociation = "add_full_association(bytes32, bytes32)",
+	SetKeys = "set_keys(bytes32,bytes32,bytes32)",
 }
 
 /// A precompile to wrap the functionality from pallet author mapping.
@@ -74,6 +77,8 @@ where
 			Action::AddAssociation => Self::add_association(input, gasometer, context),
 			Action::UpdateAssociation => Self::update_association(input, gasometer, context),
 			Action::ClearAssociation => Self::clear_association(input, gasometer, context),
+			Action::AddFullAssociation => Self::add_full_association(input, gasometer, context),
+			Action::SetKeys => Self::set_keys(input, gasometer, context),
 		}
 	}
 }
@@ -170,6 +175,77 @@ where
 		let origin = Runtime::AddressMapping::into_account_id(context.caller);
 		let call = AuthorMappingCall::<Runtime>::clear_association {
 			author_id: nimbus_id,
+		};
+
+		RuntimeHelper::<Runtime>::try_dispatch(Some(origin).into(), call, gasometer)?;
+
+		Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			cost: gasometer.used_gas(),
+			output: Default::default(),
+			logs: Default::default(),
+		})
+	}
+
+	fn add_full_association(
+		input: &mut EvmDataReader,
+		gasometer: &mut Gasometer,
+		context: &Context,
+	) -> EvmResult<PrecompileOutput> {
+		// Bound check
+		input.expect_arguments(gasometer, 2)?;
+		let nimbus_id =
+			sp_core::sr25519::Public::unchecked_from(input.read::<H256>(gasometer)?).into();
+		let keys_as_nimbus_id: NimbusId =
+			sp_core::sr25519::Public::unchecked_from(input.read::<H256>(gasometer)?).into();
+		let keys: <Runtime as pallet_author_mapping::Config>::Keys = keys_as_nimbus_id.into();
+
+		log::trace!(
+			target: "author-mapping-precompile",
+			"Adding full association with author id {:?} keys {:?}", nimbus_id, keys
+		);
+
+		let origin = Runtime::AddressMapping::into_account_id(context.caller);
+		let call = AuthorMappingCall::<Runtime>::add_full_association {
+			author_id: nimbus_id,
+			keys,
+		};
+
+		RuntimeHelper::<Runtime>::try_dispatch(Some(origin).into(), call, gasometer)?;
+
+		Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			cost: gasometer.used_gas(),
+			output: Default::default(),
+			logs: Default::default(),
+		})
+	}
+
+	fn set_keys(
+		input: &mut EvmDataReader,
+		gasometer: &mut Gasometer,
+		context: &Context,
+	) -> EvmResult<PrecompileOutput> {
+		input.expect_arguments(gasometer, 3)?;
+		let old_author_id =
+			sp_core::sr25519::Public::unchecked_from(input.read::<H256>(gasometer)?).into();
+		let new_author_id =
+			sp_core::sr25519::Public::unchecked_from(input.read::<H256>(gasometer)?).into();
+		let new_keys_as_nimbus_id: NimbusId =
+			sp_core::sr25519::Public::unchecked_from(input.read::<H256>(gasometer)?).into();
+		let new_keys: <Runtime as pallet_author_mapping::Config>::Keys =
+			new_keys_as_nimbus_id.into();
+
+		log::trace!(
+			target: "author-mapping-precompile",
+			"Setting keys old author id {:?} new author id {:?} new keys {:?}", old_author_id, new_author_id, new_keys
+		);
+
+		let origin = Runtime::AddressMapping::into_account_id(context.caller);
+		let call = AuthorMappingCall::<Runtime>::set_keys {
+			old_author_id,
+			new_author_id,
+			new_keys,
 		};
 
 		RuntimeHelper::<Runtime>::try_dispatch(Some(origin).into(), call, gasometer)?;

--- a/precompiles/author-mapping/src/mock.rs
+++ b/precompiles/author-mapping/src/mock.rs
@@ -204,6 +204,7 @@ impl pallet_author_mapping::Config for Runtime {
 	type Event = Event;
 	type DepositCurrency = Balances;
 	type DepositAmount = DepositAmount;
+	type Keys = nimbus_primitives::NimbusId;
 	type WeightInfo = ();
 }
 

--- a/precompiles/author-mapping/src/tests.rs
+++ b/precompiles/author-mapping/src/tests.rs
@@ -94,6 +94,8 @@ fn selectors() {
 	assert_eq!(Action::AddAssociation as u32, 0xaa5ac585);
 	assert_eq!(Action::UpdateAssociation as u32, 0xd9cef879);
 	assert_eq!(Action::ClearAssociation as u32, 0x7354c91d);
+	assert_eq!(Action::AddFullAssociation as u32, 0xe9bf9e98);
+	assert_eq!(Action::SetKeys as u32, 0xa8259c85);
 }
 
 #[test]
@@ -122,8 +124,9 @@ fn add_association_works() {
 					}
 					.into(),
 					AuthorMappingEvent::AuthorRegistered {
-						author_id: expected_nimbus_id,
-						account_id: Alice
+						author_id: expected_nimbus_id.clone(),
+						account_id: Alice,
+						keys: expected_nimbus_id.into(),
 					}
 					.into(),
 					EvmEvent::Executed(Precompile.into()).into(),
@@ -166,13 +169,15 @@ fn update_association_works() {
 					}
 					.into(),
 					AuthorMappingEvent::AuthorRegistered {
-						author_id: first_nimbus_id,
-						account_id: Alice
+						author_id: first_nimbus_id.clone(),
+						account_id: Alice,
+						keys: first_nimbus_id.into(),
 					}
 					.into(),
 					AuthorMappingEvent::AuthorRotated {
-						new_author_id: second_nimbus_id,
-						account_id: Alice
+						new_author_id: second_nimbus_id.clone(),
+						account_id: Alice,
+						new_keys: second_nimbus_id.into(),
 					}
 					.into(),
 					EvmEvent::Executed(Precompile.into()).into(),
@@ -212,7 +217,8 @@ fn clear_association_works() {
 					.into(),
 					AuthorMappingEvent::AuthorRegistered {
 						author_id: nimbus_id.clone(),
-						account_id: Alice
+						account_id: Alice,
+						keys: nimbus_id.clone().into(),
 					}
 					.into(),
 					BalancesEvent::Unreserved {
@@ -221,7 +227,108 @@ fn clear_association_works() {
 					}
 					.into(),
 					AuthorMappingEvent::AuthorDeRegistered {
-						author_id: nimbus_id
+						author_id: nimbus_id.clone(),
+						account_id: Alice,
+						keys: nimbus_id.into(),
+					}
+					.into(),
+					EvmEvent::Executed(Precompile.into()).into(),
+				]
+			);
+		})
+}
+
+#[test]
+fn add_full_association_works() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice, 1000)])
+		.build()
+		.execute_with(|| {
+			let expected_nimbus_id: NimbusId =
+				sp_core::sr25519::Public::unchecked_from([1u8; 32]).into();
+			let first_vrf_key: NimbusId =
+				sp_core::sr25519::Public::unchecked_from([3u8; 32]).into();
+
+			let input = EvmDataWriter::new_with_selector(Action::AddFullAssociation)
+				.write(sp_core::H256::from([1u8; 32]))
+				.write(sp_core::H256::from([3u8; 32]))
+				.build();
+
+			// Make sure the call goes through successfully
+			assert_ok!(Call::Evm(evm_call(input)).dispatch(Origin::root()));
+
+			// Assert that the events are as expected
+			assert_eq!(
+				events(),
+				vec![
+					BalancesEvent::Reserved {
+						who: Alice,
+						amount: 10
+					}
+					.into(),
+					AuthorMappingEvent::AuthorRegistered {
+						author_id: expected_nimbus_id.clone(),
+						account_id: Alice,
+						keys: first_vrf_key.into(),
+					}
+					.into(),
+					EvmEvent::Executed(Precompile.into()).into(),
+				]
+			);
+		})
+}
+
+#[test]
+fn set_keys_works() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice, 1000)])
+		.build()
+		.execute_with(|| {
+			let first_nimbus_id: NimbusId =
+				sp_core::sr25519::Public::unchecked_from([1u8; 32]).into();
+			let second_nimbus_id: NimbusId =
+				sp_core::sr25519::Public::unchecked_from([2u8; 32]).into();
+			let first_vrf_key: NimbusId =
+				sp_core::sr25519::Public::unchecked_from([3u8; 32]).into();
+			let second_vrf_key: NimbusId =
+				sp_core::sr25519::Public::unchecked_from([4u8; 32]).into();
+
+			assert_ok!(
+				Call::AuthorMapping(AuthorMappingCall::add_full_association {
+					author_id: first_nimbus_id.clone(),
+					keys: first_vrf_key.clone(),
+				})
+				.dispatch(Origin::signed(Alice))
+			);
+
+			let input = EvmDataWriter::new_with_selector(Action::SetKeys)
+				.write(sp_core::H256::from([1u8; 32]))
+				.write(sp_core::H256::from([2u8; 32]))
+				.write(sp_core::H256::from([4u8; 32]))
+				.build();
+
+			// Make sure the call goes through successfully
+			assert_ok!(Call::Evm(evm_call(input)).dispatch(Origin::root()));
+
+			// Assert that the events are as expected
+			assert_eq!(
+				events(),
+				vec![
+					BalancesEvent::Reserved {
+						who: Alice,
+						amount: 10
+					}
+					.into(),
+					AuthorMappingEvent::AuthorRegistered {
+						author_id: first_nimbus_id.clone(),
+						account_id: Alice,
+						keys: first_vrf_key.into(),
+					}
+					.into(),
+					AuthorMappingEvent::AuthorRotated {
+						new_author_id: second_nimbus_id.clone(),
+						account_id: Alice,
+						new_keys: second_vrf_key.into(),
 					}
 					.into(),
 					EvmEvent::Executed(Precompile.into()).into(),

--- a/primitives/session-keys/Cargo.toml
+++ b/primitives/session-keys/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "session-keys-primitives"
+authors = [ "PureStake" ]
+description = "Primitives for session keys"
+edition = "2018"
+version = "0.1.0"
+
+[features]
+default = [ "std" ]
+std = []

--- a/primitives/session-keys/src/lib.rs
+++ b/primitives/session-keys/src/lib.rs
@@ -1,0 +1,30 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Primitives for session keys
+#![cfg_attr(not(feature = "std"), no_std)]
+
+/// A Trait to lookup keys from AuthorIds
+pub trait KeysLookup<AuthorId, Keys> {
+	fn lookup_keys(author: &AuthorId) -> Option<Keys>;
+}
+
+// A dummy impl used in simple tests
+impl<AuthorId, Keys> KeysLookup<AuthorId, Keys> for () {
+	fn lookup_keys(_: &AuthorId) -> Option<Keys> {
+		None
+	}
+}

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -32,7 +32,10 @@ use pallet_asset_manager::{
 	},
 	Config as AssetManagerConfig,
 };
-use pallet_author_mapping::{migrations::TwoXToBlake, Config as AuthorMappingConfig};
+use pallet_author_mapping::{
+	migrations::{AddKeysToRegistrationInfo, TwoXToBlake},
+	Config as AuthorMappingConfig,
+};
 use pallet_author_slot_filter::migration::EligibleRatioToEligiblityCount;
 use pallet_author_slot_filter::Config as AuthorSlotFilterConfig;
 use pallet_base_fee::Config as BaseFeeConfig;
@@ -53,6 +56,30 @@ use xcm_transactor::{migrations::MaxTransactWeight, Config as XcmTransactorConfi
 
 /// This module acts as a registry where each migration is defined. Each migration should implement
 /// the "Migration" trait declared in the pallet-migrations crate.
+
+/// A moonbeam migration wrapping the similarly named migration in pallet-author-mapping
+pub struct AuthorMappingAddKeysToRegistrationInfo<T>(PhantomData<T>);
+impl<T: AuthorMappingConfig> Migration for AuthorMappingAddKeysToRegistrationInfo<T> {
+	fn friendly_name(&self) -> &str {
+		"MM_Author_Mapping_AddKeysToRegistrationInfo"
+	}
+
+	fn migrate(&self, _available_weight: Weight) -> Weight {
+		AddKeysToRegistrationInfo::<T>::on_runtime_upgrade()
+	}
+
+	/// Run a standard pre-runtime test. This works the same way as in a normal runtime upgrade.
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade(&self) -> Result<(), &'static str> {
+		AddKeysToRegistrationInfo::<T>::pre_upgrade()
+	}
+
+	/// Run a standard post-runtime test. This works the same way as in a normal runtime upgrade.
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(&self) -> Result<(), &'static str> {
+		AddKeysToRegistrationInfo::<T>::post_upgrade()
+	}
+}
 
 /// Patch delegations total mismatch
 pub struct ParachainStakingPatchIncorrectDelegationSums<T>(PhantomData<T>);
@@ -563,6 +590,8 @@ where
 
 		let migration_author_slot_filter_eligible_ratio_to_eligibility_count =
 			AuthorSlotFilterEligibleRatioToEligiblityCount::<Runtime>(Default::default());
+		let migration_author_mapping_add_keys_to_registration_info =
+			AuthorMappingAddKeysToRegistrationInfo::<Runtime>(Default::default());
 		vec![
 			// completed in runtime 800
 			// Box::new(migration_author_mapping_twox_to_blake),
@@ -582,6 +611,7 @@ where
 			// completed in runtime 1300
 			// Box::new(migration_base_fee),
 			Box::new(migration_author_slot_filter_eligible_ratio_to_eligibility_count),
+			Box::new(migration_author_mapping_add_keys_to_registration_info),
 		]
 	}
 }

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -775,6 +775,7 @@ impl pallet_author_mapping::Config for Runtime {
 	type Event = Event;
 	type DepositCurrency = Balances;
 	type DepositAmount = ConstU128<{ 100 * currency::UNIT * currency::SUPPLY_FACTOR }>;
+	type Keys = NimbusId; // TODO: consider making custom type?
 	type WeightInfo = pallet_author_mapping::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -723,6 +723,7 @@ impl pallet_author_mapping::Config for Runtime {
 	type Event = Event;
 	type DepositCurrency = Balances;
 	type DepositAmount = ConstU128<{ 100 * currency::GLMR * currency::SUPPLY_FACTOR }>;
+	type Keys = NimbusId; // TODO: consider making custom type?
 	type WeightInfo = pallet_author_mapping::weights::SubstrateWeight<Runtime>;
 }
 

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -753,6 +753,7 @@ impl pallet_author_mapping::Config for Runtime {
 	type Event = Event;
 	type DepositCurrency = Balances;
 	type DepositAmount = ConstU128<{ 100 * currency::MOVR * currency::SUPPLY_FACTOR }>;
+	type Keys = NimbusId; // TODO: consider making custom type?
 	type WeightInfo = pallet_author_mapping::weights::SubstrateWeight<Runtime>;
 }
 


### PR DESCRIPTION
Extracted from #1376 , to be also used for the orbiters pallet

Adds two new extrinsics which have precompile methods:
```
/**
     * Add full association
     * Selector: fa331c88
     *
     * @param author_id The new author id registered
     * @param keys The session keys
     */
    function add_full_association(bytes32 author_id, bytes32 keys) external;

    /**
     * Set keys
     * Selector: a8259c85
     *
     * @param old_author_id The old nimbusId to be replaced
     * @param new_author_id The new nimbusId to be associated
     * @param new_keys The new session keys
     */
    function set_keys(
        bytes32 old_author_id,
        bytes32 new_author_id,
        bytes32 new_keys
    ) external;
```

We kept the storage item `MappingWithDeposit` and kept the old extrinsics for backwards compatibility. WARNING: `update_association` will set `keys` to `new_author_id.into()`.