### PR TITLE
Fix author mapping setKeys precompile to take 1 input like extrinsic

### DIFF
--- a/precompiles/author-mapping/AuthorMappingInterface.sol
+++ b/precompiles/author-mapping/AuthorMappingInterface.sol
@@ -46,8 +46,7 @@ interface AuthorMapping {
      * Set keys
      * Selector: 47f92fc4
      *
-     * @param new_author_id The new nimbusId to be associated
-     * @param new_keys The new session keys
+     * @param keys The new session keys
      */
-    function set_keys(bytes32 new_author_id, bytes32 new_keys) external;
+    function set_keys(bytes memory keys) external;
 }

--- a/precompiles/author-mapping/AuthorMappingInterface.sol
+++ b/precompiles/author-mapping/AuthorMappingInterface.sol
@@ -44,7 +44,7 @@ interface AuthorMapping {
 
     /**
      * Set keys
-     * Selector: 47f92fc4
+     * Selector: bcb24ddc
      *
      * @param keys The new session keys
      */

--- a/precompiles/author-mapping/src/lib.rs
+++ b/precompiles/author-mapping/src/lib.rs
@@ -40,7 +40,7 @@ pub enum Action {
 	UpdateAssociation = "update_association(bytes32,bytes32)",
 	ClearAssociation = "clear_association(bytes32)",
 	RemoveKeys = "remove_keys()",
-	SetKeys = "set_keys(bytes32,bytes32)",
+	SetKeys = "set_keys(bytes)",
 }
 
 /// A precompile to wrap the functionality from pallet author mapping.

--- a/precompiles/author-mapping/src/tests.rs
+++ b/precompiles/author-mapping/src/tests.rs
@@ -74,7 +74,7 @@ fn selectors() {
 	assert_eq!(Action::UpdateAssociation as u32, 0xd9cef879);
 	assert_eq!(Action::ClearAssociation as u32, 0x7354c91d);
 	assert_eq!(Action::RemoveKeys as u32, 0x3b6c4284);
-	assert_eq!(Action::SetKeys as u32, 0x47f92fc4);
+	assert_eq!(Action::SetKeys as u32, 0xbcb24ddc);
 }
 
 #[test]

--- a/tests/tests/test-precompile/test-precompile-author-mapping-keys.ts
+++ b/tests/tests/test-precompile/test-precompile-author-mapping-keys.ts
@@ -21,7 +21,7 @@ const faith = keyring.addFromUri(FAITH_PRIVATE_KEY, null, "ethereum");
 
 const AUTHOR_MAPPING_PRECOMPILE_ADDRESS = "0x0000000000000000000000000000000000000807";
 const SELECTORS = {
-  set_keys: "47f92fc4",
+  set_keys: "bcb24ddc",
   remove_keys: "3b6c4284",
 };
 


### PR DESCRIPTION
Makes the `set_keys` precompile interface consistent with the extrinsic changes in #1535 . Thanks for reporting @eshaben !

⚠️ Changes `set_keys` precompile interface from `set_keys(bytes32,bytes32)` to `set_keys(bytes)`. As a result, the precompile selector changes. Tests do not require any changes.
