### PR TITLE
Fix maintenance mode executive hooks name

### DIFF
--- a/pallets/maintenance-mode/src/lib.rs
+++ b/pallets/maintenance-mode/src/lib.rs
@@ -125,7 +125,7 @@ pub mod pallet {
 		/// The executive hooks that will be used in maintenance mode
 		/// Important: Use AllPalletsReversedWithSystemFirst here if you dont want to modify the
 		/// hooks behaviour
-		type MaitenanceExecutiveHooks: OnRuntimeUpgrade
+		type MaintenanceExecutiveHooks: OnRuntimeUpgrade
 			+ OnInitialize<Self::BlockNumber>
 			+ OnIdle<Self::BlockNumber>
 			+ OnFinalize<Self::BlockNumber>

--- a/pallets/maintenance-mode/src/mock.rs
+++ b/pallets/maintenance-mode/src/mock.rs
@@ -262,7 +262,7 @@ impl Config for Test {
 	#[cfg(feature = "xcm-support")]
 	type MaintenanceDmpHandler = MaintenanceDmpHandler;
 	type NormalExecutiveHooks = NormalHooks;
-	type MaitenanceExecutiveHooks = MaintenanceHooks;
+	type MaintenanceExecutiveHooks = MaintenanceHooks;
 }
 
 /// Externality builder for pallet maintenance mode's mock runtime

--- a/pallets/maintenance-mode/src/types.rs
+++ b/pallets/maintenance-mode/src/types.rs
@@ -33,7 +33,7 @@ where
 {
 	fn on_idle(n: BlockNumberOf<T>, remaining_weight: Weight) -> Weight {
 		if Pallet::<T>::maintenance_mode() {
-			T::MaitenanceExecutiveHooks::on_idle(n, remaining_weight)
+			T::MaintenanceExecutiveHooks::on_idle(n, remaining_weight)
 		} else {
 			T::NormalExecutiveHooks::on_idle(n, remaining_weight)
 		}
@@ -46,7 +46,7 @@ where
 {
 	fn on_initialize(n: BlockNumberOf<T>) -> Weight {
 		if Pallet::<T>::maintenance_mode() {
-			T::MaitenanceExecutiveHooks::on_initialize(n)
+			T::MaintenanceExecutiveHooks::on_initialize(n)
 		} else {
 			T::NormalExecutiveHooks::on_initialize(n)
 		}
@@ -59,7 +59,7 @@ where
 {
 	fn on_finalize(n: BlockNumberOf<T>) {
 		if Pallet::<T>::maintenance_mode() {
-			T::MaitenanceExecutiveHooks::on_finalize(n)
+			T::MaintenanceExecutiveHooks::on_finalize(n)
 		} else {
 			T::NormalExecutiveHooks::on_finalize(n)
 		}
@@ -72,7 +72,7 @@ where
 {
 	fn offchain_worker(n: BlockNumberOf<T>) {
 		if Pallet::<T>::maintenance_mode() {
-			T::MaitenanceExecutiveHooks::offchain_worker(n)
+			T::MaintenanceExecutiveHooks::offchain_worker(n)
 		} else {
 			T::NormalExecutiveHooks::offchain_worker(n)
 		}
@@ -85,7 +85,7 @@ where
 {
 	fn on_runtime_upgrade() -> Weight {
 		if Pallet::<T>::maintenance_mode() {
-			T::MaitenanceExecutiveHooks::on_runtime_upgrade()
+			T::MaintenanceExecutiveHooks::on_runtime_upgrade()
 		} else {
 			T::NormalExecutiveHooks::on_runtime_upgrade()
 		}
@@ -94,7 +94,7 @@ where
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<(), &'static str> {
 		if Pallet::<T>::maintenance_mode() {
-			T::MaitenanceExecutiveHooks::pre_upgrade()
+			T::MaintenanceExecutiveHooks::pre_upgrade()
 		} else {
 			T::NormalExecutiveHooks::pre_upgrade()
 		}
@@ -103,7 +103,7 @@ where
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade() -> Result<(), &'static str> {
 		if Pallet::<T>::maintenance_mode() {
-			T::MaitenanceExecutiveHooks::post_upgrade()
+			T::MaintenanceExecutiveHooks::post_upgrade()
 		} else {
 			T::NormalExecutiveHooks::post_upgrade()
 		}

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1053,7 +1053,7 @@ impl pallet_maintenance_mode::Config for Runtime {
 	// We use AllPalletsReversedWithSystemFirst because we dont want to change the hooks in normal
 	// operation
 	type NormalExecutiveHooks = AllPalletsReversedWithSystemFirst;
-	type MaitenanceExecutiveHooks = MaintenanceHooks;
+	type MaintenanceExecutiveHooks = MaintenanceHooks;
 }
 
 impl pallet_proxy_genesis_companion::Config for Runtime {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1020,7 +1020,7 @@ impl pallet_maintenance_mode::Config for Runtime {
 	// We use AllPalletsReversedWithSystemFirst because we dont want to change the hooks in normal
 	// operation
 	type NormalExecutiveHooks = AllPalletsReversedWithSystemFirst;
-	type MaitenanceExecutiveHooks = MaintenanceHooks;
+	type MaintenanceExecutiveHooks = MaintenanceHooks;
 }
 
 impl pallet_proxy_genesis_companion::Config for Runtime {

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1029,7 +1029,7 @@ impl pallet_maintenance_mode::Config for Runtime {
 	// We use AllPalletsReversedWithSystemFirst because we dont want to change the hooks in normal
 	// operation
 	type NormalExecutiveHooks = AllPalletsReversedWithSystemFirst;
-	type MaitenanceExecutiveHooks = MaintenanceHooks;
+	type MaintenanceExecutiveHooks = MaintenanceHooks;
 }
 
 impl pallet_proxy_genesis_companion::Config for Runtime {


### PR DESCRIPTION
renames maintenance mode associated type `MaitenanceExecutiveHooks` to `MaintenanceExecutiveHooks`
