### PR TITLE
build runtimes without feature on-chain-release-build

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -28,8 +28,6 @@ jobs:
       - name: Srtool build
         id: srtool_build
         uses: chevdor/srtool-actions@v0.4.0
-        env:
-          BUILD_OPTS: --features on-chain-release-build
         with:
           chain: ${{ matrix.chain }}
           tag: 1.57.0


### PR DESCRIPTION
### What does it do?

The compilation feature `on-chain-release-build` disable runtimes logs, the goal was to reduce the runtime code size, but the gain is negligible, so we decided to remove this feature.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
