### PR TITLE
Configurable runtimes in ts tests for length fee changes

### DIFF
--- a/tests/tests/test-assets/test-assets-sufficients.ts
+++ b/tests/tests/test-assets/test-assets-sufficients.ts
@@ -144,6 +144,7 @@ describeDevMoonbeam(
     });
   },
   "Legacy",
+  "moonbase",
   true
 );
 
@@ -267,6 +268,7 @@ describeDevMoonbeam(
     });
   },
   "Legacy",
+  "moonbase",
   true
 );
 
@@ -407,5 +409,6 @@ describeDevMoonbeam(
     });
   },
   "Legacy",
+  "moonbase",
   true
 );

--- a/tests/tests/test-eth-tx/test-eth-tx-types.ts
+++ b/tests/tests/test-eth-tx/test-eth-tx-types.ts
@@ -30,6 +30,7 @@ describeDevMoonbeam(
     });
   },
   "Legacy",
+  "moonbase",
   false
 );
 
@@ -76,6 +77,7 @@ describeDevMoonbeam(
     });
   },
   "EIP2930",
+  "moonbase",
   false
 );
 
@@ -123,5 +125,6 @@ describeDevMoonbeam(
     });
   },
   "EIP1559",
+  "moonbase",
   false
 );

--- a/tests/tests/test-fees/test-length-fees.ts
+++ b/tests/tests/test-fees/test-length-fees.ts
@@ -82,7 +82,7 @@ describeDevMoonbeam(
 
 const testBalanceTransfer = async (context) => {
   let initialBalance = (
-    (await context.polkadotApi.query.system.account(baltathar.address))
+    await context.polkadotApi.query.system.account(baltathar.address)
   ).data.free.toBigInt();
 
   // send a balance transfer to self and see what our fees end up being
@@ -91,7 +91,7 @@ const testBalanceTransfer = async (context) => {
   );
 
   let afterBalance = (
-    (await context.polkadotApi.query.system.account(baltathar.address))
+    await context.polkadotApi.query.system.account(baltathar.address)
   ).data.free.toBigInt();
 
   const fee = initialBalance - afterBalance;
@@ -100,7 +100,7 @@ const testBalanceTransfer = async (context) => {
 
 const testRuntimeUpgrade = async (context) => {
   const initialBalance = (
-    (await context.polkadotApi.query.system.account(baltathar.address))
+    await context.polkadotApi.query.system.account(baltathar.address)
   ).data.free.toBigInt();
 
   // generate a mock runtime upgrade hex string
@@ -113,7 +113,7 @@ const testRuntimeUpgrade = async (context) => {
   await context.createBlock();
 
   let afterBalance = (
-    (await context.polkadotApi.query.system.account(baltathar.address))
+    await context.polkadotApi.query.system.account(baltathar.address)
   ).data.free.toBigInt();
 
   const fee = initialBalance - afterBalance;

--- a/tests/tests/test-fees/test-length-fees.ts
+++ b/tests/tests/test-fees/test-length-fees.ts
@@ -9,45 +9,23 @@ describeDevMoonbeam(
   "Substrate Length Fees - Transaction (Moonbase)",
   (context) => {
     it("should have low balance transfer fees", async () => {
-      let initialBalance = (
-        (await context.polkadotApi.query.system.account(baltathar.address)) as any
-      ).data.free.toBigInt();
-
-      // send a balance transfer to self and see what our fees end up being
-      await context.polkadotApi.tx.balances.transfer(baltathar.address, 1).signAndSend(baltathar);
-      await context.createBlock();
-
-      let afterBalance = (
-        (await context.polkadotApi.query.system.account(baltathar.address)) as any
-      ).data.free.toBigInt();
-
-      const fee = initialBalance - afterBalance;
+      const fee = await testBalanceTransfer(context);
       expect(fee).to.equal(14_325_001_520_875n);
     });
+  },
+  "Legacy",
+  "moonbase",
+);
 
+describeDevMoonbeam(
+  "Substrate Length Fees - Transaction (Moonriver)",
+  (context) => {
     it("should have expensive runtime-upgrade fees", async () => {
-      let initialBalance = (
-        (await context.polkadotApi.query.system.account(baltathar.address)) as any
-      ).data.free.toBigInt();
-
-      // generate a mock runtime upgrade hex string
-      let size = 4194304; // 2MB bytes represented in hex
-      let hex = "0x" + "F".repeat(size);
-
-      // send an enactAuthorizedUpgrade. we expect this to fail, but we just want to see that it was
-      // included in a block (not rejected) and was charged based on its length
-      await context.polkadotApi.tx.parachainSystem.enactAuthorizedUpgrade(hex).signAndSend(baltathar);
-      await context.createBlock();
-
-      let afterBalance = (
-        (await context.polkadotApi.query.system.account(baltathar.address)) as any
-      ).data.free.toBigInt();
-
-      const fee = initialBalance - afterBalance;
+      const fee = await testRuntimeUpgrade(context);
       expect(fee).to.equal(9_226_795_065_723_667_008n);
     });
   },
-  "Legacy", // not using Ethereum, doesn't matter
+  "Legacy",
   "moonbase",
 );
 
@@ -55,45 +33,23 @@ describeDevMoonbeam(
   "Substrate Length Fees - Transaction (Moonriver)",
   (context) => {
     it("should have low balance transfer fees", async () => {
-      let initialBalance = (
-        (await context.polkadotApi.query.system.account(baltathar.address)) as any
-      ).data.free.toBigInt();
-
-      // send a balance transfer to self and see what our fees end up being
-      await context.polkadotApi.tx.balances.transfer(baltathar.address, 1).signAndSend(baltathar);
-      await context.createBlock();
-
-      let afterBalance = (
-        (await context.polkadotApi.query.system.account(baltathar.address)) as any
-      ).data.free.toBigInt();
-
-      const fee = initialBalance - afterBalance;
+      const fee = await testBalanceTransfer(context);
       expect(fee).to.equal(28_535_001_520_875n);
     });
+  },
+  "Legacy",
+  "moonriver",
+);
 
+describeDevMoonbeam(
+  "Substrate Length Fees - Transaction (Moonriver)",
+  (context) => {
     it("should have expensive runtime-upgrade fees", async () => {
-      let initialBalance = (
-        (await context.polkadotApi.query.system.account(baltathar.address)) as any
-      ).data.free.toBigInt();
-
-      // generate a mock runtime upgrade hex string
-      let size = 4194304; // 2MB bytes represented in hex
-      let hex = "0x" + "F".repeat(size);
-
-      // send an enactAuthorizedUpgrade. we expect this to fail, but we just want to see that it was
-      // included in a block (not rejected) and was charged based on its length
-      await context.polkadotApi.tx.parachainSystem.enactAuthorizedUpgrade(hex).signAndSend(baltathar);
-      await context.createBlock();
-
-      let afterBalance = (
-        (await context.polkadotApi.query.system.account(baltathar.address)) as any
-      ).data.free.toBigInt();
-
-      const fee = initialBalance - afterBalance;
+      const fee = await testRuntimeUpgrade(context);
       expect(fee).to.equal(9_226_801_365_723_667_008n);
     });
   },
-  "Legacy", // not using Ethereum, doesn't matter
+  "Legacy",
   "moonriver",
 );
 
@@ -101,44 +57,64 @@ describeDevMoonbeam(
   "Substrate Length Fees - Transaction (Moonbeam)",
   (context) => {
     it("should have low balance transfer fees", async () => {
-      let initialBalance = (
-        (await context.polkadotApi.query.system.account(baltathar.address)) as any
-      ).data.free.toBigInt();
-
-      // send a balance transfer to self and see what our fees end up being
-      await context.polkadotApi.tx.balances.transfer(baltathar.address, 1).signAndSend(baltathar);
-      await context.createBlock();
-
-      let afterBalance = (
-        (await context.polkadotApi.query.system.account(baltathar.address)) as any
-      ).data.free.toBigInt();
-
-      const fee = initialBalance - afterBalance;
-      expect(fee).to.equal(2_853_500_152_087_500n); // moonbeam
+      const fee = await testBalanceTransfer(context);
+      expect(fee).to.equal(2_853_500_152_087_500n);
     });
+  },
+  "Legacy",
+  "moonbeam",
+);
 
+describeDevMoonbeam(
+  "Substrate Length Fees - Transaction (Moonriver)",
+  (context) => {
     it("should have expensive runtime-upgrade fees", async () => {
-      let initialBalance = (
-        (await context.polkadotApi.query.system.account(baltathar.address)) as any
-      ).data.free.toBigInt();
-
-      // generate a mock runtime upgrade hex string
-      let size = 4194304; // 2MB bytes represented in hex
-      let hex = "0x" + "F".repeat(size);
-
-      // send an enactAuthorizedUpgrade. we expect this to fail, but we just want to see that it was
-      // included in a block (not rejected) and was charged based on its length
-      await context.polkadotApi.tx.parachainSystem.enactAuthorizedUpgrade(hex).signAndSend(baltathar);
-      await context.createBlock();
-
-      let afterBalance = (
-        (await context.polkadotApi.query.system.account(baltathar.address)) as any
-      ).data.free.toBigInt();
-
-      const fee = initialBalance - afterBalance;
+      const fee = await testRuntimeUpgrade(context);
       expect(fee).to.equal(922_680_136_572_366_700_800n);
     });
   },
-  "Legacy", // not using Ethereum, doesn't matter
+  "Legacy",
   "moonbeam",
 );
+
+// define our tests here so we can DRY.
+// each test submits some txn then measures and returns the fees charged.
+
+const testBalanceTransfer = async (context) => {
+    let initialBalance = (
+      (await context.polkadotApi.query.system.account(baltathar.address)) as any
+    ).data.free.toBigInt();
+
+    // send a balance transfer to self and see what our fees end up being
+    await context.polkadotApi.tx.balances.transfer(baltathar.address, 1).signAndSend(baltathar);
+    await context.createBlock();
+
+    let afterBalance = (
+      (await context.polkadotApi.query.system.account(baltathar.address)) as any
+    ).data.free.toBigInt();
+
+    const fee = initialBalance - afterBalance;
+    return fee;
+}
+
+const testRuntimeUpgrade = async (context) => {
+    let initialBalance = (
+      (await context.polkadotApi.query.system.account(baltathar.address)) as any
+    ).data.free.toBigInt();
+
+    // generate a mock runtime upgrade hex string
+    let size = 4194304; // 2MB bytes represented in hex
+    let hex = "0x" + "F".repeat(size);
+
+    // send an enactAuthorizedUpgrade. we expect this to fail, but we just want to see that it was
+    // included in a block (not rejected) and was charged based on its length
+    await context.polkadotApi.tx.parachainSystem.enactAuthorizedUpgrade(hex).signAndSend(baltathar);
+    await context.createBlock();
+
+    let afterBalance = (
+      (await context.polkadotApi.query.system.account(baltathar.address)) as any
+    ).data.free.toBigInt();
+
+    const fee = initialBalance - afterBalance;
+    return fee;
+}

--- a/tests/tests/test-fees/test-length-fees.ts
+++ b/tests/tests/test-fees/test-length-fees.ts
@@ -1,0 +1,78 @@
+import "@moonbeam-network/api-augment";
+import { expect } from "chai";
+import { TREASURY_ACCOUNT } from "../../util/constants";
+import { describeDevMoonbeam } from "../../util/setup-dev-tests";
+import { createTransfer } from "../../util/transactions";
+import { baltathar } from "../../util/accounts";
+
+describeDevMoonbeam(
+  "Substrate Length Fees - Transaction",
+  (context) => {
+    it("should have low balance transfer fees", async () => {
+      let initialBalance = (
+        (await context.polkadotApi.query.system.account(baltathar.address)) as any
+      ).data.free.toBigInt();
+
+      // send a balance transfer to self and see what our fees end up being
+      await context.polkadotApi.tx.balances.transfer(baltathar.address, 1).signAndSend(baltathar);
+      await context.createBlock();
+
+      let afterBalance = (
+        (await context.polkadotApi.query.system.account(baltathar.address)) as any
+      ).data.free.toBigInt();
+
+      const fee = initialBalance - afterBalance;
+      expect(fee).to.equal(14_325_001_520_875n);
+    });
+  },
+  "Legacy", // not using Ethereum, doesn't matter
+  "moonbase",
+);
+
+describeDevMoonbeam(
+  "Substrate Length Fees - Transaction",
+  (context) => {
+    it("should have low balance transfer fees", async () => {
+      let initialBalance = (
+        (await context.polkadotApi.query.system.account(baltathar.address)) as any
+      ).data.free.toBigInt();
+
+      // send a balance transfer to self and see what our fees end up being
+      await context.polkadotApi.tx.balances.transfer(baltathar.address, 1).signAndSend(baltathar);
+      await context.createBlock();
+
+      let afterBalance = (
+        (await context.polkadotApi.query.system.account(baltathar.address)) as any
+      ).data.free.toBigInt();
+
+      const fee = initialBalance - afterBalance;
+      expect(fee).to.equal(28_535_001_520_875n);
+    });
+  },
+  "Legacy", // not using Ethereum, doesn't matter
+  "moonriver",
+);
+
+describeDevMoonbeam(
+  "Substrate Length Fees - Transaction",
+  (context) => {
+    it("should have low balance transfer fees", async () => {
+      let initialBalance = (
+        (await context.polkadotApi.query.system.account(baltathar.address)) as any
+      ).data.free.toBigInt();
+
+      // send a balance transfer to self and see what our fees end up being
+      await context.polkadotApi.tx.balances.transfer(baltathar.address, 1).signAndSend(baltathar);
+      await context.createBlock();
+
+      let afterBalance = (
+        (await context.polkadotApi.query.system.account(baltathar.address)) as any
+      ).data.free.toBigInt();
+
+      const fee = initialBalance - afterBalance;
+      expect(fee).to.equal(2_853_500_152_087_500n); // moonbeam
+    });
+  },
+  "Legacy", // not using Ethereum, doesn't matter
+  "moonbeam",
+);

--- a/tests/tests/test-fees/test-length-fees.ts
+++ b/tests/tests/test-fees/test-length-fees.ts
@@ -86,8 +86,9 @@ const testBalanceTransfer = async (context) => {
   ).data.free.toBigInt();
 
   // send a balance transfer to self and see what our fees end up being
-  await context.polkadotApi.tx.balances.transfer(baltathar.address, 1).signAndSend(baltathar);
-  await context.createBlock();
+  await context.createBlock(
+    context.polkadotApi.tx.balances.transfer(baltathar.address, 1).signAsync(baltathar)
+  );
 
   let afterBalance = (
     (await context.polkadotApi.query.system.account(baltathar.address)) as any

--- a/tests/tests/test-fees/test-length-fees.ts
+++ b/tests/tests/test-fees/test-length-fees.ts
@@ -6,7 +6,7 @@ import { createTransfer } from "../../util/transactions";
 import { baltathar } from "../../util/accounts";
 
 describeDevMoonbeam(
-  "Substrate Length Fees - Transaction",
+  "Substrate Length Fees - Transaction (Moonbase)",
   (context) => {
     it("should have low balance transfer fees", async () => {
       let initialBalance = (
@@ -24,13 +24,35 @@ describeDevMoonbeam(
       const fee = initialBalance - afterBalance;
       expect(fee).to.equal(14_325_001_520_875n);
     });
+
+    it("should have expensive runtime-upgrade fees", async () => {
+      let initialBalance = (
+        (await context.polkadotApi.query.system.account(baltathar.address)) as any
+      ).data.free.toBigInt();
+
+      // generate a mock runtime upgrade hex string
+      let size = 4194304; // 2MB bytes represented in hex
+      let hex = "0x" + "F".repeat(size);
+
+      // send an enactAuthorizedUpgrade. we expect this to fail, but we just want to see that it was
+      // included in a block (not rejected) and was charged based on its length
+      await context.polkadotApi.tx.parachainSystem.enactAuthorizedUpgrade(hex).signAndSend(baltathar);
+      await context.createBlock();
+
+      let afterBalance = (
+        (await context.polkadotApi.query.system.account(baltathar.address)) as any
+      ).data.free.toBigInt();
+
+      const fee = initialBalance - afterBalance;
+      expect(fee).to.equal(9_226_795_065_723_667_008n);
+    });
   },
   "Legacy", // not using Ethereum, doesn't matter
   "moonbase",
 );
 
 describeDevMoonbeam(
-  "Substrate Length Fees - Transaction",
+  "Substrate Length Fees - Transaction (Moonriver)",
   (context) => {
     it("should have low balance transfer fees", async () => {
       let initialBalance = (
@@ -48,13 +70,35 @@ describeDevMoonbeam(
       const fee = initialBalance - afterBalance;
       expect(fee).to.equal(28_535_001_520_875n);
     });
+
+    it("should have expensive runtime-upgrade fees", async () => {
+      let initialBalance = (
+        (await context.polkadotApi.query.system.account(baltathar.address)) as any
+      ).data.free.toBigInt();
+
+      // generate a mock runtime upgrade hex string
+      let size = 4194304; // 2MB bytes represented in hex
+      let hex = "0x" + "F".repeat(size);
+
+      // send an enactAuthorizedUpgrade. we expect this to fail, but we just want to see that it was
+      // included in a block (not rejected) and was charged based on its length
+      await context.polkadotApi.tx.parachainSystem.enactAuthorizedUpgrade(hex).signAndSend(baltathar);
+      await context.createBlock();
+
+      let afterBalance = (
+        (await context.polkadotApi.query.system.account(baltathar.address)) as any
+      ).data.free.toBigInt();
+
+      const fee = initialBalance - afterBalance;
+      expect(fee).to.equal(9_226_801_365_723_667_008n);
+    });
   },
   "Legacy", // not using Ethereum, doesn't matter
   "moonriver",
 );
 
 describeDevMoonbeam(
-  "Substrate Length Fees - Transaction",
+  "Substrate Length Fees - Transaction (Moonbeam)",
   (context) => {
     it("should have low balance transfer fees", async () => {
       let initialBalance = (
@@ -71,6 +115,28 @@ describeDevMoonbeam(
 
       const fee = initialBalance - afterBalance;
       expect(fee).to.equal(2_853_500_152_087_500n); // moonbeam
+    });
+
+    it("should have expensive runtime-upgrade fees", async () => {
+      let initialBalance = (
+        (await context.polkadotApi.query.system.account(baltathar.address)) as any
+      ).data.free.toBigInt();
+
+      // generate a mock runtime upgrade hex string
+      let size = 4194304; // 2MB bytes represented in hex
+      let hex = "0x" + "F".repeat(size);
+
+      // send an enactAuthorizedUpgrade. we expect this to fail, but we just want to see that it was
+      // included in a block (not rejected) and was charged based on its length
+      await context.polkadotApi.tx.parachainSystem.enactAuthorizedUpgrade(hex).signAndSend(baltathar);
+      await context.createBlock();
+
+      let afterBalance = (
+        (await context.polkadotApi.query.system.account(baltathar.address)) as any
+      ).data.free.toBigInt();
+
+      const fee = initialBalance - afterBalance;
+      expect(fee).to.equal(922_680_136_572_366_700_800n);
     });
   },
   "Legacy", // not using Ethereum, doesn't matter

--- a/tests/tests/test-fees/test-length-fees.ts
+++ b/tests/tests/test-fees/test-length-fees.ts
@@ -14,7 +14,7 @@ describeDevMoonbeam(
     });
   },
   "Legacy",
-  "moonbase",
+  "moonbase"
 );
 
 describeDevMoonbeam(
@@ -26,7 +26,7 @@ describeDevMoonbeam(
     });
   },
   "Legacy",
-  "moonbase",
+  "moonbase"
 );
 
 describeDevMoonbeam(
@@ -38,7 +38,7 @@ describeDevMoonbeam(
     });
   },
   "Legacy",
-  "moonriver",
+  "moonriver"
 );
 
 describeDevMoonbeam(
@@ -50,7 +50,7 @@ describeDevMoonbeam(
     });
   },
   "Legacy",
-  "moonriver",
+  "moonriver"
 );
 
 describeDevMoonbeam(
@@ -62,7 +62,7 @@ describeDevMoonbeam(
     });
   },
   "Legacy",
-  "moonbeam",
+  "moonbeam"
 );
 
 describeDevMoonbeam(
@@ -74,47 +74,47 @@ describeDevMoonbeam(
     });
   },
   "Legacy",
-  "moonbeam",
+  "moonbeam"
 );
 
 // define our tests here so we can DRY.
 // each test submits some txn then measures and returns the fees charged.
 
 const testBalanceTransfer = async (context) => {
-    let initialBalance = (
-      (await context.polkadotApi.query.system.account(baltathar.address)) as any
-    ).data.free.toBigInt();
+  let initialBalance = (
+    (await context.polkadotApi.query.system.account(baltathar.address)) as any
+  ).data.free.toBigInt();
 
-    // send a balance transfer to self and see what our fees end up being
-    await context.polkadotApi.tx.balances.transfer(baltathar.address, 1).signAndSend(baltathar);
-    await context.createBlock();
+  // send a balance transfer to self and see what our fees end up being
+  await context.polkadotApi.tx.balances.transfer(baltathar.address, 1).signAndSend(baltathar);
+  await context.createBlock();
 
-    let afterBalance = (
-      (await context.polkadotApi.query.system.account(baltathar.address)) as any
-    ).data.free.toBigInt();
+  let afterBalance = (
+    (await context.polkadotApi.query.system.account(baltathar.address)) as any
+  ).data.free.toBigInt();
 
-    const fee = initialBalance - afterBalance;
-    return fee;
-}
+  const fee = initialBalance - afterBalance;
+  return fee;
+};
 
 const testRuntimeUpgrade = async (context) => {
-    let initialBalance = (
-      (await context.polkadotApi.query.system.account(baltathar.address)) as any
-    ).data.free.toBigInt();
+  let initialBalance = (
+    (await context.polkadotApi.query.system.account(baltathar.address)) as any
+  ).data.free.toBigInt();
 
-    // generate a mock runtime upgrade hex string
-    let size = 4194304; // 2MB bytes represented in hex
-    let hex = "0x" + "F".repeat(size);
+  // generate a mock runtime upgrade hex string
+  let size = 4194304; // 2MB bytes represented in hex
+  let hex = "0x" + "F".repeat(size);
 
-    // send an enactAuthorizedUpgrade. we expect this to fail, but we just want to see that it was
-    // included in a block (not rejected) and was charged based on its length
-    await context.polkadotApi.tx.parachainSystem.enactAuthorizedUpgrade(hex).signAndSend(baltathar);
-    await context.createBlock();
+  // send an enactAuthorizedUpgrade. we expect this to fail, but we just want to see that it was
+  // included in a block (not rejected) and was charged based on its length
+  await context.polkadotApi.tx.parachainSystem.enactAuthorizedUpgrade(hex).signAndSend(baltathar);
+  await context.createBlock();
 
-    let afterBalance = (
-      (await context.polkadotApi.query.system.account(baltathar.address)) as any
-    ).data.free.toBigInt();
+  let afterBalance = (
+    (await context.polkadotApi.query.system.account(baltathar.address)) as any
+  ).data.free.toBigInt();
 
-    const fee = initialBalance - afterBalance;
-    return fee;
-}
+  const fee = initialBalance - afterBalance;
+  return fee;
+};

--- a/tests/tests/test-fees/test-length-fees.ts
+++ b/tests/tests/test-fees/test-length-fees.ts
@@ -82,7 +82,7 @@ describeDevMoonbeam(
 
 const testBalanceTransfer = async (context) => {
   let initialBalance = (
-    (await context.polkadotApi.query.system.account(baltathar.address)) as any
+    (await context.polkadotApi.query.system.account(baltathar.address))
   ).data.free.toBigInt();
 
   // send a balance transfer to self and see what our fees end up being
@@ -91,7 +91,7 @@ const testBalanceTransfer = async (context) => {
   );
 
   let afterBalance = (
-    (await context.polkadotApi.query.system.account(baltathar.address)) as any
+    (await context.polkadotApi.query.system.account(baltathar.address))
   ).data.free.toBigInt();
 
   const fee = initialBalance - afterBalance;
@@ -99,8 +99,8 @@ const testBalanceTransfer = async (context) => {
 };
 
 const testRuntimeUpgrade = async (context) => {
-  let initialBalance = (
-    (await context.polkadotApi.query.system.account(baltathar.address)) as any
+  const initialBalance = (
+    (await context.polkadotApi.query.system.account(baltathar.address))
   ).data.free.toBigInt();
 
   // generate a mock runtime upgrade hex string
@@ -113,7 +113,7 @@ const testRuntimeUpgrade = async (context) => {
   await context.createBlock();
 
   let afterBalance = (
-    (await context.polkadotApi.query.system.account(baltathar.address)) as any
+    (await context.polkadotApi.query.system.account(baltathar.address))
   ).data.free.toBigInt();
 
   const fee = initialBalance - afterBalance;

--- a/tests/tests/test-fees/test-length-fees.ts
+++ b/tests/tests/test-fees/test-length-fees.ts
@@ -18,7 +18,7 @@ describeDevMoonbeam(
 );
 
 describeDevMoonbeam(
-  "Substrate Length Fees - Transaction (Moonriver)",
+  "Substrate Length Fees - Transaction (Moonbase)",
   (context) => {
     it("should have expensive runtime-upgrade fees", async () => {
       const fee = await testRuntimeUpgrade(context);
@@ -66,7 +66,7 @@ describeDevMoonbeam(
 );
 
 describeDevMoonbeam(
-  "Substrate Length Fees - Transaction (Moonriver)",
+  "Substrate Length Fees - Transaction (Moonbeam)",
   (context) => {
     it("should have expensive runtime-upgrade fees", async () => {
       const fee = await testRuntimeUpgrade(context);

--- a/tests/util/dev-node.ts
+++ b/tests/util/dev-node.ts
@@ -37,6 +37,8 @@ export async function findAvailablePorts() {
   };
 }
 
+export type RuntimeChain = "moonbase" | "moonriver" | "moonbeam";
+
 // Stores if the node has already started.
 // It is used when a test file contains multiple describeDevMoonbeam. Those are
 // executed within the same PID and so would generate a race condition if started
@@ -45,7 +47,7 @@ let nodeStarted = false;
 
 // This will start a moonbeam dev node, only 1 at a time (check every 100ms).
 // This will prevent race condition on the findAvailablePorts which uses the PID of the process
-export async function startMoonbeamDevNode(withWasm?: boolean): Promise<{
+export async function startMoonbeamDevNode(withWasm?: boolean, runtime: RuntimeChain = "moonbase"): Promise<{
   p2pPort: number;
   rpcPort: number;
   wsPort: number;
@@ -73,7 +75,10 @@ export async function startMoonbeamDevNode(withWasm?: boolean): Promise<{
     ETHAPI_CMD != "" ? `${ETHAPI_CMD}` : `--ethapi=txpool`,
     `--no-telemetry`,
     `--no-prometheus`,
-    `--dev`,
+    `--force-authoring`,
+    `--rpc-cors=all`,
+    `--alice`,
+    `--chain=${runtime}-dev`,
     `--sealing=manual`,
     `-l${MOONBEAM_LOG}`,
     `--port=${p2pPort}`,

--- a/tests/util/dev-node.ts
+++ b/tests/util/dev-node.ts
@@ -83,6 +83,8 @@ export async function startMoonbeamDevNode(
     `--alice`,
     `--chain=${runtime}-dev`,
     `--sealing=manual`,
+    `--in-peers=0`,
+    `--out-peers=0`,
     `-l${MOONBEAM_LOG}`,
     `--port=${p2pPort}`,
     `--rpc-port=${rpcPort}`,

--- a/tests/util/dev-node.ts
+++ b/tests/util/dev-node.ts
@@ -47,7 +47,10 @@ let nodeStarted = false;
 
 // This will start a moonbeam dev node, only 1 at a time (check every 100ms).
 // This will prevent race condition on the findAvailablePorts which uses the PID of the process
-export async function startMoonbeamDevNode(withWasm?: boolean, runtime: RuntimeChain = "moonbase"): Promise<{
+export async function startMoonbeamDevNode(
+  withWasm?: boolean,
+  runtime: RuntimeChain = "moonbase"
+): Promise<{
   p2pPort: number;
   rpcPort: number;
   wsPort: number;

--- a/tests/util/setup-dev-tests.ts
+++ b/tests/util/setup-dev-tests.ts
@@ -7,7 +7,7 @@ import { RegistryError } from "@polkadot/types/types";
 import { EventRecord } from "@polkadot/types/interfaces";
 
 import { ethers } from "ethers";
-import { startMoonbeamDevNode } from "./dev-node";
+import { startMoonbeamDevNode, RuntimeChain } from "./dev-node";
 import {
   provideWeb3Api,
   provideEthersApi,
@@ -81,6 +81,7 @@ export function describeDevMoonbeam(
   title: string,
   cb: (context: DevTestContext) => void,
   ethTransactionType: EthTransactionType = "Legacy",
+  runtime: RuntimeChain = "moonbase",
   withWasm?: boolean
 ) {
   describe(title, function () {
@@ -98,7 +99,7 @@ export function describeDevMoonbeam(
     before("Starting Moonbeam Test Node", async function () {
       this.timeout(SPAWNING_TIME);
       const init = !DEBUG_MODE
-        ? await startMoonbeamDevNode(withWasm)
+        ? await startMoonbeamDevNode(withWasm, runtime)
         : {
             runningNode: null,
             p2pPort: 19931,
@@ -273,7 +274,7 @@ export function describeDevMoonbeamAllEthTxTypes(
   withWasm?: boolean
 ) {
   let wasm = withWasm !== undefined ? withWasm : false;
-  describeDevMoonbeam(title + " (Legacy)", cb, "Legacy", wasm);
-  describeDevMoonbeam(title + " (EIP1559)", cb, "EIP1559", wasm);
-  describeDevMoonbeam(title + " (EIP2930)", cb, "EIP2930", wasm);
+  describeDevMoonbeam(title + " (Legacy)", cb, "Legacy", "moonbase", wasm);
+  describeDevMoonbeam(title + " (EIP1559)", cb, "EIP1559", "moonbase", wasm);
+  describeDevMoonbeam(title + " (EIP2930)", cb, "EIP2930", "moonbase", wasm);
 }


### PR DESCRIPTION
### What does it do?

This PR proposes a way to configure which runtime a ts test should be run against and uses this new feature to test length fees which currently differ for each runtime.