### PR TITLE
Update copyright year notices to 2022

### DIFF
--- a/client/rpc/finality/src/lib.rs
+++ b/client/rpc/finality/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 PureStake Inc.
+// Copyright 2019-2022 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/asset-manager/src/migrations.rs
+++ b/pallets/asset-manager/src/migrations.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 PureStake Inc.
+// Copyright 2019-2022 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/migrations/src/lib.rs
+++ b/pallets/migrations/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2022 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/pallets/xcm-transactor/src/migrations.rs
+++ b/pallets/xcm-transactor/src/migrations.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 PureStake Inc.
+// Copyright 2019-2022 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2020 PureStake Inc.
+// Copyright 2019-2022 PureStake Inc.
 // This file is part of Moonbeam.
 
 // Moonbeam is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Updates our copyright notice comments to consistently use year 2022