### PR TITLE
Improve precompile-utils

### DIFF
--- a/precompiles/assets-erc20/src/eip2612.rs
+++ b/precompiles/assets-erc20/src/eip2612.rs
@@ -232,15 +232,14 @@ where
 			asset_id, handle, owner, spender, value,
 		)?;
 
-		let log_builder = LogsBuilder::new(address);
-		log_builder
-			.log3(
-				SELECTOR_LOG_APPROVAL,
-				owner,
-				spender,
-				EvmDataWriter::new().write(value).build(),
-			)
-			.record(handle)?;
+		log3(
+			address,
+			SELECTOR_LOG_APPROVAL,
+			owner,
+			spender,
+			EvmDataWriter::new().write(value).build(),
+		)
+		.record(handle)?;
 
 		Ok(succeed([]))
 	}

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -28,10 +28,7 @@ use frame_support::{
 	sp_runtime::traits::StaticLookup,
 };
 use pallet_evm::{AddressMapping, PrecompileSet};
-use precompile_utils::{
-	keccak256, revert, succeed, Address, Bytes, EvmData, EvmDataWriter, EvmResult,
-	FunctionModifier, LogExt, LogsBuilder, PrecompileHandleExt, RuntimeHelper,
-};
+use precompile_utils::prelude::*;
 use sp_runtime::traits::Bounded;
 use sp_std::vec::Vec;
 
@@ -64,7 +61,7 @@ pub type AssetIdOf<Runtime, Instance = ()> = <Runtime as pallet_assets::Config<I
 pub type IsLocal = ConstBool<true>;
 pub type IsForeign = ConstBool<false>;
 
-#[precompile_utils::generate_function_selector]
+#[generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
 	TotalSupply = "totalSupply()",
@@ -330,14 +327,14 @@ where
 
 		Self::approve_inner(asset_id, handle, handle.context().caller, spender, amount)?;
 
-		LogsBuilder::new(handle.context().address)
-			.log3(
-				SELECTOR_LOG_APPROVAL,
-				handle.context().caller,
-				spender,
-				EvmDataWriter::new().write(amount).build(),
-			)
-			.record(handle)?;
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_APPROVAL,
+			handle.context().caller,
+			spender,
+			EvmDataWriter::new().write(amount).build(),
+		)
+		.record(handle)?;
 
 		// Build output.
 		Ok(succeed(EvmDataWriter::new().write(true).build()))
@@ -414,14 +411,14 @@ where
 			)?;
 		}
 
-		LogsBuilder::new(handle.context().address)
-			.log3(
-				SELECTOR_LOG_TRANSFER,
-				handle.context().caller,
-				to,
-				EvmDataWriter::new().write(amount).build(),
-			)
-			.record(handle)?;
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_TRANSFER,
+			handle.context().caller,
+			to,
+			EvmDataWriter::new().write(amount).build(),
+		)
+		.record(handle)?;
 
 		// Build output.
 		Ok(succeed(EvmDataWriter::new().write(true).build()))
@@ -473,14 +470,14 @@ where
 			}
 		}
 
-		LogsBuilder::new(handle.context().address)
-			.log3(
-				SELECTOR_LOG_TRANSFER,
-				from,
-				to,
-				EvmDataWriter::new().write(amount).build(),
-			)
-			.record(handle)?;
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_TRANSFER,
+			from,
+			to,
+			EvmDataWriter::new().write(amount).build(),
+		)
+		.record(handle)?;
 
 		// Build output.
 		Ok(succeed(EvmDataWriter::new().write(true).build()))
@@ -573,14 +570,14 @@ where
 			)?;
 		}
 
-		LogsBuilder::new(handle.context().address)
-			.log3(
-				SELECTOR_LOG_TRANSFER,
-				H160::default(),
-				to,
-				EvmDataWriter::new().write(amount).build(),
-			)
-			.record(handle)?;
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_TRANSFER,
+			H160::default(),
+			to,
+			EvmDataWriter::new().write(amount).build(),
+		)
+		.record(handle)?;
 
 		// Build output.
 		Ok(succeed(EvmDataWriter::new().write(true).build()))
@@ -620,14 +617,14 @@ where
 			)?;
 		}
 
-		LogsBuilder::new(handle.context().address)
-			.log3(
-				SELECTOR_LOG_TRANSFER,
-				to,
-				H160::default(),
-				EvmDataWriter::new().write(amount).build(),
-			)
-			.record(handle)?;
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_TRANSFER,
+			to,
+			H160::default(),
+			EvmDataWriter::new().write(amount).build(),
+		)
+		.record(handle)?;
 
 		// Build output.
 		Ok(succeed(EvmDataWriter::new().write(true).build()))

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -2318,7 +2318,7 @@ fn transfer_from_overflow() {
 				)
 				.expect_cost(1756u64) // 1 weight => 1 gas in mock
 				.expect_no_logs()
-				.execute_reverts(|e| e == b"value too big for for u128");
+				.execute_reverts(|e| e == b"value too big for u128");
 		});
 }
 

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -21,7 +21,7 @@ use crate::{eip2612::Eip2612, mock::*, *};
 
 use hex_literal::hex;
 use libsecp256k1::{sign, Message, SecretKey};
-use precompile_utils::{testing::*, EvmDataWriter, LogsBuilder};
+use precompile_utils::testing::*;
 use sha3::{Digest, Keccak256};
 use sp_core::H256;
 
@@ -221,14 +221,13 @@ fn approve() {
 						.build(),
 				)
 				.expect_cost(30832756u64)
-				.expect_log(
-					LogsBuilder::new(Account::ForeignAssetId(0u128).into()).log3(
-						SELECTOR_LOG_APPROVAL,
-						Account::Alice,
-						Account::Bob,
-						EvmDataWriter::new().write(U256::from(500)).build(),
-					),
-				)
+				.expect_log(log3(
+					Account::ForeignAssetId(0u128),
+					SELECTOR_LOG_APPROVAL,
+					Account::Alice,
+					Account::Bob,
+					EvmDataWriter::new().write(U256::from(500)).build(),
+				))
 				.execute_returns(EvmDataWriter::new().write(true).build());
 		});
 }
@@ -263,14 +262,13 @@ fn approve_saturating() {
 						.build(),
 				)
 				.expect_cost(30832756u64)
-				.expect_log(
-					LogsBuilder::new(Account::ForeignAssetId(0u128).into()).log3(
-						SELECTOR_LOG_APPROVAL,
-						Account::Alice,
-						Account::Bob,
-						EvmDataWriter::new().write(U256::MAX).build(),
-					),
-				)
+				.expect_log(log3(
+					Account::ForeignAssetId(0u128),
+					SELECTOR_LOG_APPROVAL,
+					Account::Alice,
+					Account::Bob,
+					EvmDataWriter::new().write(U256::MAX).build(),
+				))
 				.execute_returns(EvmDataWriter::new().write(true).build());
 
 			precompiles()
@@ -393,14 +391,13 @@ fn transfer() {
 						.build(),
 				)
 				.expect_cost(44001756u64) // 1 weight => 1 gas in mock
-				.expect_log(
-					LogsBuilder::new(Account::ForeignAssetId(0u128).into()).log3(
-						SELECTOR_LOG_TRANSFER,
-						Account::Alice,
-						Account::Bob,
-						EvmDataWriter::new().write(U256::from(400)).build(),
-					),
-				)
+				.expect_log(log3(
+					Account::ForeignAssetId(0u128),
+					SELECTOR_LOG_TRANSFER,
+					Account::Alice,
+					Account::Bob,
+					EvmDataWriter::new().write(U256::from(400)).build(),
+				))
 				.execute_returns(EvmDataWriter::new().write(true).build());
 
 			precompiles()
@@ -520,14 +517,13 @@ fn transfer_from() {
 						.build(),
 				)
 				.expect_cost(56268756u64) // 1 weight => 1 gas in mock
-				.expect_log(
-					LogsBuilder::new(Account::ForeignAssetId(0u128).into()).log3(
-						SELECTOR_LOG_TRANSFER,
-						Account::Alice,
-						Account::Charlie,
-						EvmDataWriter::new().write(U256::from(400)).build(),
-					),
-				)
+				.expect_log(log3(
+					Account::ForeignAssetId(0u128),
+					SELECTOR_LOG_TRANSFER,
+					Account::Alice,
+					Account::Charlie,
+					EvmDataWriter::new().write(U256::from(400)).build(),
+				))
 				.execute_returns(EvmDataWriter::new().write(true).build());
 
 			precompiles()
@@ -599,14 +595,13 @@ fn transfer_from_non_incremental_approval() {
 						.build(),
 				)
 				.expect_cost(30832756u64)
-				.expect_log(
-					LogsBuilder::new(Account::ForeignAssetId(0u128).into()).log3(
-						SELECTOR_LOG_APPROVAL,
-						Account::Alice,
-						Account::Bob,
-						EvmDataWriter::new().write(U256::from(500)).build(),
-					),
-				)
+				.expect_log(log3(
+					Account::ForeignAssetId(0u128),
+					SELECTOR_LOG_APPROVAL,
+					Account::Alice,
+					Account::Bob,
+					EvmDataWriter::new().write(U256::from(500)).build(),
+				))
 				.execute_returns(EvmDataWriter::new().write(true).build());
 
 			// We then approve 300. Non-incremental, so this is
@@ -623,14 +618,13 @@ fn transfer_from_non_incremental_approval() {
 						.build(),
 				)
 				.expect_cost(62796756u64)
-				.expect_log(
-					LogsBuilder::new(Account::ForeignAssetId(0u128).into()).log3(
-						SELECTOR_LOG_APPROVAL,
-						Account::Alice,
-						Account::Bob,
-						EvmDataWriter::new().write(U256::from(300)).build(),
-					),
-				)
+				.expect_log(log3(
+					Account::ForeignAssetId(0u128),
+					SELECTOR_LOG_APPROVAL,
+					Account::Alice,
+					Account::Bob,
+					EvmDataWriter::new().write(U256::from(300)).build(),
+				))
 				.execute_returns(EvmDataWriter::new().write(true).build());
 
 			// This should fail, as now the new approved quantity is 300
@@ -736,14 +730,13 @@ fn transfer_from_self() {
 						.build(),
 				)
 				.expect_cost(44001756u64) // 1 weight => 1 gas in mock
-				.expect_log(
-					LogsBuilder::new(Account::ForeignAssetId(0u128).into()).log3(
-						SELECTOR_LOG_TRANSFER,
-						Account::Alice,
-						Account::Bob,
-						EvmDataWriter::new().write(U256::from(400)).build(),
-					),
-				)
+				.expect_log(log3(
+					Account::ForeignAssetId(0u128),
+					SELECTOR_LOG_TRANSFER,
+					Account::Alice,
+					Account::Bob,
+					EvmDataWriter::new().write(U256::from(400)).build(),
+				))
 				.execute_returns(EvmDataWriter::new().write(true).build());
 
 			precompiles()
@@ -908,7 +901,8 @@ fn mint_local_assets() {
 						.build(),
 				)
 				.expect_cost(26633756u64) // 1 weight => 1 gas in mock
-				.expect_log(LogsBuilder::new(Account::LocalAssetId(0u128).into()).log3(
+				.expect_log(log3(
+					Account::LocalAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
 					Account::Zero,
 					Account::Bob,
@@ -968,7 +962,8 @@ fn burn_local_assets() {
 						.build(),
 				)
 				.expect_cost(30049756u64) // 1 weight => 1 gas in mock
-				.expect_log(LogsBuilder::new(Account::LocalAssetId(0u128).into()).log3(
+				.expect_log(log3(
+					Account::LocalAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
 					Account::Alice,
 					Account::Zero,
@@ -1110,7 +1105,8 @@ fn thaw_local_assets() {
 						.build(),
 				)
 				.expect_cost(44001756u64) // 1 weight => 1 gas in mock
-				.expect_log(LogsBuilder::new(Account::LocalAssetId(0u128).into()).log3(
+				.expect_log(log3(
+					Account::LocalAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
 					Account::Bob,
 					Account::Alice,
@@ -1234,7 +1230,8 @@ fn thaw_asset_local_assets() {
 						.build(),
 				)
 				.expect_cost(44001756u64) // 1 weight => 1 gas in mock
-				.expect_log(LogsBuilder::new(Account::LocalAssetId(0u128).into()).log3(
+				.expect_log(log3(
+					Account::LocalAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
 					Account::Bob,
 					Account::Alice,
@@ -1371,7 +1368,8 @@ fn set_team_local_assets() {
 						.build(),
 				)
 				.expect_cost(26633756u64) // 1 weight => 1 gas in mock
-				.expect_log(LogsBuilder::new(Account::LocalAssetId(0u128).into()).log3(
+				.expect_log(log3(
+					Account::LocalAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
 					Account::Zero,
 					Account::Bob,
@@ -1609,14 +1607,13 @@ fn permit_valid() {
 						.build(),
 				)
 				.expect_cost(30831000u64)
-				.expect_log(
-					LogsBuilder::new(Account::ForeignAssetId(0u128).into()).log3(
-						SELECTOR_LOG_APPROVAL,
-						Account::Alice,
-						Account::Bob,
-						EvmDataWriter::new().write(U256::from(500)).build(),
-					),
-				)
+				.expect_log(log3(
+					Account::ForeignAssetId(0u128),
+					SELECTOR_LOG_APPROVAL,
+					Account::Alice,
+					Account::Bob,
+					EvmDataWriter::new().write(U256::from(500)).build(),
+				))
 				.execute_returns(vec![]);
 
 			precompiles()
@@ -1719,14 +1716,13 @@ fn permit_valid_named_asset() {
 						.build(),
 				)
 				.expect_cost(30831000u64)
-				.expect_log(
-					LogsBuilder::new(Account::ForeignAssetId(0u128).into()).log3(
-						SELECTOR_LOG_APPROVAL,
-						Account::Alice,
-						Account::Bob,
-						EvmDataWriter::new().write(U256::from(500)).build(),
-					),
-				)
+				.expect_log(log3(
+					Account::ForeignAssetId(0u128),
+					SELECTOR_LOG_APPROVAL,
+					Account::Alice,
+					Account::Bob,
+					EvmDataWriter::new().write(U256::from(500)).build(),
+				))
 				.execute_returns(vec![]);
 
 			precompiles()
@@ -2198,14 +2194,13 @@ fn permit_valid_with_metamask_signed_data() {
 						.build(),
 				)
 				.expect_cost(30831000u64)
-				.expect_log(
-					LogsBuilder::new(Account::ForeignAssetId(1u128).into()).log3(
-						SELECTOR_LOG_APPROVAL,
-						Account::Alice,
-						Account::Bob,
-						EvmDataWriter::new().write(U256::from(1000)).build(),
-					),
-				)
+				.expect_log(log3(
+					Account::ForeignAssetId(1u128),
+					SELECTOR_LOG_APPROVAL,
+					Account::Alice,
+					Account::Bob,
+					EvmDataWriter::new().write(U256::from(1000)).build(),
+				))
 				.execute_returns(vec![]);
 		});
 }

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -2204,3 +2204,200 @@ fn permit_valid_with_metamask_signed_data() {
 				.execute_returns(vec![]);
 		});
 }
+
+#[test]
+fn transfer_amount_overflow() {
+	ExtBuilder::default()
+		.with_balances(vec![(Account::Alice, 1000)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(ForeignAssets::force_create(
+				Origin::root(),
+				0u128,
+				Account::Alice.into(),
+				true,
+				1
+			));
+			assert_ok!(ForeignAssets::mint(
+				Origin::signed(Account::Alice),
+				0u128,
+				Account::Alice.into(),
+				1000
+			));
+
+			precompiles()
+				.prepare_test(
+					Account::Alice,
+					Account::ForeignAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::Transfer)
+						.write(Address(Account::Bob.into()))
+						.write(U256::from(u128::MAX) + 1)
+						.build(),
+				)
+				.expect_cost(1756u64) // 1 weight => 1 gas in mock
+				.expect_no_logs()
+				.execute_reverts(|e| e == b"amount is too large for balance type");
+
+			precompiles()
+				.prepare_test(
+					Account::Bob,
+					Account::ForeignAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::BalanceOf)
+						.write(Address(Account::Bob.into()))
+						.build(),
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns(EvmDataWriter::new().write(U256::from(0)).build());
+
+			precompiles()
+				.prepare_test(
+					Account::Alice,
+					Account::ForeignAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::BalanceOf)
+						.write(Address(Account::Alice.into()))
+						.build(),
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns(EvmDataWriter::new().write(U256::from(1000)).build());
+		});
+}
+
+#[test]
+fn transfer_from_overflow() {
+	ExtBuilder::default()
+		.with_balances(vec![(Account::Alice, 1000)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(ForeignAssets::force_create(
+				Origin::root(),
+				0u128,
+				Account::Alice.into(),
+				true,
+				1
+			));
+			assert_ok!(ForeignAssets::mint(
+				Origin::signed(Account::Alice),
+				0u128,
+				Account::Alice.into(),
+				1000
+			));
+
+			precompiles()
+				.prepare_test(
+					Account::Alice,
+					Account::ForeignAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::Approve)
+						.write(Address(Account::Bob.into()))
+						.write(U256::from(500))
+						.build(),
+				)
+				.execute_some();
+
+			precompiles()
+				.prepare_test(
+					Account::Alice,
+					Account::ForeignAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::Approve)
+						.write(Address(Account::Bob.into()))
+						.write(U256::from(500))
+						.build(),
+				)
+				.execute_some();
+
+			precompiles()
+				.prepare_test(
+					Account::Bob, // Bob is the one sending transferFrom!
+					Account::ForeignAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::TransferFrom)
+						.write(Address(Account::Alice.into()))
+						.write(Address(Account::Charlie.into()))
+						.write(U256::from(u128::MAX) + 1)
+						.build(),
+				)
+				.expect_cost(1756u64) // 1 weight => 1 gas in mock
+				.expect_no_logs()
+				.execute_reverts(|e| e == b"amount is too large for balance type");
+		});
+}
+
+#[test]
+fn mint_overflow() {
+	ExtBuilder::default()
+		.with_balances(vec![(Account::Alice, 1000), (Account::Bob, 2500)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(LocalAssets::force_create(
+				Origin::root(),
+				0u128,
+				Account::Alice.into(),
+				true,
+				1
+			));
+			assert_ok!(LocalAssets::force_set_metadata(
+				Origin::root(),
+				0u128,
+				b"TestToken".to_vec(),
+				b"Test".to_vec(),
+				12,
+				false
+			));
+
+			precompiles()
+				.prepare_test(
+					Account::Alice,
+					Account::LocalAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::Mint)
+						.write(Address(Account::Bob.into()))
+						.write(U256::from(u128::MAX) + 1)
+						.build(),
+				)
+				.expect_cost(1756u64) // 1 weight => 1 gas in mock
+				.expect_no_logs()
+				.execute_reverts(|e| e == b"amount is too large for balance type");
+		});
+}
+
+#[test]
+fn burn_overflow() {
+	ExtBuilder::default()
+		.with_balances(vec![(Account::Alice, 1000), (Account::Bob, 2500)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(LocalAssets::force_create(
+				Origin::root(),
+				0u128,
+				Account::Alice.into(),
+				true,
+				1
+			));
+			assert_ok!(LocalAssets::force_set_metadata(
+				Origin::root(),
+				0u128,
+				b"TestToken".to_vec(),
+				b"Test".to_vec(),
+				12,
+				false
+			));
+			assert_ok!(LocalAssets::mint(
+				Origin::signed(Account::Alice),
+				0u128,
+				Account::Alice.into(),
+				1000
+			));
+
+			precompiles()
+				.prepare_test(
+					Account::Alice,
+					Account::LocalAssetId(0u128),
+					EvmDataWriter::new_with_selector(Action::Burn)
+						.write(Address(Account::Alice.into()))
+						.write(U256::from(u128::MAX) + 1)
+						.build(),
+				)
+				.expect_cost(1756u64) // 1 weight => 1 gas in mock
+				.expect_no_logs()
+				.execute_reverts(|e| e == b"amount is too large for balance type");
+		});
+}

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -2236,7 +2236,7 @@ fn transfer_amount_overflow() {
 				)
 				.expect_cost(1756u64) // 1 weight => 1 gas in mock
 				.expect_no_logs()
-				.execute_reverts(|e| e == b"amount is too large for balance type");
+				.execute_reverts(|e| e == b"value too big for u128");
 
 			precompiles()
 				.prepare_test(
@@ -2318,7 +2318,7 @@ fn transfer_from_overflow() {
 				)
 				.expect_cost(1756u64) // 1 weight => 1 gas in mock
 				.expect_no_logs()
-				.execute_reverts(|e| e == b"amount is too large for balance type");
+				.execute_reverts(|e| e == b"value too big for for u128");
 		});
 }
 
@@ -2355,7 +2355,7 @@ fn mint_overflow() {
 				)
 				.expect_cost(1756u64) // 1 weight => 1 gas in mock
 				.expect_no_logs()
-				.execute_reverts(|e| e == b"amount is too large for balance type");
+				.execute_reverts(|e| e == b"value too big for u128");
 		});
 }
 
@@ -2398,6 +2398,6 @@ fn burn_overflow() {
 				)
 				.expect_cost(1756u64) // 1 weight => 1 gas in mock
 				.expect_no_logs()
-				.execute_reverts(|e| e == b"amount is too large for balance type");
+				.execute_reverts(|e| e == b"value too big for u128");
 		});
 }

--- a/precompiles/author-mapping/src/lib.rs
+++ b/precompiles/author-mapping/src/lib.rs
@@ -23,7 +23,7 @@ use fp_evm::{PrecompileHandle, PrecompileOutput};
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
 use pallet_author_mapping::Call as AuthorMappingCall;
 use pallet_evm::{AddressMapping, Precompile};
-use precompile_utils::{succeed, EvmResult, FunctionModifier, PrecompileHandleExt, RuntimeHelper};
+use precompile_utils::prelude::*;
 use sp_core::crypto::UncheckedFrom;
 use sp_core::H256;
 use sp_std::{fmt::Debug, marker::PhantomData};
@@ -33,7 +33,7 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-#[precompile_utils::generate_function_selector]
+#[generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
 	AddAssociation = "add_association(bytes32)",
@@ -46,7 +46,6 @@ pub enum Action {
 /// A precompile to wrap the functionality from pallet author mapping.
 pub struct AuthorMappingWrapper<Runtime>(PhantomData<Runtime>);
 
-// TODO: Migrate to precompile_utils::Precompile.
 impl<Runtime> Precompile for AuthorMappingWrapper<Runtime>
 where
 	Runtime: pallet_author_mapping::Config + pallet_evm::Config + frame_system::Config,

--- a/precompiles/author-mapping/src/tests.rs
+++ b/precompiles/author-mapping/src/tests.rs
@@ -27,7 +27,7 @@ use nimbus_primitives::NimbusId;
 use pallet_author_mapping::{keys_wrapper, Call as AuthorMappingCall, Event as AuthorMappingEvent};
 use pallet_balances::Event as BalancesEvent;
 use pallet_evm::{Call as EvmCall, Event as EvmEvent};
-use precompile_utils::{testing::*, EvmDataWriter};
+use precompile_utils::{prelude::*, testing::*};
 use sp_core::crypto::UncheckedFrom;
 use sp_core::U256;
 

--- a/precompiles/balances-erc20/src/eip2612.rs
+++ b/precompiles/balances-erc20/src/eip2612.rs
@@ -144,14 +144,14 @@ where
 			ApprovesStorage::<Runtime, Instance>::insert(owner, spender, amount);
 		}
 
-		LogsBuilder::new(handle.context().address)
-			.log3(
-				SELECTOR_LOG_APPROVAL,
-				owner,
-				spender,
-				EvmDataWriter::new().write(value).build(),
-			)
-			.record(handle)?;
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_APPROVAL,
+			owner,
+			spender,
+			EvmDataWriter::new().write(value).build(),
+		)
+		.record(handle)?;
 
 		Ok(succeed([]))
 	}

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -32,10 +32,7 @@ use pallet_balances::pallet::{
 	Instance2, Instance3, Instance4, Instance5, Instance6, Instance7, Instance8, Instance9,
 };
 use pallet_evm::AddressMapping;
-use precompile_utils::{
-	keccak256, revert, succeed, Address, Bytes, EvmDataReader, EvmDataWriter, EvmResult,
-	FunctionModifier, LogExt, LogsBuilder, PrecompileHandleExt, RuntimeHelper,
-};
+use precompile_utils::prelude::*;
 use sp_core::{H160, U256};
 use sp_std::{
 	convert::{TryFrom, TryInto},
@@ -157,7 +154,7 @@ pub type NoncesStorage<Instance> = StorageMap<
 	ValueQuery,
 >;
 
-#[precompile_utils::generate_function_selector]
+#[generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
 	TotalSupply = "totalSupply()",
@@ -339,14 +336,14 @@ where
 			ApprovesStorage::<Runtime, Instance>::insert(caller, spender, amount);
 		}
 
-		LogsBuilder::new(handle.context().address)
-			.log3(
-				SELECTOR_LOG_APPROVAL,
-				handle.context().caller,
-				spender,
-				EvmDataWriter::new().write(amount).build(),
-			)
-			.record(handle)?;
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_APPROVAL,
+			handle.context().caller,
+			spender,
+			EvmDataWriter::new().write(amount).build(),
+		)
+		.record(handle)?;
 
 		// Build output.
 		Ok(succeed(EvmDataWriter::new().write(true).build()))
@@ -379,14 +376,14 @@ where
 			)?;
 		}
 
-		LogsBuilder::new(handle.context().address)
-			.log3(
-				SELECTOR_LOG_TRANSFER,
-				handle.context().caller,
-				to,
-				EvmDataWriter::new().write(amount).build(),
-			)
-			.record(handle)?;
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_TRANSFER,
+			handle.context().caller,
+			to,
+			EvmDataWriter::new().write(amount).build(),
+		)
+		.record(handle)?;
 
 		// Build output.
 		Ok(succeed(EvmDataWriter::new().write(true).build()))
@@ -441,14 +438,14 @@ where
 			)?;
 		}
 
-		LogsBuilder::new(handle.context().address)
-			.log3(
-				SELECTOR_LOG_TRANSFER,
-				from,
-				to,
-				EvmDataWriter::new().write(amount).build(),
-			)
-			.record(handle)?;
+		log3(
+			handle.context().address,
+			SELECTOR_LOG_TRANSFER,
+			from,
+			to,
+			EvmDataWriter::new().write(amount).build(),
+		)
+		.record(handle)?;
 
 		// Build output.
 		Ok(succeed(EvmDataWriter::new().write(true).build()))
@@ -506,15 +503,15 @@ where
 			},
 		)?;
 
-		LogsBuilder::new(handle.context().address)
-			.log2(
-				SELECTOR_LOG_DEPOSIT,
-				handle.context().caller,
-				EvmDataWriter::new()
-					.write(handle.context().apparent_value)
-					.build(),
-			)
-			.record(handle)?;
+		log2(
+			handle.context().address,
+			SELECTOR_LOG_DEPOSIT,
+			handle.context().caller,
+			EvmDataWriter::new()
+				.write(handle.context().apparent_value)
+				.build(),
+		)
+		.record(handle)?;
 
 		Ok(succeed([]))
 	}
@@ -540,13 +537,13 @@ where
 			return Err(revert("trying to withdraw more than owned"));
 		}
 
-		LogsBuilder::new(handle.context().address)
-			.log2(
-				SELECTOR_LOG_WITHDRAWAL,
-				handle.context().caller,
-				EvmDataWriter::new().write(withdrawn_amount).build(),
-			)
-			.record(handle)?;
+		log2(
+			handle.context().address,
+			SELECTOR_LOG_WITHDRAWAL,
+			handle.context().caller,
+			EvmDataWriter::new().write(withdrawn_amount).build(),
+		)
+		.record(handle)?;
 
 		Ok(succeed([]))
 	}

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -16,10 +16,14 @@
 
 use std::str::from_utf8;
 
-use crate::{eip2612::Eip2612, mock::*, *};
+use crate::{
+	eip2612::Eip2612,
+	mock::{Account::*, *},
+	*,
+};
 
 use libsecp256k1::{sign, Message, SecretKey};
-use precompile_utils::{testing::*, Bytes, EvmDataWriter, LogsBuilder};
+use precompile_utils::testing::*;
 use sha3::{Digest, Keccak256};
 use sp_core::{H256, U256};
 
@@ -139,7 +143,8 @@ fn approve() {
 						.build(),
 				)
 				.expect_cost(1756)
-				.expect_log(LogsBuilder::new(Account::Precompile.into()).log3(
+				.expect_log(log3(
+					Precompile,
 					SELECTOR_LOG_APPROVAL,
 					Account::Alice,
 					Account::Bob,
@@ -165,7 +170,8 @@ fn approve_saturating() {
 						.build(),
 				)
 				.expect_cost(1756u64)
-				.expect_log(LogsBuilder::new(Account::Precompile.into()).log3(
+				.expect_log(log3(
+					Precompile,
 					SELECTOR_LOG_APPROVAL,
 					Account::Alice,
 					Account::Bob,
@@ -257,7 +263,8 @@ fn transfer() {
 						.build(),
 				)
 				.expect_cost(159201756u64) // 1 weight => 1 gas in mock
-				.expect_log(LogsBuilder::new(Account::Precompile.into()).log3(
+				.expect_log(log3(
+					Precompile,
 					SELECTOR_LOG_TRANSFER,
 					Account::Alice,
 					Account::Bob,
@@ -343,7 +350,8 @@ fn transfer_from() {
 						.build(),
 				)
 				.expect_cost(159201756u64) // 1 weight => 1 gas in mock
-				.expect_log(LogsBuilder::new(Account::Precompile.into()).log3(
+				.expect_log(log3(
+					Precompile,
 					SELECTOR_LOG_TRANSFER,
 					Account::Alice,
 					Account::Bob,
@@ -438,7 +446,8 @@ fn transfer_from_self() {
 						.build(),
 				)
 				.expect_cost(159201756u64) // 1 weight => 1 gas in mock
-				.expect_log(LogsBuilder::new(Account::Precompile.into()).log3(
+				.expect_log(log3(
+					Precompile,
 					SELECTOR_LOG_TRANSFER,
 					Account::Alice,
 					Account::Bob,
@@ -588,13 +597,12 @@ fn deposit(data: Vec<u8>) {
 						amount: 500
 					}),
 					// Log is correctly emited.
-					Event::Evm(pallet_evm::Event::Log(
-						LogsBuilder::new(Account::Precompile.into()).log2(
-							SELECTOR_LOG_DEPOSIT,
-							Account::Alice,
-							EvmDataWriter::new().write(U256::from(500)).build(),
-						)
-					)),
+					Event::Evm(pallet_evm::Event::Log(log2(
+						Precompile,
+						SELECTOR_LOG_DEPOSIT,
+						Account::Alice,
+						EvmDataWriter::new().write(U256::from(500)).build(),
+					))),
 					Event::Evm(pallet_evm::Event::Executed(Account::Precompile.into())),
 				]
 			);
@@ -742,7 +750,8 @@ fn withdraw() {
 						.build(),
 				)
 				.expect_cost(1381)
-				.expect_log(LogsBuilder::new(Account::Precompile.into()).log2(
+				.expect_log(log2(
+					Precompile,
 					SELECTOR_LOG_WITHDRAWAL,
 					Account::Alice,
 					EvmDataWriter::new().write(U256::from(500)).build(),
@@ -860,7 +869,8 @@ fn permit_valid() {
 						.build(),
 				)
 				.expect_cost(0) // TODO: Test db read/write costs
-				.expect_log(LogsBuilder::new(Account::Precompile.into()).log3(
+				.expect_log(log3(
+					Precompile,
 					SELECTOR_LOG_APPROVAL,
 					Account::Alice,
 					Account::Bob,
@@ -1278,7 +1288,8 @@ fn permit_valid_with_metamask_signed_data() {
 						.build(),
 				)
 				.expect_cost(0) // TODO: Test db read/write costs
-				.expect_log(LogsBuilder::new(Account::Precompile.into()).log3(
+				.expect_log(log3(
+					Precompile,
 					SELECTOR_LOG_APPROVAL,
 					Account::Alice,
 					Account::Bob,

--- a/precompiles/batch/src/lib.rs
+++ b/precompiles/batch/src/lib.rs
@@ -22,10 +22,7 @@ use evm::{ExitError, ExitReason};
 use fp_evm::{
 	Context, Log, Precompile, PrecompileFailure, PrecompileHandle, PrecompileOutput, Transfer,
 };
-use precompile_utils::{
-	call_cost, keccak256, revert, succeed, Address, Bytes, EvmDataWriter, EvmResult,
-	FunctionModifier, LogExt, LogsBuilder, PrecompileHandleExt,
-};
+use precompile_utils::{costs::call_cost, prelude::*};
 use sp_core::{H160, U256};
 use sp_std::{iter::repeat, marker::PhantomData, vec, vec::Vec};
 
@@ -34,7 +31,7 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-#[precompile_utils::generate_function_selector]
+#[generate_function_selector]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Action {
 	BatchSome = "batchSome(address[],uint256[],bytes[],uint64[])",
@@ -46,14 +43,16 @@ pub const LOG_SUBCALL_SUCCEEDED: [u8; 32] = keccak256!("SubcallSucceeded(uint256
 pub const LOG_SUBCALL_FAILED: [u8; 32] = keccak256!("SubcallFailed(uint256)");
 
 pub fn log_subcall_succeeded(address: impl Into<H160>, index: usize) -> Log {
-	LogsBuilder::new(address.into()).log1(
+	log1(
+		address,
 		LOG_SUBCALL_SUCCEEDED,
 		EvmDataWriter::new().write(U256::from(index)).build(),
 	)
 }
 
 pub fn log_subcall_failed(address: impl Into<H160>, index: usize) -> Log {
-	LogsBuilder::new(address.into()).log1(
+	log1(
+		address,
 		LOG_SUBCALL_FAILED,
 		EvmDataWriter::new().write(U256::from(index)).build(),
 	)

--- a/precompiles/batch/src/tests.rs
+++ b/precompiles/batch/src/tests.rs
@@ -26,7 +26,7 @@ use evm::ExitReason;
 use fp_evm::{ExitError, ExitRevert, ExitSucceed};
 use frame_support::{assert_ok, dispatch::Dispatchable};
 use pallet_evm::Call as EvmCall;
-use precompile_utils::{call_cost, testing::*, Address, Bytes, EvmDataWriter, LogExt, LogsBuilder};
+use precompile_utils::{costs::call_cost, prelude::*, testing::*};
 use sp_core::{H160, H256, U256};
 
 fn precompiles() -> TestPrecompiles<Runtime> {
@@ -187,9 +187,7 @@ fn batch_returns(
 						reason: ExitReason::Succeed(ExitSucceed::Returned),
 						output: Vec::new(),
 						cost: 13,
-						logs: vec![
-							LogsBuilder::new(Bob.into()).log1(H256::repeat_byte(0x11), vec![])
-						],
+						logs: vec![log1(Bob, H256::repeat_byte(0x11), vec![])],
 					}
 				}
 				a if a == Charlie.into() => {
@@ -215,9 +213,7 @@ fn batch_returns(
 						reason: ExitReason::Succeed(ExitSucceed::Returned),
 						output: Vec::new(),
 						cost: 17,
-						logs: vec![
-							LogsBuilder::new(Charlie.into()).log1(H256::repeat_byte(0x22), vec![])
-						],
+						logs: vec![log1(Charlie, H256::repeat_byte(0x22), vec![])],
 					}
 				}
 				_ => panic!("unexpected subcall"),
@@ -230,9 +226,9 @@ fn batch_returns(
 fn batch_some_returns() {
 	ExtBuilder::default().build().execute_with(|| {
 		batch_returns(&precompiles(), Action::BatchSome)
-			.expect_log(LogsBuilder::new(Bob.into()).log1(H256::repeat_byte(0x11), vec![]))
+			.expect_log(log1(Bob, H256::repeat_byte(0x11), vec![]))
 			.expect_log(log_subcall_succeeded(Precompile, 0))
-			.expect_log(LogsBuilder::new(Charlie.into()).log1(H256::repeat_byte(0x22), vec![]))
+			.expect_log(log1(Charlie, H256::repeat_byte(0x22), vec![]))
 			.expect_log(log_subcall_succeeded(Precompile, 1))
 			.execute_returns(Vec::new())
 	})
@@ -242,9 +238,9 @@ fn batch_some_returns() {
 fn batch_some_until_failure_returns() {
 	ExtBuilder::default().build().execute_with(|| {
 		batch_returns(&precompiles(), Action::BatchSomeUntilFailure)
-			.expect_log(LogsBuilder::new(Bob.into()).log1(H256::repeat_byte(0x11), vec![]))
+			.expect_log(log1(Bob, H256::repeat_byte(0x11), vec![]))
 			.expect_log(log_subcall_succeeded(Precompile, 0))
-			.expect_log(LogsBuilder::new(Charlie.into()).log1(H256::repeat_byte(0x22), vec![]))
+			.expect_log(log1(Charlie, H256::repeat_byte(0x22), vec![]))
 			.expect_log(log_subcall_succeeded(Precompile, 1))
 			.execute_returns(Vec::new())
 	})
@@ -254,9 +250,9 @@ fn batch_some_until_failure_returns() {
 fn batch_all_returns() {
 	ExtBuilder::default().build().execute_with(|| {
 		batch_returns(&precompiles(), Action::BatchAll)
-			.expect_log(LogsBuilder::new(Bob.into()).log1(H256::repeat_byte(0x11), vec![]))
+			.expect_log(log1(Bob, H256::repeat_byte(0x11), vec![]))
 			.expect_log(log_subcall_succeeded(Precompile, 0))
-			.expect_log(LogsBuilder::new(Charlie.into()).log1(H256::repeat_byte(0x22), vec![]))
+			.expect_log(log1(Charlie, H256::repeat_byte(0x22), vec![]))
 			.expect_log(log_subcall_succeeded(Precompile, 1))
 			.execute_returns(Vec::new())
 	})
@@ -410,9 +406,7 @@ fn batch_incomplete(
 						reason: ExitReason::Succeed(ExitSucceed::Returned),
 						output: Vec::new(),
 						cost: 13,
-						logs: vec![
-							LogsBuilder::new(Bob.into()).log1(H256::repeat_byte(0x11), vec![])
-						],
+						logs: vec![log1(Bob, H256::repeat_byte(0x11), vec![])],
 					}
 				}
 				a if a == Charlie.into() => {
@@ -464,9 +458,7 @@ fn batch_incomplete(
 						reason: ExitReason::Succeed(ExitSucceed::Returned),
 						output: Vec::new(),
 						cost: 19,
-						logs: vec![
-							LogsBuilder::new(Alice.into()).log1(H256::repeat_byte(0x33), vec![])
-						],
+						logs: vec![log1(Alice, H256::repeat_byte(0x33), vec![])],
 					}
 				}
 				_ => panic!("unexpected subcall"),
@@ -480,10 +472,10 @@ fn batch_some_incomplete() {
 		let (_, total_call_cost) = costs();
 
 		batch_incomplete(&precompiles(), Action::BatchSome)
-			.expect_log(LogsBuilder::new(Bob.into()).log1(H256::repeat_byte(0x11), vec![]))
+			.expect_log(log1(Bob, H256::repeat_byte(0x11), vec![]))
 			.expect_log(log_subcall_succeeded(Precompile, 0))
 			.expect_log(log_subcall_failed(Precompile, 1))
-			.expect_log(LogsBuilder::new(Alice.into()).log1(H256::repeat_byte(0x33), vec![]))
+			.expect_log(log1(Alice, H256::repeat_byte(0x33), vec![]))
 			.expect_log(log_subcall_succeeded(Precompile, 2))
 			.expect_cost(13 + 17 + 19 + total_call_cost * 3)
 			.execute_returns(Vec::new())
@@ -496,7 +488,7 @@ fn batch_some_until_failure_incomplete() {
 		let (_, total_call_cost) = costs();
 
 		batch_incomplete(&precompiles(), Action::BatchSomeUntilFailure)
-			.expect_log(LogsBuilder::new(Bob.into()).log1(H256::repeat_byte(0x11), vec![]))
+			.expect_log(log1(Bob, H256::repeat_byte(0x11), vec![]))
 			.expect_log(log_subcall_succeeded(Precompile, 0))
 			.expect_log(log_subcall_failed(Precompile, 1))
 			.expect_cost(13 + 17 + total_call_cost * 2)

--- a/precompiles/crowdloan-rewards/src/lib.rs
+++ b/precompiles/crowdloan-rewards/src/lib.rs
@@ -25,10 +25,7 @@ use frame_support::{
 	traits::Currency,
 };
 use pallet_evm::AddressMapping;
-use precompile_utils::{
-	revert, succeed, Address, EvmDataWriter, EvmResult, FunctionModifier, PrecompileHandleExt,
-	RuntimeHelper,
-};
+use precompile_utils::prelude::*;
 
 use sp_core::{H160, U256};
 use sp_std::{
@@ -47,7 +44,7 @@ pub type BalanceOf<Runtime> =
 		<Runtime as frame_system::Config>::AccountId,
 	>>::Balance;
 
-#[precompile_utils::generate_function_selector]
+#[generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
 	IsContributor = "is_contributor(address)",

--- a/precompiles/crowdloan-rewards/src/tests.rs
+++ b/precompiles/crowdloan-rewards/src/tests.rs
@@ -23,7 +23,7 @@ use crate::Action;
 use frame_support::{assert_ok, dispatch::Dispatchable};
 use pallet_crowdloan_rewards::{Call as CrowdloanCall, Event as CrowdloanEvent};
 use pallet_evm::Call as EvmCall;
-use precompile_utils::{testing::*, Address, EvmDataWriter};
+use precompile_utils::{prelude::*, testing::*};
 use sha3::{Digest, Keccak256};
 use sp_core::{H160, U256};
 

--- a/precompiles/pallet-democracy/src/lib.rs
+++ b/precompiles/pallet-democracy/src/lib.rs
@@ -24,10 +24,7 @@ use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
 use frame_support::traits::Currency;
 use pallet_democracy::{AccountVote, Call as DemocracyCall, Vote};
 use pallet_evm::{AddressMapping, Precompile};
-use precompile_utils::{
-	revert, succeed, Address, Bytes, EvmData, EvmDataWriter, EvmResult, FunctionModifier,
-	PrecompileHandleExt, RuntimeHelper,
-};
+use precompile_utils::prelude::*;
 use sp_core::{H160, H256, U256};
 use sp_std::{
 	convert::{TryFrom, TryInto},
@@ -47,7 +44,7 @@ type BalanceOf<Runtime> = <<Runtime as pallet_democracy::Config>::Currency as Cu
 
 type DemocracyOf<Runtime> = pallet_democracy::Pallet<Runtime>;
 
-#[precompile_utils::generate_function_selector]
+#[generate_function_selector]
 #[derive(Debug, PartialEq)]
 enum Action {
 	PublicPropCount = "public_prop_count()",

--- a/precompiles/pallet-democracy/src/tests.rs
+++ b/precompiles/pallet-democracy/src/tests.rs
@@ -29,7 +29,7 @@ use pallet_democracy::{
 	PreimageStatus, Vote, VoteThreshold, Voting,
 };
 use pallet_evm::{Call as EvmCall, Event as EvmEvent};
-use precompile_utils::{testing::*, Address, Bytes, EvmDataWriter};
+use precompile_utils::{prelude::*, testing::*};
 use sp_core::{H160, U256};
 use std::{convert::TryInto, str::from_utf8};
 

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -28,10 +28,7 @@ use fp_evm::{PrecompileHandle, PrecompileOutput};
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
 use frame_support::traits::{Currency, Get};
 use pallet_evm::AddressMapping;
-use precompile_utils::{
-	revert, succeed, Address, EvmData, EvmDataReader, EvmDataWriter, EvmResult, FunctionModifier,
-	PrecompileHandleExt, RuntimeHelper,
-};
+use precompile_utils::prelude::*;
 use sp_core::H160;
 use sp_std::{convert::TryInto, fmt::Debug, marker::PhantomData, vec::Vec};
 
@@ -39,7 +36,7 @@ type BalanceOf<Runtime> = <<Runtime as pallet_parachain_staking::Config>::Curren
 	<Runtime as frame_system::Config>::AccountId,
 >>::Balance;
 
-#[precompile_utils::generate_function_selector]
+#[generate_function_selector]
 #[derive(Debug, PartialEq)]
 enum Action {
 	// DEPRECATED

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -23,7 +23,7 @@ use crate::Action;
 use frame_support::{assert_ok, dispatch::Dispatchable};
 use pallet_evm::Call as EvmCall;
 use pallet_parachain_staking::Event as StakingEvent;
-use precompile_utils::{testing::*, Address, EvmDataWriter};
+use precompile_utils::{prelude::*, testing::*};
 use sp_core::U256;
 
 fn precompiles() -> TestPrecompiles<Runtime> {

--- a/precompiles/relay-encoder/src/lib.rs
+++ b/precompiles/relay-encoder/src/lib.rs
@@ -26,10 +26,7 @@ use frame_support::{
 	ensure,
 };
 use pallet_staking::RewardDestination;
-use precompile_utils::{
-	revert, succeed, Bytes, EvmData, EvmDataReader, EvmDataWriter, EvmResult, FunctionModifier,
-	PrecompileHandleExt, RuntimeHelper,
-};
+use precompile_utils::prelude::*;
 use sp_core::{H256, U256};
 use sp_runtime::AccountId32;
 use sp_runtime::Perbill;
@@ -64,7 +61,7 @@ pub trait StakeEncodeCall {
 	fn encode_call(call: AvailableStakeCalls) -> Vec<u8>;
 }
 
-#[precompile_utils::generate_function_selector]
+#[generate_function_selector]
 #[derive(Debug, PartialEq)]
 enum Action {
 	EncodeBond = "encode_bond(uint256,uint256,bytes)",

--- a/precompiles/relay-encoder/src/tests.rs
+++ b/precompiles/relay-encoder/src/tests.rs
@@ -23,7 +23,7 @@ use crate::StakeEncodeCall;
 use crate::*;
 use pallet_staking::RewardDestination;
 use pallet_staking::ValidatorPrefs;
-use precompile_utils::{testing::*, Bytes, EvmDataWriter};
+use precompile_utils::testing::*;
 use sp_core::{H256, U256};
 use sp_runtime::Perbill;
 

--- a/precompiles/utils/src/costs.rs
+++ b/precompiles/utils/src/costs.rs
@@ -1,0 +1,117 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Cost calculations.
+//! TODO: PR EVM to make those cost calculations public.
+
+use {
+	crate::EvmResult,
+	fp_evm::{ExitError, PrecompileFailure},
+	sp_core::U256,
+};
+
+pub fn log_costs(topics: usize, data_len: usize) -> EvmResult<u64> {
+	// Cost calculation is copied from EVM code that is not publicly exposed by the crates.
+	// https://github.com/rust-blockchain/evm/blob/master/gasometer/src/costs.rs#L148
+
+	const G_LOG: u64 = 375;
+	const G_LOGDATA: u64 = 8;
+	const G_LOGTOPIC: u64 = 375;
+
+	let topic_cost = G_LOGTOPIC
+		.checked_mul(topics as u64)
+		.ok_or(PrecompileFailure::Error {
+			exit_status: ExitError::OutOfGas,
+		})?;
+
+	let data_cost = G_LOGDATA
+		.checked_mul(data_len as u64)
+		.ok_or(PrecompileFailure::Error {
+			exit_status: ExitError::OutOfGas,
+		})?;
+
+	G_LOG
+		.checked_add(topic_cost)
+		.ok_or(PrecompileFailure::Error {
+			exit_status: ExitError::OutOfGas,
+		})?
+		.checked_add(data_cost)
+		.ok_or(PrecompileFailure::Error {
+			exit_status: ExitError::OutOfGas,
+		})
+}
+
+// Compute the cost of doing a subcall.
+// Some parameters cannot be known in advance, so we estimate the worst possible cost.
+pub fn call_cost(value: U256, config: &evm::Config) -> u64 {
+	// Copied from EVM code since not public.
+	pub const G_CALLVALUE: u64 = 9000;
+	pub const G_NEWACCOUNT: u64 = 25000;
+
+	fn address_access_cost(is_cold: bool, regular_value: u64, config: &evm::Config) -> u64 {
+		if config.increase_state_access_gas {
+			if is_cold {
+				config.gas_account_access_cold
+			} else {
+				config.gas_storage_read_warm
+			}
+		} else {
+			regular_value
+		}
+	}
+
+	fn xfer_cost(is_call_or_callcode: bool, transfers_value: bool) -> u64 {
+		if is_call_or_callcode && transfers_value {
+			G_CALLVALUE
+		} else {
+			0
+		}
+	}
+
+	fn new_cost(
+		is_call_or_staticcall: bool,
+		new_account: bool,
+		transfers_value: bool,
+		config: &evm::Config,
+	) -> u64 {
+		let eip161 = !config.empty_considered_exists;
+		if is_call_or_staticcall {
+			if eip161 {
+				if transfers_value && new_account {
+					G_NEWACCOUNT
+				} else {
+					0
+				}
+			} else if new_account {
+				G_NEWACCOUNT
+			} else {
+				0
+			}
+		} else {
+			0
+		}
+	}
+
+	let transfers_value = value != U256::default();
+	let is_cold = true;
+	let is_call_or_callcode = true;
+	let is_call_or_staticcall = true;
+	let new_account = true;
+
+	address_access_cost(is_cold, config.gas_call, config)
+		+ xfer_cost(is_call_or_callcode, transfers_value)
+		+ new_cost(is_call_or_staticcall, new_account, transfers_value, config)
+}

--- a/precompiles/utils/src/data.rs
+++ b/precompiles/utils/src/data.rs
@@ -419,24 +419,18 @@ macro_rules! impl_evmdata_for_uints {
 		$(
 			impl EvmData for $uint {
 				fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
-					let range = reader.move_cursor(32)?;
+					let value256: U256 = reader.read()?;
 
-					let data = reader
-						.input
-						.get(range)
-						.ok_or_else(|| revert(alloc::format!(
-							"tried to parse {} out of bounds", core::any::type_name::<Self>()
-						)))?;
-
-					let mut buffer = [0u8; core::mem::size_of::<Self>()];
-					buffer.copy_from_slice(&data[32 - core::mem::size_of::<Self>()..]);
-					Ok(Self::from_be_bytes(buffer))
+					value256
+						.try_into()
+						.map_err(|_| revert(alloc::format!(
+							"value too big for {}",
+							core::any::type_name::<Self>()
+						)))
 				}
 
 				fn write(writer: &mut EvmDataWriter, value: Self) {
-					let mut buffer = [0u8; 32];
-					buffer[32 - core::mem::size_of::<Self>()..].copy_from_slice(&value.to_be_bytes());
-					writer.data.extend_from_slice(&buffer);
+					U256::write(writer, value.into());
 				}
 
 				fn has_static_size() -> bool {
@@ -447,32 +441,32 @@ macro_rules! impl_evmdata_for_uints {
 	};
 }
 
-impl_evmdata_for_uints!(u16, u32, u64, u128,);
+impl_evmdata_for_uints!(u8, u16, u32, u64, u128,);
 
-// The implementation for u8 is specific, for performance reasons.
-impl EvmData for u8 {
-	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
-		let range = reader.move_cursor(32)?;
+// // The implementation for u8 is specific, for performance reasons.
+// impl EvmData for u8 {
+// 	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
+// 		let range = reader.move_cursor(32)?;
 
-		let data = reader
-			.input
-			.get(range)
-			.ok_or_else(|| revert("tried to parse u64 out of bounds"))?;
+// 		let data = reader
+// 			.input
+// 			.get(range)
+// 			.ok_or_else(|| revert("tried to parse u64 out of bounds"))?;
 
-		Ok(data[31])
-	}
+// 		Ok(data[31])
+// 	}
 
-	fn write(writer: &mut EvmDataWriter, value: Self) {
-		let mut buffer = [0u8; 32];
-		buffer[31] = value;
+// 	fn write(writer: &mut EvmDataWriter, value: Self) {
+// 		let mut buffer = [0u8; 32];
+// 		buffer[31] = value;
 
-		writer.data.extend_from_slice(&buffer);
-	}
+// 		writer.data.extend_from_slice(&buffer);
+// 	}
 
-	fn has_static_size() -> bool {
-		true
-	}
-}
+// 	fn has_static_size() -> bool {
+// 		true
+// 	}
+// }
 
 impl EvmData for bool {
 	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {

--- a/precompiles/utils/src/data/mod.rs
+++ b/precompiles/utils/src/data/mod.rs
@@ -14,15 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{revert, EvmResult};
-
-use alloc::borrow::ToOwned;
-use core::{any::type_name, ops::Range};
-use impl_trait_for_tuples::impl_for_tuples;
-use sp_core::{H160, H256, U256};
-use sp_std::{convert::TryInto, vec, vec::Vec};
-
 pub mod xcm;
+
+use {
+	crate::{revert, EvmResult},
+	alloc::borrow::ToOwned,
+	core::{any::type_name, ops::Range},
+	impl_trait_for_tuples::impl_for_tuples,
+	sp_core::{H160, H256, U256},
+	sp_std::{convert::TryInto, vec, vec::Vec},
+};
 
 /// The `address` type of Solidity.
 /// H160 could represent 2 types of data (bytes20 and address) that are not encoded the same way.
@@ -442,31 +443,6 @@ macro_rules! impl_evmdata_for_uints {
 }
 
 impl_evmdata_for_uints!(u8, u16, u32, u64, u128,);
-
-// // The implementation for u8 is specific, for performance reasons.
-// impl EvmData for u8 {
-// 	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
-// 		let range = reader.move_cursor(32)?;
-
-// 		let data = reader
-// 			.input
-// 			.get(range)
-// 			.ok_or_else(|| revert("tried to parse u64 out of bounds"))?;
-
-// 		Ok(data[31])
-// 	}
-
-// 	fn write(writer: &mut EvmDataWriter, value: Self) {
-// 		let mut buffer = [0u8; 32];
-// 		buffer[31] = value;
-
-// 		writer.data.extend_from_slice(&buffer);
-// 	}
-
-// 	fn has_static_size() -> bool {
-// 		true
-// 	}
-// }
 
 impl EvmData for bool {
 	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {

--- a/precompiles/utils/src/data/xcm.rs
+++ b/precompiles/utils/src/data/xcm.rs
@@ -16,12 +16,15 @@
 
 //! Encoding of XCM types for solidity
 
-use crate::{revert, Bytes, EvmData, EvmDataReader, EvmDataWriter, EvmResult};
-
-use frame_support::ensure;
-use sp_std::vec::Vec;
-use xcm::latest::{Junction, Junctions, MultiLocation, NetworkId};
-
+use {
+	crate::{
+		data::{Bytes, EvmData, EvmDataReader, EvmDataWriter},
+		revert, EvmResult,
+	},
+	frame_support::ensure,
+	sp_std::vec::Vec,
+	xcm::latest::{Junction, Junctions, MultiLocation, NetworkId},
+};
 // Function to convert network id to bytes
 // We don't implement EVMData here as these bytes will be appended only
 // to certain Junction variants

--- a/precompiles/utils/src/handle.rs
+++ b/precompiles/utils/src/handle.rs
@@ -1,0 +1,89 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use {
+	crate::{data::EvmDataReader, modifier::FunctionModifier, EvmResult},
+	fp_evm::{Log, PrecompileHandle},
+};
+
+pub trait PrecompileHandleExt: PrecompileHandle {
+	/// Record cost of a log manually.
+	/// This can be useful to record log costs early when their content have static size.
+	#[must_use]
+	fn record_log_costs_manual(&mut self, topics: usize, data_len: usize) -> EvmResult;
+
+	/// Record cost of logs.
+	#[must_use]
+	fn record_log_costs(&mut self, logs: &[&Log]) -> EvmResult;
+
+	#[must_use]
+	/// Check that a function call is compatible with the context it is
+	/// called into.
+	fn check_function_modifier(&self, modifier: FunctionModifier) -> EvmResult;
+
+	#[must_use]
+	/// Read the selector from the input data.
+	fn read_selector<T>(&self) -> EvmResult<T>
+	where
+		T: num_enum::TryFromPrimitive<Primitive = u32>;
+
+	#[must_use]
+	/// Returns a reader of the input, skipping the selector.
+	fn read_input(&self) -> EvmResult<EvmDataReader>;
+}
+
+impl<T: PrecompileHandle> PrecompileHandleExt for T {
+	/// Record cost of a log manualy.
+	/// This can be useful to record log costs early when their content have static size.
+	#[must_use]
+	fn record_log_costs_manual(&mut self, topics: usize, data_len: usize) -> EvmResult {
+		self.record_cost(crate::costs::log_costs(topics, data_len)?)?;
+
+		Ok(())
+	}
+
+	/// Record cost of logs.
+	#[must_use]
+	fn record_log_costs(&mut self, logs: &[&Log]) -> EvmResult {
+		for log in logs {
+			self.record_log_costs_manual(log.topics.len(), log.data.len())?;
+		}
+
+		Ok(())
+	}
+
+	#[must_use]
+	/// Check that a function call is compatible with the context it is
+	/// called into.
+	fn check_function_modifier(&self, modifier: FunctionModifier) -> EvmResult {
+		crate::modifier::check_function_modifier(self.context(), self.is_static(), modifier)
+	}
+
+	#[must_use]
+	/// Read the selector from the input data.
+	fn read_selector<S>(&self) -> EvmResult<S>
+	where
+		S: num_enum::TryFromPrimitive<Primitive = u32>,
+	{
+		EvmDataReader::read_selector(self.input())
+	}
+
+	#[must_use]
+	/// Returns a reader of the input, skipping the selector.
+	fn read_input(&self) -> EvmResult<EvmDataReader> {
+		EvmDataReader::new_skip_selector(self.input())
+	}
+}

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -19,26 +19,12 @@
 
 extern crate alloc;
 
-use crate::alloc::borrow::ToOwned;
-use fp_evm::{
-	Context, ExitError, ExitRevert, ExitSucceed, PrecompileFailure, PrecompileHandle,
-	PrecompileOutput,
-};
-use frame_support::{
-	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
-	traits::Get,
-};
-use pallet_evm::{GasWeightMapping, Log};
-use sp_core::{H160, H256, U256};
-use sp_std::{marker::PhantomData, vec, vec::Vec};
-
-mod data;
-
-pub use data::{Address, Bytes, EvmData, EvmDataReader, EvmDataWriter};
-pub use fp_evm::Precompile;
-pub use precompile_utils_macro::{generate_function_selector, keccak256};
-
+pub mod costs;
+pub mod handle;
+pub mod logs;
+pub mod modifier;
 pub mod precompile_set;
+pub mod substrate;
 
 #[cfg(feature = "testing")]
 pub mod testing;
@@ -46,373 +32,25 @@ pub mod testing;
 #[cfg(test)]
 mod tests;
 
-/// Alias for Result returning an EVM precompile error.
-pub type EvmResult<T = ()> = Result<T, PrecompileFailure>;
+use crate::alloc::borrow::ToOwned;
+use fp_evm::{
+	ExitError, ExitRevert, ExitSucceed, PrecompileFailure, PrecompileHandle, PrecompileOutput,
+};
 
-/// Trait similar to `fp_evm::Precompile` but with a `&self` parameter to manage some
-/// state (this state is only kept in a single transaction and is lost afterward).
-pub trait StatefulPrecompile {
-	/// Instanciate the precompile.
-	/// Will be called once when building the PrecompileSet at the start of each
-	/// Ethereum transaction.
-	fn new() -> Self;
+pub mod data;
 
-	/// Execute the precompile with a reference to its state.
-	fn execute(&self, handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput>;
-}
+// pub use data::{Address, Bytes, EvmData, EvmDataReader, EvmDataWriter};
+// pub use fp_evm::Precompile;
+// pub use precompile_utils_macro::{generate_function_selector, keccak256};
 
 /// Return an error with provided (static) text.
 /// Using the `revert` function of `Gasometer` is preferred as erroring
 /// consumed all the gas limit and the error message is not easily
 /// retrievable.
+#[must_use]
 pub fn error<T: Into<alloc::borrow::Cow<'static, str>>>(text: T) -> PrecompileFailure {
 	PrecompileFailure::Error {
 		exit_status: ExitError::Other(text.into()),
-	}
-}
-
-/// Builder for PrecompileOutput.
-#[derive(Clone, Debug)]
-pub struct LogsBuilder {
-	address: H160,
-}
-
-impl LogsBuilder {
-	/// Create a new builder with no logs.
-	/// Takes the address of the precompile (usually `context.address`).
-	pub fn new(address: H160) -> Self {
-		Self { address }
-	}
-
-	/// Create a 0-topic log.
-	#[must_use]
-	pub fn log0(&self, data: impl Into<Vec<u8>>) -> Log {
-		Log {
-			address: self.address,
-			topics: vec![],
-			data: data.into(),
-		}
-	}
-
-	/// Create a 1-topic log.
-	#[must_use]
-	pub fn log1(&self, topic0: impl Into<H256>, data: impl Into<Vec<u8>>) -> Log {
-		Log {
-			address: self.address,
-			topics: vec![topic0.into()],
-			data: data.into(),
-		}
-	}
-
-	/// Create a 2-topics log.
-	#[must_use]
-	pub fn log2(
-		&self,
-		topic0: impl Into<H256>,
-		topic1: impl Into<H256>,
-		data: impl Into<Vec<u8>>,
-	) -> Log {
-		Log {
-			address: self.address,
-			topics: vec![topic0.into(), topic1.into()],
-			data: data.into(),
-		}
-	}
-
-	/// Create a 3-topics log.
-	#[must_use]
-	pub fn log3(
-		&self,
-		topic0: impl Into<H256>,
-		topic1: impl Into<H256>,
-		topic2: impl Into<H256>,
-		data: impl Into<Vec<u8>>,
-	) -> Log {
-		Log {
-			address: self.address,
-			topics: vec![topic0.into(), topic1.into(), topic2.into()],
-			data: data.into(),
-		}
-	}
-
-	/// Create a 4-topics log.
-	#[must_use]
-	pub fn log4(
-		&self,
-		topic0: impl Into<H256>,
-		topic1: impl Into<H256>,
-		topic2: impl Into<H256>,
-		topic3: impl Into<H256>,
-		data: impl Into<Vec<u8>>,
-	) -> Log {
-		Log {
-			address: self.address,
-			topics: vec![topic0.into(), topic1.into(), topic2.into(), topic3.into()],
-			data: data.into(),
-		}
-	}
-}
-
-/// Extension trait allowing to record logs into a PrecompileHandle.
-pub trait LogExt {
-	fn record(self, handle: &mut impl PrecompileHandle) -> EvmResult;
-
-	fn compute_cost(&self) -> EvmResult<u64>;
-}
-
-impl LogExt for Log {
-	fn record(self, handle: &mut impl PrecompileHandle) -> EvmResult {
-		handle.log(self.address, self.topics, self.data)?;
-		Ok(())
-	}
-
-	fn compute_cost(&self) -> EvmResult<u64> {
-		log_costs(self.topics.len(), self.data.len())
-	}
-}
-
-/// Helper functions requiring a Runtime.
-/// This runtime must of course implement `pallet_evm::Config`.
-#[derive(Clone, Copy, Debug)]
-pub struct RuntimeHelper<Runtime>(PhantomData<Runtime>);
-
-impl<Runtime> RuntimeHelper<Runtime>
-where
-	Runtime: pallet_evm::Config,
-	Runtime::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
-{
-	/// Try to dispatch a Substrate call.
-	/// Return an error if there are not enough gas, or if the call fails.
-	/// If successful returns the used gas using the Runtime GasWeightMapping.
-	pub fn try_dispatch<Call>(
-		handle: &mut impl PrecompileHandleExt,
-		origin: <Runtime::Call as Dispatchable>::Origin,
-		call: Call,
-	) -> EvmResult<()>
-	where
-		Runtime::Call: From<Call>,
-	{
-		let call = Runtime::Call::from(call);
-		let dispatch_info = call.get_dispatch_info();
-
-		// Make sure there is enough gas.
-		let remaining_gas = handle.remaining_gas();
-		let required_gas = Runtime::GasWeightMapping::weight_to_gas(dispatch_info.weight);
-		if required_gas > remaining_gas {
-			return Err(PrecompileFailure::Error {
-				exit_status: ExitError::OutOfGas,
-			});
-		}
-
-		// Dispatch call.
-		// It may be possible to not record gas cost if the call returns Pays::No.
-		// However while Substrate handle checking weight while not making the sender pay for it,
-		// the EVM doesn't. It seems this safer to always record the costs to avoid unmetered
-		// computations.
-		let used_weight = call
-			.dispatch(origin)
-			.map_err(|e| revert(alloc::format!("Dispatched call failed with error: {:?}", e)))?
-			.actual_weight;
-
-		let used_gas =
-			Runtime::GasWeightMapping::weight_to_gas(used_weight.unwrap_or(dispatch_info.weight));
-
-		handle.record_cost(used_gas)?;
-
-		Ok(())
-	}
-}
-
-impl<Runtime> RuntimeHelper<Runtime>
-where
-	Runtime: pallet_evm::Config,
-{
-	/// Cost of a Substrate DB write in gas.
-	pub fn db_write_gas_cost() -> u64 {
-		<Runtime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(
-			<Runtime as frame_system::Config>::DbWeight::get().write,
-		)
-	}
-
-	/// Cost of a Substrate DB read in gas.
-	pub fn db_read_gas_cost() -> u64 {
-		<Runtime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(
-			<Runtime as frame_system::Config>::DbWeight::get().read,
-		)
-	}
-}
-
-/// Represents modifiers a Solidity function can be annotated with.
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub enum FunctionModifier {
-	/// Function that doesn't modify the state.
-	View,
-	/// Function that modifies the state but refuse receiving funds.
-	/// Correspond to a Solidity function with no modifiers.
-	NonPayable,
-	/// Function that modifies the state and accept funds.
-	Payable,
-}
-
-pub trait PrecompileHandleExt: PrecompileHandle {
-	/// Record cost of a log manually.
-	/// This can be useful to record log costs early when their content have static size.
-	#[must_use]
-	fn record_log_costs_manual(&mut self, topics: usize, data_len: usize) -> EvmResult;
-
-	/// Record cost of logs.
-	#[must_use]
-	fn record_log_costs(&mut self, logs: &[&Log]) -> EvmResult;
-
-	#[must_use]
-	/// Check that a function call is compatible with the context it is
-	/// called into.
-	fn check_function_modifier(&self, modifier: FunctionModifier) -> EvmResult;
-
-	#[must_use]
-	/// Read the selector from the input data.
-	fn read_selector<T>(&self) -> EvmResult<T>
-	where
-		T: num_enum::TryFromPrimitive<Primitive = u32>;
-
-	#[must_use]
-	/// Returns a reader of the input, skipping the selector.
-	fn read_input(&self) -> EvmResult<EvmDataReader>;
-}
-
-pub fn log_costs(topics: usize, data_len: usize) -> EvmResult<u64> {
-	// Cost calculation is copied from EVM code that is not publicly exposed by the crates.
-	// https://github.com/rust-blockchain/evm/blob/master/gasometer/src/costs.rs#L148
-
-	const G_LOG: u64 = 375;
-	const G_LOGDATA: u64 = 8;
-	const G_LOGTOPIC: u64 = 375;
-
-	let topic_cost = G_LOGTOPIC
-		.checked_mul(topics as u64)
-		.ok_or(PrecompileFailure::Error {
-			exit_status: ExitError::OutOfGas,
-		})?;
-
-	let data_cost = G_LOGDATA
-		.checked_mul(data_len as u64)
-		.ok_or(PrecompileFailure::Error {
-			exit_status: ExitError::OutOfGas,
-		})?;
-
-	G_LOG
-		.checked_add(topic_cost)
-		.ok_or(PrecompileFailure::Error {
-			exit_status: ExitError::OutOfGas,
-		})?
-		.checked_add(data_cost)
-		.ok_or(PrecompileFailure::Error {
-			exit_status: ExitError::OutOfGas,
-		})
-}
-
-// Compute the cost of doing a subcall.
-// Some parameters cannot be known in advance, so we estimate the worst possible cost.
-pub fn call_cost(value: U256, config: &evm::Config) -> u64 {
-	// Copied from EVM code since not public.
-	pub const G_CALLVALUE: u64 = 9000;
-	pub const G_NEWACCOUNT: u64 = 25000;
-
-	fn address_access_cost(is_cold: bool, regular_value: u64, config: &evm::Config) -> u64 {
-		if config.increase_state_access_gas {
-			if is_cold {
-				config.gas_account_access_cold
-			} else {
-				config.gas_storage_read_warm
-			}
-		} else {
-			regular_value
-		}
-	}
-
-	fn xfer_cost(is_call_or_callcode: bool, transfers_value: bool) -> u64 {
-		if is_call_or_callcode && transfers_value {
-			G_CALLVALUE
-		} else {
-			0
-		}
-	}
-
-	fn new_cost(
-		is_call_or_staticcall: bool,
-		new_account: bool,
-		transfers_value: bool,
-		config: &evm::Config,
-	) -> u64 {
-		let eip161 = !config.empty_considered_exists;
-		if is_call_or_staticcall {
-			if eip161 {
-				if transfers_value && new_account {
-					G_NEWACCOUNT
-				} else {
-					0
-				}
-			} else if new_account {
-				G_NEWACCOUNT
-			} else {
-				0
-			}
-		} else {
-			0
-		}
-	}
-
-	let transfers_value = value != U256::default();
-	let is_cold = true;
-	let is_call_or_callcode = true;
-	let is_call_or_staticcall = true;
-	let new_account = true;
-
-	address_access_cost(is_cold, config.gas_call, config)
-		+ xfer_cost(is_call_or_callcode, transfers_value)
-		+ new_cost(is_call_or_staticcall, new_account, transfers_value, config)
-}
-
-impl<T: PrecompileHandle> PrecompileHandleExt for T {
-	/// Record cost of a log manualy.
-	/// This can be useful to record log costs early when their content have static size.
-	#[must_use]
-	fn record_log_costs_manual(&mut self, topics: usize, data_len: usize) -> EvmResult {
-		self.record_cost(log_costs(topics, data_len)?)?;
-
-		Ok(())
-	}
-
-	/// Record cost of logs.
-	#[must_use]
-	fn record_log_costs(&mut self, logs: &[&Log]) -> EvmResult {
-		for log in logs {
-			self.record_log_costs_manual(log.topics.len(), log.data.len())?;
-		}
-
-		Ok(())
-	}
-
-	#[must_use]
-	/// Check that a function call is compatible with the context it is
-	/// called into.
-	fn check_function_modifier(&self, modifier: FunctionModifier) -> EvmResult {
-		check_function_modifier(self.context(), self.is_static(), modifier)
-	}
-
-	#[must_use]
-	/// Read the selector from the input data.
-	fn read_selector<S>(&self) -> EvmResult<S>
-	where
-		S: num_enum::TryFromPrimitive<Primitive = u32>,
-	{
-		EvmDataReader::read_selector(self.input())
-	}
-
-	#[must_use]
-	/// Returns a reader of the input, skipping the selector.
-	fn read_input(&self) -> EvmResult<EvmDataReader> {
-		EvmDataReader::new_skip_selector(self.input())
 	}
 }
 
@@ -432,21 +70,34 @@ pub fn succeed(output: impl AsRef<[u8]>) -> PrecompileOutput {
 	}
 }
 
-#[must_use]
-/// Check that a function call is compatible with the context it is
-/// called into.
-fn check_function_modifier(
-	context: &Context,
-	is_static: bool,
-	modifier: FunctionModifier,
-) -> EvmResult {
-	if is_static && modifier != FunctionModifier::View {
-		return Err(revert("can't call non-static function in static context"));
-	}
+/// Alias for Result returning an EVM precompile error.
+pub type EvmResult<T = ()> = Result<T, PrecompileFailure>;
 
-	if modifier != FunctionModifier::Payable && context.apparent_value > U256::zero() {
-		return Err(revert("function is not payable"));
-	}
+/// Trait similar to `fp_evm::Precompile` but with a `&self` parameter to manage some
+/// state (this state is only kept in a single transaction and is lost afterward).
+pub trait StatefulPrecompile {
+	/// Instanciate the precompile.
+	/// Will be called once when building the PrecompileSet at the start of each
+	/// Ethereum transaction.
+	fn new() -> Self;
 
-	Ok(())
+	/// Execute the precompile with a reference to its state.
+	fn execute(&self, handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput>;
+}
+
+pub mod prelude {
+	pub use {
+		crate::{
+			data::{Address, Bytes, EvmData, EvmDataReader, EvmDataWriter},
+			error,
+			handle::PrecompileHandleExt,
+			logs::{log0, log1, log2, log3, log4, LogExt},
+			modifier::{check_function_modifier, FunctionModifier},
+			revert,
+			substrate::RuntimeHelper,
+			succeed, EvmResult, StatefulPrecompile,
+		},
+		pallet_evm::PrecompileHandle,
+		precompile_utils_macro::{generate_function_selector, keccak256},
+	};
 }

--- a/precompiles/utils/src/logs.rs
+++ b/precompiles/utils/src/logs.rs
@@ -1,0 +1,108 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use {
+	crate::EvmResult,
+	pallet_evm::{Log, PrecompileHandle},
+	sp_core::{H160, H256},
+	sp_std::{vec, vec::Vec},
+};
+
+/// Create a 0-topic log.
+#[must_use]
+pub fn log0(address: impl Into<H160>, data: impl Into<Vec<u8>>) -> Log {
+	Log {
+		address: address.into(),
+		topics: vec![],
+		data: data.into(),
+	}
+}
+
+/// Create a 1-topic log.
+#[must_use]
+pub fn log1(address: impl Into<H160>, topic0: impl Into<H256>, data: impl Into<Vec<u8>>) -> Log {
+	Log {
+		address: address.into(),
+		topics: vec![topic0.into()],
+		data: data.into(),
+	}
+}
+
+/// Create a 2-topics log.
+#[must_use]
+pub fn log2(
+	address: impl Into<H160>,
+	topic0: impl Into<H256>,
+	topic1: impl Into<H256>,
+	data: impl Into<Vec<u8>>,
+) -> Log {
+	Log {
+		address: address.into(),
+		topics: vec![topic0.into(), topic1.into()],
+		data: data.into(),
+	}
+}
+
+/// Create a 3-topics log.
+#[must_use]
+pub fn log3(
+	address: impl Into<H160>,
+	topic0: impl Into<H256>,
+	topic1: impl Into<H256>,
+	topic2: impl Into<H256>,
+	data: impl Into<Vec<u8>>,
+) -> Log {
+	Log {
+		address: address.into(),
+		topics: vec![topic0.into(), topic1.into(), topic2.into()],
+		data: data.into(),
+	}
+}
+
+/// Create a 4-topics log.
+#[must_use]
+pub fn log4(
+	address: impl Into<H160>,
+	topic0: impl Into<H256>,
+	topic1: impl Into<H256>,
+	topic2: impl Into<H256>,
+	topic3: impl Into<H256>,
+	data: impl Into<Vec<u8>>,
+) -> Log {
+	Log {
+		address: address.into(),
+		topics: vec![topic0.into(), topic1.into(), topic2.into(), topic3.into()],
+		data: data.into(),
+	}
+}
+
+/// Extension trait allowing to record logs into a PrecompileHandle.
+pub trait LogExt {
+	fn record(self, handle: &mut impl PrecompileHandle) -> EvmResult;
+
+	fn compute_cost(&self) -> EvmResult<u64>;
+}
+
+impl LogExt for Log {
+	fn record(self, handle: &mut impl PrecompileHandle) -> EvmResult {
+		handle.log(self.address, self.topics, self.data)?;
+		Ok(())
+	}
+
+	fn compute_cost(&self) -> EvmResult<u64> {
+		crate::costs::log_costs(self.topics.len(), self.data.len())
+	}
+}

--- a/precompiles/utils/src/modifier.rs
+++ b/precompiles/utils/src/modifier.rs
@@ -1,0 +1,54 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Provide checks related to function modifiers (view/payable).
+
+use {
+	crate::{revert, EvmResult},
+	evm::Context,
+	sp_core::U256,
+};
+
+/// Represents modifiers a Solidity function can be annotated with.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum FunctionModifier {
+	/// Function that doesn't modify the state.
+	View,
+	/// Function that modifies the state but refuse receiving funds.
+	/// Correspond to a Solidity function with no modifiers.
+	NonPayable,
+	/// Function that modifies the state and accept funds.
+	Payable,
+}
+
+#[must_use]
+/// Check that a function call is compatible with the context it is
+/// called into.
+pub fn check_function_modifier(
+	context: &Context,
+	is_static: bool,
+	modifier: FunctionModifier,
+) -> EvmResult {
+	if is_static && modifier != FunctionModifier::View {
+		return Err(revert("can't call non-static function in static context"));
+	}
+
+	if modifier != FunctionModifier::Payable && context.apparent_value > U256::zero() {
+		return Err(revert("function is not payable"));
+	}
+
+	Ok(())
+}

--- a/precompiles/utils/src/substrate.rs
+++ b/precompiles/utils/src/substrate.rs
@@ -1,0 +1,101 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Utils related to Substrate features:
+//! - Substrate call dispatch.
+//! - Substrate DB read and write costs
+
+use {
+	crate::{revert, EvmResult},
+	core::marker::PhantomData,
+	fp_evm::{ExitError, PrecompileFailure, PrecompileHandle},
+	frame_support::{
+		dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
+		traits::Get,
+	},
+	pallet_evm::GasWeightMapping,
+};
+
+/// Helper functions requiring a Substrate runtime.
+/// This runtime must of course implement `pallet_evm::Config`.
+#[derive(Clone, Copy, Debug)]
+pub struct RuntimeHelper<Runtime>(PhantomData<Runtime>);
+
+impl<Runtime> RuntimeHelper<Runtime>
+where
+	Runtime: pallet_evm::Config,
+	Runtime::Call: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
+{
+	/// Try to dispatch a Substrate call.
+	/// Return an error if there are not enough gas, or if the call fails.
+	/// If successful returns the used gas using the Runtime GasWeightMapping.
+	pub fn try_dispatch<Call>(
+		handle: &mut impl PrecompileHandle,
+		origin: <Runtime::Call as Dispatchable>::Origin,
+		call: Call,
+	) -> EvmResult<()>
+	where
+		Runtime::Call: From<Call>,
+	{
+		let call = Runtime::Call::from(call);
+		let dispatch_info = call.get_dispatch_info();
+
+		// Make sure there is enough gas.
+		let remaining_gas = handle.remaining_gas();
+		let required_gas = Runtime::GasWeightMapping::weight_to_gas(dispatch_info.weight);
+		if required_gas > remaining_gas {
+			return Err(PrecompileFailure::Error {
+				exit_status: ExitError::OutOfGas,
+			});
+		}
+
+		// Dispatch call.
+		// It may be possible to not record gas cost if the call returns Pays::No.
+		// However while Substrate handle checking weight while not making the sender pay for it,
+		// the EVM doesn't. It seems this safer to always record the costs to avoid unmetered
+		// computations.
+		let used_weight = call
+			.dispatch(origin)
+			.map_err(|e| revert(alloc::format!("Dispatched call failed with error: {:?}", e)))?
+			.actual_weight;
+
+		let used_gas =
+			Runtime::GasWeightMapping::weight_to_gas(used_weight.unwrap_or(dispatch_info.weight));
+
+		handle.record_cost(used_gas)?;
+
+		Ok(())
+	}
+}
+
+impl<Runtime> RuntimeHelper<Runtime>
+where
+	Runtime: pallet_evm::Config,
+{
+	/// Cost of a Substrate DB write in gas.
+	pub fn db_write_gas_cost() -> u64 {
+		<Runtime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(
+			<Runtime as frame_system::Config>::DbWeight::get().write,
+		)
+	}
+
+	/// Cost of a Substrate DB read in gas.
+	pub fn db_read_gas_cost() -> u64 {
+		<Runtime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(
+			<Runtime as frame_system::Config>::DbWeight::get().read,
+		)
+	}
+}

--- a/precompiles/utils/src/testing.rs
+++ b/precompiles/utils/src/testing.rs
@@ -14,12 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::*;
-use core::assert_matches::assert_matches;
-use fp_evm::{
-	ExitReason, ExitSucceed, PrecompileOutput, PrecompileResult, PrecompileSet, Transfer,
+use {
+	core::assert_matches::assert_matches,
+	fp_evm::{
+		Context, ExitError, ExitReason, ExitSucceed, Log, PrecompileFailure, PrecompileHandle,
+		PrecompileOutput, PrecompileResult, PrecompileSet, Transfer,
+	},
+	sp_core::{H160, H256, U256},
+	sp_std::boxed::Box,
 };
-use sp_std::boxed::Box;
 
 pub struct Subcall {
 	pub address: H160,
@@ -68,20 +71,6 @@ impl MockHandle {
 			is_static: false,
 		}
 	}
-
-	// pub fn with_gas_limit(gas_limit: u64) -> Self {
-	// 	Self {
-	// 		gas_limit,
-	// 		gas_used: 0,
-	// 		logs: vec![],
-	// 		subcall_handle: None,
-	// 	}
-	// }
-
-	// pub fn with_subcall_handle(mut self, handle: Option<SubcallHandle>) -> Self {
-	// 	self.subcall_handle = handle;
-	// 	self
-	// }
 }
 
 impl PrecompileHandle for MockHandle {
@@ -97,7 +86,7 @@ impl PrecompileHandle for MockHandle {
 		context: &Context,
 	) -> (ExitReason, Vec<u8>) {
 		if self
-			.record_cost(super::call_cost(
+			.record_cost(crate::costs::call_cost(
 				context.apparent_value,
 				&evm::Config::london(),
 			))

--- a/precompiles/utils/src/tests.rs
+++ b/precompiles/utils/src/tests.rs
@@ -14,12 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::*;
-use crate::data::xcm::{network_id_from_bytes, network_id_to_bytes};
-use hex_literal::hex;
-use sp_core::{H256, U256};
-use sp_std::convert::TryInto;
-use xcm::latest::{Junction, Junctions, NetworkId};
+use {
+	crate::{
+		data::xcm::{network_id_from_bytes, network_id_to_bytes},
+		prelude::*,
+	},
+	fp_evm::PrecompileFailure,
+	hex_literal::hex,
+	pallet_evm::Context,
+	sp_core::{H160, H256, U256},
+	sp_std::convert::TryInto,
+	xcm::latest::{Junction, Junctions, NetworkId},
+};
 
 fn u256_repeat_byte(byte: u8) -> U256 {
 	let value = H256::repeat_byte(byte);
@@ -675,7 +681,7 @@ impl EvmData for MultiLocation {
 	}
 }
 
-#[crate::generate_function_selector]
+#[generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
 	TransferMultiAsset = "transfer_multiasset((uint8,bytes[]),uint256,(uint8,bytes[]),uint64)",

--- a/precompiles/xcm-transactor/src/lib.rs
+++ b/precompiles/xcm-transactor/src/lib.rs
@@ -23,10 +23,7 @@ use fp_evm::PrecompileHandle;
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
 use pallet_evm::{AddressMapping, PrecompileOutput};
 use pallet_xcm_transactor::RemoteTransactInfoWithMaxWeight;
-use precompile_utils::{
-	revert, succeed, Address, Bytes, EvmDataWriter, EvmResult, FunctionModifier,
-	PrecompileHandleExt, RuntimeHelper,
-};
+use precompile_utils::prelude::*;
 use sp_core::H160;
 use sp_std::{
 	boxed::Box,
@@ -45,7 +42,7 @@ mod tests;
 pub type TransactorOf<Runtime> = <Runtime as pallet_xcm_transactor::Config>::Transactor;
 pub type CurrencyIdOf<Runtime> = <Runtime as pallet_xcm_transactor::Config>::CurrencyId;
 
-#[precompile_utils::generate_function_selector]
+#[generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
 	IndexToAccount = "index_to_account(uint16)",

--- a/precompiles/xcm-transactor/src/tests.rs
+++ b/precompiles/xcm-transactor/src/tests.rs
@@ -19,7 +19,7 @@ use crate::mock::{
 use crate::Action;
 
 use frame_support::assert_ok;
-use precompile_utils::{testing::*, Address, Bytes, EvmDataWriter};
+use precompile_utils::{prelude::*, testing::*};
 use sp_core::{H160, U256};
 use sp_std::boxed::Box;
 use xcm::v1::MultiLocation;

--- a/precompiles/xtokens/src/lib.rs
+++ b/precompiles/xtokens/src/lib.rs
@@ -26,10 +26,7 @@ use frame_support::{
 	traits::Get,
 };
 use pallet_evm::{AddressMapping, Precompile};
-use precompile_utils::{
-	revert, succeed, Address, EvmData, EvmDataReader, EvmDataWriter, EvmResult, FunctionModifier,
-	PrecompileHandleExt, RuntimeHelper,
-};
+use precompile_utils::prelude::*;
 use sp_core::{H160, U256};
 use sp_std::{
 	boxed::Box,
@@ -54,7 +51,7 @@ pub type MaxAssetsForTransfer<Runtime> = <Runtime as orml_xtokens::Config>::MaxA
 
 pub type CurrencyIdOf<Runtime> = <Runtime as orml_xtokens::Config>::CurrencyId;
 
-#[precompile_utils::generate_function_selector]
+#[generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
 	Transfer = "transfer(address,uint256,(uint8,bytes[]),uint64)",

--- a/precompiles/xtokens/src/tests.rs
+++ b/precompiles/xtokens/src/tests.rs
@@ -20,7 +20,7 @@ use crate::mock::{
 };
 use crate::{Action, Currency, EvmMultiAsset};
 use orml_xtokens::Event as XtokensEvent;
-use precompile_utils::{testing::*, Address, EvmDataWriter};
+use precompile_utils::{prelude::*, testing::*};
 use sp_core::U256;
 use sp_runtime::traits::Convert;
 use xcm::latest::{

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -19,7 +19,7 @@
 mod common;
 use common::*;
 
-use precompile_utils::{testing::*, Address as EvmAddress, EvmDataWriter, LogsBuilder};
+use precompile_utils::{prelude::*, testing::*};
 
 use fp_evm::Context;
 use frame_support::{
@@ -849,7 +849,7 @@ fn is_contributor_via_precompile() {
 					ALICE,
 					crowdloan_precompile_address,
 					EvmDataWriter::new_with_selector(CrowdloanAction::IsContributor)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -862,7 +862,7 @@ fn is_contributor_via_precompile() {
 					ALICE,
 					crowdloan_precompile_address,
 					EvmDataWriter::new_with_selector(CrowdloanAction::IsContributor)
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(CHARLIE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -932,7 +932,7 @@ fn reward_info_via_precompile() {
 					ALICE,
 					crowdloan_precompile_address,
 					EvmDataWriter::new_with_selector(CrowdloanAction::RewardInfo)
-						.write(EvmAddress(AccountId::from(CHARLIE).into()))
+						.write(Address(AccountId::from(CHARLIE).into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1110,7 +1110,7 @@ fn asset_erc20_precompiles_supply_and_balance() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(ALICE.into()))
+						.write(Address(ALICE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1142,12 +1142,13 @@ fn asset_erc20_precompiles_transfer() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Transfer)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(400 * UNIT))
 						.build(),
 				)
 				.expect_cost(23516u64)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(ALICE),
 					H160::from(BOB),
@@ -1161,7 +1162,7 @@ fn asset_erc20_precompiles_transfer() {
 					BOB,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1193,12 +1194,13 @@ fn asset_erc20_precompiles_approve() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Approve)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(400 * UNIT))
 						.build(),
 				)
 				.expect_cost(13989)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_APPROVAL,
 					H160::from(ALICE),
 					H160::from(BOB),
@@ -1212,13 +1214,14 @@ fn asset_erc20_precompiles_approve() {
 					BOB,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::TransferFrom)
-						.write(EvmAddress(ALICE.into()))
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(ALICE.into()))
+						.write(Address(CHARLIE.into()))
 						.write(U256::from(400 * UNIT))
 						.build(),
 				)
 				.expect_cost(29006)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(ALICE),
 					H160::from(CHARLIE),
@@ -1232,7 +1235,7 @@ fn asset_erc20_precompiles_approve() {
 					CHARLIE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(CHARLIE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1264,12 +1267,13 @@ fn asset_erc20_precompiles_mint_burn() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Mint)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(1000 * UNIT))
 						.build(),
 				)
 				.expect_cost(12821)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::default(),
 					H160::from(BOB),
@@ -1290,12 +1294,13 @@ fn asset_erc20_precompiles_mint_burn() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Burn)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(500 * UNIT))
 						.build(),
 				)
 				.expect_cost(12957)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(BOB),
 					H160::default(),
@@ -1335,7 +1340,7 @@ fn asset_erc20_precompiles_freeze_thaw_account() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Freeze)
-						.write(EvmAddress(ALICE.into()))
+						.write(Address(ALICE.into()))
 						.build(),
 				)
 				.expect_cost(6732)
@@ -1354,7 +1359,7 @@ fn asset_erc20_precompiles_freeze_thaw_account() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Thaw)
-						.write(EvmAddress(ALICE.into()))
+						.write(Address(ALICE.into()))
 						.build(),
 				)
 				.expect_cost(6731)
@@ -1438,7 +1443,7 @@ fn asset_erc20_precompiles_freeze_transfer_ownership() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::TransferOwnership)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(6666)
@@ -1470,9 +1475,9 @@ fn asset_erc20_precompiles_freeze_set_team() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::SetTeam)
-						.write(EvmAddress(BOB.into()))
-						.write(EvmAddress(BOB.into()))
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
+						.write(Address(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(5614)
@@ -1548,7 +1553,7 @@ fn xcm_asset_erc20_precompiles_supply_and_balance() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(ALICE.into()))
+						.write(Address(ALICE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1592,12 +1597,13 @@ fn xcm_asset_erc20_precompiles_transfer() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Transfer)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(400 * UNIT))
 						.build(),
 				)
 				.expect_cost(23516)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(ALICE),
 					H160::from(BOB),
@@ -1611,7 +1617,7 @@ fn xcm_asset_erc20_precompiles_transfer() {
 					BOB,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1655,12 +1661,13 @@ fn xcm_asset_erc20_precompiles_approve() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Approve)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(400 * UNIT))
 						.build(),
 				)
 				.expect_cost(13989)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_APPROVAL,
 					H160::from(ALICE),
 					H160::from(BOB),
@@ -1674,13 +1681,14 @@ fn xcm_asset_erc20_precompiles_approve() {
 					BOB,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::TransferFrom)
-						.write(EvmAddress(ALICE.into()))
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(ALICE.into()))
+						.write(Address(CHARLIE.into()))
 						.write(U256::from(400 * UNIT))
 						.build(),
 				)
 				.expect_cost(29006)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(ALICE),
 					H160::from(CHARLIE),
@@ -1694,7 +1702,7 @@ fn xcm_asset_erc20_precompiles_approve() {
 					CHARLIE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(CHARLIE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1750,7 +1758,7 @@ fn xtokens_precompiles_transfer() {
 					ALICE,
 					xtokens_precompile_address,
 					EvmDataWriter::new_with_selector(XtokensAction::Transfer)
-						.write(EvmAddress(asset_precompile_address.into()))
+						.write(Address(asset_precompile_address.into()))
 						.write(U256::from(500_000_000_000_000u128))
 						.write(destination.clone())
 						.write(U256::from(4000000))
@@ -1844,7 +1852,7 @@ fn xtokens_precompiles_transfer_native() {
 					ALICE,
 					xtokens_precompile_address,
 					EvmDataWriter::new_with_selector(XtokensAction::Transfer)
-						.write(EvmAddress(asset_precompile_address))
+						.write(Address(asset_precompile_address))
 						.write(U256::from(500 * UNIT))
 						.write(destination.clone())
 						.write(U256::from(4000000))
@@ -1892,7 +1900,7 @@ fn xtokens_precompile_transfer_local_asset() {
 					ALICE,
 					xtokens_precompile_address,
 					EvmDataWriter::new_with_selector(XtokensAction::Transfer)
-						.write(EvmAddress(asset_precompile_address))
+						.write(Address(asset_precompile_address))
 						.write(U256::from(500 * UNIT))
 						.write(destination.clone())
 						.write(U256::from(4000000))

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -47,7 +47,7 @@ use pallet_evm_precompileset_assets_erc20::{
 };
 use pallet_transaction_payment::Multiplier;
 use parity_scale_codec::Encode;
-use precompile_utils::{testing::*, Address as EvmAddress, EvmDataWriter, LogsBuilder};
+use precompile_utils::{prelude::*, testing::*};
 use sha3::{Digest, Keccak256};
 use sp_core::{ByteArray, Pair, H160, U256};
 use sp_runtime::{
@@ -862,7 +862,7 @@ fn is_contributor_via_precompile() {
 					ALICE,
 					crowdloan_precompile_address,
 					EvmDataWriter::new_with_selector(CrowdloanAction::IsContributor)
-						.write(EvmAddress(AccountId::from(BOB).into()))
+						.write(Address(AccountId::from(BOB).into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -875,7 +875,7 @@ fn is_contributor_via_precompile() {
 					ALICE,
 					crowdloan_precompile_address,
 					EvmDataWriter::new_with_selector(CrowdloanAction::IsContributor)
-						.write(EvmAddress(AccountId::from(CHARLIE).into()))
+						.write(Address(AccountId::from(CHARLIE).into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -945,7 +945,7 @@ fn reward_info_via_precompile() {
 					ALICE,
 					crowdloan_precompile_address,
 					EvmDataWriter::new_with_selector(CrowdloanAction::RewardInfo)
-						.write(EvmAddress(AccountId::from(CHARLIE).into()))
+						.write(Address(AccountId::from(CHARLIE).into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1482,7 +1482,7 @@ fn asset_erc20_precompiles_supply_and_balance() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(ALICE.into()))
+						.write(Address(ALICE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1514,12 +1514,13 @@ fn asset_erc20_precompiles_transfer() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Transfer)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(400 * GLMR))
 						.build(),
 				)
 				.expect_cost(23516u64)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(ALICE),
 					H160::from(BOB),
@@ -1533,7 +1534,7 @@ fn asset_erc20_precompiles_transfer() {
 					BOB,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1565,12 +1566,13 @@ fn asset_erc20_precompiles_approve() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Approve)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(400 * GLMR))
 						.build(),
 				)
 				.expect_cost(13989)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_APPROVAL,
 					H160::from(ALICE),
 					H160::from(BOB),
@@ -1584,13 +1586,14 @@ fn asset_erc20_precompiles_approve() {
 					BOB,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::TransferFrom)
-						.write(EvmAddress(ALICE.into()))
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(ALICE.into()))
+						.write(Address(CHARLIE.into()))
 						.write(U256::from(400 * GLMR))
 						.build(),
 				)
 				.expect_cost(29006)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(ALICE),
 					H160::from(CHARLIE),
@@ -1604,7 +1607,7 @@ fn asset_erc20_precompiles_approve() {
 					CHARLIE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(CHARLIE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1636,12 +1639,13 @@ fn asset_erc20_precompiles_mint_burn() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Mint)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(1000 * GLMR))
 						.build(),
 				)
 				.expect_cost(12821)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::default(),
 					H160::from(BOB),
@@ -1662,12 +1666,13 @@ fn asset_erc20_precompiles_mint_burn() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Burn)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(500 * GLMR))
 						.build(),
 				)
 				.expect_cost(12957)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(BOB),
 					H160::default(),
@@ -1707,7 +1712,7 @@ fn asset_erc20_precompiles_freeze_thaw_account() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Freeze)
-						.write(EvmAddress(ALICE.into()))
+						.write(Address(ALICE.into()))
 						.build(),
 				)
 				.expect_cost(6732)
@@ -1726,7 +1731,7 @@ fn asset_erc20_precompiles_freeze_thaw_account() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Thaw)
-						.write(EvmAddress(ALICE.into()))
+						.write(Address(ALICE.into()))
 						.build(),
 				)
 				.expect_cost(6731)
@@ -1815,7 +1820,7 @@ fn asset_erc20_precompiles_freeze_transfer_ownership() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::TransferOwnership)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(6666)
@@ -1855,9 +1860,9 @@ fn asset_erc20_precompiles_freeze_set_team() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::SetTeam)
-						.write(EvmAddress(BOB.into()))
-						.write(EvmAddress(BOB.into()))
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
+						.write(Address(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(5614)
@@ -1934,7 +1939,7 @@ fn xcm_asset_erc20_precompiles_supply_and_balance() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(ALICE.into()))
+						.write(Address(ALICE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1979,12 +1984,13 @@ fn xcm_asset_erc20_precompiles_transfer() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Transfer)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(400 * GLMR))
 						.build(),
 				)
 				.expect_cost(23516)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(ALICE),
 					H160::from(BOB),
@@ -1998,7 +2004,7 @@ fn xcm_asset_erc20_precompiles_transfer() {
 					BOB,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -2043,12 +2049,13 @@ fn xcm_asset_erc20_precompiles_approve() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Approve)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(400 * GLMR))
 						.build(),
 				)
 				.expect_cost(13989)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_APPROVAL,
 					H160::from(ALICE),
 					H160::from(BOB),
@@ -2062,13 +2069,14 @@ fn xcm_asset_erc20_precompiles_approve() {
 					BOB,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::TransferFrom)
-						.write(EvmAddress(ALICE.into()))
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(ALICE.into()))
+						.write(Address(CHARLIE.into()))
 						.write(U256::from(400 * GLMR))
 						.build(),
 				)
 				.expect_cost(29006)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(ALICE),
 					H160::from(CHARLIE),
@@ -2082,7 +2090,7 @@ fn xcm_asset_erc20_precompiles_approve() {
 					CHARLIE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(CHARLIE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -2139,7 +2147,7 @@ fn xtokens_precompiles_transfer() {
 					ALICE,
 					xtokens_precompile_address,
 					EvmDataWriter::new_with_selector(XtokensAction::Transfer)
-						.write(EvmAddress(asset_precompile_address.into()))
+						.write(Address(asset_precompile_address.into()))
 						.write(U256::from(500_000_000_000_000u128))
 						.write(destination.clone())
 						.write(U256::from(4000000))

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -46,7 +46,7 @@ use pallet_evm_precompileset_assets_erc20::{
 };
 use pallet_transaction_payment::Multiplier;
 use parity_scale_codec::Encode;
-use precompile_utils::{testing::*, Address as EvmAddress, EvmDataWriter, LogsBuilder};
+use precompile_utils::{prelude::*, testing::*};
 use sha3::{Digest, Keccak256};
 use sp_core::{ByteArray, Pair, H160, U256};
 use sp_runtime::{
@@ -849,7 +849,7 @@ fn is_contributor_via_precompile() {
 					ALICE,
 					crowdloan_precompile_address,
 					EvmDataWriter::new_with_selector(CrowdloanAction::IsContributor)
-						.write(EvmAddress(AccountId::from(BOB).into()))
+						.write(Address(AccountId::from(BOB).into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -862,7 +862,7 @@ fn is_contributor_via_precompile() {
 					ALICE,
 					crowdloan_precompile_address,
 					EvmDataWriter::new_with_selector(CrowdloanAction::IsContributor)
-						.write(EvmAddress(AccountId::from(CHARLIE).into()))
+						.write(Address(AccountId::from(CHARLIE).into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -932,7 +932,7 @@ fn reward_info_via_precompile() {
 					ALICE,
 					crowdloan_precompile_address,
 					EvmDataWriter::new_with_selector(CrowdloanAction::RewardInfo)
-						.write(EvmAddress(AccountId::from(CHARLIE).into()))
+						.write(Address(AccountId::from(CHARLIE).into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1473,7 +1473,7 @@ fn asset_erc20_precompiles_supply_and_balance() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(ALICE.into()))
+						.write(Address(ALICE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1505,12 +1505,13 @@ fn asset_erc20_precompiles_transfer() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Transfer)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(400 * MOVR))
 						.build(),
 				)
 				.expect_cost(23516u64)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(ALICE),
 					H160::from(BOB),
@@ -1524,7 +1525,7 @@ fn asset_erc20_precompiles_transfer() {
 					BOB,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1556,12 +1557,13 @@ fn asset_erc20_precompiles_approve() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Approve)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(400 * MOVR))
 						.build(),
 				)
 				.expect_cost(13989)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_APPROVAL,
 					H160::from(ALICE),
 					H160::from(BOB),
@@ -1575,13 +1577,14 @@ fn asset_erc20_precompiles_approve() {
 					BOB,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::TransferFrom)
-						.write(EvmAddress(ALICE.into()))
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(ALICE.into()))
+						.write(Address(CHARLIE.into()))
 						.write(U256::from(400 * MOVR))
 						.build(),
 				)
 				.expect_cost(29006)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(ALICE),
 					H160::from(CHARLIE),
@@ -1595,7 +1598,7 @@ fn asset_erc20_precompiles_approve() {
 					CHARLIE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(CHARLIE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1627,12 +1630,13 @@ fn asset_erc20_precompiles_mint_burn() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Mint)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(1000 * MOVR))
 						.build(),
 				)
 				.expect_cost(12821)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::default(),
 					H160::from(BOB),
@@ -1653,12 +1657,13 @@ fn asset_erc20_precompiles_mint_burn() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Burn)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(500 * MOVR))
 						.build(),
 				)
 				.expect_cost(12957)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(BOB),
 					H160::default(),
@@ -1698,7 +1703,7 @@ fn asset_erc20_precompiles_freeze_thaw_account() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Freeze)
-						.write(EvmAddress(ALICE.into()))
+						.write(Address(ALICE.into()))
 						.build(),
 				)
 				.expect_cost(6732)
@@ -1717,7 +1722,7 @@ fn asset_erc20_precompiles_freeze_thaw_account() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Thaw)
-						.write(EvmAddress(ALICE.into()))
+						.write(Address(ALICE.into()))
 						.build(),
 				)
 				.expect_cost(6731)
@@ -1806,7 +1811,7 @@ fn asset_erc20_precompiles_freeze_transfer_ownership() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::TransferOwnership)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(6666)
@@ -1846,9 +1851,9 @@ fn asset_erc20_precompiles_freeze_set_team() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::SetTeam)
-						.write(EvmAddress(BOB.into()))
-						.write(EvmAddress(BOB.into()))
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
+						.write(Address(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(5614)
@@ -1924,7 +1929,7 @@ fn xcm_asset_erc20_precompiles_supply_and_balance() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(ALICE.into()))
+						.write(Address(ALICE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -1968,12 +1973,13 @@ fn xcm_asset_erc20_precompiles_transfer() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Transfer)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(400 * MOVR))
 						.build(),
 				)
 				.expect_cost(23516)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(ALICE),
 					H160::from(BOB),
@@ -1987,7 +1993,7 @@ fn xcm_asset_erc20_precompiles_transfer() {
 					BOB,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -2031,12 +2037,13 @@ fn xcm_asset_erc20_precompiles_approve() {
 					ALICE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::Approve)
-						.write(EvmAddress(BOB.into()))
+						.write(Address(BOB.into()))
 						.write(U256::from(400 * MOVR))
 						.build(),
 				)
 				.expect_cost(13989)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_APPROVAL,
 					H160::from(ALICE),
 					H160::from(BOB),
@@ -2050,13 +2057,14 @@ fn xcm_asset_erc20_precompiles_approve() {
 					BOB,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::TransferFrom)
-						.write(EvmAddress(ALICE.into()))
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(ALICE.into()))
+						.write(Address(CHARLIE.into()))
 						.write(U256::from(400 * MOVR))
 						.build(),
 				)
 				.expect_cost(29006)
-				.expect_log(LogsBuilder::new(asset_precompile_address.into()).log3(
+				.expect_log(log3(
+					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
 					H160::from(ALICE),
 					H160::from(CHARLIE),
@@ -2070,7 +2078,7 @@ fn xcm_asset_erc20_precompiles_approve() {
 					CHARLIE,
 					asset_precompile_address,
 					EvmDataWriter::new_with_selector(AssetAction::BalanceOf)
-						.write(EvmAddress(CHARLIE.into()))
+						.write(Address(CHARLIE.into()))
 						.build(),
 				)
 				.expect_cost(1000)
@@ -2127,7 +2135,7 @@ fn xtokens_precompiles_transfer() {
 					ALICE,
 					xtokens_precompile_address,
 					EvmDataWriter::new_with_selector(XtokensAction::Transfer)
-						.write(EvmAddress(asset_precompile_address.into()))
+						.write(Address(asset_precompile_address.into()))
 						.write(U256::from(500_000_000_000_000u128))
 						.write(destination.clone())
 						.write(U256::from(4000000))


### PR DESCRIPTION
### What does it do?

- More defencive uintX parsing. It will always parse first a 256bit number, then use `try_into()` to convert it into the wanted size. This will prevent accidental truncation. (replace #1630)
- Refactor the crate.
- Provide a `prelude` module re-exporting all the important tools. 
- Get rid of `LogsBuilder`, and instead have plain functions that takes the emitter address directly.
- Update the rest of the codebase to those changes.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

- PR evm repo to make cost computation public, to avoid duplication in utils
- Potentially PR frontier to move utils in it?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
