### PR TITLE
Corrects ERC20.sol annotation

### DIFF
--- a/precompiles/balances-erc20/ERC20.sol
+++ b/precompiles/balances-erc20/ERC20.sol
@@ -130,7 +130,7 @@ interface WrappedNativeCurrency {
    * @dev Provide compatibility for contracts that expect wETH design.
    * Does nothing.
    * Selector: 2e1a7d4d
-   * @param Amount to withdraw/unwrap.
+   * @param value uint256 The amount to withdraw/unwrap.
    */
   function withdraw(uint256 value) external;
 


### PR DESCRIPTION
### What does it do?

Fixes the annotation of the withdraw function in this interface, which currently has a parameter name mismatch, and causes a DocstringParsingError on compile. 

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?

Makes this interface contract compile without the above error. 
