### PR TITLE
Fix version-bump script (add dashes)

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           cd tools
           yarn install
-          yarn --silent run print-version-bump-info --from ${{ github.event.inputs.from }} --to ${{ github.event.inputs.to }} | tee ../version-bump.md
+          yarn --silent run print-version-bump-info -- --from ${{ github.event.inputs.from }} --to ${{ github.event.inputs.to }} | tee ../version-bump.md
       - name: Create version bump issue
         uses: peter-evans/create-issue-from-file@v3
         with:


### PR DESCRIPTION
### What does it do?

Adds `--` to the invocation of the print-version-bump-info script.