### PR TITLE
Staking Locks: Multi-block Migration

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -450,7 +450,6 @@ pub mod pallet {
 							delegator_state.adjust_bond_lock::<T>(None);
 						}
 
-						migration_key[..16].copy_from_slice(&pallet_hash);
 						migration_key[16..].copy_from_slice(&candidate_info_hash);
 						for (account, candidate_info) in <CandidateInfo<T>>::iter_from(migration_key.to_vec()) {
 							let reserved = candidate_info.bond;

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -81,7 +81,7 @@ pub mod pallet {
 	use crate::{set::OrderedSet, traits::*, types::*, InflationInfo, Range, WeightInfo};
 	use frame_support::pallet_prelude::*;
 	use frame_support::traits::{
-		tokens::WithdrawReasons, Contains, Currency, Get, Imbalance, LockableCurrency,
+		tokens::WithdrawReasons, Contains, Currency, Get, Imbalance, IsSubType, LockableCurrency,
 		ReservableCurrency,
 	};
 
@@ -1781,10 +1781,13 @@ pub mod pallet {
 		}
 	}
 
-	impl<T: Config> Contains<T::Call> for Pallet<T> {
+	impl<T: Config> Contains<T::Call> for Pallet<T>
+	where
+		T::Call: IsSubType<Call<T>>,
+	{
 		fn contains(call: &T::Call) -> bool {
-			match call {
-				T::Call::ParachainStaking(_) => <ReserveToLockMigrationStep<T>>::get().len() > 0,
+			match IsSubType::<Call<T>>::is_sub_type(call) {
+				Some(_) => <ReserveToLockMigrationStep<T>>::get().len() > 0,
 				_ => T::NormalCallFilter::contains(call),
 			}
 		}

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -430,7 +430,9 @@ pub mod pallet {
 			// 1 value will be process at each block, during the on_initialize
 			// The value correspond to a range of 16 prefixes being appended to 
 			// the delegator_state_prefix in order to process 1/16th of the whole list
-			
+			//
+			// It is expected with usual delegator count of 15000 to have around 1000
+			// delegator processed each time
 			let mut migration_steps = <ReserveToLockMigrationStep<T>>::get();
 			match migration_steps.pop() {
 				Some(next_migration_prefix) if next_migration_prefix < 16 => {

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -679,6 +679,7 @@ impl pallet_parachain_staking::OnNewRound for OnNewRound {
 impl pallet_parachain_staking::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
+	type NormalCallFilter = NormalFilter;
 	type MonetaryGovernanceOrigin = EnsureRoot<AccountId>;
 	/// Minimum round length is 2 minutes (10 * 12 second block times)
 	type MinBlocksPerRound = ConstU32<10>;
@@ -943,7 +944,6 @@ impl Contains<Call> for NormalFilter {
 				pallet_xcm::Call::force_default_xcm_version { .. } => true,
 				_ => false,
 			},
-			_ => true,
 		}
 	}
 }
@@ -1022,7 +1022,7 @@ impl OffchainWorker<BlockNumber> for MaintenanceHooks {
 
 impl pallet_maintenance_mode::Config for Runtime {
 	type Event = Event;
-	type NormalCallFilter = NormalFilter;
+	type NormalCallFilter = ParachainStaking;
 	type MaintenanceCallFilter = MaintenanceFilter;
 	type MaintenanceOrigin =
 		pallet_collective::EnsureProportionAtLeast<AccountId, TechCommitteeInstance, 2, 3>;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -944,6 +944,7 @@ impl Contains<Call> for NormalFilter {
 				pallet_xcm::Call::force_default_xcm_version { .. } => true,
 				_ => false,
 			},
+			_ => true,
 		}
 	}
 }


### PR DESCRIPTION
### What does it do?

Attempt at a multi-block migration using a single hex nibble and `iter_from` to break the keys up into 16 equal-ish chunks.