### PR TITLE
Better Batch precompile gas estimation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2665,7 +2665,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "async-trait",
  "fc-db",
@@ -2684,7 +2684,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "fp-storage",
  "kvdb-rocksdb",
@@ -2700,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "fc-db",
  "fp-consensus",
@@ -2717,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2728,6 +2728,7 @@ dependencies = [
  "fp-storage",
  "futures 0.3.21",
  "hex",
+ "hex-literal",
  "jsonrpc-core",
  "jsonrpc-core-client",
  "jsonrpc-pubsub",
@@ -2759,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2889,7 +2890,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2901,7 +2902,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "evm",
  "frame-support",
@@ -2914,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2931,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -2947,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -6975,7 +6976,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7249,7 +7250,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -7289,7 +7290,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "evm",
  "fp-evm",
@@ -7400,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "fp-evm",
 ]
@@ -7408,7 +7409,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7418,7 +7419,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7428,7 +7429,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "fp-evm",
  "num",
@@ -7437,7 +7438,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -7446,7 +7447,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#22d54c34e8487231187b3f6527a24af471c46cd9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.20#652abf16eb99435c37895ff2517f7deec6b6b0ca"
 dependencies = [
  "fp-evm",
  "ripemd",


### PR DESCRIPTION
### What does it do?

Companion to https://github.com/PureStake/frontier/pull/70

Estimate gas performs a binary search to find the lowest amount of gas for which the transaction will not revert.
However batchSome and batchSomeUntilFailure will not revert even if subcalls don't have enough gas to execute.
Since all Batch functions follow the same code path and have the same cost we thus estimate the call as if it was a batchAll, since
any out of gas will make batchAll revert, thus allowing the gas estimation to work properly.

A test is added to ensure gas estimation of all functions is identical.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
