### PR TITLE
[MOON-1711] cleanup state on collator exit

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1003,6 +1003,7 @@ pub mod pallet {
 			// return stake to collator
 			T::Currency::unreserve(&candidate, state.bond);
 			<CandidateInfo<T>>::remove(&candidate);
+			<DelegationScheduledRequests<T>>::remove(&candidate);
 			<TopDelegations<T>>::remove(&candidate);
 			<BottomDelegations<T>>::remove(&candidate);
 			let new_total_staked = <Total<T>>::get().saturating_sub(total_backing);

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -30,8 +30,8 @@ use crate::{
 	assert_eq_events, assert_eq_last_events, assert_event_emitted, assert_event_not_emitted,
 	assert_last_event, assert_tail_eq, set::OrderedSet, AtStake, Bond, BottomDelegations,
 	CandidateInfo, CandidateMetadata, CandidatePool, CandidateState, CapacityStatus,
-	CollatorCandidate, CollatorStatus, Config, Delegations, Delegator, DelegatorAdded,
-	DelegatorState, DelegatorStatus, Error, Event, Range, TopDelegations, Total,
+	CollatorCandidate, CollatorStatus, Config, DelegationScheduledRequests, Delegations, Delegator,
+	DelegatorAdded, DelegatorState, DelegatorStatus, Error, Event, Range, TopDelegations, Total,
 };
 use frame_support::{assert_noop, assert_ok, traits::ReservableCurrency};
 use sp_runtime::{traits::Zero, DispatchError, ModuleError, Perbill, Percent};
@@ -1110,7 +1110,11 @@ fn execute_leave_candidates_removes_pending_delegation_requests() {
 					.iter()
 					.any(|x| x.delegator == 2),
 				"delegation request not removed"
-			)
+			);
+			assert!(
+				!<DelegationScheduledRequests<Test>>::contains_key(&1),
+				"the key was not removed from storage"
+			);
 		});
 }
 

--- a/tests/tests/test-staking.ts
+++ b/tests/tests/test-staking.ts
@@ -618,7 +618,7 @@ describeDevMoonbeam("Staking - Delegation Requests", (context) => {
     await context.createBlock();
 
     const delegationRequestsBefore =
-      await context.polkadotApi.query.parachainStaking.delegationScheduledRequests(ALITH);
+      await context.polkadotApi.query.parachainStaking.delegationScheduledRequests(BALTATHAR);
     expect(delegationRequestsBefore.toJSON()).to.be.empty;
 
     // schedule bond less
@@ -637,8 +637,12 @@ describeDevMoonbeam("Staking - Delegation Requests", (context) => {
       .signAndSend(ethan);
     await context.createBlock();
     const delegationRequestsAfter =
-      await context.polkadotApi.query.parachainStaking.delegationScheduledRequests(ALITH);
+      await context.polkadotApi.query.parachainStaking.delegationScheduledRequests(BALTATHAR);
     expect(delegationRequestsAfter.toJSON()).to.be.empty;
+    const delegationRequestsKeysAfter = (
+      await context.polkadotApi.query.parachainStaking.delegationScheduledRequests.keys()
+    ).map(({ args: [accountId] }) => accountId.toString());
+    expect(delegationRequestsKeysAfter).to.not.contain(BALTATHAR);
   });
 
   it("should successfully remove scheduled requests on delegator leave", async function () {


### PR DESCRIPTION
### What does it do?
Removes the empty entry completely from `DelegationScheduledRequests` when a candidate exists. Previously only the values would be removed leaving an empty entry. This is problematic since with every  changing collators, some storage would always leak if we they leave the platform permanently.

#### Before
```typescript
// DelegationScheduledRequests 
{
  0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0 => [0x123.., 0x456..],
  0xffe.. => [0x78f..],
}

// 0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0 exits
{
  0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0 => [],
  0xffe.. => [0x78f..],
}
```

#### After
```typescript
// DelegationScheduledRequests 
{
  0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0 => [0x123.., 0x456..],
  0xffe.. => [0x78f..],
}

// 0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0 exits
{
  0xffe.. => [0x78f..],
}
```

#### Breaking Change
:heavy_check_mark: For a user using a `get` operation, nothing changes since the default storage behavior is to return an empty array when key does not exist.
:warning: For a user using a `keys` operation, the key will no longer exist if a candidate has exited.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
