### PR TITLE
Add relay chain network when converting accountId into multilocation

### DIFF
--- a/primitives/xcm/src/lib.rs
+++ b/primitives/xcm/src/lib.rs
@@ -78,17 +78,20 @@ where
 }
 
 /// Instructs how to convert a 20 byte accountId into a MultiLocation
-pub struct AccountIdToMultiLocation<AccountId>(sp_std::marker::PhantomData<AccountId>);
-impl<AccountId> sp_runtime::traits::Convert<AccountId, MultiLocation>
-	for AccountIdToMultiLocation<AccountId>
+pub struct AccountIdToMultiLocation<AccountId, Network>(
+	sp_std::marker::PhantomData<(AccountId, Network)>,
+);
+impl<AccountId, Network> sp_runtime::traits::Convert<AccountId, MultiLocation>
+	for AccountIdToMultiLocation<AccountId, Network>
 where
 	AccountId: Into<[u8; 20]>,
+	Network: Get<NetworkId>,
 {
 	fn convert(account: AccountId) -> MultiLocation {
 		MultiLocation {
 			parents: 0,
 			interior: X1(AccountKey20 {
-				network: NetworkId::Any,
+				network: Network::get(),
 				key: account.into(),
 			}),
 		}

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -462,7 +462,7 @@ impl orml_xtokens::Config for Runtime {
 	type Event = Event;
 	type Balance = Balance;
 	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId>;
+	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId, RelayNetwork>;
 	type CurrencyIdConvert =
 		CurrencyIdtoMultiLocation<AsAssetType<AssetId, AssetType, AssetManager>>;
 	type XcmExecutor = XcmExecutor;
@@ -519,7 +519,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type DerivativeAddressRegistrationOrigin = EnsureRoot<AccountId>;
 	type SovereignAccountDispatcherOrigin = EnsureRoot<AccountId>;
 	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId>;
+	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId, RelayNetwork>;
 	type CurrencyIdToMultiLocation =
 		CurrencyIdtoMultiLocation<AsAssetType<AssetId, AssetType, AssetManager>>;
 	type XcmSender = XcmRouter;

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -424,7 +424,8 @@ impl orml_xtokens::Config for Runtime {
 	type Event = Event;
 	type Balance = Balance;
 	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = xcm_primitives::AccountIdToMultiLocation<AccountId>;
+	type AccountIdToMultiLocation =
+		xcm_primitives::AccountIdToMultiLocation<AccountId, RelayNetwork>;
 	type CurrencyIdConvert =
 		CurrencyIdtoMultiLocation<xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>>;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
@@ -841,7 +842,8 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type DerivativeAddressRegistrationOrigin = EnsureRoot<AccountId>;
 	type SovereignAccountDispatcherOrigin = frame_system::EnsureRoot<AccountId>;
 	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = xcm_primitives::AccountIdToMultiLocation<AccountId>;
+	type AccountIdToMultiLocation =
+		xcm_primitives::AccountIdToMultiLocation<AccountId, RelayNetwork>;
 	type CurrencyIdToMultiLocation =
 		CurrencyIdtoMultiLocation<xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>>;
 	type SelfLocation = SelfLocation;

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -2188,7 +2188,7 @@ fn transact_through_signed_multilocation() {
 
 	// Let's construct the Junction that we will append with DescendOrigin
 	let signed_origin: Junctions = X1(AccountKey20 {
-		network: NetworkId::Any,
+		network: parachain::RelayNetwork::get(),
 		key: PARAALICE,
 	});
 
@@ -2291,7 +2291,7 @@ fn transact_through_signed_multilocation_para_to_para() {
 
 	// Let's construct the Junction that we will append with DescendOrigin
 	let signed_origin: Junctions = X1(AccountKey20 {
-		network: NetworkId::Any,
+		network: parachain::RelayNetwork::get(),
 		key: PARAALICE,
 	});
 

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -444,7 +444,7 @@ impl orml_xtokens::Config for Runtime {
 	type Event = Event;
 	type Balance = Balance;
 	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId>;
+	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId, RelayNetwork>;
 	type CurrencyIdConvert =
 		CurrencyIdtoMultiLocation<AsAssetType<AssetId, AssetType, AssetManager>>;
 	type XcmExecutor = XcmExecutor;
@@ -502,7 +502,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type DerivativeAddressRegistrationOrigin = EnsureRoot<AccountId>;
 	type SovereignAccountDispatcherOrigin = EnsureRoot<AccountId>;
 	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId>;
+	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId, RelayNetwork>;
 	type CurrencyIdToMultiLocation =
 		CurrencyIdtoMultiLocation<AsAssetType<AssetId, AssetType, AssetManager>>;
 	type XcmSender = XcmRouter;

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -403,7 +403,8 @@ impl orml_xtokens::Config for Runtime {
 	type Event = Event;
 	type Balance = Balance;
 	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = xcm_primitives::AccountIdToMultiLocation<AccountId>;
+	type AccountIdToMultiLocation =
+		xcm_primitives::AccountIdToMultiLocation<AccountId, RelayNetwork>;
 	type CurrencyIdConvert =
 		CurrencyIdtoMultiLocation<xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>>;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
@@ -821,7 +822,8 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type DerivativeAddressRegistrationOrigin = EnsureRoot<AccountId>;
 	type SovereignAccountDispatcherOrigin = frame_system::EnsureRoot<AccountId>;
 	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = xcm_primitives::AccountIdToMultiLocation<AccountId>;
+	type AccountIdToMultiLocation =
+		xcm_primitives::AccountIdToMultiLocation<AccountId, RelayNetwork>;
 	type CurrencyIdToMultiLocation =
 		CurrencyIdtoMultiLocation<xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>>;
 	type SelfLocation = SelfLocation;

--- a/runtime/moonbeam/tests/xcm_tests.rs
+++ b/runtime/moonbeam/tests/xcm_tests.rs
@@ -1913,7 +1913,7 @@ fn transact_through_signed_multilocation() {
 
 	// Let's construct the Junction that we will append with DescendOrigin
 	let signed_origin: Junctions = X1(AccountKey20 {
-		network: NetworkId::Any,
+		network: parachain::RelayNetwork::get(),
 		key: PARAALICE,
 	});
 

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -457,7 +457,7 @@ impl orml_xtokens::Config for Runtime {
 	type Event = Event;
 	type Balance = Balance;
 	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId>;
+	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId, RelayNetwork>;
 	type CurrencyIdConvert =
 		CurrencyIdtoMultiLocation<AsAssetType<AssetId, AssetType, AssetManager>>;
 	type XcmExecutor = XcmExecutor;
@@ -514,7 +514,7 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type DerivativeAddressRegistrationOrigin = EnsureRoot<AccountId>;
 	type SovereignAccountDispatcherOrigin = EnsureRoot<AccountId>;
 	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId>;
+	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId, RelayNetwork>;
 	type CurrencyIdToMultiLocation =
 		CurrencyIdtoMultiLocation<AsAssetType<AssetId, AssetType, AssetManager>>;
 	type XcmSender = XcmRouter;

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -416,7 +416,8 @@ impl orml_xtokens::Config for Runtime {
 	type Event = Event;
 	type Balance = Balance;
 	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = xcm_primitives::AccountIdToMultiLocation<AccountId>;
+	type AccountIdToMultiLocation =
+		xcm_primitives::AccountIdToMultiLocation<AccountId, RelayNetwork>;
 	type CurrencyIdConvert =
 		CurrencyIdtoMultiLocation<xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>>;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
@@ -832,7 +833,8 @@ impl pallet_xcm_transactor::Config for Runtime {
 	type DerivativeAddressRegistrationOrigin = EnsureRoot<AccountId>;
 	type SovereignAccountDispatcherOrigin = frame_system::EnsureRoot<AccountId>;
 	type CurrencyId = CurrencyId;
-	type AccountIdToMultiLocation = xcm_primitives::AccountIdToMultiLocation<AccountId>;
+	type AccountIdToMultiLocation =
+		xcm_primitives::AccountIdToMultiLocation<AccountId, RelayNetwork>;
 	type CurrencyIdToMultiLocation =
 		CurrencyIdtoMultiLocation<xcm_primitives::AsAssetType<AssetId, AssetType, AssetManager>>;
 	type SelfLocation = SelfLocation;

--- a/runtime/moonriver/tests/xcm_tests.rs
+++ b/runtime/moonriver/tests/xcm_tests.rs
@@ -2221,7 +2221,7 @@ fn transact_through_signed_multilocation() {
 
 	// Let's construct the Junction that we will append with DescendOrigin
 	let signed_origin: Junctions = X1(AccountKey20 {
-		network: NetworkId::Any,
+		network: parachain::RelayNetwork::get(),
 		key: PARAALICE,
 	});
 


### PR DESCRIPTION
### What does it do?
Appends the relay network identifier in the `networkId` parameter when we convert an AccountId to a MultiLocation. This should guarantee we can send cross-network messages in the future.

For Moonbase I left the `NetworkId::Polkadot` parameter as **Westend will come in V3**, similar to what Statemine does. With xcmv3 we can change this to `NetworkId::Westend`
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
