### PR TITLE
Bound length of Vec and Bytes when parsing precompile input

### DIFF
--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -52,7 +52,7 @@ pub const SELECTOR_LOG_TRANSFER: [u8; 32] = keccak256!("Transfer(address,address
 pub const SELECTOR_LOG_APPROVAL: [u8; 32] = keccak256!("Approval(address,address,uint256)");
 
 /// Length limit of strings (symbol and name).
-pub const STRING_LIMIT: usize = 128;
+type GetAssetsStringLimit<R, I> = <R as pallet_assets::Config<I>>::StringLimit;
 
 /// Alias for the Balance type for the provided Runtime and Instance.
 pub type BalanceOf<Runtime, Instance = ()> = <Runtime as pallet_assets::Config<Instance>>::Balance;
@@ -835,8 +835,8 @@ where
 		let mut input = handle.read_input()?;
 		input.expect_arguments(3)?;
 
-		let name: BoundedBytes<STRING_LIMIT> = input.read()?;
-		let symbol: BoundedBytes<STRING_LIMIT> = input.read()?;
+		let name: BoundedBytes<GetAssetsStringLimit<Runtime, Instance>> = input.read()?;
+		let symbol: BoundedBytes<GetAssetsStringLimit<Runtime, Instance>> = input.read()?;
 		let decimals: u8 = input.read()?;
 
 		// Build call with origin.
@@ -849,8 +849,8 @@ where
 				Some(origin).into(),
 				pallet_assets::Call::<Runtime, Instance>::set_metadata {
 					id: asset_id,
-					name: name.0,
-					symbol: symbol.0,
+					name: name.into_vec(),
+					symbol: symbol.into_vec(),
 					decimals,
 				},
 			)?;

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -51,6 +51,9 @@ pub const SELECTOR_LOG_TRANSFER: [u8; 32] = keccak256!("Transfer(address,address
 /// Solidity selector of the Approval log, which is the Keccak of the Log signature.
 pub const SELECTOR_LOG_APPROVAL: [u8; 32] = keccak256!("Approval(address,address,uint256)");
 
+/// Length limit of strings (symbol and name).
+pub const STRING_LIMIT: usize = 128;
+
 /// Alias for the Balance type for the provided Runtime and Instance.
 pub type BalanceOf<Runtime, Instance = ()> = <Runtime as pallet_assets::Config<Instance>>::Balance;
 
@@ -832,9 +835,9 @@ where
 		let mut input = handle.read_input()?;
 		input.expect_arguments(3)?;
 
-		let name: Bytes = input.read::<Bytes>()?.into();
-		let symbol: Bytes = input.read::<Bytes>()?.into();
-		let decimals: u8 = input.read::<u8>()?.into();
+		let name: BoundedBytes<STRING_LIMIT> = input.read()?;
+		let symbol: BoundedBytes<STRING_LIMIT> = input.read()?;
+		let decimals: u8 = input.read()?;
 
 		// Build call with origin.
 		{
@@ -846,8 +849,8 @@ where
 				Some(origin).into(),
 				pallet_assets::Call::<Runtime, Instance>::set_metadata {
 					id: asset_id,
-					name: name.into(),
-					symbol: symbol.into(),
+					name: name.0,
+					symbol: symbol.0,
 					decimals,
 				},
 			)?;

--- a/precompiles/batch/src/lib.rs
+++ b/precompiles/batch/src/lib.rs
@@ -41,6 +41,7 @@ pub enum Action {
 
 pub const LOG_SUBCALL_SUCCEEDED: [u8; 32] = keccak256!("SubcallSucceeded(uint256)");
 pub const LOG_SUBCALL_FAILED: [u8; 32] = keccak256!("SubcallFailed(uint256)");
+pub const CALL_DATA_LIMIT: usize = 2usize.pow(16);
 
 pub fn log_subcall_succeeded(address: impl Into<H160>, index: usize) -> Log {
 	log1(
@@ -85,7 +86,7 @@ where
 		let mut input = handle.read_input()?;
 		let addresses: Vec<Address> = input.read()?;
 		let values: Vec<U256> = input.read()?;
-		let calls_data: Vec<Bytes> = input.read()?;
+		let calls_data: Vec<BoundedBytes<CALL_DATA_LIMIT>> = input.read()?;
 		let gas_limits: Vec<u64> = input.read()?;
 
 		let addresses = addresses.into_iter().enumerate();
@@ -110,7 +111,7 @@ where
 		{
 			let address = address.0;
 			let value = value.unwrap_or(U256::zero());
-			let call_data = call_data.unwrap_or(Bytes(vec![])).0;
+			let call_data = call_data.unwrap_or(BoundedBytes(vec![])).0;
 
 			let sub_context = Context {
 				caller: handle.context().caller,

--- a/precompiles/batch/src/lib.rs
+++ b/precompiles/batch/src/lib.rs
@@ -125,7 +125,6 @@ where
 			let address = address.0;
 			let value = value.unwrap_or(U256::zero());
 			let call_data = call_data.unwrap_or(vec![]);
-			// let call_data = call_data.unwrap_or(BoundedBytes(vec![])).0;
 
 			let sub_context = Context {
 				caller: handle.context().caller,

--- a/precompiles/batch/src/lib.rs
+++ b/precompiles/batch/src/lib.rs
@@ -43,7 +43,7 @@ pub enum Action {
 pub const LOG_SUBCALL_SUCCEEDED: [u8; 32] = keccak256!("SubcallSucceeded(uint256)");
 pub const LOG_SUBCALL_FAILED: [u8; 32] = keccak256!("SubcallFailed(uint256)");
 pub const CALL_DATA_LIMIT: u32 = 2u32.pow(16);
-pub const ARRAY_LIMIT: u32 = 512;
+pub const ARRAY_LIMIT: u32 = 2u32.pow(9);
 
 type GetCallDataLimit = ConstU32<CALL_DATA_LIMIT>;
 type GetArrayLimit = ConstU32<ARRAY_LIMIT>;

--- a/precompiles/call-permit/src/lib.rs
+++ b/precompiles/call-permit/src/lib.rs
@@ -70,6 +70,8 @@ const PERMIT_DOMAIN: [u8; 32] = keccak256!(
 	"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
 );
 
+pub const CALL_DATA_LIMIT: usize = 2usize.pow(16);
+
 #[generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
@@ -171,7 +173,7 @@ where
 		let from = input.read::<Address>()?.0;
 		let to = input.read::<Address>()?.0;
 		let value: U256 = input.read()?;
-		let data = input.read::<Bytes>()?.0;
+		let data = input.read::<BoundedBytes<CALL_DATA_LIMIT>>()?.0;
 		let gas_limit: u64 = input.read()?;
 		let deadline: U256 = input.read()?;
 		let v: u8 = input.read()?;

--- a/precompiles/call-permit/src/lib.rs
+++ b/precompiles/call-permit/src/lib.rs
@@ -24,7 +24,7 @@ use fp_evm::{
 use frame_support::{
 	ensure,
 	storage::types::{StorageMap, ValueQuery},
-	traits::{Get, StorageInstance},
+	traits::{ConstU32, Get, StorageInstance},
 	Blake2_128Concat,
 };
 use precompile_utils::{costs::call_cost, prelude::*};
@@ -70,7 +70,7 @@ const PERMIT_DOMAIN: [u8; 32] = keccak256!(
 	"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
 );
 
-pub const CALL_DATA_LIMIT: usize = 2usize.pow(16);
+pub const CALL_DATA_LIMIT: u32 = 2u32.pow(16);
 
 #[generate_function_selector]
 #[derive(Debug, PartialEq)]
@@ -173,7 +173,9 @@ where
 		let from = input.read::<Address>()?.0;
 		let to = input.read::<Address>()?.0;
 		let value: U256 = input.read()?;
-		let data = input.read::<BoundedBytes<CALL_DATA_LIMIT>>()?.0;
+		let data = input
+			.read::<BoundedBytes<ConstU32<CALL_DATA_LIMIT>>>()?
+			.into_vec();
 		let gas_limit: u64 = input.read()?;
 		let deadline: U256 = input.read()?;
 		let v: u8 = input.read()?;

--- a/precompiles/pallet-democracy/src/lib.rs
+++ b/precompiles/pallet-democracy/src/lib.rs
@@ -21,7 +21,7 @@
 
 use fp_evm::{PrecompileHandle, PrecompileOutput};
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
-use frame_support::traits::Currency;
+use frame_support::traits::{ConstU32, Currency};
 use pallet_democracy::{AccountVote, Call as DemocracyCall, Vote};
 use pallet_evm::{AddressMapping, Precompile};
 use precompile_utils::prelude::*;
@@ -44,7 +44,8 @@ type BalanceOf<Runtime> = <<Runtime as pallet_democracy::Config>::Currency as Cu
 
 type DemocracyOf<Runtime> = pallet_democracy::Pallet<Runtime>;
 
-pub const ENCODED_PROPOSAL_SIZE_LIMIT: usize = 2usize.pow(16);
+pub const ENCODED_PROPOSAL_SIZE_LIMIT: u32 = 2u32.pow(16);
+type GetEncodedProposalSizeLimit = ConstU32<ENCODED_PROPOSAL_SIZE_LIMIT>;
 
 #[generate_function_selector]
 #[derive(Debug, PartialEq)]
@@ -398,8 +399,9 @@ where
 
 	fn note_preimage(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
 		let mut input = handle.read_input()?;
-		let encoded_proposal: Vec<u8> =
-			input.read::<BoundedBytes<ENCODED_PROPOSAL_SIZE_LIMIT>>()?.0;
+		let encoded_proposal: Vec<u8> = input
+			.read::<BoundedBytes<GetEncodedProposalSizeLimit>>()?
+			.into_vec();
 
 		log::trace!(
 			target: "democracy-precompile",
@@ -416,8 +418,9 @@ where
 
 	fn note_imminent_preimage(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
 		let mut input = handle.read_input()?;
-		let encoded_proposal: Vec<u8> =
-			input.read::<BoundedBytes<ENCODED_PROPOSAL_SIZE_LIMIT>>()?.0;
+		let encoded_proposal: Vec<u8> = input
+			.read::<BoundedBytes<GetEncodedProposalSizeLimit>>()?
+			.into_vec();
 
 		log::trace!(
 			target: "democracy-precompile",

--- a/precompiles/pallet-democracy/src/lib.rs
+++ b/precompiles/pallet-democracy/src/lib.rs
@@ -44,6 +44,8 @@ type BalanceOf<Runtime> = <<Runtime as pallet_democracy::Config>::Currency as Cu
 
 type DemocracyOf<Runtime> = pallet_democracy::Pallet<Runtime>;
 
+pub const ENCODED_PROPOSAL_SIZE_LIMIT: usize = 2usize.pow(16);
+
 #[generate_function_selector]
 #[derive(Debug, PartialEq)]
 enum Action {
@@ -396,7 +398,8 @@ where
 
 	fn note_preimage(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
 		let mut input = handle.read_input()?;
-		let encoded_proposal: Vec<u8> = input.read::<Bytes>()?.into();
+		let encoded_proposal: Vec<u8> =
+			input.read::<BoundedBytes<ENCODED_PROPOSAL_SIZE_LIMIT>>()?.0;
 
 		log::trace!(
 			target: "democracy-precompile",
@@ -413,7 +416,8 @@ where
 
 	fn note_imminent_preimage(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
 		let mut input = handle.read_input()?;
-		let encoded_proposal: Vec<u8> = input.read::<Bytes>()?.into();
+		let encoded_proposal: Vec<u8> =
+			input.read::<BoundedBytes<ENCODED_PROPOSAL_SIZE_LIMIT>>()?.0;
 
 		log::trace!(
 			target: "democracy-precompile",

--- a/precompiles/relay-encoder/src/lib.rs
+++ b/precompiles/relay-encoder/src/lib.rs
@@ -61,6 +61,8 @@ pub trait StakeEncodeCall {
 	fn encode_call(call: AvailableStakeCalls) -> Vec<u8>;
 }
 
+pub const REWARD_DESTINATION_SIZE_LIMIT: usize = 2usize.pow(16);
+
 #[generate_function_selector]
 #[derive(Debug, PartialEq)]
 enum Action {
@@ -309,8 +311,8 @@ impl Into<RewardDestination<AccountId32>> for RewardDestinationWrapper {
 
 impl EvmData for RewardDestinationWrapper {
 	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
-		let reward_destination = reader.read::<Bytes>()?;
-		let reward_destination_bytes = reward_destination.as_bytes();
+		let reward_destination = reader.read::<BoundedBytes<REWARD_DESTINATION_SIZE_LIMIT>>()?;
+		let reward_destination_bytes = reward_destination.0;
 		ensure!(
 			reward_destination_bytes.len() > 0,
 			revert("Reward destinations cannot be empty")

--- a/precompiles/relay-encoder/src/lib.rs
+++ b/precompiles/relay-encoder/src/lib.rs
@@ -62,6 +62,7 @@ pub trait StakeEncodeCall {
 }
 
 pub const REWARD_DESTINATION_SIZE_LIMIT: usize = 2usize.pow(16);
+pub const ARRAY_LIMIT: usize = 512;
 
 #[generate_function_selector]
 #[derive(Debug, PartialEq)]
@@ -212,9 +213,10 @@ where
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 
 		let mut input = handle.read_input()?;
-		let nominated_as_h256: Vec<H256> = input.read()?;
+		let nominated_as_h256: BoundedVec<H256, ARRAY_LIMIT> = input.read()?;
 
 		let nominated: Vec<AccountId32> = nominated_as_h256
+			.0
 			.iter()
 			.map(|&add| {
 				let as_bytes: [u8; 32] = add.into();

--- a/precompiles/utils/src/data/xcm.rs
+++ b/precompiles/utils/src/data/xcm.rs
@@ -18,13 +18,16 @@
 
 use {
 	crate::{
-		data::{Bytes, EvmData, EvmDataReader, EvmDataWriter},
+		data::{BoundedBytes, Bytes, EvmData, EvmDataReader, EvmDataWriter},
 		revert, EvmResult,
 	},
 	frame_support::ensure,
 	sp_std::vec::Vec,
 	xcm::latest::{Junction, Junctions, MultiLocation, NetworkId},
 };
+
+pub const JUNCTION_SIZE_LIMIT: usize = 2usize.pow(16);
+
 // Function to convert network id to bytes
 // We don't implement EVMData here as these bytes will be appended only
 // to certain Junction variants
@@ -77,8 +80,8 @@ pub(crate) fn network_id_from_bytes(encoded_bytes: Vec<u8>) -> EvmResult<Network
 
 impl EvmData for Junction {
 	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
-		let junction = reader.read::<Bytes>()?;
-		let junction_bytes = junction.as_bytes();
+		let junction = reader.read::<BoundedBytes<JUNCTION_SIZE_LIMIT>>()?;
+		let junction_bytes = junction.0;
 
 		ensure!(
 			junction_bytes.len() > 0,

--- a/precompiles/utils/src/data/xcm.rs
+++ b/precompiles/utils/src/data/xcm.rs
@@ -21,12 +21,12 @@ use {
 		data::{BoundedBytes, Bytes, EvmData, EvmDataReader, EvmDataWriter},
 		revert, EvmResult,
 	},
-	frame_support::ensure,
+	frame_support::{ensure, traits::ConstU32},
 	sp_std::vec::Vec,
 	xcm::latest::{Junction, Junctions, MultiLocation, NetworkId},
 };
 
-pub const JUNCTION_SIZE_LIMIT: usize = 2usize.pow(16);
+pub const JUNCTION_SIZE_LIMIT: u32 = 2u32.pow(16);
 
 // Function to convert network id to bytes
 // We don't implement EVMData here as these bytes will be appended only
@@ -80,8 +80,8 @@ pub(crate) fn network_id_from_bytes(encoded_bytes: Vec<u8>) -> EvmResult<Network
 
 impl EvmData for Junction {
 	fn read(reader: &mut EvmDataReader) -> EvmResult<Self> {
-		let junction = reader.read::<BoundedBytes<JUNCTION_SIZE_LIMIT>>()?;
-		let junction_bytes = junction.0;
+		let junction = reader.read::<BoundedBytes<ConstU32<JUNCTION_SIZE_LIMIT>>>()?;
+		let junction_bytes = junction.into_vec();
 
 		ensure!(
 			junction_bytes.len() > 0,

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -88,7 +88,7 @@ pub trait StatefulPrecompile {
 pub mod prelude {
 	pub use {
 		crate::{
-			data::{Address, Bytes, EvmData, EvmDataReader, EvmDataWriter},
+			data::{Address, BoundedBytes, Bytes, EvmData, EvmDataReader, EvmDataWriter},
 			error,
 			handle::PrecompileHandleExt,
 			logs::{log0, log1, log2, log3, log4, LogExt},

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -88,7 +88,9 @@ pub trait StatefulPrecompile {
 pub mod prelude {
 	pub use {
 		crate::{
-			data::{Address, BoundedBytes, Bytes, EvmData, EvmDataReader, EvmDataWriter},
+			data::{
+				Address, BoundedBytes, BoundedVec, Bytes, EvmData, EvmDataReader, EvmDataWriter,
+			},
 			error,
 			handle::PrecompileHandleExt,
 			logs::{log0, log1, log2, log3, log4, LogExt},

--- a/precompiles/xcm-transactor/src/lib.rs
+++ b/precompiles/xcm-transactor/src/lib.rs
@@ -42,6 +42,8 @@ mod tests;
 pub type TransactorOf<Runtime> = <Runtime as pallet_xcm_transactor::Config>::Transactor;
 pub type CurrencyIdOf<Runtime> = <Runtime as pallet_xcm_transactor::Config>::CurrencyId;
 
+pub const CALL_DATA_LIMIT: usize = 2usize.pow(16);
+
 #[generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
@@ -214,7 +216,7 @@ where
 		let weight: u64 = input.read::<u64>()?;
 
 		// inner call
-		let inner_call = input.read::<Bytes>()?;
+		let inner_call = input.read::<BoundedBytes<CALL_DATA_LIMIT>>()?;
 
 		// Depending on the Runtime, this might involve a DB read. This is not the case in
 		// moonbeam, as we are using IdentityMapping
@@ -252,7 +254,7 @@ where
 		let weight: u64 = input.read::<u64>()?;
 
 		// inner call
-		let inner_call = input.read::<Bytes>()?;
+		let inner_call = input.read::<BoundedBytes<CALL_DATA_LIMIT>>()?;
 
 		let to_account = Runtime::AddressMapping::into_account_id(to_address);
 
@@ -298,7 +300,7 @@ where
 		let weight: u64 = input.read::<u64>()?;
 
 		// call
-		let call = input.read::<Bytes>()?;
+		let call = input.read::<BoundedBytes<CALL_DATA_LIMIT>>()?;
 
 		// Depending on the Runtime, this might involve a DB read. This is not the case in
 		// moonbeam, as we are using IdentityMapping
@@ -342,7 +344,7 @@ where
 		let weight: u64 = input.read::<u64>()?;
 
 		// call
-		let call = input.read::<Bytes>()?;
+		let call = input.read::<BoundedBytes<CALL_DATA_LIMIT>>()?;
 
 		// Depending on the Runtime, this might involve a DB read. This is not the case in
 		// moonbeam, as we are using IdentityMapping

--- a/precompiles/xtokens/src/lib.rs
+++ b/precompiles/xtokens/src/lib.rs
@@ -50,7 +50,6 @@ pub type MaxAssetsForTransfer<Runtime> = <Runtime as orml_xtokens::Config>::MaxA
 
 pub type CurrencyIdOf<Runtime> = <Runtime as orml_xtokens::Config>::CurrencyId;
 
-// pub const ARRAY_LIMIT: usize = 512;
 struct GetMaxAssets<R>(PhantomData<R>);
 
 impl<R> Get<u32> for GetMaxAssets<R>
@@ -284,16 +283,6 @@ where
 		let non_mapped_currencies: BoundedVec<Currency, GetMaxAssets<Runtime>> = input.read()?;
 		let non_mapped_currencies = non_mapped_currencies.into_vec();
 
-		// Now checked using BoundedVec.
-		// TODO: Improve error message customization.
-
-		// // We check this here so that we avoid iterating over the vec
-		// // if the len is more than the max permitted
-		// ensure!(
-		// 	max_assets >= non_mapped_currencies.len(),
-		// 	revert("More than max number of assets given")
-		// );
-
 		let fee_item: u32 = input.read::<u32>()?;
 
 		// read destination
@@ -348,16 +337,6 @@ where
 		input.expect_arguments(4)?;
 		let assets: BoundedVec<EvmMultiAsset, GetMaxAssets<Runtime>> = input.read()?;
 		let assets = assets.into_vec();
-
-		// Now checked using BoundedVec.
-		// TODO: Improve error message customization.
-
-		// // We check this here so that we avoid iterating over the vec
-		// // if the len is more than the max permitted
-		// ensure!(
-		// 	max_assets >= assets.len(),
-		// 	revert("More than max number of assets given")
-		// );
 
 		let fee_item: u32 = input.read::<u32>()?;
 

--- a/precompiles/xtokens/src/lib.rs
+++ b/precompiles/xtokens/src/lib.rs
@@ -51,6 +51,8 @@ pub type MaxAssetsForTransfer<Runtime> = <Runtime as orml_xtokens::Config>::MaxA
 
 pub type CurrencyIdOf<Runtime> = <Runtime as orml_xtokens::Config>::CurrencyId;
 
+pub const ARRAY_LIMIT: usize = 512;
+
 #[generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
@@ -270,7 +272,8 @@ where
 	) -> EvmResult<PrecompileOutput> {
 		let mut input = handle.read_input()?;
 		input.expect_arguments(4)?;
-		let non_mapped_currencies: Vec<Currency> = input.read::<Vec<Currency>>()?;
+		let non_mapped_currencies: BoundedVec<Currency, ARRAY_LIMIT> = input.read()?;
+		let non_mapped_currencies = non_mapped_currencies.0;
 		let max_assets = MaxAssetsForTransfer::<Runtime>::get();
 
 		// We check this here so that we avoid iterating over the vec
@@ -332,7 +335,8 @@ where
 	fn transfer_multi_assets(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
 		let mut input = handle.read_input()?;
 		input.expect_arguments(4)?;
-		let assets: Vec<EvmMultiAsset> = input.read::<Vec<EvmMultiAsset>>()?;
+		let assets: BoundedVec<EvmMultiAsset, ARRAY_LIMIT> = input.read()?;
+		let assets = assets.0;
 		let max_assets = MaxAssetsForTransfer::<Runtime>::get();
 
 		// We check this here so that we avoid iterating over the vec

--- a/precompiles/xtokens/src/lib.rs
+++ b/precompiles/xtokens/src/lib.rs
@@ -51,7 +51,17 @@ pub type MaxAssetsForTransfer<Runtime> = <Runtime as orml_xtokens::Config>::MaxA
 
 pub type CurrencyIdOf<Runtime> = <Runtime as orml_xtokens::Config>::CurrencyId;
 
-pub const ARRAY_LIMIT: usize = 512;
+// pub const ARRAY_LIMIT: usize = 512;
+struct GetMaxAssets<R>(PhantomData<R>);
+
+impl<R> Get<u32> for GetMaxAssets<R>
+where
+	R: orml_xtokens::Config,
+{
+	fn get() -> u32 {
+		<R as orml_xtokens::Config>::MaxAssetsForTransfer::get() as u32
+	}
+}
 
 #[generate_function_selector]
 #[derive(Debug, PartialEq)]
@@ -272,8 +282,8 @@ where
 	) -> EvmResult<PrecompileOutput> {
 		let mut input = handle.read_input()?;
 		input.expect_arguments(4)?;
-		let non_mapped_currencies: BoundedVec<Currency, ARRAY_LIMIT> = input.read()?;
-		let non_mapped_currencies = non_mapped_currencies.0;
+		let non_mapped_currencies: BoundedVec<Currency, GetMaxAssets<Runtime>> = input.read()?;
+		let non_mapped_currencies = non_mapped_currencies.into_vec();
 		let max_assets = MaxAssetsForTransfer::<Runtime>::get();
 
 		// We check this here so that we avoid iterating over the vec
@@ -335,8 +345,8 @@ where
 	fn transfer_multi_assets(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
 		let mut input = handle.read_input()?;
 		input.expect_arguments(4)?;
-		let assets: BoundedVec<EvmMultiAsset, ARRAY_LIMIT> = input.read()?;
-		let assets = assets.0;
+		let assets: BoundedVec<EvmMultiAsset, GetMaxAssets<Runtime>> = input.read()?;
+		let assets = assets.into_vec();
 		let max_assets = MaxAssetsForTransfer::<Runtime>::get();
 
 		// We check this here so that we avoid iterating over the vec

--- a/precompiles/xtokens/src/lib.rs
+++ b/precompiles/xtokens/src/lib.rs
@@ -22,7 +22,6 @@
 use fp_evm::{PrecompileHandle, PrecompileOutput};
 use frame_support::{
 	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
-	ensure,
 	traits::Get,
 };
 use pallet_evm::{AddressMapping, Precompile};
@@ -284,14 +283,16 @@ where
 		input.expect_arguments(4)?;
 		let non_mapped_currencies: BoundedVec<Currency, GetMaxAssets<Runtime>> = input.read()?;
 		let non_mapped_currencies = non_mapped_currencies.into_vec();
-		let max_assets = MaxAssetsForTransfer::<Runtime>::get();
 
-		// We check this here so that we avoid iterating over the vec
-		// if the len is more than the max permitted
-		ensure!(
-			max_assets >= non_mapped_currencies.len(),
-			revert("More than max number of assets given")
-		);
+		// Now checked using BoundedVec.
+		// TODO: Improve error message customization.
+
+		// // We check this here so that we avoid iterating over the vec
+		// // if the len is more than the max permitted
+		// ensure!(
+		// 	max_assets >= non_mapped_currencies.len(),
+		// 	revert("More than max number of assets given")
+		// );
 
 		let fee_item: u32 = input.read::<u32>()?;
 
@@ -347,14 +348,16 @@ where
 		input.expect_arguments(4)?;
 		let assets: BoundedVec<EvmMultiAsset, GetMaxAssets<Runtime>> = input.read()?;
 		let assets = assets.into_vec();
-		let max_assets = MaxAssetsForTransfer::<Runtime>::get();
 
-		// We check this here so that we avoid iterating over the vec
-		// if the len is more than the max permitted
-		ensure!(
-			max_assets >= assets.len(),
-			revert("More than max number of assets given")
-		);
+		// Now checked using BoundedVec.
+		// TODO: Improve error message customization.
+
+		// // We check this here so that we avoid iterating over the vec
+		// // if the len is more than the max permitted
+		// ensure!(
+		// 	max_assets >= assets.len(),
+		// 	revert("More than max number of assets given")
+		// );
 
 		let fee_item: u32 = input.read::<u32>()?;
 

--- a/precompiles/xtokens/src/tests.rs
+++ b/precompiles/xtokens/src/tests.rs
@@ -719,7 +719,7 @@ fn transfer_multi_currencies_cannot_insert_more_than_max() {
 						.write(U256::from(4000000))
 						.build(),
 				)
-				.execute_reverts(|output| output == b"More than max number of assets given");
+				.execute_reverts(|output| output == b"array length is too large");
 		});
 }
 
@@ -772,7 +772,7 @@ fn transfer_multi_assets_cannot_insert_more_than_max() {
 						.write(U256::from(4000000))
 						.build(),
 				)
-				.execute_reverts(|output| output == b"More than max number of assets given");
+				.execute_reverts(|output| output == b"array length is too large");
 		});
 }
 


### PR DESCRIPTION
### What does it do?

Add new utils BoundedVec and BoundedBytes to limit the size of dynamic types.
In live networks the cost of memory should prevent providing inputs too big, but this adds a safeguard and put lower explicit limits.

Feel free to suggest better values for the limits.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

Improve precompile-utils to allow better formatting of errors.

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
