### PR TITLE
fix tracing tests

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -35,7 +35,7 @@
     "test": "mocha --parallel -r ts-node/register 'tests/**/test-*.ts' -- -j 4",
     "test-seq": "mocha -r ts-node/register 'tests/**/test-*.ts'",
     "tracing-test": "ETHAPI_CMD='--ethapi=txpool,debug,trace' FORCE_WASM_EXECUTION='true' FORCE_COMPILED_WASM='true' WASM_RUNTIME_OVERRIDES='moonbase-overrides' mocha --parallel -r ts-node/register 'tracing-tests/**/*.ts'",
-    "tracing-test-single": "ETHAPI_CMD='--ethapi=txpool,debug,trace' FORCE_WASM_EXECUTION='true' FORCE_COMPILED_WASM='true' WASM_RUNTIME_OVERRIDES='moonbase-overrides' mocha -r ts-node/register 'tracing-tests/test-trace.ts'",
+    "tracing-test-single": "ETHAPI_CMD='--ethapi=txpool,debug,trace' FORCE_WASM_EXECUTION='true' FORCE_COMPILED_WASM='true' WASM_RUNTIME_OVERRIDES='moonbase-overrides' mocha -r ts-node/register 'tracing-tests/test-trace-filter.ts'",
     "para-test": "mocha -r ts-node/register 'para-tests/**/test-*.ts'",
     "para-test-single": "mocha -r ts-node/register 'para-tests-no-ci/test-xcm-para.ts'",
     "smoke-test": "mocha -r ts-node/register 'smoke-tests/**/test-*.ts'",

--- a/tests/tracing-tests/test-trace-filter.ts
+++ b/tests/tracing-tests/test-trace-filter.ts
@@ -18,13 +18,14 @@ describeDevMoonbeam("Trace filter - Contract creation ", (context) => {
     const { contract, rawTx } = await createContract(context, "TraceFilter", {}, [false]);
     await context.createBlock(rawTx);
 
-    const { rawTx: rawTx2 } = await createContract(context, "TraceFilter", {}, [true]);
+    const { rawTx: rawTx2 } = await createContract(context, "TraceFilter", { gas: 90_000 }, [true],);
+
     await context.createBlock([rawTx2]);
 
     const { rawTx: rawTx3 } = await createContract(context, "TraceFilter", {}, [false]);
     const { rawTx: rawTx4 } = await createContract(context, "TraceFilter", { nonce: 3 }, [false]);
     await context.createBlock([rawTx3, rawTx4]);
-
+  
     await context.createBlock(
       createContractExecution(context, {
         contract,
@@ -50,7 +51,7 @@ describeDevMoonbeam("Trace filter - Contract creation ", (context) => {
     expect(response.result[0].action).to.include({
       creationMethod: "create",
       from: ALITH_ADDRESS,
-      gas: "0xb5c13a",
+      gas: "0x6bdea",
       value: "0x0",
     });
     expect(response.result[0].result).to.include({
@@ -81,7 +82,7 @@ describeDevMoonbeam("Trace filter - Contract creation ", (context) => {
     expect(response.result.length).to.equal(1);
     expect(response.result[0].action.creationMethod).to.equal("create");
     expect(response.result[0].action.from).to.equal(ALITH_ADDRESS);
-    expect(response.result[0].action.gas).to.equal("0xb5c2c8");
+    expect(response.result[0].action.gas).to.equal("0x758");
     expect(response.result[0].action.init).to.be.a("string");
     expect(response.result[0].action.value).to.equal("0x0");
     expect(response.result[0].blockHash).to.be.a("string");

--- a/tests/tracing-tests/test-trace-filter.ts
+++ b/tests/tracing-tests/test-trace-filter.ts
@@ -18,14 +18,14 @@ describeDevMoonbeam("Trace filter - Contract creation ", (context) => {
     const { contract, rawTx } = await createContract(context, "TraceFilter", {}, [false]);
     await context.createBlock(rawTx);
 
-    const { rawTx: rawTx2 } = await createContract(context, "TraceFilter", { gas: 90_000 }, [true],);
+    const { rawTx: rawTx2 } = await createContract(context, "TraceFilter", { gas: 90_000 }, [true]);
 
     await context.createBlock([rawTx2]);
 
     const { rawTx: rawTx3 } = await createContract(context, "TraceFilter", {}, [false]);
     const { rawTx: rawTx4 } = await createContract(context, "TraceFilter", { nonce: 3 }, [false]);
     await context.createBlock([rawTx3, rawTx4]);
-  
+
     await context.createBlock(
       createContractExecution(context, {
         contract,

--- a/tests/tracing-tests/test-trace.ts
+++ b/tests/tracing-tests/test-trace.ts
@@ -398,7 +398,7 @@ describeDevMoonbeam(
       ]);
       let res = traceTx.result;
       // Fields
-      expect(Object.keys(res)).to.deep.equal([
+      expect(Object.keys(res).sort()).to.deep.equal([
         "calls",
         "from",
         "gas",
@@ -437,7 +437,7 @@ describeDevMoonbeam(
 
       let res = traceTx.result;
       // Fields
-      expect(Object.keys(res)).to.deep.equal([
+      expect(Object.keys(res).sort()).to.deep.equal([
         "from",
         "gas",
         "gasUsed",
@@ -487,7 +487,7 @@ describeDevMoonbeam(
       expect(block.transactions.length).to.be.equal(traceTx.result.length);
       traceTx.result.forEach((trace: { [key: string]: any }) => {
         expect(trace.calls.length).to.be.equal(1);
-        expect(Object.keys(trace)).to.deep.equal([
+        expect(Object.keys(trace).sort()).to.deep.equal([
           "calls",
           "from",
           "gas",
@@ -507,7 +507,7 @@ describeDevMoonbeam(
       expect(block.transactions.length).to.be.equal(traceTx.result.length);
       traceTx.result.forEach((trace: { [key: string]: any }) => {
         expect(trace.calls.length).to.be.equal(1);
-        expect(Object.keys(trace)).to.deep.equal([
+        expect(Object.keys(trace).sort()).to.deep.equal([
           "calls",
           "from",
           "gas",


### PR DESCRIPTION
### What does it do?

Fix tracing tests, that are broken by the 0.9.23 dependencies upgrade.

3/4 of tracing tests was broken because the json response is not sorted anymore by the server.

For the 4th test, the problem comes from the fact that from now on we call estimate gas to indicate a gas limit, whereas before we used the block gas limit.
This is a problem in the tests when a step consists in submitting a transaction that must be reverted, which is the case in this 4th test. The solution: hardcode a reasonable gas limit.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
