### PR TITLE
Add migrations.md to author-mapping

### DIFF
--- a/pallets/author-mapping/migrations.md
+++ b/pallets/author-mapping/migrations.md
@@ -1,0 +1,10 @@
+# Migration History
+
+## Add session keys to author mapping pallet
+
+- [Migration PR `#1407`](https://github.com/PureStake/moonbeam/pull/1407)
+
+## Manage author mapping blake2 migration
+
+- [Migration PR `#796`](https://github.com/PureStake/moonbeam/pull/796)
+- [Migration Removal PR `#1434`](https://github.com/PureStake/moonbeam/pull/1434)


### PR DESCRIPTION
### What does it do?

This PR adds a `migration.md` file to `author-mapping`.

### What important points reviewers should know?

This aligns the bookkeeping of `author-mapping` migrations with how it's done within `parachain-staking`.

### What value does it bring to the blockchain users?

Runtime engineers have an accurate overview of migrations they might have to apply.