### PR TITLE
Force author if there is a pending migration to be executed

### DIFF
--- a/pallets/migrations/src/lib.rs
+++ b/pallets/migrations/src/lib.rs
@@ -322,4 +322,16 @@ pub mod pallet {
 
 		weight
 	}
+
+	impl<T: Config> Pallet<T> {
+		pub fn pending_migration() -> bool {
+			for migration in &T::MigrationsList::get_migrations() {
+				if !<MigrationState<T>>::get(migration.friendly_name().as_bytes()) {
+					// at least 1 migration is pending execution
+					return true;
+				}
+			}
+			false
+		}
+	}
 }

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -356,6 +356,10 @@ macro_rules! impl_runtime_apis_plus_common {
 					slot: u32,
 					parent_header: &<Block as BlockT>::Header
 				) -> bool {
+					if pallet_migrations::Pallet::<Self>::pending_migration() {
+						// force author if there is a pending migration
+						return true;
+					}
 					let block_number = parent_header.number + 1;
 
 					// The Moonbeam runtimes use an entropy source that needs to do some accounting


### PR DESCRIPTION
Return true from `can_author` if there is a migration to be executed. To determine if a migration needed to be executed, added helper function `pending_migration` to pallet-migrations.

We thought that this was already implemented, as discussed in MOON-1651

Is there a simpler helper function to determine if the runtime version number was changed? Then I can revert the change to pallet-migrations.