### PR TITLE
Make author_mapping::set_keys take 1 input like pallet_session::set_keys

### DIFF
--- a/pallets/author-mapping/src/benchmarks.rs
+++ b/pallets/author-mapping/src/benchmarks.rs
@@ -83,7 +83,7 @@ benchmarks! {
 		let caller = create_funded_user::<T>();
 		let id = nimbus_id(1u8);
 		let key: T::Keys = nimbus_id(2u8).into();
-	}: _(RawOrigin::Signed(caller.clone()), id.clone(), key.clone())
+	}: _(RawOrigin::Signed(caller.clone()), (id.clone(), key.clone()))
 	verify {
 		assert_eq!(Pallet::<T>::account_id_of(&id), Some(caller));
 		assert_eq!(Pallet::<T>::keys_of(&id), Some(key));
@@ -101,10 +101,9 @@ benchmarks! {
 				first_keys.clone(),
 			)
 		);
-	}: _(RawOrigin::Signed(caller.clone()),
-		first_id.clone(),
-		second_id.clone(),
-		second_keys.clone()) verify {
+	}: _(RawOrigin::Signed(caller.clone())
+		(second_id.clone(),
+		second_keys.clone())) verify {
 		assert_eq!(Pallet::<T>::account_id_of(&first_id), None);
 		assert_eq!(Pallet::<T>::keys_of(&first_id), None);
 		assert_eq!(Pallet::<T>::account_id_of(&second_id), Some(caller));

--- a/pallets/author-mapping/src/benchmarks.rs
+++ b/pallets/author-mapping/src/benchmarks.rs
@@ -101,7 +101,7 @@ benchmarks! {
 				first_keys.clone(),
 			)
 		);
-	}: _(RawOrigin::Signed(caller.clone())
+	}: _(RawOrigin::Signed(caller.clone()),
 		(second_id.clone(),
 		second_keys.clone())) verify {
 		assert_eq!(Pallet::<T>::account_id_of(&first_id), None);

--- a/pallets/author-mapping/src/benchmarks.rs
+++ b/pallets/author-mapping/src/benchmarks.rs
@@ -97,8 +97,8 @@ benchmarks! {
 		let second_keys: T::Keys = nimbus_id(3u8).into();
 		assert_ok!(Pallet::<T>::register_keys(
 				RawOrigin::Signed(caller.clone()).into(),
-				first_id.clone(),
-				first_keys.clone(),
+				(first_id.clone(),
+				first_keys.clone()),
 			)
 		);
 	}: _(RawOrigin::Signed(caller.clone()),

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -221,13 +221,9 @@ pub mod pallet {
 
 		/// Add association and set session keys
 		#[pallet::weight(<T as Config>::WeightInfo::register_keys())]
-		pub fn register_keys(
-			origin: OriginFor<T>,
-			author_id: NimbusId,
-			keys: T::Keys,
-		) -> DispatchResult {
+		pub fn register_keys(origin: OriginFor<T>, keys: (NimbusId, T::Keys)) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;
-
+			let (author_id, keys) = keys;
 			ensure!(
 				MappingWithDeposit::<T>::get(&author_id).is_none(),
 				Error::<T>::AlreadyAssociated

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -181,6 +181,7 @@ pub mod pallet {
 				..stored_info
 			};
 			MappingWithDeposit::<T>::insert(&new_author_id, &new_stored_info);
+			NimbusLookup::<T>::insert(&account_id, &new_author_id);
 
 			<Pallet<T>>::deposit_event(Event::AuthorRotated {
 				new_author_id: new_author_id,

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -318,7 +318,7 @@ pub mod pallet {
 	#[pallet::getter(fn nimbus_lookup)]
 	/// We maintain a reverse mapping from AccountIds to NimbusIDS
 	pub type NimbusLookup<T: Config> =
-		StorageMap<_, Twox64Concat, T::AccountId, NimbusId, OptionQuery>;
+		StorageMap<_, Blake2_128Concat, T::AccountId, NimbusId, OptionQuery>;
 
 	#[pallet::genesis_config]
 	/// Genesis config for author mapping pallet

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -254,7 +254,7 @@ pub mod pallet {
 		/// No new security deposit is required. Will replace `update_association` which is kept
 		/// now for backwards compatibility reasons.
 		#[pallet::weight(<T as Config>::WeightInfo::set_keys())]
-		pub fn set_keys(origin: OriginFor<T>, keys: T::AllKeys) -> DispatchResult {
+		pub fn set_keys(origin: OriginFor<T>, keys: (NimbusId, T::Keys)) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;
 			let old_author_id =
 				NimbusLookup::<T>::get(&account_id).ok_or(Error::<T>::OldAuthorIdNotFound)?;

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -93,8 +93,6 @@ pub mod pallet {
 		AlreadyAssociated,
 		/// No existing NimbusId can be found for the account
 		OldAuthorIdNotFound,
-		NewAuthorIdNotIncluded,
-		NewVrfKeyNotIncluded,
 	}
 
 	#[pallet::event]

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -74,9 +74,8 @@ pub mod pallet {
 		type DepositCurrency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
 		/// The amount that should be taken as a security deposit when registering a NimbusId.
 		type DepositAmount: Get<<Self::DepositCurrency as Currency<Self::AccountId>>::Balance>;
-		// TODO: rename to Keys
-		type BothKeys: OpaqueKeys + Member + Parameter + MaybeSerializeDeserialize;
-		// TODO: rename to VrfKeys
+		/// Nimbus keys and the key(s) stored in `Self::Keys`
+		type AllKeys: OpaqueKeys + Member + Parameter + MaybeSerializeDeserialize;
 		/// Additional keys
 		/// Convertible From<NimbusId> to get default keys for each mapping (for the migration)
 		type Keys: Parameter + Member + MaybeSerializeDeserialize + From<NimbusId>;
@@ -255,7 +254,7 @@ pub mod pallet {
 		/// No new security deposit is required. Will replace `update_association` which is kept
 		/// now for backwards compatibility reasons.
 		#[pallet::weight(<T as Config>::WeightInfo::set_keys())]
-		pub fn set_keys(origin: OriginFor<T>, keys: T::BothKeys) -> DispatchResult {
+		pub fn set_keys(origin: OriginFor<T>, keys: T::AllKeys) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;
 			let old_author_id =
 				NimbusLookup::<T>::get(&account_id).ok_or(Error::<T>::OldAuthorIdNotFound)?;
@@ -269,7 +268,7 @@ pub mod pallet {
 			// Error if either new key is not included
 			let mut maybe_new_author_id: Option<NimbusId> = None;
 			let mut maybe_new_vrf_key: Option<T::Keys> = None;
-			for id in T::BothKeys::key_ids() {
+			for id in T::AllKeys::key_ids() {
 				let key = keys.get_raw(*id);
 				if id == &nimbus_primitives::NIMBUS_KEY_ID {
 					maybe_new_author_id = Some(session_keys_primitives::nimbus_id_from_bytes(key));

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -206,6 +206,7 @@ pub mod pallet {
 			);
 
 			MappingWithDeposit::<T>::remove(&author_id);
+			NimbusLookup::<T>::remove(&account_id);
 
 			T::DepositCurrency::unreserve(&account_id, stored_info.deposit);
 
@@ -252,7 +253,7 @@ pub mod pallet {
 		pub fn set_keys(origin: OriginFor<T>, keys: (NimbusId, T::Keys)) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;
 			let old_author_id =
-				NimbusLookup::<T>::get(&account_id).ok_or(Error::<T>::OldAuthorIdNotFound)?;
+				Self::nimbus_id_of(&account_id).ok_or(Error::<T>::OldAuthorIdNotFound)?;
 			let stored_info = MappingWithDeposit::<T>::try_get(&old_author_id)
 				.map_err(|_| Error::<T>::AssociationNotFound)?;
 

--- a/pallets/author-mapping/src/tests.rs
+++ b/pallets/author-mapping/src/tests.rs
@@ -426,9 +426,7 @@ fn registered_can_full_rotate() {
 		.execute_with(|| {
 			assert_ok!(AuthorMapping::set_keys(
 				Origin::signed(2),
-				TestAuthor::Bob.into(),
-				TestAuthor::Charlie.into(),
-				TestAuthor::Charlie.into(),
+				(TestAuthor::Charlie.into(), TestAuthor::Charlie.into())
 			));
 
 			assert_eq!(AuthorMapping::account_id_of(&TestAuthor::Bob.into()), None);
@@ -453,11 +451,9 @@ fn unregistered_author_cannot_be_full_rotated() {
 		assert_noop!(
 			AuthorMapping::set_keys(
 				Origin::signed(2),
-				TestAuthor::Alice.into(),
-				TestAuthor::Bob.into(),
-				TestAuthor::Bob.into(),
+				(TestAuthor::Bob.into(), TestAuthor::Bob.into()),
 			),
-			Error::<Runtime>::AssociationNotFound
+			Error::<Runtime>::OldAuthorIdNotFound
 		);
 	})
 }
@@ -472,11 +468,9 @@ fn registered_author_cannot_be_full_rotated_by_non_owner() {
 			assert_noop!(
 				AuthorMapping::set_keys(
 					Origin::signed(2),
-					TestAuthor::Alice.into(),
-					TestAuthor::Bob.into(),
-					TestAuthor::Bob.into(),
+					(TestAuthor::Bob.into(), TestAuthor::Bob.into())
 				),
-				Error::<Runtime>::NotYourAssociation
+				Error::<Runtime>::OldAuthorIdNotFound
 			);
 		})
 }
@@ -491,9 +485,7 @@ fn full_rotating_to_the_same_author_id_leaves_registration_in_tact() {
 			assert_noop!(
 				AuthorMapping::set_keys(
 					Origin::signed(1),
-					TestAuthor::Alice.into(),
-					TestAuthor::Alice.into(),
-					TestAuthor::Alice.into(),
+					(TestAuthor::Alice.into(), TestAuthor::Alice.into())
 				),
 				Error::<Runtime>::AlreadyAssociated
 			);

--- a/pallets/author-mapping/src/tests.rs
+++ b/pallets/author-mapping/src/tests.rs
@@ -297,8 +297,7 @@ fn eligible_account_can_full_register() {
 		.execute_with(|| {
 			assert_ok!(AuthorMapping::register_keys(
 				Origin::signed(2),
-				TestAuthor::Bob.into(),
-				TestAuthor::Alice.into(),
+				(TestAuthor::Bob.into(), TestAuthor::Alice.into()),
 			));
 
 			assert_eq!(Balances::free_balance(&2), 900);
@@ -328,8 +327,7 @@ fn cannot_register_keys_without_deposit() {
 			assert_noop!(
 				AuthorMapping::register_keys(
 					Origin::signed(2),
-					TestAuthor::Alice.into(),
-					TestAuthor::Bob.into(),
+					(TestAuthor::Alice.into(), TestAuthor::Bob.into()),
 				),
 				Error::<Runtime>::CannotAffordSecurityDeposit
 			);
@@ -348,8 +346,7 @@ fn double_full_registration_counts_twice_as_much() {
 			// Register once as Bob
 			assert_ok!(AuthorMapping::register_keys(
 				Origin::signed(2),
-				TestAuthor::Bob.into(),
-				TestAuthor::Charlie.into(),
+				(TestAuthor::Bob.into(), TestAuthor::Charlie.into()),
 			));
 
 			assert_eq!(Balances::free_balance(&2), 900);
@@ -371,8 +368,7 @@ fn double_full_registration_counts_twice_as_much() {
 			// Register again as Alice
 			assert_ok!(AuthorMapping::register_keys(
 				Origin::signed(2),
-				TestAuthor::Alice.into(),
-				TestAuthor::Bob.into(),
+				(TestAuthor::Alice.into(), TestAuthor::Bob.into()),
 			));
 
 			assert_eq!(Balances::free_balance(&2), 800);
@@ -409,8 +405,7 @@ fn full_registered_author_cannot_be_overwritten() {
 			assert_noop!(
 				AuthorMapping::register_keys(
 					Origin::signed(2),
-					TestAuthor::Alice.into(),
-					TestAuthor::Bob.into()
+					(TestAuthor::Alice.into(), TestAuthor::Bob.into()),
 				),
 				Error::<Runtime>::AlreadyAssociated
 			);

--- a/pallets/author-mapping/src/weights.rs
+++ b/pallets/author-mapping/src/weights.rs
@@ -73,41 +73,46 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
+	// Storage: AuthorMapping NimbusLookup (r:0 w:1)
 	#[rustfmt::skip]
 	fn add_association() -> Weight {
-		(33_145_000 as Weight)
+		(34_709_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	// Storage: AuthorMapping MappingWithDeposit (r:2 w:2)
+	// Storage: AuthorMapping NimbusLookup (r:0 w:1)
 	#[rustfmt::skip]
 	fn update_association() -> Weight {
-		(25_754_000 as Weight)
+		(29_759_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	// Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
+	// Storage: AuthorMapping NimbusLookup (r:0 w:1)
 	#[rustfmt::skip]
 	fn clear_association() -> Weight {
-		(36_253_000 as Weight)
+		(36_180_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	// Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
+	// Storage: AuthorMapping NimbusLookup (r:0 w:1)
 	#[rustfmt::skip]
 	fn register_keys() -> Weight {
-		(33_600_000 as Weight)
+		(35_722_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
+	// Storage: AuthorMapping NimbusLookup (r:1 w:1)
 	// Storage: AuthorMapping MappingWithDeposit (r:2 w:2)
 	#[rustfmt::skip]
 	fn set_keys() -> Weight {
-		(25_578_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+		(32_010_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(3 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 }
 
@@ -115,40 +120,45 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 impl WeightInfo for () {
 	// Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
+	// Storage: AuthorMapping NimbusLookup (r:0 w:1)
 	#[rustfmt::skip]
 	fn add_association() -> Weight {
-		(33_145_000 as Weight)
+		(34_709_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
 	// Storage: AuthorMapping MappingWithDeposit (r:2 w:2)
+	// Storage: AuthorMapping NimbusLookup (r:0 w:1)
 	#[rustfmt::skip]
 	fn update_association() -> Weight {
-		(25_754_000 as Weight)
+		(29_759_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
 	// Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
+	// Storage: AuthorMapping NimbusLookup (r:0 w:1)
 	#[rustfmt::skip]
 	fn clear_association() -> Weight {
-		(36_253_000 as Weight)
+		(36_180_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
 	// Storage: AuthorMapping MappingWithDeposit (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
+	// Storage: AuthorMapping NimbusLookup (r:0 w:1)
 	#[rustfmt::skip]
 	fn register_keys() -> Weight {
-		(33_600_000 as Weight)
+		(35_722_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
+	// Storage: AuthorMapping NimbusLookup (r:1 w:1)
 	// Storage: AuthorMapping MappingWithDeposit (r:2 w:2)
 	#[rustfmt::skip]
 	fn set_keys() -> Weight {
-		(25_578_000 as Weight)
-			.saturating_add(RocksDbWeight::get().reads(2 as Weight))
-			.saturating_add(RocksDbWeight::get().writes(2 as Weight))
+		(32_010_000 as Weight)
+			.saturating_add(RocksDbWeight::get().reads(3 as Weight))
+			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
 }

--- a/precompiles/author-mapping/AuthorMappingInterface.sol
+++ b/precompiles/author-mapping/AuthorMappingInterface.sol
@@ -46,15 +46,10 @@ interface AuthorMapping {
 
     /**
      * Set keys
-     * Selector: a8259c85
+     * Selector: 47f92fc4
      *
-     * @param old_author_id The old nimbusId to be replaced
      * @param new_author_id The new nimbusId to be associated
      * @param new_keys The new session keys
      */
-    function set_keys(
-        bytes32 old_author_id,
-        bytes32 new_author_id,
-        bytes32 new_keys
-    ) external;
+    function set_keys(bytes32 new_author_id, bytes32 new_keys) external;
 }

--- a/precompiles/author-mapping/src/lib.rs
+++ b/precompiles/author-mapping/src/lib.rs
@@ -42,7 +42,7 @@ pub enum Action {
 	UpdateAssociation = "update_association(bytes32,bytes32)",
 	ClearAssociation = "clear_association(bytes32)",
 	RegisterKeys = "register_keys(bytes32,bytes32)",
-	SetKeys = "set_keys(bytes32,bytes32,bytes32)",
+	SetKeys = "set_keys(bytes32,bytes32)",
 }
 
 /// A precompile to wrap the functionality from pallet author mapping.
@@ -207,8 +207,7 @@ where
 
 		let origin = Runtime::AddressMapping::into_account_id(context.caller);
 		let call = AuthorMappingCall::<Runtime>::register_keys {
-			author_id: nimbus_id,
-			keys,
+			keys: (nimbus_id, keys),
 		};
 
 		RuntimeHelper::<Runtime>::try_dispatch(Some(origin).into(), call, gasometer)?;
@@ -226,9 +225,7 @@ where
 		gasometer: &mut Gasometer,
 		context: &Context,
 	) -> EvmResult<PrecompileOutput> {
-		input.expect_arguments(gasometer, 3)?;
-		let old_author_id =
-			sp_core::sr25519::Public::unchecked_from(input.read::<H256>(gasometer)?).into();
+		input.expect_arguments(gasometer, 2)?;
 		let new_author_id =
 			sp_core::sr25519::Public::unchecked_from(input.read::<H256>(gasometer)?).into();
 		let new_keys_as_nimbus_id: NimbusId =
@@ -238,15 +235,13 @@ where
 
 		log::trace!(
 			target: "author-mapping-precompile",
-			"Setting keys old author id {:?} new author id {:?} new keys {:?}",
-			old_author_id, new_author_id, new_keys
+			"Setting keys: new author id {:?} new keys {:?}",
+			new_author_id, new_keys
 		);
 
 		let origin = Runtime::AddressMapping::into_account_id(context.caller);
 		let call = AuthorMappingCall::<Runtime>::set_keys {
-			old_author_id,
-			new_author_id,
-			new_keys,
+			keys: (new_author_id, new_keys),
 		};
 
 		RuntimeHelper::<Runtime>::try_dispatch(Some(origin).into(), call, gasometer)?;

--- a/precompiles/author-mapping/src/tests.rs
+++ b/precompiles/author-mapping/src/tests.rs
@@ -95,7 +95,7 @@ fn selectors() {
 	assert_eq!(Action::UpdateAssociation as u32, 0xd9cef879);
 	assert_eq!(Action::ClearAssociation as u32, 0x7354c91d);
 	assert_eq!(Action::RegisterKeys as u32, 0x4f50accf);
-	assert_eq!(Action::SetKeys as u32, 0xa8259c85);
+	assert_eq!(Action::SetKeys as u32, 0x47f92fc4);
 }
 
 #[test]
@@ -294,13 +294,11 @@ fn set_keys_works() {
 				sp_core::sr25519::Public::unchecked_from([4u8; 32]).into();
 
 			assert_ok!(Call::AuthorMapping(AuthorMappingCall::register_keys {
-				author_id: first_nimbus_id.clone(),
-				keys: first_vrf_key.clone(),
+				keys: (first_nimbus_id.clone(), first_vrf_key.clone()),
 			})
 			.dispatch(Origin::signed(Alice)));
 
 			let input = EvmDataWriter::new_with_selector(Action::SetKeys)
-				.write(sp_core::H256::from([1u8; 32]))
 				.write(sp_core::H256::from([2u8; 32]))
 				.write(sp_core::H256::from([4u8; 32]))
 				.build();

--- a/primitives/session-keys/src/vrf.rs
+++ b/primitives/session-keys/src/vrf.rs
@@ -34,18 +34,6 @@ impl From<NimbusId> for VrfId {
 	}
 }
 
-pub fn nimbus_id_from_bytes(bytes: &[u8]) -> NimbusId {
-	// let sr25519_as_bytes: [u8; 32] = bytes.into();
-	// sr25519::Public::unchecked_from(sr25519_as_bytes).into()
-	todo!()
-}
-
-pub fn vrf_id_from_bytes(bytes: &[u8]) -> VrfId {
-	// let sr25519_as_bytes: [u8; 32] = bytes.into();
-	// sr25519::Public::unchecked_from(sr25519_as_bytes).into()
-	todo!()
-}
-
 /// The ConsensusEngineId for VRF keys
 pub const VRF_ENGINE_ID: ConsensusEngineId = *b"rand";
 

--- a/primitives/session-keys/src/vrf.rs
+++ b/primitives/session-keys/src/vrf.rs
@@ -34,6 +34,18 @@ impl From<NimbusId> for VrfId {
 	}
 }
 
+pub fn nimbus_id_from_bytes(bytes: &[u8]) -> NimbusId {
+	// let sr25519_as_bytes: [u8; 32] = bytes.into();
+	// sr25519::Public::unchecked_from(sr25519_as_bytes).into()
+	todo!()
+}
+
+pub fn vrf_id_from_bytes(bytes: &[u8]) -> VrfId {
+	// let sr25519_as_bytes: [u8; 32] = bytes.into();
+	// sr25519::Public::unchecked_from(sr25519_as_bytes).into()
+	todo!()
+}
+
 /// The ConsensusEngineId for VRF keys
 pub const VRF_ENGINE_ID: ConsensusEngineId = *b"rand";
 

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -32,7 +32,10 @@ use pallet_asset_manager::{
 	},
 	Config as AssetManagerConfig,
 };
-use pallet_author_mapping::{migrations::AddKeysToRegistrationInfo, Config as AuthorMappingConfig};
+use pallet_author_mapping::{
+	migrations::{AddAccountIdToNimbusLookup, AddKeysToRegistrationInfo},
+	Config as AuthorMappingConfig,
+};
 use pallet_author_slot_filter::migration::EligibleRatioToEligiblityCount;
 use pallet_author_slot_filter::Config as AuthorSlotFilterConfig;
 use pallet_base_fee::Config as BaseFeeConfig;
@@ -53,6 +56,30 @@ use xcm_transactor::{migrations::MaxTransactWeight, Config as XcmTransactorConfi
 
 /// This module acts as a registry where each migration is defined. Each migration should implement
 /// the "Migration" trait declared in the pallet-migrations crate.
+
+/// A moonbeam migration wrapping the similarly named migration in pallet-author-mapping
+pub struct AuthorMappingAddAccountIdToNimbusLookup<T>(PhantomData<T>);
+impl<T: AuthorMappingConfig> Migration for AuthorMappingAddAccountIdToNimbusLookup<T> {
+	fn friendly_name(&self) -> &str {
+		"MM_Author_Mapping_AddAccountIdToNimbusLookup"
+	}
+
+	fn migrate(&self, _available_weight: Weight) -> Weight {
+		AddAccountIdToNimbusLookup::<T>::on_runtime_upgrade()
+	}
+
+	/// Run a standard pre-runtime test. This works the same way as in a normal runtime upgrade.
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade(&self) -> Result<(), &'static str> {
+		AddAccountIdToNimbusLookup::<T>::pre_upgrade()
+	}
+
+	/// Run a standard post-runtime test. This works the same way as in a normal runtime upgrade.
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(&self) -> Result<(), &'static str> {
+		AddAccountIdToNimbusLookup::<T>::post_upgrade()
+	}
+}
 
 /// A moonbeam migration wrapping the similarly named migration in pallet-author-mapping
 pub struct AuthorMappingAddKeysToRegistrationInfo<T>(PhantomData<T>);
@@ -619,6 +646,8 @@ where
 			ParachainStakingSplitDelegatorStateIntoDelegationScheduledRequests::<Runtime>(
 				Default::default(),
 			);
+		let migration_author_mapping_add_account_id_to_nimbus_lookup =
+			AuthorMappingAddAccountIdToNimbusLookup::<Runtime>(Default::default());
 		vec![
 			// completed in runtime 800
 			// Box::new(migration_author_mapping_twox_to_blake),
@@ -640,6 +669,7 @@ where
 			Box::new(migration_author_slot_filter_eligible_ratio_to_eligibility_count),
 			Box::new(migration_author_mapping_add_keys_to_registration_info),
 			Box::new(staking_delegator_state_requests),
+			Box::new(migration_author_mapping_add_account_id_to_nimbus_lookup),
 		]
 	}
 }

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -2594,7 +2594,7 @@ fn author_mapping_precompile_associate_update_and_clear() {
 			let associate_expected_result = Some(Ok(PrecompileOutput {
 				exit_status: ExitSucceed::Returned,
 				output: Default::default(),
-				cost: 11325u64,
+				cost: 15388u64,
 				logs: Default::default(),
 			}));
 
@@ -2712,7 +2712,7 @@ fn author_mapping_register_and_set_keys() {
 			let associate_expected_result = Some(Ok(PrecompileOutput {
 				exit_status: ExitSucceed::Returned,
 				output: Default::default(),
-				cost: 11344u64,
+				cost: 15428u64,
 				logs: Default::default(),
 			}));
 

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -2661,7 +2661,7 @@ fn author_mapping_precompile_associate_update_and_clear() {
 			let clear_expected_result = Some(Ok(PrecompileOutput {
 				exit_status: ExitSucceed::Returned,
 				output: Default::default(),
-				cost: 11450u64,
+				cost: 15447u64,
 				logs: Default::default(),
 			}));
 

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -2627,7 +2627,7 @@ fn author_mapping_precompile_associate_update_and_clear() {
 			let update_expected_result = Some(Ok(PrecompileOutput {
 				exit_status: ExitSucceed::Returned,
 				output: Default::default(),
-				cost: 11030u64,
+				cost: 15190u64,
 				logs: Default::default(),
 			}));
 
@@ -2746,7 +2746,7 @@ fn author_mapping_register_and_set_keys() {
 			let update_expected_result = Some(Ok(PrecompileOutput {
 				exit_status: ExitSucceed::Returned,
 				output: Default::default(),
-				cost: 11023u64,
+				cost: 16280u64,
 				logs: Default::default(),
 			}));
 

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -2755,7 +2755,6 @@ fn author_mapping_register_and_set_keys() {
 				Precompiles::new().execute(
 					author_mapping_precompile_address,
 					&EvmDataWriter::new_with_selector(AuthorMappingAction::SetKeys)
-						.write(sp_core::H256::from([1u8; 32]))
 						.write(sp_core::H256::from([2u8; 32]))
 						.write(sp_core::H256::from([4u8; 32]))
 						.build(),

--- a/tests/tests/test-author-mapping.ts
+++ b/tests/tests/test-author-mapping.ts
@@ -68,7 +68,7 @@ describeDevMoonbeam("Author Mapping - simple association", (context) => {
     expect((await getMappingInfo(context, bobAuthorId)).account).to.eq(ALITH);
     expect(
       ((await context.polkadotApi.query.system.account(ALITH)) as any).data.free.toBigInt()
-    ).to.eq(1207725818354628766561176n);
+    ).to.eq(1207725818354628664997176n);
     expect(
       ((await context.polkadotApi.query.system.account(ALITH)) as any).data.reserved.toBigInt()
     ).to.eq(2n * DEFAULT_GENESIS_MAPPING + DEFAULT_GENESIS_STAKING);
@@ -95,7 +95,7 @@ describeDevMoonbeam("Author Mapping - Fail to reassociate alice", (context) => {
     //check state
     expect(
       ((await context.polkadotApi.query.system.account(BALTATHAR)) as any).data.free.toBigInt()
-    ).to.eq(1208925818354628766561176n);
+    ).to.eq(1208925818354628664997176n);
     expect(
       ((await context.polkadotApi.query.system.account(BALTATHAR)) as any).data.reserved.toBigInt()
     ).to.eq(0n);


### PR DESCRIPTION
### What does it do?

Changes `set_keys` extrinsic from

```rust
set_keys(
	origin: OriginFor<T>,
	old_author_id: NimbusId,
	new_author_id: NimbusId,
	new_keys: T::Keys,
)
```

to

```rust
set_keys(origin: OriginFor<T>, keys: (NimbusId, T::Keys))
```

Changes `register_keys` extrinsic from

```rust
register_keys(origin: OriginFor<T>, author_id: NimbusId, keys: T::Keys)
```

to

```rust
register_keys(origin: OriginFor<T>, keys: (NimbusId, T::Keys))
```

This will allow collators to copy paste their output from RPC `author_rotateKeys` into these extrinsics just like the Polkadot/Kusama UX.

In order to do this, it adds a reverse mapping from AccountId to NimbusId.

## Breaking Change (Maximum 1 NimbusId Per AccountId)

The migration will take the first `NimbusId` owned by a given `AccountId` to insert into `NimbusLookup: AccountId => Option<NimbusId>`. For any additional `NimbusId` owned by that `AccountId`, the migration clears the association and returns (unreserves) the deposit.