### PR TITLE
Switch to exhaustive selector match in staking precompiles

### DIFF
--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -134,20 +134,52 @@ where
 			context,
 			is_static,
 			match selector {
+				// Views
 				Action::IsNominator
 				| Action::IsDelegator
 				| Action::IsCandidate
 				| Action::IsSelectedCandidate
-				| Action::Points
 				| Action::MinNomination
 				| Action::MinDelegation
+				| Action::Points
 				| Action::CandidateCount
+				| Action::Round
 				| Action::CollatorNominationCount
-				| Action::CandidateDelegationCount
 				| Action::NominatorNominationCount
+				| Action::CandidateDelegationCount
 				| Action::DelegatorDelegationCount
-				| Action::SelectedCandidates => FunctionModifier::View,
-				_ => FunctionModifier::NonPayable,
+				| Action::SelectedCandidates
+				| Action::DelegationRequestIsPending
+				| Action::DelegatorExitIsPending
+				| Action::CandidateExitIsPending
+				| Action::CandidateRequestIsPending => FunctionModifier::View,
+				// Non-payables
+				Action::JoinCandidates
+				| Action::LeaveCandidates
+				| Action::ScheduleLeaveCandidates
+				| Action::ExecuteLeaveCandidates
+				| Action::CancelLeaveCandidates
+				| Action::GoOffline
+				| Action::GoOnline
+				| Action::CandidateBondLess
+				| Action::ScheduleCandidateBondLess
+				| Action::CandidateBondMore
+				| Action::ExecuteCandidateBondLess
+				| Action::CancelCandidateBondLess
+				| Action::Nominate
+				| Action::Delegate
+				| Action::LeaveNominators
+				| Action::ScheduleLeaveDelegators
+				| Action::ExecuteLeaveDelegators
+				| Action::CancelLeaveDelegators
+				| Action::RevokeNomination
+				| Action::ScheduleRevokeDelegation
+				| Action::NominatorBondLess
+				| Action::ScheduleDelegatorBondLess
+				| Action::NominatorBondMore
+				| Action::DelegatorBondMore
+				| Action::ExecuteDelegationRequest
+				| Action::CancelDelegationRequest => FunctionModifier::NonPayable,
 			},
 		)?;
 


### PR DESCRIPTION
### What does it do?

Falling back to `FunctionModifier::NonPayable` with a wildcard can cause undesired behaviour when introducing new views and the non-exhaustive match is not updated. Rel https://github.com/PureStake/moonbeam/issues/1520

This PR changes to exhaustive match so when a new `Action` variant is introduced, the compiler guides us to explicitly update it.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
