### PR TITLE
Expose round number in staking precompile

### DIFF
--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -60,6 +60,11 @@ interface ParachainStaking {
     /// @return The CandidateCount weight hint
     function candidate_count() external view returns (uint256);
 
+    /// @dev Get the current round number
+    /// Selector: 146ca531
+    /// @return The current round number
+    function round() external view returns (uint256);
+
     /// DEPRECATED, replaced by candidate_delegation_count
     /// @dev Get the CollatorNominationCount weight hint
     /// Selector: 0ad6a7be

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -48,6 +48,7 @@ enum Action {
 	MinDelegation = "min_delegation()",
 	Points = "points(uint256)",
 	CandidateCount = "candidate_count()",
+	Round = "round()",
 	// DEPRECATED
 	CollatorNominationCount = "collator_nomination_count(address)",
 	// DEPRECATED
@@ -157,6 +158,7 @@ where
 			Action::MinDelegation => return Self::min_delegation(gasometer),
 			Action::Points => return Self::points(input, gasometer),
 			Action::CandidateCount => return Self::candidate_count(gasometer),
+			Action::Round => return Self::round(gasometer),
 			// DEPRECATED
 			Action::CollatorNominationCount => {
 				return Self::candidate_delegation_count(input, gasometer)
@@ -324,6 +326,20 @@ where
 			exit_status: ExitSucceed::Returned,
 			cost: gasometer.used_gas(),
 			output: EvmDataWriter::new().write(candidate_count).build(),
+			logs: vec![],
+		})
+	}
+
+	fn round(gasometer: &mut Gasometer) -> EvmResult<PrecompileOutput> {
+		// Fetch info.
+		gasometer.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+		let round: u32 = <parachain_staking::Pallet<Runtime>>::round().current;
+
+		// Build output.
+		Ok(PrecompileOutput {
+			exit_status: ExitSucceed::Returned,
+			cost: gasometer.used_gas(),
+			output: EvmDataWriter::new().write(round).build(),
 			logs: vec![],
 		})
 	}

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -387,6 +387,13 @@ pub(crate) fn roll_to(n: u64) {
 	}
 }
 
+/// Rolls block-by-block to the beginning of the specified round.
+/// This will complete the block in which the round change occurs.
+pub(crate) fn roll_to_round_begin(round: u64) {
+	let block = (round - 1) * DefaultBlocksPerRound::get() as u64;
+	roll_to(block)
+}
+
 pub(crate) fn events() -> Vec<Event> {
 	System::events()
 		.into_iter()

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -15,8 +15,8 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::mock::{
-	events, evm_test_context, precompile_address, roll_to, set_points, Call, ExtBuilder, Origin,
-	ParachainStaking, PrecompilesValue, Runtime, TestAccount, TestPrecompiles,
+	events, evm_test_context, precompile_address, roll_to, roll_to_round_begin, set_points, Call,
+	ExtBuilder, Origin, ParachainStaking, PrecompilesValue, Runtime, TestAccount, TestPrecompiles,
 };
 use crate::{Action, PrecompileOutput};
 use fp_evm::{Context, PrecompileFailure};
@@ -304,15 +304,11 @@ fn round_works() {
 			expected_result
 		);
 		// Default round length is 5 so test next few round transitions
-		const ROUND_TRANSITIONS_TO_TEST: u64 = 10;
-		let mut current_block: u64 = 1;
-		let mut current_round: u32 = 1;
-		while current_block
-			< (ROUND_TRANSITIONS_TO_TEST * crate::mock::DefaultBlocksPerRound::get() as u64)
-		{
-			current_block += crate::mock::DefaultBlocksPerRound::get() as u64;
+		const ROUNDS_TO_TEST: u64 = 10;
+		let mut current_round: u64 = 1;
+		while current_round < ROUNDS_TO_TEST {
 			current_round += 1;
-			roll_to(current_block);
+			roll_to_round_begin(current_round);
 			expected_result = Some(Ok(PrecompileOutput {
 				exit_status: ExitSucceed::Returned,
 				output: EvmDataWriter::new().write(current_round).build(),

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -303,7 +303,7 @@ fn round_works() {
 			),
 			expected_result
 		);
-		// Default round length is 5 so test next few round transitions
+		// test next `ROUNDS_TO_TEST` rounds
 		const ROUNDS_TO_TEST: u64 = 10;
 		let mut current_round: u64 = 1;
 		while current_round < ROUNDS_TO_TEST {


### PR DESCRIPTION
### What does it do?

Expose current round number in staking precompile

[MOON-1639] Requested by user via discord, reported by @albertov19 