### PR TITLE
Improves xcm fee smoke test computation

### DIFF
--- a/tests/smoke-tests/test-relay-xcm-fees.ts
+++ b/tests/smoke-tests/test-relay-xcm-fees.ts
@@ -32,18 +32,38 @@ describeSmokeSuite(`Verify XCM weight fees for relay`, { wssUrl, relayWssUrl }, 
     // Load data
     const transactInfos = await apiAt.query.xcmTransactor.transactInfoWithWeightLimit.entries();
 
+    const relayRuntime = context.relayApi.runtimeVersion.specName.toString();
+    console.log(relayRuntime);
+
+    const units = relayRuntime.startsWith("polkadot")
+      ? 10_000_000_000n
+      : relayRuntime.startsWith("kusama") ||
+        relayRuntime.startsWith("rococo") ||
+        relayRuntime.startsWith("westend")
+      ? 1_000_000_000_000n
+      : 1_000_000_000_000n;
+
+    const seconds = 1_000_000_000_000n;
+
+    const cent =
+      relayRuntime.startsWith("polkadot") ||
+      relayRuntime.startsWith("rococo") ||
+      relayRuntime.startsWith("westend")
+        ? units / 100n
+        : relayRuntime.startsWith("kusama")
+        ? units / 30_000n
+        : units / 100n;
+    const coef = cent / 10n;
+
     const relayBaseWeight =
       relayApiAt.consts.system.blockWeights.perClass.normal.baseExtrinsic.toBigInt();
-    const seconds = 1_000_000_000_000n;
-    const cent = seconds / 30_000n;
-    const coef = cent / 10n;
     const expectedFeePerSecond = (coef * seconds) / relayBaseWeight;
 
     expect(transactInfos.length, "Missing transactInfoWithWeightLimit data").to.be.at.least(1);
     for (const transactInfo of transactInfos) {
       const feePerSecond = transactInfo[1].unwrap().feePerSecond.toBigInt();
       expect(
-        feePerSecond > expectedFeePerSecond,
+        feePerSecond >= expectedFeePerSecond,
         `failed check: feePerSecond: ${feePerSecond} > expected ${expectedFeePerSecond}`
       ).to.be.true;
       expect(


### PR DESCRIPTION
The XCM smoke test relies on expected fee computation from the runtime, however those are hardcoded in the runtime itself and not accessible through state/const. So the test is now hardcoding them too.

It will require maintenance to update those if/when modified by Parity.