### PR TITLE
[MOON-1510] add check-features build action

### DIFF
--- a/.github/workflows/check-features.yml
+++ b/.github/workflows/check-features.yml
@@ -1,0 +1,26 @@
+name: Check rarely used build features
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  check:
+    name: check features
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+      - name: Setup Rust toolchain
+        run: rustup show
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-check-features-${{ hashFiles('**/Cargo.lock') }}
+      - name: cargo check
+        run: cargo check --features try-runtime,runtime-benchmarks


### PR DESCRIPTION
### What does it do?
Adds a `check-features` build action on pushes to master that checks if `try-runtime` and `runtime-benchmarks` compile successfully. This action should be marked as an optional check.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
