### PR TITLE
Add migration to clear pallet-ethereum `Pending` storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5854,6 +5854,8 @@ dependencies = [
 name = "moonbeam-runtime-common"
 version = "0.8.0-dev"
 dependencies = [
+ "ethereum",
+ "ethereum-types",
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
@@ -5864,6 +5866,7 @@ dependencies = [
  "pallet-author-slot-filter",
  "pallet-base-fee",
  "pallet-collective",
+ "pallet-ethereum",
  "pallet-evm",
  "pallet-migrations",
  "pallet-parachain-staking",

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -30,6 +30,9 @@ sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 # Frontier
 pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.20", default-features = false }
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.20", default-features = false }
+pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.20", default-features = false }
+ethereum = { version = "0.12.0", default-features = false, features = ["with-codec"] }
+ethereum-types = { version = "0.13.1", default-features = false }
 
 # Nimbus
 pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.20", default-features = false }
@@ -40,11 +43,14 @@ xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.2
 
 [features]
 std = [
+	"ethereum/std",
+	"ethereum-types/std",
 	"frame-support/std",
 	"pallet-asset-manager/std",
 	"pallet-author-inherent/std",
 	"pallet-author-mapping/std",
 	"pallet-base-fee/std",
+	"pallet-ethereum/std",
 	"pallet-evm/std",
 	"pallet-migrations/std",
 	"pallet-parachain-staking/std",

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -28,11 +28,11 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.20", default-features = false }
 
 # Frontier
-pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.20", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.20", default-features = false }
-pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.20", default-features = false }
-ethereum = { version = "0.12.0", default-features = false, features = ["with-codec"] }
+ethereum = { version = "0.12.0", default-features = false, features = [ "with-codec" ] }
 ethereum-types = { version = "0.13.1", default-features = false }
+pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.20", default-features = false }
+pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.20", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.20", default-features = false }
 
 # Nimbus
 pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.20", default-features = false }
@@ -43,8 +43,8 @@ xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.2
 
 [features]
 std = [
-	"ethereum/std",
 	"ethereum-types/std",
+	"ethereum/std",
 	"frame-support/std",
 	"pallet-asset-manager/std",
 	"pallet-author-inherent/std",

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -435,7 +435,6 @@ impl<T: EthereumConfig> OnRuntimeUpgrade for EthereumPending<T> {
 	#[cfg(feature = "try-runtime")]
 	fn pre_upgrade() -> Result<(), &'static str> {
 		let module: &[u8] = b"Ethereum";
-		// Before the upgrade, we fill the storage with some value.
 		let item: &[u8] = b"Pending";
 		let value = get_storage_value::<Vec<(TransactionV2, TransactionStatus, ReceiptV3)>>(
 			module,

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -26,7 +26,7 @@ use ethereum_types::{Bloom, H160, H256};
 
 use frame_support::{
 	dispatch::GetStorageVersion,
-	storage::migration::{get_storage_value, put_storage_value, remove_storage_prefix},
+	storage::migration::{get_storage_value, put_storage_value, take_storage_value},
 	traits::{Get, OnRuntimeUpgrade, PalletInfoAccess},
 	weights::Weight,
 };
@@ -511,7 +511,11 @@ impl<T: EthereumConfig> OnRuntimeUpgrade for EthereumPending<T> {
 			.unwrap_or_default();
 		if !current_value.is_empty() {
 			// Kill the `Pending` storage if not empty.
-			remove_storage_prefix(module, item, &[]);
+			let _ = take_storage_value::<Vec<(TransactionV2, TransactionStatus, ReceiptV3)>>(
+				module,
+				item,
+				&[],
+			);
 			weight = weight.saturating_add(db_weights.write);
 		}
 		weight

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -525,7 +525,7 @@ impl<T: EthereumConfig> OnRuntimeUpgrade for EthereumPending<T> {
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade() -> Result<(), &'static str> {
 		let _ = Self::get_temp_storage::<bool>("pending_is_empty")
-			.expect("`pending_is_empty` temp storage was set.");
+			.expect("`pending_is_empty` temp storage was not set.");
 
 		let module: &[u8] = b"Ethereum";
 		let item: &[u8] = b"Pending";

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -19,14 +19,15 @@
 #[cfg(feature = "try-runtime")]
 use frame_support::traits::OnRuntimeUpgradeHelpersExt;
 
-use ethereum::{
-	EIP1559ReceiptData, EIP1559Transaction, ReceiptV3, TransactionAction, TransactionV2,
-};
+#[cfg(feature = "try-runtime")]
+use ethereum::{EIP1559ReceiptData, EIP1559Transaction, TransactionAction};
+use ethereum::{ReceiptV3, TransactionV2};
+#[cfg(feature = "try-runtime")]
 use ethereum_types::{Bloom, H160, H256};
 
 use frame_support::{
 	dispatch::GetStorageVersion,
-	storage::migration::{get_storage_value, put_storage_value, take_storage_value},
+	storage::migration::{get_storage_value, take_storage_value},
 	traits::{Get, OnRuntimeUpgrade, PalletInfoAccess},
 	weights::Weight,
 };
@@ -59,6 +60,7 @@ use pallet_parachain_staking::{
 use pallet_xcm_transactor::{
 	migrations::TransactSignedWeightAndFeePerSecond, Config as XcmTransactorConfig,
 };
+#[cfg(feature = "try-runtime")]
 use sp_core::U256;
 use sp_runtime::Permill;
 use sp_std::{marker::PhantomData, prelude::*};
@@ -477,7 +479,7 @@ impl<T: EthereumConfig> OnRuntimeUpgrade for EthereumPending<T> {
 			});
 			let new_value = vec![(transaction, status, receipt)];
 			// Fill the storage item with some value.
-			put_storage_value(module, item, &[], new_value);
+			frame_support::storage::migration::put_storage_value(module, item, &[], new_value);
 			// Make sure the storage item holds the new value.
 			let value = get_storage_value::<Vec<(TransactionV2, TransactionStatus, ReceiptV3)>>(
 				module,

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -17,12 +17,13 @@
 //! # Migrations
 
 #[cfg(feature = "try-runtime")]
+use frame_support::traits::OnRuntimeUpgradeHelpersExt;
+
 use ethereum::{
 	EIP1559ReceiptData, EIP1559Transaction, ReceiptV3, TransactionAction, TransactionV2,
 };
 use ethereum_types::{Bloom, H160, H256};
 
-use frame_support::traits::OnRuntimeUpgradeHelpersExt;
 use frame_support::{
 	dispatch::GetStorageVersion,
 	storage::migration::{get_storage_value, put_storage_value, remove_storage_prefix},


### PR DESCRIPTION
### What does it do?

Add a migration for clearing the pallet-ethereum `Pending` storage on runtime upgrade. See https://github.com/paritytech/frontier/pull/638#issuecomment-1165693039

### What important points reviewers should know?

This _migration_ is added to solve an issue caused by introducing a change where a `StorageValue` previously cleared `on_initialize`, is cleared `on_finalize` after a runtime upgrade.

That change results in the first block of the new runtime version to contain the `StorageValue` data of the block prior the runtime upgrade.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
