### PR TITLE
Preserve enum variant attributes in `generate_function_selector` macro

### DIFF
--- a/precompiles/utils/macro/src/lib.rs
+++ b/precompiles/utils/macro/src/lib.rs
@@ -18,7 +18,9 @@ use proc_macro::TokenStream;
 use proc_macro2::Literal;
 use quote::{quote, quote_spanned};
 use sha3::{Digest, Keccak256};
-use syn::{parse_macro_input, spanned::Spanned, Expr, ExprLit, Ident, ItemEnum, Lit, LitStr};
+use syn::{
+	parse_macro_input, spanned::Spanned, Attribute, Expr, ExprLit, Ident, ItemEnum, Lit, LitStr,
+};
 
 struct Bytes(Vec<u8>);
 
@@ -93,6 +95,7 @@ pub fn generate_function_selector(_: TokenStream, input: TokenStream) -> TokenSt
 
 	let mut ident_expressions: Vec<Ident> = vec![];
 	let mut variant_expressions: Vec<Expr> = vec![];
+	let mut variant_attrs: Vec<Vec<Attribute>> = vec![];
 	for variant in variants {
 		match variant.discriminant {
 			Some((_, Expr::Lit(ExprLit { lit, .. }))) => {
@@ -104,6 +107,7 @@ pub fn generate_function_selector(_: TokenStream, input: TokenStream) -> TokenSt
 						lit: Lit::Verbatim(Literal::u32_suffixed(selector)),
 						attrs: Default::default(),
 					}));
+					variant_attrs.push(variant.attrs);
 				} else {
 					return quote_spanned! {
 						lit.span() => compile_error("Expected literal string");
@@ -132,6 +136,7 @@ pub fn generate_function_selector(_: TokenStream, input: TokenStream) -> TokenSt
 		#[repr(u32)]
 		#vis #enum_token #ident {
 			#(
+				#(#variant_attrs)*
 				#ident_expressions = #variant_expressions,
 			)*
 		}


### PR DESCRIPTION
### What does it do?

Small change to the `generate_function_selector` macro that keeps the resulting enum variant attributes. This helps with documentation, and keeps clippy from complaining about missing docs.

### What important points reviewers should know?

Not sure if allowing attributes will conflict with functionality of the macro. If so, we'll need to consider another aproach.

### Is there something left for follow-up PRs?

No

### What alternative implementations were considered?

We could just allow missing docs to workaround clippy, but generated docs would still be missing.

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

Largely in preparation for precompile-utils wider use #1633.

### What value does it bring to the blockchain users?

Small improvement to development experience. 