### PR TITLE
[MOON-1745] re-add status Leaving as deprecated

### DIFF
--- a/pallets/parachain-staking/src/delegation_requests.rs
+++ b/pallets/parachain-staking/src/delegation_requests.rs
@@ -457,9 +457,6 @@ impl<T: Config> Pallet<T> {
 		// backwards compatible handling for DelegatorStatus::Leaving
 		#[allow(deprecated)]
 		if let DelegatorStatus::Leaving(when) = state.status {
-			state.status = DelegatorStatus::Active;
-			<DelegatorState<T>>::insert(delegator.clone(), state.clone());
-
 			ensure!(
 				<Round<T>>::get().current >= when,
 				Error::<T>::DelegatorCannotLeaveYet

--- a/pallets/parachain-staking/src/delegation_requests.rs
+++ b/pallets/parachain-staking/src/delegation_requests.rs
@@ -457,6 +457,9 @@ impl<T: Config> Pallet<T> {
 		// backwards compatible handling for DelegatorStatus::Leaving
 		#[allow(deprecated)]
 		if let DelegatorStatus::Leaving(when) = state.status {
+			state.status = DelegatorStatus::Active;
+			<DelegatorState<T>>::insert(delegator.clone(), state.clone());
+
 			ensure!(
 				<Round<T>>::get().current >= when,
 				Error::<T>::DelegatorCannotLeaveYet

--- a/pallets/parachain-staking/src/delegation_requests.rs
+++ b/pallets/parachain-staking/src/delegation_requests.rs
@@ -456,7 +456,7 @@ impl<T: Config> Pallet<T> {
 
 		// backwards compatible handling for DelegatorStatus::Leaving
 		#[allow(deprecated)]
-		if matches!(state.status, DelegatorStatus::Leaving(when)) {
+		if let DelegatorStatus::Leaving(when) = state.status {
 			ensure!(
 				<Round<T>>::get().current >= when,
 				Error::<T>::DelegatorCannotLeaveYet

--- a/pallets/parachain-staking/src/delegation_requests.rs
+++ b/pallets/parachain-staking/src/delegation_requests.rs
@@ -456,15 +456,11 @@ impl<T: Config> Pallet<T> {
 
 		// backwards compatible handling for DelegatorStatus::Leaving
 		#[allow(deprecated)]
-		if matches!(state.status, DelegatorStatus::Leaving(_)) {
-			if let DelegatorStatus::Leaving(when) = state.status {
-				ensure!(
-					<Round<T>>::get().current >= when,
-					Error::<T>::DelegatorCannotLeaveYet
-				);
-			} else {
-				return Err(Error::<T>::DelegatorNotLeaving.into());
-			}
+		if matches!(state.status, DelegatorStatus::Leaving(when)) {
+			ensure!(
+				<Round<T>>::get().current >= when,
+				Error::<T>::DelegatorCannotLeaveYet
+			);
 
 			for bond in state.delegations.0.clone() {
 				if let Err(error) = Self::delegator_leaves_candidate(

--- a/pallets/parachain-staking/src/delegation_requests.rs
+++ b/pallets/parachain-staking/src/delegation_requests.rs
@@ -457,9 +457,6 @@ impl<T: Config> Pallet<T> {
 		// backwards compatible handling for DelegatorStatus::Leaving
 		#[allow(deprecated)]
 		if matches!(state.status, DelegatorStatus::Leaving(_)) {
-			state.status = DelegatorStatus::Active;
-			<DelegatorState<T>>::insert(delegator.clone(), state.clone());
-
 			if let DelegatorStatus::Leaving(when) = state.status {
 				ensure!(
 					<Round<T>>::get().current >= when,

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -9041,7 +9041,7 @@ fn test_delegator_with_deprecated_status_leaving_can_execute_leave_delegators_as
 
 #[allow(deprecated)]
 #[test]
-fn test_delegator_with_deprecated_status_leaving_cannot_execute_leave_delegators_and_not_fixed() {
+fn test_delegator_with_deprecated_status_leaving_cannot_execute_leave_delegators_early_no_fix() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 20), (2, 40)])
 		.with_candidates(vec![(1, 20)])

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -33,7 +33,7 @@ use crate::{
 	CollatorCandidate, CollatorStatus, Config, DelegationScheduledRequests, Delegations, Delegator,
 	DelegatorAdded, DelegatorState, DelegatorStatus, Error, Event, Range, TopDelegations, Total,
 };
-use frame_support::{assert_err, assert_noop, assert_ok, traits::ReservableCurrency};
+use frame_support::{assert_noop, assert_ok, traits::ReservableCurrency};
 use sp_runtime::{traits::Zero, DispatchError, ModuleError, Perbill, Percent};
 
 // ~~ ROOT ~~
@@ -9041,7 +9041,7 @@ fn test_delegator_with_deprecated_status_leaving_can_execute_leave_delegators_as
 
 #[allow(deprecated)]
 #[test]
-fn test_delegator_with_deprecated_status_leaving_cannot_execute_leave_delegators_early_yet_fixed() {
+fn test_delegator_with_deprecated_status_leaving_cannot_execute_leave_delegators_and_not_fixed() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 20), (2, 40)])
 		.with_candidates(vec![(1, 20)])
@@ -9056,12 +9056,9 @@ fn test_delegator_with_deprecated_status_leaving_cannot_execute_leave_delegators
 			let state = <DelegatorState<Test>>::get(2);
 			assert!(matches!(state.unwrap().status, DelegatorStatus::Leaving(_)));
 
-			assert_err!(
+			assert_noop!(
 				ParachainStaking::execute_leave_delegators(Origin::signed(2), 2, 1),
 				Error::<Test>::DelegatorCannotLeaveYet
 			);
-
-			let state = <DelegatorState<Test>>::get(2);
-			assert!(matches!(state.unwrap().status, DelegatorStatus::Active));
 		});
 }

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -1197,10 +1197,14 @@ impl<A: Clone, B: Copy> From<CollatorCandidate<A, B>> for CollatorSnapshot<A, B>
 	}
 }
 
+#[allow(deprecated)]
 #[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
 pub enum DelegatorStatus {
 	/// Active with no scheduled exit
 	Active,
+	/// Schedule exit to revoke all ongoing delegations
+	#[deprecated(note = "must only be used for backwards compatibility reasons")]
+	Leaving(RoundIndex),
 }
 
 #[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo)]


### PR DESCRIPTION
### What does it do?
Re-adds `DelegationStatus::Leaving` as a deprecated variant. This fixes decode problems for any delegators containing the old variant in their `status` field under the `DelegatorState` storage.

`schedule_leave_delegators`, `cancel_leave_delegators` & `execute_leave_delegators` will now infallibly update the `DelegatorStatus::Leaving` to `DelegatorStatus::Active` if encountered.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
