### PR TITLE
fix indirect read of bond.amount value

### DIFF
--- a/pallets/parachain-staking/src/delegation_requests.rs
+++ b/pallets/parachain-staking/src/delegation_requests.rs
@@ -338,10 +338,8 @@ impl<T: Config> Pallet<T> {
 		let mut existing_revoke_count = 0;
 		for bond in state.delegations.0.clone() {
 			let collator = bond.owner;
+			let bonded_amount = bond.amount;
 			let mut scheduled_requests = <DelegationScheduledRequests<T>>::get(&collator);
-			let bonded_amount = state
-				.get_bond_amount(&collator)
-				.ok_or(<Error<T>>::DelegationDNE)?;
 
 			// cancel any existing requests
 			let request =


### PR DESCRIPTION
### What does it do?
fixes indirect read of `bond.amount` value. The information was already there since we're iterating over `state.delegations`

```rust
pub fn get_bond_amount(&self, collator: &AccountId) -> Option<Balance> {
	self.delegations
		.0
		.iter()
		.find(|b| &b.owner == collator)
		.map(|b| b.amount)
}
```
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
