### PR TITLE
automate typescript API upgrade

### DIFF
--- a/.github/workflows/upgrade-typescript-api.yml
+++ b/.github/workflows/upgrade-typescript-api.yml
@@ -1,0 +1,32 @@
+name: Upgrade typescript API
+on:
+  workflow_dispatch:
+    inputs:
+      spec_version:
+        description: runtime spec version
+        required: true
+
+jobs:
+  create-tracing-runtime:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: runtime-${{ github.event.inputs.spec_version }}
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: import runtime
+        run: |
+          cd typescript-api
+          ./scripts/runtime-upgrade.sh ${{ github.event.inputs.spec_version }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: "typescript-api-${{ github.event.inputs.spec_version }}"
+          commit-message: typescript API v0.${{ github.event.inputs.spec_version }}.0"
+          draft: true
+          title: "Upgrade typescript API for runtime  ${{ github.event.inputs.spec_version }}"
+          reviewers: "librelois,ekenigs,crystalin"

--- a/tools/github/print-runtime-release-issue.ts
+++ b/tools/github/print-runtime-release-issue.ts
@@ -44,6 +44,7 @@ async function main() {
   - [ ] Review the generated Draft and clean a bit the messages if needed (keep it draft)
   - [ ] Create the tracing runtime on moonbeam-runtime-overrides
   (see https://github.com/PureStake/moonbeam-runtime-overrides/blob/master/README.md)
+  - [ ] Upgrade typescript API: Start the github action "Upgrade typescript API"
   - [ ] Add new substitute in stagenet configuration 
   - [ ] Upgrade stagenet
   - [ ] Create new tracing image for partners: start the github action Publish Docker

--- a/typescript-api/README.md
+++ b/typescript-api/README.md
@@ -29,7 +29,7 @@ Add to your codebase entry point before any imports from the API itself.
 Update package version.
 
 ```bash
-npm --no-git-tag-version 0.1500.0
+npm version --no-git-tag-version 0.1500.0
 ```
 
 Generate new types.

--- a/typescript-api/scripts/runtime-upgrade.sh
+++ b/typescript-api/scripts/runtime-upgrade.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+CHAINS=(
+  moonbase
+  moonriver
+  moonbeam
+)
+
+# params
+RUNTIME_CHAIN_SPEC=$1
+
+# Bump package version
+if [[ $# -gt 0 ]]; then
+  npm version --no-git-tag-version 0.$RUNTIME_CHAIN_SPEC.0
+fi
+
+# Install dependencies
+npm install
+
+# Generate typescript api code
+npm run generate
+
+# Manually fix BTreeSet issue
+echo "Manually fix BTreeSet issue..."
+for CHAIN in ${CHAINS[@]}; do
+  sed -i -e 's/BTreeSet,/BTreeSet as BTreeSetType,/g' src/$CHAIN/interfaces/types-lookup.ts
+  sed -i -e 's/BTreeSet<Bytes>/BTreeSetType<Bytes>/g' src/$CHAIN/interfaces/types-lookup.ts
+done
+
+# Build the package
+npm run build


### PR DESCRIPTION
### What does it do?

Adds a GA workflow that creates a PR with the updated typescript API according to the runtime version indicated.
The idea is that there is always a human control to validate, as we do for the tracing runtime.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
