### PR TITLE
ci: create a manual workflow to publish typescript API

### DIFF
--- a/.github/workflows/publish-typescript-api.yml
+++ b/.github/workflows/publish-typescript-api.yml
@@ -1,0 +1,30 @@
+name: Publish Typescript API
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: full sha to build the npm package from
+        required: true
+
+jobs:
+  create-tracing-runtime:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.sha }}
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+      - name: Build typescript API
+        run: |
+          cd typescript-api
+          npm install
+          npm run build
+      - name: Publish typescript API
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: typescript-api/package.json


### PR DESCRIPTION
### What does it do?

Add a manual GA workflow to publish the npm package `@moonbeam-network/api-augment`.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
