### PR TITLE
fix(orbiters): panic if we trying to add an orbiter just after removing another

### DIFF
--- a/pallets/moonbeam-orbiters/src/tests.rs
+++ b/pallets/moonbeam-orbiters/src/tests.rs
@@ -181,6 +181,45 @@ fn test_collator_remove_orbiter() {
 }
 
 #[test]
+fn test_collator_remove_orbiter_then_add_orbiter() {
+	ExtBuilder::default()
+		.with_balances(vec![(2, 20_000), (3, 20_000)])
+		.with_min_orbiter_deposit(10_000)
+		.build()
+		.execute_with(|| {
+			// Add a collator to the orbiter program
+			assert_ok!(MoonbeamOrbiters::add_collator(Origin::root(), 1),);
+			// Register an orbiter
+			assert_ok!(MoonbeamOrbiters::orbiter_register(Origin::signed(2)),);
+			assert_ok!(MoonbeamOrbiters::collator_add_orbiter(Origin::signed(1), 2),);
+
+			// Try to remove an orbiter to a collator pool, should success
+			assert_ok!(MoonbeamOrbiters::collator_remove_orbiter(
+				Origin::signed(1),
+				2
+			),);
+			System::assert_last_event(
+				Event::<Test>::OrbiterLeaveCollatorPool {
+					collator: 1,
+					orbiter: 2,
+				}
+				.into(),
+			);
+
+			// Try to register another orbiter, should success
+			assert_ok!(MoonbeamOrbiters::orbiter_register(Origin::signed(3)),);
+			assert_ok!(MoonbeamOrbiters::collator_add_orbiter(Origin::signed(1), 3),);
+			System::assert_last_event(
+				Event::<Test>::OrbiterJoinCollatorPool {
+					collator: 1,
+					orbiter: 3,
+				}
+				.into(),
+			);
+		});
+}
+
+#[test]
 fn test_orbiter_register_fail_if_insufficient_balance() {
 	ExtBuilder::default()
 		.with_min_orbiter_deposit(10_000)

--- a/pallets/moonbeam-orbiters/src/types.rs
+++ b/pallets/moonbeam-orbiters/src/types.rs
@@ -66,6 +66,9 @@ impl<AccountId> Default for CollatorPoolInfo<AccountId> {
 
 impl<AccountId: Clone + PartialEq> CollatorPoolInfo<AccountId> {
 	pub(super) fn add_orbiter(&mut self, orbiter: AccountId) {
+		if self.next_orbiter > self.orbiters.len() as u32 {
+			self.next_orbiter = 0;
+		}
 		self.orbiters.insert(self.next_orbiter as usize, orbiter);
 		self.next_orbiter += 1;
 	}


### PR DESCRIPTION
### What does it do?

Fixes a bug that occurs in a case that was not covered by the tests: adding an orbiter just after deleting another one (without waiting for the rotation of the orbiters).

This PR also adds a test to cover this case. I checked that if we comment the changes, the test fails.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
