### PR TITLE
EIP2612: fix timestamp units

### DIFF
--- a/precompiles/assets-erc20/src/eip2612.rs
+++ b/precompiles/assets-erc20/src/eip2612.rs
@@ -199,7 +199,8 @@ where
 		let r: H256 = input.read(gasometer)?;
 		let s: H256 = input.read(gasometer)?;
 
-		let timestamp: U256 = pallet_timestamp::Pallet::<Runtime>::get().into();
+		// pallet_timestamp is in ms while Ethereum use second timestamps.
+		let timestamp: U256 = (pallet_timestamp::Pallet::<Runtime>::get()).into() / 1000;
 
 		ensure!(deadline >= timestamp, gasometer.revert("permit expired"));
 

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -2689,7 +2689,7 @@ fn permit_invalid_deadline() {
 				1000
 			));
 
-			pallet_timestamp::Pallet::<Runtime>::set_timestamp(10);
+			pallet_timestamp::Pallet::<Runtime>::set_timestamp(10_000);
 
 			let owner: H160 = Account::Alice.into();
 			let spender: H160 = Account::Bob.into();

--- a/precompiles/balances-erc20/src/eip2612.rs
+++ b/precompiles/balances-erc20/src/eip2612.rs
@@ -105,7 +105,8 @@ where
 		let r: H256 = input.read(gasometer)?;
 		let s: H256 = input.read(gasometer)?;
 
-		let timestamp: U256 = pallet_timestamp::Pallet::<Runtime>::get().into();
+		// pallet_timestamp is in ms while Ethereum use second timestamps.
+		let timestamp: U256 = (pallet_timestamp::Pallet::<Runtime>::get()).into() / 1000;
 
 		ensure!(deadline >= timestamp, gasometer.revert("permit expired"));
 

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -1533,7 +1533,7 @@ fn permit_invalid_deadline() {
 		.with_balances(vec![(Account::Alice, 1000)])
 		.build()
 		.execute_with(|| {
-			pallet_timestamp::Pallet::<Runtime>::set_timestamp(10);
+			pallet_timestamp::Pallet::<Runtime>::set_timestamp(10_000);
 
 			let owner: H160 = Account::Alice.into();
 			let spender: H160 = Account::Bob.into();


### PR DESCRIPTION
### What does it do?

EIP2612 and Ethereum blocks deals with timestamps in seconds, while our pallet_timestamp deals with milliseconds.
With thus need to divide by 1000 so that dapps used to EIP2612 on Ethereum don't need to handle milliseconds.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
