### PR TITLE
Improve amount parsing in assets-erc20

### DIFF
--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -395,7 +395,8 @@ where
 		input.expect_arguments(2)?;
 
 		let to: H160 = input.read::<Address>()?.into();
-		let amount = input.read::<BalanceOf<Runtime, Instance>>()?;
+		let amount: U256 = input.read()?;
+		let amount = Self::u256_to_amount(amount)?;
 
 		// Build call with origin.
 		{
@@ -438,7 +439,8 @@ where
 		input.expect_arguments(3)?;
 		let from: H160 = input.read::<Address>()?.into();
 		let to: H160 = input.read::<Address>()?.into();
-		let amount = input.read::<BalanceOf<Runtime, Instance>>()?;
+		let amount: U256 = input.read()?;
+		let amount = Self::u256_to_amount(amount)?;
 
 		{
 			let caller: Runtime::AccountId =
@@ -554,7 +556,8 @@ where
 		input.expect_arguments(2)?;
 
 		let to: H160 = input.read::<Address>()?.into();
-		let amount = input.read::<BalanceOf<Runtime, Instance>>()?;
+		let amount: U256 = input.read()?;
+		let amount = Self::u256_to_amount(amount)?;
 
 		// Build call with origin.
 		{
@@ -601,7 +604,8 @@ where
 		input.expect_arguments(2)?;
 
 		let to: H160 = input.read::<Address>()?.into();
-		let amount = input.read::<BalanceOf<Runtime, Instance>>()?;
+		let amount: U256 = input.read()?;
+		let amount = Self::u256_to_amount(amount)?;
 
 		// Build call with origin.
 		{
@@ -882,5 +886,11 @@ where
 
 		// Build output.
 		Ok(succeed(EvmDataWriter::new().write(true).build()))
+	}
+
+	fn u256_to_amount(value: U256) -> EvmResult<BalanceOf<Runtime, Instance>> {
+		value
+			.try_into()
+			.map_err(|_| revert("amount is too large for balance type"))
 	}
 }

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -2268,3 +2268,141 @@ fn transfer_amount_overflow() {
 				.execute_returns(EvmDataWriter::new().write(U256::from(1000)).build());
 		});
 }
+
+#[test]
+fn transfer_from_overflow() {
+	ExtBuilder::default()
+		.with_balances(vec![(Account::Alice, 1000)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(ForeignAssets::force_create(
+				Origin::root(),
+				0u128,
+				Account::Alice.into(),
+				true,
+				1
+			));
+			assert_ok!(ForeignAssets::mint(
+				Origin::signed(Account::Alice),
+				0u128,
+				Account::Alice.into(),
+				1000
+			));
+
+			precompiles()
+				.prepare_test(
+					Account::Alice,
+					Account::ForeignAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::Approve)
+						.write(Address(Account::Bob.into()))
+						.write(U256::from(500))
+						.build(),
+				)
+				.execute_some();
+
+			precompiles()
+				.prepare_test(
+					Account::Alice,
+					Account::ForeignAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::Approve)
+						.write(Address(Account::Bob.into()))
+						.write(U256::from(500))
+						.build(),
+				)
+				.execute_some();
+
+			precompiles()
+				.prepare_test(
+					Account::Bob, // Bob is the one sending transferFrom!
+					Account::ForeignAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::TransferFrom)
+						.write(Address(Account::Alice.into()))
+						.write(Address(Account::Charlie.into()))
+						.write(U256::from(u128::MAX) + 1)
+						.build(),
+				)
+				.expect_cost(1756u64) // 1 weight => 1 gas in mock
+				.expect_no_logs()
+				.execute_reverts(|e| e == b"amount is too large for balance type");
+		});
+}
+
+#[test]
+fn mint_overflow() {
+	ExtBuilder::default()
+		.with_balances(vec![(Account::Alice, 1000), (Account::Bob, 2500)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(LocalAssets::force_create(
+				Origin::root(),
+				0u128,
+				Account::Alice.into(),
+				true,
+				1
+			));
+			assert_ok!(LocalAssets::force_set_metadata(
+				Origin::root(),
+				0u128,
+				b"TestToken".to_vec(),
+				b"Test".to_vec(),
+				12,
+				false
+			));
+
+			precompiles()
+				.prepare_test(
+					Account::Alice,
+					Account::LocalAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::Mint)
+						.write(Address(Account::Bob.into()))
+						.write(U256::from(u128::MAX) + 1)
+						.build(),
+				)
+				.expect_cost(1756u64) // 1 weight => 1 gas in mock
+				.expect_no_logs()
+				.execute_reverts(|e| e == b"amount is too large for balance type");
+		});
+}
+
+#[test]
+fn burn_overflow() {
+	ExtBuilder::default()
+		.with_balances(vec![(Account::Alice, 1000), (Account::Bob, 2500)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(LocalAssets::force_create(
+				Origin::root(),
+				0u128,
+				Account::Alice.into(),
+				true,
+				1
+			));
+			assert_ok!(LocalAssets::force_set_metadata(
+				Origin::root(),
+				0u128,
+				b"TestToken".to_vec(),
+				b"Test".to_vec(),
+				12,
+				false
+			));
+			assert_ok!(LocalAssets::mint(
+				Origin::signed(Account::Alice),
+				0u128,
+				Account::Alice.into(),
+				1000
+			));
+
+			precompiles()
+				.prepare_test(
+					Account::Alice,
+					Account::LocalAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::Burn)
+						.write(Address(Account::Alice.into()))
+						.write(U256::from(u128::MAX) + 1)
+						.build(),
+				)
+				.expect_cost(1756u64) // 1 weight => 1 gas in mock
+				.expect_no_logs()
+				.execute_reverts(|e| e == b"amount is too large for balance type");
+		});
+}

--- a/precompiles/pallet-democracy/src/lib.rs
+++ b/precompiles/pallet-democracy/src/lib.rs
@@ -242,7 +242,8 @@ where
 		input.expect_arguments(2)?;
 
 		let proposal_hash = input.read::<H256>()?.into();
-		let amount = input.read::<BalanceOf<Runtime>>()?;
+		let amount: U256 = input.read()?;
+		let amount = Self::u256_to_amount(amount)?;
 
 		log::trace!(
 			target: "democracy-precompile",
@@ -291,7 +292,8 @@ where
 
 		let ref_index = input.read()?;
 		let aye = input.read()?;
-		let balance = input.read()?;
+		let amount: U256 = input.read()?;
+		let balance = Self::u256_to_amount(amount)?;
 		let conviction = input
 			.read::<u8>()?
 			.try_into()
@@ -348,7 +350,8 @@ where
 			.read::<u8>()?
 			.try_into()
 			.map_err(|_| revert("Conviction must be an integer in the range 0-6"))?;
-		let balance = input.read()?;
+		let amount: U256 = input.read()?;
+		let balance = Self::u256_to_amount(amount)?;
 
 		log::trace!(target: "democracy-precompile",
 			"Delegating vote to {:?} with balance {:?} and {:?}",
@@ -429,5 +432,11 @@ where
 		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
 
 		Ok(succeed([]))
+	}
+
+	fn u256_to_amount(value: U256) -> EvmResult<BalanceOf<Runtime>> {
+		value
+			.try_into()
+			.map_err(|_| revert("amount is too large for balance type"))
 	}
 }

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -532,7 +532,8 @@ where
 		let mut input = EvmDataReader::new_skip_selector(handle.input())?;
 		// Read input.
 		input.expect_arguments(2)?;
-		let bond: BalanceOf<Runtime> = input.read()?;
+		let amount: U256 = input.read()?;
+		let bond = Self::u256_to_amount(amount)?;
 		let candidate_count = input.read()?;
 
 		// Build call with origin.
@@ -648,7 +649,8 @@ where
 		let mut input = EvmDataReader::new_skip_selector(handle.input())?;
 		// Read input.
 		input.expect_arguments(1)?;
-		let more: BalanceOf<Runtime> = input.read()?;
+		let amount: U256 = input.read()?;
+		let more = Self::u256_to_amount(amount)?;
 
 		// Build call with origin.
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
@@ -667,7 +669,8 @@ where
 		let mut input = EvmDataReader::new_skip_selector(handle.input())?;
 		// Read input.
 		input.expect_arguments(1)?;
-		let less: BalanceOf<Runtime> = input.read()?;
+		let amount: U256 = input.read()?;
+		let less = Self::u256_to_amount(amount)?;
 
 		// Build call with origin.
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
@@ -722,7 +725,8 @@ where
 		// Read input.
 		input.expect_arguments(4)?;
 		let candidate = Runtime::AddressMapping::into_account_id(input.read::<Address>()?.0);
-		let amount: BalanceOf<Runtime> = input.read()?;
+		let amount: U256 = input.read()?;
+		let amount = Self::u256_to_amount(amount)?;
 		let candidate_delegation_count = input.read()?;
 		let delegation_count = input.read()?;
 
@@ -823,7 +827,8 @@ where
 		input.expect_arguments(2)?;
 		let candidate = input.read::<Address>()?.0;
 		let candidate = Runtime::AddressMapping::into_account_id(candidate);
-		let more: BalanceOf<Runtime> = input.read()?;
+		let amount: U256 = input.read()?;
+		let more = Self::u256_to_amount(amount)?;
 
 		// Build call with origin.
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
@@ -845,7 +850,8 @@ where
 		input.expect_arguments(2)?;
 		let candidate = input.read::<Address>()?.0;
 		let candidate = Runtime::AddressMapping::into_account_id(candidate);
-		let less: BalanceOf<Runtime> = input.read()?;
+		let amount: U256 = input.read()?;
+		let less = Self::u256_to_amount(amount)?;
 
 		// Build call with origin.
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
@@ -902,5 +908,11 @@ where
 
 		// Return call information
 		Ok((Some(origin).into(), call))
+	}
+
+	fn u256_to_amount(value: U256) -> EvmResult<BalanceOf<Runtime>> {
+		value
+			.try_into()
+			.map_err(|_| revert("amount is too large for balance type"))
 	}
 }

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -32,7 +32,7 @@ use precompile_utils::{
 	revert, succeed, Address, EvmData, EvmDataReader, EvmDataWriter, EvmResult, FunctionModifier,
 	PrecompileHandleExt, RuntimeHelper,
 };
-use sp_core::H160;
+use sp_core::{H160, U256};
 use sp_std::{convert::TryInto, fmt::Debug, marker::PhantomData, vec::Vec};
 
 type BalanceOf<Runtime> = <<Runtime as pallet_parachain_staking::Config>::Currency as Currency<
@@ -111,7 +111,7 @@ pub struct ParachainStakingWrapper<Runtime>(PhantomData<Runtime>);
 impl<Runtime> pallet_evm::Precompile for ParachainStakingWrapper<Runtime>
 where
 	Runtime: pallet_parachain_staking::Config + pallet_evm::Config,
-	BalanceOf<Runtime>: EvmData,
+	BalanceOf<Runtime>: TryFrom<U256> + TryInto<u128> + EvmData,
 	Runtime::AccountId: Into<H160>,
 	Runtime::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
 	<Runtime::Call as Dispatchable>::Origin: From<Option<Runtime::AccountId>>,
@@ -239,7 +239,7 @@ where
 impl<Runtime> ParachainStakingWrapper<Runtime>
 where
 	Runtime: pallet_parachain_staking::Config + pallet_evm::Config,
-	BalanceOf<Runtime>: EvmData,
+	BalanceOf<Runtime>: TryFrom<U256> + TryInto<u128> + EvmData,
 	Runtime::AccountId: Into<H160>,
 	Runtime::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
 	<Runtime::Call as Dispatchable>::Origin: From<Option<Runtime::AccountId>>,


### PR DESCRIPTION
### What does it do?

First parse an U256 (corresponding to the Solidity interface), then try to convert it to the balance type.
Revert if the amount is too big.

Prevents an silent overflow that transfered less than requested.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
