### PR TITLE
Orbiters: add storage entry RegisteredOrbiter & events OrbiterRegistered & OrbiterUnRegistered

### DIFF
--- a/pallets/moonbeam-orbiters/src/lib.rs
+++ b/pallets/moonbeam-orbiters/src/lib.rs
@@ -141,6 +141,11 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
+	#[pallet::storage]
+	#[pallet::getter(fn orbiter)]
+	/// Account lookup override
+	pub type RegisteredOrbiter<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, bool>;
+
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
 		pub min_orbiter_deposit: BalanceOf<T>,
@@ -307,7 +312,9 @@ pub mod pallet {
 					&T::OrbiterReserveIdentifier::get(),
 					&orbiter,
 					min_orbiter_deposit,
-				)
+				)?;
+				RegisteredOrbiter::<T>::insert(&orbiter, true);
+				Ok(())
 			} else {
 				Err(Error::<T>::MinOrbiterDepositNotSet.into())
 			}
@@ -336,6 +343,7 @@ pub mod pallet {
 			);
 
 			T::Currency::unreserve_all_named(&T::OrbiterReserveIdentifier::get(), &orbiter);
+			RegisteredOrbiter::<T>::remove(&orbiter);
 
 			Ok(())
 		}

--- a/pallets/moonbeam-orbiters/src/lib.rs
+++ b/pallets/moonbeam-orbiters/src/lib.rs
@@ -143,7 +143,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn orbiter)]
-	/// Account lookup override
+	/// Check if account is an orbiter
 	pub type RegisteredOrbiter<T: Config> = StorageMap<_, Blake2_128Concat, T::AccountId, bool>;
 
 	#[pallet::genesis_config]

--- a/pallets/moonbeam-orbiters/src/lib.rs
+++ b/pallets/moonbeam-orbiters/src/lib.rs
@@ -233,6 +233,13 @@ pub mod pallet {
 			old_orbiter: Option<T::AccountId>,
 			new_orbiter: Option<T::AccountId>,
 		},
+		/// An orbiter has registered
+		OrbiterRegistered {
+			account: T::AccountId,
+			deposit: BalanceOf<T>,
+		},
+		/// An orbiter has unregistered
+		OrbiterUnRegistered { account: T::AccountId },
 	}
 
 	#[pallet::call]
@@ -314,6 +321,10 @@ pub mod pallet {
 					min_orbiter_deposit,
 				)?;
 				RegisteredOrbiter::<T>::insert(&orbiter, true);
+				Self::deposit_event(Event::OrbiterRegistered {
+					account: orbiter,
+					deposit: min_orbiter_deposit,
+				});
 				Ok(())
 			} else {
 				Err(Error::<T>::MinOrbiterDepositNotSet.into())
@@ -344,6 +355,7 @@ pub mod pallet {
 
 			T::Currency::unreserve_all_named(&T::OrbiterReserveIdentifier::get(), &orbiter);
 			RegisteredOrbiter::<T>::remove(&orbiter);
+			Self::deposit_event(Event::OrbiterUnRegistered { account: orbiter });
 
 			Ok(())
 		}

--- a/pallets/moonbeam-orbiters/src/lib.rs
+++ b/pallets/moonbeam-orbiters/src/lib.rs
@@ -239,7 +239,7 @@ pub mod pallet {
 			deposit: BalanceOf<T>,
 		},
 		/// An orbiter has unregistered
-		OrbiterUnRegistered { account: T::AccountId },
+		OrbiterUnregistered { account: T::AccountId },
 	}
 
 	#[pallet::call]
@@ -355,7 +355,7 @@ pub mod pallet {
 
 			T::Currency::unreserve_all_named(&T::OrbiterReserveIdentifier::get(), &orbiter);
 			RegisteredOrbiter::<T>::remove(&orbiter);
-			Self::deposit_event(Event::OrbiterUnRegistered { account: orbiter });
+			Self::deposit_event(Event::OrbiterUnregistered { account: orbiter });
 
 			Ok(())
 		}

--- a/pallets/moonbeam-orbiters/src/tests.rs
+++ b/pallets/moonbeam-orbiters/src/tests.rs
@@ -239,11 +239,20 @@ fn test_orbiter_register_ok() {
 		.with_min_orbiter_deposit(10_000)
 		.build()
 		.execute_with(|| {
+			assert!(MoonbeamOrbiters::orbiter(1).is_none());
 			assert_ok!(MoonbeamOrbiters::orbiter_register(Origin::signed(1)),);
-			System::assert_last_event(
+			assert!(MoonbeamOrbiters::orbiter(1).is_some());
+			System::assert_has_event(
 				pallet_balances::Event::<Test>::Reserved {
 					who: 1,
 					amount: 10_000,
+				}
+				.into(),
+			);
+			System::assert_last_event(
+				Event::<Test>::OrbiterRegistered {
+					account: 1,
+					deposit: 10_000,
 				}
 				.into(),
 			);
@@ -281,6 +290,21 @@ fn test_orbiter_unregister() {
 			);
 
 			// Try to unregister an orbiter with right hint, should success
+			assert!(MoonbeamOrbiters::orbiter(2).is_some());
 			assert_ok!(MoonbeamOrbiters::orbiter_unregister(Origin::signed(2), 1),);
+			assert!(MoonbeamOrbiters::orbiter(2).is_none());
+			System::assert_has_event(
+				pallet_balances::Event::<Test>::Unreserved {
+					who: 2,
+					amount: 10_000,
+				}
+				.into(),
+			);
+			System::assert_last_event(
+				Event::<Test>::OrbiterUnRegistered {
+					account: 2,
+				}
+				.into(),
+			);
 		});
 }

--- a/pallets/moonbeam-orbiters/src/tests.rs
+++ b/pallets/moonbeam-orbiters/src/tests.rs
@@ -300,11 +300,6 @@ fn test_orbiter_unregister() {
 				}
 				.into(),
 			);
-			System::assert_last_event(
-				Event::<Test>::OrbiterUnRegistered {
-					account: 2,
-				}
-				.into(),
-			);
+			System::assert_last_event(Event::<Test>::OrbiterUnRegistered { account: 2 }.into());
 		});
 }

--- a/pallets/moonbeam-orbiters/src/tests.rs
+++ b/pallets/moonbeam-orbiters/src/tests.rs
@@ -300,6 +300,6 @@ fn test_orbiter_unregister() {
 				}
 				.into(),
 			);
-			System::assert_last_event(Event::<Test>::OrbiterUnRegistered { account: 2 }.into());
+			System::assert_last_event(Event::<Test>::OrbiterUnregistered { account: 2 }.into());
 		});
 }

--- a/pallets/moonbeam-orbiters/src/weights.rs
+++ b/pallets/moonbeam-orbiters/src/weights.rs
@@ -97,16 +97,18 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: MoonbeamOrbiters MinOrbiterDeposit (r:1 w:0)
 	// Storage: Balances Reserves (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
+	// Storage: MoonbeamOrbiters RegisteredOrbiter (r:0 w:1)
 	#[rustfmt::skip]
 	fn orbiter_register() -> Weight {
 		(32_506_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	// Storage: MoonbeamOrbiters CounterForCollatorsPool (r:1 w:0)
 	// Storage: MoonbeamOrbiters CollatorsPool (r:1 w:0)
 	// Storage: Balances Reserves (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
+	// Storage: MoonbeamOrbiters RegisteredOrbiter (r:0 w:1)
 	#[rustfmt::skip]
 	fn orbiter_unregister(n: u32, ) -> Weight {
 		(33_919_000 as Weight)
@@ -114,7 +116,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add((6_981_000 as Weight).saturating_mul(n as Weight))
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(n as Weight)))
-			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	// Storage: MoonbeamOrbiters CollatorsPool (r:1 w:1)
 	// Storage: MoonbeamOrbiters CounterForCollatorsPool (r:1 w:1)


### PR DESCRIPTION
### What does it do?

### What important points reviewers should know?

Theoretically, it would be necessary to make a migration but as the orbiter is not used yet  in the production networks, it will not be implemented.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
