### PR TITLE
[MOON-1674] skip minting rewards if amount is 0

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1532,7 +1532,9 @@ pub mod pallet {
 					for Bond { owner, amount } in state.delegations {
 						let percent = Perbill::from_rational(amount, state.total);
 						let due = percent * amt_due;
-						mint(due, owner.clone());
+						if !due.is_zero() {
+							mint(due, owner.clone());
+						}
 					}
 				}
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -8429,16 +8429,10 @@ fn test_delegator_scheduled_for_revoke_is_rewarded_for_previous_rounds_but_not_f
 
 			roll_to_round_begin(4);
 			assert_eq_last_events!(
-				vec![
-					Event::<Test>::Rewarded {
-						account: 1,
-						rewards: 4,
-					},
-					Event::<Test>::Rewarded {
-						account: 2,
-						rewards: 0,
-					},
-				],
+				vec![Event::<Test>::Rewarded {
+					account: 1,
+					rewards: 4,
+				}],
 				"delegator was rewarded unexpectedly"
 			);
 			let collator_snapshot =
@@ -8496,16 +8490,10 @@ fn test_delegator_scheduled_for_revoke_is_rewarded_when_request_cancelled() {
 
 			roll_to_round_begin(4);
 			assert_eq_last_events!(
-				vec![
-					Event::<Test>::Rewarded {
-						account: 1,
-						rewards: 4,
-					},
-					Event::<Test>::Rewarded {
-						account: 2,
-						rewards: 0,
-					},
-				],
+				vec![Event::<Test>::Rewarded {
+					account: 1,
+					rewards: 4,
+				}],
 				"delegator was rewarded unexpectedly",
 			);
 			let collator_snapshot =


### PR DESCRIPTION
### What does it do?
Skips minting rewards if the amount is 0. 

:warning: Breaking change - The rewarded event will no longer be emitted if the reward amount is `0`.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
