### PR TITLE
Girazoki remove moonbase runtime benchmarks flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,5 @@
 [alias]
 moonbase = " build --release -p moonbeam --no-default-features --features moonbase-native"
-moonbase-benchmarks = " build --release -p moonbeam --no-default-features --features moonbase-runtime-benchmarks"
 moonbase-rococo = " build --release -p moonbeam --no-default-features --features moonbase-native,rococo-native"
 moonriver = " build --release -p moonbeam --no-default-features --features moonriver-native"
 moonriver-rococo = " build --release -p moonbeam --no-default-features --features moonriver-native,rococo-native"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -47,9 +47,3 @@ runtime-benchmarks = [
 	"pallet-xcm/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 ]
-
-moonbase-runtime-benchmarks = [
-	"moonbeam-cli/moonbase-runtime-benchmarks",
-	"pallet-xcm/runtime-benchmarks",
-	"xcm-builder/runtime-benchmarks",
-]

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -50,7 +50,6 @@ moonbase-native = [ "service/moonbase-native", "westend-native" ]
 moonbeam-native = [ "service/moonbeam-native" ]
 moonriver-native = [ "service/moonriver-native" ]
 
-moonbase-runtime-benchmarks = [ "service/moonbase-runtime-benchmarks" ]
 runtime-benchmarks = [ "service/runtime-benchmarks" ]
 try-runtime = [
 	"service/try-runtime",

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -570,12 +570,6 @@ pub fn run() -> Result<()> {
 							#[cfg(not(feature = "moonbase-native"))]
 							_ => panic!("invalid chain spec"),
 						}
-					} else if cfg!(feature = "moonbase-runtime-benchmarks") {
-						return runner.sync_run(|config| {
-							cmd.run::<service::moonbase_runtime::Block, service::MoonbaseExecutor>(
-								config,
-							)
-						});
 					} else {
 						Err("Benchmarking wasn't enabled when building the node. \
 					You can enable it with `--features runtime-benchmarks`."

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -176,14 +176,6 @@ runtime-benchmarks = [
 	"pallet-ethereum/runtime-benchmarks",
 ]
 
-
-moonbase-runtime-benchmarks = [
-	"moonbase-native",
-	"moonbase-runtime/moonbase-runtime-benchmarks",
-	"moonbase-runtime/runtime-benchmarks",
-	"pallet-ethereum/runtime-benchmarks",
-]
-
 try-runtime = [
 	"moonbase-runtime",
 	"moonbase-runtime/try-runtime",

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -427,9 +427,7 @@ macro_rules! impl_runtime_apis_plus_common {
 					use pallet_author_mapping::Pallet as PalletAuthorMappingBench;
 					use pallet_author_slot_filter::Pallet as PalletAuthorSlotFilter;
 					use pallet_moonbeam_orbiters::Pallet as PalletMoonbeamOrbiters;
-					#[cfg(feature = "moonbase-runtime-benchmarks")]
 					use pallet_asset_manager::Pallet as PalletAssetManagerBench;
-					#[cfg(feature = "moonbase-runtime-benchmarks")]
 					use xcm_transactor::Pallet as XcmTransactorBench;
 
 					let mut list = Vec::<BenchmarkList>::new();
@@ -440,9 +438,7 @@ macro_rules! impl_runtime_apis_plus_common {
 					list_benchmark!(list, extra, pallet_author_mapping, PalletAuthorMappingBench::<Runtime>);
 					list_benchmark!(list, extra, pallet_author_slot_filter, PalletAuthorSlotFilter::<Runtime>);
 					list_benchmark!(list, extra, pallet_moonbeam_orbiters, PalletMoonbeamOrbiters::<Runtime>);
-					#[cfg(feature = "moonbase-runtime-benchmarks")]
 					list_benchmark!(list, extra, pallet_asset_manager, PalletAssetManagerBench::<Runtime>);
-					#[cfg(feature = "moonbase-runtime-benchmarks")]
 					list_benchmark!(list, extra, xcm_transactor, XcmTransactorBench::<Runtime>);
 
 					let storage_info = AllPalletsWithSystem::storage_info();
@@ -465,9 +461,7 @@ macro_rules! impl_runtime_apis_plus_common {
 					use pallet_author_mapping::Pallet as PalletAuthorMappingBench;
 					use pallet_author_slot_filter::Pallet as PalletAuthorSlotFilter;
 					use pallet_moonbeam_orbiters::Pallet as PalletMoonbeamOrbiters;
-					#[cfg(feature = "moonbase-runtime-benchmarks")]
 					use pallet_asset_manager::Pallet as PalletAssetManagerBench;
-					#[cfg(feature = "moonbase-runtime-benchmarks")]
 					use xcm_transactor::Pallet as XcmTransactorBench;
 
 					let whitelist: Vec<TrackedStorageKey> = vec![
@@ -554,14 +548,12 @@ macro_rules! impl_runtime_apis_plus_common {
 						pallet_moonbeam_orbiters,
 						PalletMoonbeamOrbiters::<Runtime>
 					);
-					#[cfg(feature = "moonbase-runtime-benchmarks")]
 					add_benchmark!(
 						params,
 						batches,
 						pallet_asset_manager,
 						PalletAssetManagerBench::<Runtime>
 					);
-					#[cfg(feature = "moonbase-runtime-benchmarks")]
 					add_benchmark!(
 						params,
 						batches,

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -247,7 +247,6 @@ runtime-wasm = []
 # to make it smaller like logging for example.
 on-chain-release-build = [ "sp-api/disable-logging" ]
 
-moonbase-runtime-benchmarks = []
 runtime-benchmarks = [
 	"frame-benchmarking",
 	"frame-support/runtime-benchmarks",

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -261,6 +261,7 @@ runtime-benchmarks = [
 	"parachain-staking/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
+	"xcm-transactor/runtime-benchmarks",
 ]
 
 try-runtime = [

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -250,6 +250,7 @@ runtime-benchmarks = [
 	"frame-system-benchmarking",
 	"frame-system/runtime-benchmarks",
 	"hex-literal",
+	"pallet-asset-manager/runtime-benchmarks",
 	"pallet-author-mapping/runtime-benchmarks",
 	"pallet-author-slot-filter/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
@@ -263,6 +264,7 @@ runtime-benchmarks = [
 	"parachain-staking/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
+	"xcm-transactor/runtime-benchmarks",
 ]
 try-runtime = [
 	"frame-executive/try-runtime",


### PR DESCRIPTION
### What does it do?
Removes moonbase-runtime-benchmarks flags. This flag was introduced to be able to benchmark pallets only included in the moonbase runtime, and not in moonriver and moonbeam. Initially this was thought for `pallet-asset-manager `and `xcm-transactor`.

This does not seem the case anymore, so I removed it. Might be interesting to maintain the flag but without using it for now, I am open to suggestions
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
