### PR TITLE
Update call-permit following precompile-utils changes

### DIFF
--- a/precompiles/call-permit/src/lib.rs
+++ b/precompiles/call-permit/src/lib.rs
@@ -27,10 +27,7 @@ use frame_support::{
 	traits::{Get, StorageInstance},
 	Blake2_128Concat,
 };
-use precompile_utils::{
-	call_cost, keccak256, revert, succeed, Address, Bytes, EvmDataWriter, EvmResult,
-	FunctionModifier, PrecompileHandleExt, RuntimeHelper,
-};
+use precompile_utils::{costs::call_cost, prelude::*};
 use sp_core::{H160, H256, U256};
 use sp_io::hashing::keccak_256;
 use sp_std::vec::Vec;
@@ -73,7 +70,7 @@ const PERMIT_DOMAIN: [u8; 32] = keccak256!(
 	"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
 );
 
-#[precompile_utils::generate_function_selector]
+#[generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
 	Dispatch = "dispatch(address,address,uint256,bytes,uint64,uint256,uint8,bytes32,bytes32)",

--- a/precompiles/call-permit/src/tests.rs
+++ b/precompiles/call-permit/src/tests.rs
@@ -24,7 +24,7 @@ use crate::{
 use evm::ExitReason;
 use fp_evm::{ExitRevert, ExitSucceed};
 use libsecp256k1::{sign, Message, SecretKey};
-use precompile_utils::{call_cost, testing::*, Address, Bytes, EvmDataWriter, LogsBuilder};
+use precompile_utils::{costs::call_cost, prelude::*, testing::*};
 use sp_core::{H160, H256, U256};
 
 fn precompiles() -> TestPrecompiles<Runtime> {
@@ -131,14 +131,12 @@ fn valid_permit_returns() {
 						reason: ExitReason::Succeed(ExitSucceed::Returned),
 						output: b"TEST".to_vec(),
 						cost: 13,
-						logs: vec![
-							LogsBuilder::new(Bob.into()).log1(H256::repeat_byte(0x11), vec![])
-						],
+						logs: vec![log1(Bob, H256::repeat_byte(0x11), vec![])],
 					}
 				})
 				.with_target_gas(Some(call_cost + 100_000 + dispatch_cost()))
 				.expect_cost(call_cost + 13 + dispatch_cost())
-				.expect_log(LogsBuilder::new(Bob.into()).log1(H256::repeat_byte(0x11), vec![]))
+				.expect_log(log1(Bob, H256::repeat_byte(0x11), vec![]))
 				.execute_returns(b"TEST".to_vec());
 		})
 }
@@ -653,14 +651,12 @@ fn valid_permit_returns_with_metamask_signed_data() {
 						reason: ExitReason::Succeed(ExitSucceed::Returned),
 						output: b"TEST".to_vec(),
 						cost: 13,
-						logs: vec![
-							LogsBuilder::new(Bob.into()).log1(H256::repeat_byte(0x11), vec![])
-						],
+						logs: vec![log1(Bob, H256::repeat_byte(0x11), vec![])],
 					}
 				})
 				.with_target_gas(Some(call_cost + 100_000 + dispatch_cost()))
 				.expect_cost(call_cost + 13 + dispatch_cost())
-				.expect_log(LogsBuilder::new(Bob.into()).log1(H256::repeat_byte(0x11), vec![]))
+				.expect_log(log1(Bob, H256::repeat_byte(0x11), vec![]))
 				.execute_returns(b"TEST".to_vec());
 		})
 }


### PR DESCRIPTION
### What does it do?

master don't build after merging #1642 , as the call permit precompile is not updated to the changes.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
