### PR TITLE
[MOON-1714] disallow bond_more when revoke is pending

### DIFF
--- a/pallets/parachain-staking/src/delegation_requests.rs
+++ b/pallets/parachain-staking/src/delegation_requests.rs
@@ -519,6 +519,16 @@ impl<T: Config> Pallet<T> {
 			.iter()
 			.any(|req| &req.delegator == delegator)
 	}
+
+	/// Returns true if a [ScheduledRequest] exists for a given delegation
+	pub fn delegation_request_revoke_exists(
+		collator: &T::AccountId,
+		delegator: &T::AccountId,
+	) -> bool {
+		<DelegationScheduledRequests<T>>::get(collator)
+			.iter()
+			.any(|req| &req.delegator == delegator && matches!(req, DelegationAction::Revoke(_)))
+	}
 }
 
 #[cfg(test)]

--- a/pallets/parachain-staking/src/delegation_requests.rs
+++ b/pallets/parachain-staking/src/delegation_requests.rs
@@ -520,14 +520,16 @@ impl<T: Config> Pallet<T> {
 			.any(|req| &req.delegator == delegator)
 	}
 
-	/// Returns true if a [ScheduledRequest] exists for a given delegation
+	/// Returns true if a [DelegationAction::Revoke] [ScheduledRequest] exists for a given delegation
 	pub fn delegation_request_revoke_exists(
 		collator: &T::AccountId,
 		delegator: &T::AccountId,
 	) -> bool {
 		<DelegationScheduledRequests<T>>::get(collator)
 			.iter()
-			.any(|req| &req.delegator == delegator && matches!(req, DelegationAction::Revoke(_)))
+			.any(|req| {
+				&req.delegator == delegator && matches!(req.action, DelegationAction::Revoke(_))
+			})
 	}
 }
 

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1270,7 +1270,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			let delegator = ensure_signed(origin)?;
 			ensure!(
-				!Self::delegation_request_exists(&candidate, &delegator),
+				!Self::delegation_request_revoke_exists(&candidate, &delegator),
 				Error::<T>::PendingDelegationRevoke
 			);
 			let mut state = <DelegatorState<T>>::get(&delegator).ok_or(Error::<T>::DelegatorDNE)?;

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -215,6 +215,7 @@ pub mod pallet {
 		PendingDelegationRequestAlreadyExists,
 		PendingDelegationRequestNotDueYet,
 		CannotDelegateLessThanOrEqualToLowestBottomWhenFull,
+		PendingDelegationRevoke,
 	}
 
 	#[pallet::event]
@@ -1268,6 +1269,10 @@ pub mod pallet {
 			more: BalanceOf<T>,
 		) -> DispatchResultWithPostInfo {
 			let delegator = ensure_signed(origin)?;
+			ensure!(
+				!Self::delegation_request_exists(&candidate, &delegator),
+				Error::<T>::PendingDelegationRevoke
+			);
 			let mut state = <DelegatorState<T>>::get(&delegator).ok_or(Error::<T>::DelegatorDNE)?;
 			state.increase_delegation::<T>(candidate.clone(), more)?;
 			Ok(().into())

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -2726,7 +2726,7 @@ fn can_delegator_bond_more_for_leaving_candidate() {
 #[test]
 fn delegator_bond_more_disallowed_when_revoke_scheduled() {
 	ExtBuilder::default()
-		.with_balances(vec![(1, 30), (2, 15)])
+		.with_balances(vec![(1, 30), (2, 25)])
 		.with_candidates(vec![(1, 30)])
 		.with_delegations(vec![(2, 1, 10)])
 		.build()
@@ -2739,6 +2739,27 @@ fn delegator_bond_more_disallowed_when_revoke_scheduled() {
 				ParachainStaking::delegator_bond_more(Origin::signed(2), 1, 5),
 				<Error<Test>>::PendingDelegationRevoke
 			);
+		});
+}
+
+#[test]
+fn delegator_bond_more_allowed_when_bond_decrease_scheduled() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 30), (2, 25)])
+		.with_candidates(vec![(1, 30)])
+		.with_delegations(vec![(2, 1, 15)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(ParachainStaking::schedule_delegator_bond_less(
+				Origin::signed(2),
+				1,
+				5,
+			));
+			assert_ok!(ParachainStaking::delegator_bond_more(
+				Origin::signed(2),
+				1,
+				5
+			));
 		});
 }
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -2723,6 +2723,25 @@ fn can_delegator_bond_more_for_leaving_candidate() {
 		});
 }
 
+#[test]
+fn delegator_bond_more_disallowed_when_revoke_scheduled() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 30), (2, 15)])
+		.with_candidates(vec![(1, 30)])
+		.with_delegations(vec![(2, 1, 10)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(ParachainStaking::schedule_revoke_delegation(
+				Origin::signed(2),
+				1
+			));
+			assert_noop!(
+				ParachainStaking::delegator_bond_more(Origin::signed(2), 1, 5),
+				<Error<Test>>::PendingDelegationRevoke
+			);
+		});
+}
+
 // DELEGATOR BOND LESS
 
 #[test]

--- a/tests/tests/test-staking.ts
+++ b/tests/tests/test-staking.ts
@@ -689,6 +689,94 @@ describeDevMoonbeam("Staking - Delegation Requests", (context) => {
   });
 });
 
+describeDevMoonbeam("Staking - Bond More", (context) => {
+  const BOND_AMOUNT = MIN_GLMR_NOMINATOR + 100n;
+  const keyring = new Keyring({ type: "ethereum" });
+  const ethan = keyring.addFromUri(ETHAN_PRIVKEY, null, "ethereum");
+
+  before("should successfully call delegate on ALITH", async () => {
+    await context.polkadotApi.tx.parachainStaking
+      .delegate(ALITH, BOND_AMOUNT, 0, 0)
+      .signAndSend(ethan);
+    await context.createBlock();
+  });
+
+  afterEach("should clean up delegation requests", async () => {
+    await context.polkadotApi.tx.parachainStaking.cancelDelegationRequest(ALITH).signAndSend(ethan);
+    await context.createBlock();
+  });
+
+  it("should allow bond more when no delgation request scheduled", async function () {
+    const bondAmountBefore = (
+      await context.polkadotApi.query.parachainStaking.delegatorState(ETHAN)
+    ).unwrap().total;
+
+    // schedule bond less
+    const increaseAmount = 5;
+    await context.polkadotApi.tx.parachainStaking
+      .delegatorBondMore(ALITH, increaseAmount)
+      .signAndSend(ethan);
+    await context.createBlock();
+
+    const bondAmountAfter = (
+      await context.polkadotApi.query.parachainStaking.delegatorState(ETHAN)
+    ).unwrap().total;
+    expect(bondAmountAfter.eq(bondAmountBefore.addn(increaseAmount))).to.be.true;
+  });
+
+  it("should allow bond more when bond less schedule", async function () {
+    const bondAmountBefore = (
+      await context.polkadotApi.query.parachainStaking.delegatorState(ETHAN)
+    ).unwrap().total;
+
+    // schedule bond less
+    await context.polkadotApi.tx.parachainStaking
+      .scheduleDelegatorBondLess(ALITH, 10n)
+      .signAndSend(ethan);
+    await context.createBlock();
+
+    const increaseAmount = 5;
+    await context.polkadotApi.tx.parachainStaking
+      .delegatorBondMore(ALITH, increaseAmount)
+      .signAndSend(ethan);
+    await context.createBlock();
+
+    const bondAmountAfter = (
+      await context.polkadotApi.query.parachainStaking.delegatorState(ETHAN)
+    ).unwrap().total;
+    expect(bondAmountAfter.eq(bondAmountBefore.addn(increaseAmount))).to.be.true;
+  });
+
+  it("should not allow bond more when revoke schedule", async function () {
+    const bondAmountBefore = (
+      await context.polkadotApi.query.parachainStaking.delegatorState(ETHAN)
+    ).unwrap().total;
+
+    // schedule bond less
+    await context.polkadotApi.tx.parachainStaking
+      .scheduleRevokeDelegation(ALITH)
+      .signAndSend(ethan);
+    await context.createBlock();
+
+    const increaseAmount = 5n;
+    await context.polkadotApi.tx.parachainStaking
+      .delegatorBondMore(ALITH, increaseAmount)
+      .signAndSend(ethan);
+    await context.createBlock();
+
+    const extrinsicError = await getExtrinsicResult(
+      context,
+      "parachainStaking",
+      "delegatorBondMore"
+    );
+    expect(extrinsicError).to.equal("PendingDelegationRevoke");
+    const bondAmountAfter = (
+      await context.polkadotApi.query.parachainStaking.delegatorState(ETHAN)
+    ).unwrap().total;
+    expect(bondAmountAfter.eq(bondAmountBefore)).to.be.true;
+  });
+});
+
 describeDevMoonbeam("Staking - Rewards", (context) => {
   const EXTRA_BOND_AMOUNT = 1_000_000_000_000_000_000n;
   const BOND_AMOUNT = MIN_GLMR_NOMINATOR + EXTRA_BOND_AMOUNT;


### PR DESCRIPTION
### What does it do?
:warning: _Breaking change_ 
Disallows `BondMore` while a revoke is pending for the delegation. 

Introduces a new error that is returned in the case above - `PendingDelegationRevoke`.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
