### PR TITLE
Add candidate request is pending to staking precompile

### DIFF
--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -113,6 +113,15 @@ interface ParachainStaking {
         view
         returns (bool);
 
+    /// @dev Whether there exists a pending bond less request for a candidate made by a candidate
+    /// Selector: 26ab05fb
+    /// @param candidate the candidate for which the request was made
+    /// @return Whether a pending request exist for such candidate
+    function candidate_request_is_pending(address candidate)
+        external
+        view
+        returns (bool);
+
     /// @dev Join the set of collator candidates
     /// Selector: 0a1bff60
     /// @param amount The amount self-bonded by the caller to become a collator candidate

--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -113,6 +113,24 @@ interface ParachainStaking {
         view
         returns (bool);
 
+    /// @dev Whether there exists a pending exit for delegator
+    /// Selector: dc3ec64b
+    /// @param delegator the delegator that made the delegation
+    /// @return Whether a pending request exist for such delegation
+    function delegator_exit_is_pending(address delegator)
+        external
+        view
+        returns (bool);
+
+    /// @dev Whether there exists a pending exit for candidate
+    /// Selector: eb613b8a
+    /// @param candidate the candidate for which the delegation was made
+    /// @return Whether a pending request exist for such delegation
+    function candidate_exit_is_pending(address candidate)
+        external
+        view
+        returns (bool);
+
     /// @dev Whether there exists a pending bond less request for a candidate made by a candidate
     /// Selector: 26ab05fb
     /// @param candidate the candidate for which the request was made

--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -131,10 +131,10 @@ interface ParachainStaking {
         view
         returns (bool);
 
-    /// @dev Whether there exists a pending bond less request for a candidate made by a candidate
+    /// @dev Whether there exists a pending bond less request made by a candidate
     /// Selector: 26ab05fb
-    /// @param candidate the candidate for which the request was made
-    /// @return Whether a pending request exist for such candidate
+    /// @param candidate the candidate which made the request
+    /// @return Whether a pending bond less request was made by the candidate
     function candidate_request_is_pending(address candidate)
         external
         view

--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -107,7 +107,7 @@ interface ParachainStaking {
     /// Selector: 192e1db3
     /// @param delegator the delegator that made the delegation
     /// @param candidate the candidate for which the delegation was made
-    /// @return Whether a pending request exist for such delegation
+    /// @return Whether a pending request exists for such delegation
     function delegation_request_is_pending(address delegator, address candidate)
         external
         view
@@ -115,8 +115,8 @@ interface ParachainStaking {
 
     /// @dev Whether there exists a pending exit for delegator
     /// Selector: dc3ec64b
-    /// @param delegator the delegator that made the delegation
-    /// @return Whether a pending request exist for such delegation
+    /// @param delegator the delegator that made the exit request
+    /// @return Whether a pending exit exists for delegator
     function delegator_exit_is_pending(address delegator)
         external
         view
@@ -124,8 +124,8 @@ interface ParachainStaking {
 
     /// @dev Whether there exists a pending exit for candidate
     /// Selector: eb613b8a
-    /// @param candidate the candidate for which the delegation was made
-    /// @return Whether a pending request exist for such delegation
+    /// @param candidate the candidate for which the exit request was made
+    /// @return Whether a pending request exists for such delegation
     function candidate_exit_is_pending(address candidate)
         external
         view

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -587,7 +587,7 @@ where
 		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 
 		// If we are not able to get delegator state, we return false
-		// Users can call `is_delegator` to determine when this happens
+		// Users can call `is_candidate` to determine when this happens
 		let pending =
 			if let Some(state) = <parachain_staking::Pallet<Runtime>>::candidate_info(&candidate) {
 				state.is_leaving()

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -61,6 +61,7 @@ enum Action {
 	IsCandidate = "is_candidate(address)",
 	IsSelectedCandidate = "is_selected_candidate(address)",
 	DelegationRequestIsPending = "delegation_request_is_pending(address,address)",
+	CandidateRequestIsPending = "candidate_request_is_pending(address)",
 	JoinCandidates = "join_candidates(uint256,uint256)",
 	// DEPRECATED
 	LeaveCandidates = "leave_candidates(uint256)",
@@ -176,6 +177,9 @@ where
 			Action::IsSelectedCandidate => return Self::is_selected_candidate(input, gasometer),
 			Action::DelegationRequestIsPending => {
 				return Self::delegation_request_is_pending(input, gasometer)
+			}
+			Action::CandidateRequestIsPending => {
+				return Self::candidate_request_is_pending(input, gasometer)
 			}
 			// runtime methods (dispatchables)
 			Action::JoinCandidates => Self::join_candidates(input, gasometer, context)?,
@@ -499,7 +503,7 @@ where
 		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 
 		// If we are not able to get delegator state, we return false
-		// TODO: evaluate whether we should early-return instead of returning false
+		// Users can call `is_delegator` to determine when this happens
 		let pending = if let Some(state) =
 			<parachain_staking::Pallet<Runtime>>::delegator_state(&delegator)
 		{
@@ -512,6 +516,43 @@ where
 			);
 			false
 		};
+
+		// Build output.
+		Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			cost: gasometer.used_gas(),
+			output: EvmDataWriter::new().write(pending).build(),
+			logs: vec![],
+		})
+	}
+
+	fn candidate_request_is_pending(
+		input: &mut EvmDataReader,
+		gasometer: &mut Gasometer,
+	) -> EvmResult<PrecompileOutput> {
+		// Read input.
+		input.expect_arguments(gasometer, 1)?;
+
+		// Only argument is candidate
+		let candidate =
+			Runtime::AddressMapping::into_account_id(input.read::<Address>(gasometer)?.0);
+
+		// Fetch info.
+		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		// If we are not able to get candidate metadata, we return false
+		// Users can call `is_candidate` to determine when this happens
+		let pending =
+			if let Some(state) = <parachain_staking::Pallet<Runtime>>::candidate_info(&candidate) {
+				state.request.is_some()
+			} else {
+				log::trace!(
+					target: "staking-precompile",
+					"Candidate metadata for {:?} not found, so pending request is false",
+					candidate
+				);
+				false
+			};
 
 		// Build output.
 		Ok(PrecompileOutput {

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -64,6 +64,8 @@ fn selectors() {
 	assert_eq!(Action::DelegatorDelegationCount as u32, 0xfbc51bca);
 	assert_eq!(Action::SelectedCandidates as u32, 0x89f47a21);
 	assert_eq!(Action::DelegationRequestIsPending as u32, 0x192e1db3);
+	assert_eq!(Action::DelegatorExitIsPending as u32, 0xdc3ec64b);
+	assert_eq!(Action::CandidateExitIsPending as u32, 0xeb613b8a);
 	assert_eq!(Action::CandidateRequestIsPending as u32, 0x26ab05fb);
 	assert_eq!(Action::JoinCandidates as u32, 0x0a1bff60);
 	// DEPRECATED
@@ -850,6 +852,33 @@ fn delegation_request_is_pending_works() {
 
 #[test]
 fn delegation_request_is_pending_returns_false_for_non_existing_delegator() {
+	ExtBuilder::default().build().execute_with(|| {
+		// Expected false because delegator Bob does not exist
+		let expected_result = Some(Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			output: EvmDataWriter::new().write(false).build(),
+			cost: Default::default(),
+			logs: Default::default(),
+		}));
+		// Assert that we return false
+		assert_eq!(
+			precompiles().execute(
+				precompile_address(),
+				&EvmDataWriter::new_with_selector(Action::DelegationRequestIsPending)
+					.write(Address(TestAccount::Bob.into()))
+					.write(Address(TestAccount::Alice.into()))
+					.build(),
+				None,
+				&evm_test_context(),
+				false
+			),
+			expected_result
+		);
+	})
+}
+
+#[test]
+fn delegation_exit_is_pending_works() {
 	ExtBuilder::default()
 		.with_balances(vec![
 			(TestAccount::Alice, 1_000),
@@ -860,19 +889,160 @@ fn delegation_request_is_pending_returns_false_for_non_existing_delegator() {
 		.with_delegations(vec![(TestAccount::Charlie, TestAccount::Alice, 50)])
 		.build()
 		.execute_with(|| {
-			// Expected false because delegator Bob does not exist
-			let expected_result = Some(Ok(PrecompileOutput {
+			// Expected false because we dont have pending requests yet
+			let mut expected_result = Some(Ok(PrecompileOutput {
 				exit_status: ExitSucceed::Returned,
 				output: EvmDataWriter::new().write(false).build(),
 				cost: Default::default(),
 				logs: Default::default(),
 			}));
-			// Assert that we return false
+			// Assert that we don't have pending requests
 			assert_eq!(
 				precompiles().execute(
 					precompile_address(),
-					&EvmDataWriter::new_with_selector(Action::DelegationRequestIsPending)
-						.write(Address(TestAccount::Bob.into()))
+					&EvmDataWriter::new_with_selector(Action::DelegatorExitIsPending)
+						.write(Address(TestAccount::Charlie.into()))
+						.build(),
+					None,
+					&evm_test_context(),
+					false
+				),
+				expected_result
+			);
+
+			// Schedule exit request
+			assert_eq!(
+				precompiles().execute(
+					precompile_address(),
+					&EvmDataWriter::new_with_selector(Action::ScheduleLeaveDelegators).build(),
+					None,
+					&Context {
+						address: precompile_address(),
+						caller: TestAccount::Charlie.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				Some(Ok(PrecompileOutput {
+					exit_status: ExitSucceed::Returned,
+					output: Default::default(),
+					cost: 177353000,
+					logs: Default::default(),
+				}))
+			);
+
+			// Expected true because we scheduled exit
+			expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: Default::default(),
+				logs: Default::default(),
+			}));
+			// Assert that we have pending exit
+			assert_eq!(
+				precompiles().execute(
+					precompile_address(),
+					&EvmDataWriter::new_with_selector(Action::DelegatorExitIsPending)
+						.write(Address(TestAccount::Charlie.into()))
+						.build(),
+					None,
+					&evm_test_context(),
+					false
+				),
+				expected_result
+			);
+		})
+}
+
+#[test]
+fn delegation_exit_is_pending_returns_false_for_non_existing_delegator() {
+	ExtBuilder::default().build().execute_with(|| {
+		// Expected false because delegator Bob does not exist
+		let expected_result = Some(Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			output: EvmDataWriter::new().write(false).build(),
+			cost: Default::default(),
+			logs: Default::default(),
+		}));
+		// Assert that we return false
+		assert_eq!(
+			precompiles().execute(
+				precompile_address(),
+				&EvmDataWriter::new_with_selector(Action::DelegatorExitIsPending)
+					.write(Address(TestAccount::Bob.into()))
+					.build(),
+				None,
+				&evm_test_context(),
+				false
+			),
+			expected_result
+		);
+	})
+}
+
+#[test]
+fn candidate_exit_is_pending_works() {
+	ExtBuilder::default()
+		.with_balances(vec![(TestAccount::Alice, 1_000)])
+		.with_candidates(vec![(TestAccount::Alice, 1_000)])
+		.build()
+		.execute_with(|| {
+			// Expected false because we dont have pending requests yet
+			let mut expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(false).build(),
+				cost: Default::default(),
+				logs: Default::default(),
+			}));
+			// Assert that we don't have pending requests
+			assert_eq!(
+				precompiles().execute(
+					precompile_address(),
+					&EvmDataWriter::new_with_selector(Action::CandidateExitIsPending)
+						.write(Address(TestAccount::Alice.into()))
+						.build(),
+					None,
+					&evm_test_context(),
+					false
+				),
+				expected_result
+			);
+
+			// Schedule exit request
+			assert_eq!(
+				precompiles().execute(
+					precompile_address(),
+					&EvmDataWriter::new_with_selector(Action::ScheduleLeaveCandidates)
+						.write(U256::one())
+						.build(),
+					None,
+					&Context {
+						address: precompile_address(),
+						caller: TestAccount::Alice.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				Some(Ok(PrecompileOutput {
+					exit_status: ExitSucceed::Returned,
+					output: Default::default(),
+					cost: 328890000,
+					logs: Default::default(),
+				}))
+			);
+
+			// Expected true because we scheduled exit
+			expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: Default::default(),
+				logs: Default::default(),
+			}));
+			// Assert that we have pending exit
+			assert_eq!(
+				precompiles().execute(
+					precompile_address(),
+					&EvmDataWriter::new_with_selector(Action::CandidateExitIsPending)
 						.write(Address(TestAccount::Alice.into()))
 						.build(),
 					None,
@@ -882,6 +1052,32 @@ fn delegation_request_is_pending_returns_false_for_non_existing_delegator() {
 				expected_result
 			);
 		})
+}
+
+#[test]
+fn candidate_exit_is_pending_returns_false_for_non_existing_delegator() {
+	ExtBuilder::default().build().execute_with(|| {
+		// Expected false because candidate Bob does not exist
+		let expected_result = Some(Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			output: EvmDataWriter::new().write(false).build(),
+			cost: Default::default(),
+			logs: Default::default(),
+		}));
+		// Assert that we return false
+		assert_eq!(
+			precompiles().execute(
+				precompile_address(),
+				&EvmDataWriter::new_with_selector(Action::CandidateExitIsPending)
+					.write(Address(TestAccount::Bob.into()))
+					.build(),
+				None,
+				&evm_test_context(),
+				false
+			),
+			expected_result
+		);
+	})
 }
 
 #[test]

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -64,6 +64,7 @@ fn selectors() {
 	assert_eq!(Action::DelegatorDelegationCount as u32, 0xfbc51bca);
 	assert_eq!(Action::SelectedCandidates as u32, 0x89f47a21);
 	assert_eq!(Action::DelegationRequestIsPending as u32, 0x192e1db3);
+	assert_eq!(Action::CandidateRequestIsPending as u32, 0x26ab05fb);
 	assert_eq!(Action::JoinCandidates as u32, 0x0a1bff60);
 	// DEPRECATED
 	assert_eq!(Action::LeaveCandidates as u32, 0x72b02a31);
@@ -848,7 +849,7 @@ fn delegation_request_is_pending_works() {
 }
 
 #[test]
-fn delegation_request_is_pending_returns_false_for_non_existing_del() {
+fn delegation_request_is_pending_returns_false_for_non_existing_delegator() {
 	ExtBuilder::default()
 		.with_balances(vec![
 			(TestAccount::Alice, 1_000),
@@ -881,6 +882,106 @@ fn delegation_request_is_pending_returns_false_for_non_existing_del() {
 				expected_result
 			);
 		})
+}
+
+#[test]
+fn candidate_request_is_pending_works() {
+	ExtBuilder::default()
+		.with_balances(vec![(TestAccount::Alice, 1_050)])
+		.with_candidates(vec![(TestAccount::Alice, 1_050)])
+		.build()
+		.execute_with(|| {
+			// Expected false because we dont have pending requests yet
+			let mut expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(false).build(),
+				cost: Default::default(),
+				logs: Default::default(),
+			}));
+			// Assert that we dont have pending requests
+			assert_eq!(
+				precompiles().execute(
+					precompile_address(),
+					&EvmDataWriter::new_with_selector(Action::CandidateRequestIsPending)
+						.write(Address(TestAccount::Alice.into()))
+						.build(),
+					None,
+					&evm_test_context(),
+					false
+				),
+				expected_result
+			);
+
+			// Schedule bond less request
+			assert_eq!(
+				precompiles().execute(
+					precompile_address(),
+					&EvmDataWriter::new_with_selector(Action::ScheduleCandidateBondLess)
+						.write(U256::zero())
+						.build(),
+					None,
+					&Context {
+						address: precompile_address(),
+						caller: TestAccount::Alice.into(),
+						apparent_value: From::from(0),
+					},
+					false,
+				),
+				Some(Ok(PrecompileOutput {
+					exit_status: ExitSucceed::Returned,
+					output: Default::default(),
+					cost: 176422000,
+					logs: Default::default(),
+				}))
+			);
+
+			// Expected true because we scheduled a bond less request
+			expected_result = Some(Ok(PrecompileOutput {
+				exit_status: ExitSucceed::Returned,
+				output: EvmDataWriter::new().write(true).build(),
+				cost: Default::default(),
+				logs: Default::default(),
+			}));
+			// Assert that we have pending requests
+			assert_eq!(
+				precompiles().execute(
+					precompile_address(),
+					&EvmDataWriter::new_with_selector(Action::CandidateRequestIsPending)
+						.write(Address(TestAccount::Alice.into()))
+						.build(),
+					None,
+					&evm_test_context(),
+					false
+				),
+				expected_result
+			);
+		})
+}
+
+#[test]
+fn candidate_request_is_pending_returns_false_for_non_existing_candidate() {
+	ExtBuilder::default().build().execute_with(|| {
+		// Expected false because candidate Bob does not exist
+		let expected_result = Some(Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			output: EvmDataWriter::new().write(false).build(),
+			cost: Default::default(),
+			logs: Default::default(),
+		}));
+		// Assert that we return false
+		assert_eq!(
+			precompiles().execute(
+				precompile_address(),
+				&EvmDataWriter::new_with_selector(Action::CandidateRequestIsPending)
+					.write(Address(TestAccount::Bob.into()))
+					.build(),
+				None,
+				&evm_test_context(),
+				false
+			),
+			expected_result
+		);
+	})
 }
 
 #[test]


### PR DESCRIPTION
Requested in https://github.com/PureStake/moonbeam/issues/1128#issuecomment-1100648276

Follow up to #1406 but for candidate bond less requests. It returns whether the candidate has a pending bond less request.

Also adds precompile methods for
* if candidate leave request is pending
* if delegator leave request is pending

These just provide the same functionality for the similar leave interface.

## Future

Upon request, we can also add a precompile method to return whether each request is pending && executable (named `{request}_is_executable`).
