### PR TITLE
handle delegators with 0-value bond in staking-rewards smoke test

### DIFF
--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -11,16 +11,13 @@ const debug = require("debug")("smoke:staking");
 const wssUrl = process.env.WSS_URL || null;
 const relayWssUrl = process.env.RELAY_WSS_URL || null;
 
-describeSmokeSuite(
-  `Verify staking rewards`,
-  { wssUrl, relayWssUrl, timeout: 500000 },
-  function (context) {
-    it("rewards are given as expected", async () => {
-      const atBlockNumber = (await context.polkadotApi.rpc.chain.getHeader()).number.toNumber();
-      await assertRewardsAtRoundBefore(context.polkadotApi, atBlockNumber);
-    });
-  }
-);
+describeSmokeSuite(`Verify staking rewards`, { wssUrl, relayWssUrl }, function (context) {
+  it("rewards are given as expected", async () => {
+    this.timeout(500000);
+    const atBlockNumber = (await context.polkadotApi.rpc.chain.getHeader()).number.toNumber();
+    await assertRewardsAtRoundBefore(context.polkadotApi, atBlockNumber);
+  });
+});
 
 async function assertRewardsAtRoundBefore(api: ApiPromise, nowBlockNumber: number) {
   const nowBlockHash = await api.rpc.chain.getBlockHash(nowBlockNumber);

--- a/tests/util/setup-smoke-tests.ts
+++ b/tests/util/setup-smoke-tests.ts
@@ -10,7 +10,6 @@ export interface SmokeTestContext {
 export type SmokeTestOptions = {
   wssUrl: string;
   relayWssUrl: string;
-  timeout?: number;
 };
 
 export function describeSmokeSuite(
@@ -20,7 +19,7 @@ export function describeSmokeSuite(
 ) {
   describe(title, function () {
     // Set timeout to 5000 for all tests.
-    this.timeout(options.timeout || 23700);
+    this.timeout(23700);
 
     // The context is initialized empty to allow passing a reference
     // and to be filled once the node information is retrieved


### PR DESCRIPTION
### What does it do?
* Correctly handles delegators with 0-value bond and rewarded event in staking-rewards smoke test, so they are non incorrectly flagged as not rewarded.
* Adds block information to STDOUT and error messages
* Fixes account Id `0x` uppercase issue


### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
