### PR TITLE
Make `cargo test` from runtimes compile

### DIFF
--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -144,6 +144,8 @@ cumulus-test-relay-sproof-builder = { git = "https://github.com/paritytech/cumul
 polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.20" }
 xcm-simulator = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.20" }
 
+precompile-utils = { path = "../../precompiles/utils", default-features = false, features = [ "testing" ] }
+
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
 

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -142,6 +142,8 @@ cumulus-test-relay-sproof-builder = { git = "https://github.com/paritytech/cumul
 polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.20" }
 xcm-simulator = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.20" }
 
+precompile-utils = { path = "../../precompiles/utils", default-features = false, features = [ "testing" ] }
+
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
 

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -143,6 +143,8 @@ cumulus-test-relay-sproof-builder = { git = "https://github.com/paritytech/cumul
 polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.20" }
 xcm-simulator = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.20" }
 
+precompile-utils = { path = "../../precompiles/utils", default-features = false, features = [ "testing" ] }
+
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20" }
 


### PR DESCRIPTION
### What does it do?

Fixes running `cargo test` from e.g. PWD = `runtime/moonbase`. Without this change, doing so produces compilation errors because `precompile-utils` crate isn't compiled with the `testing` feature, which these tests depend on.

To reproduce the original problem:
```bash
# current dir is root of moonbeam repo
cd runtime/moonbase
cargo test
```

Running in this manner (from the runtime dir as opposed to using something like `cargo test -p moonbase-runtime`) is what `vscode` wants to do when you try to Debug an individual test:

![image](https://user-images.githubusercontent.com/2967426/172484859-f0ca2611-2400-409b-85de-7bd5e8d91a54.png)

Running this way makes debugging possible, although I'd be happy to hear of other ways to debug test code (I'm a vscode noob!)