### PR TITLE
Girazoki test limits outbound xcmp queue

### DIFF
--- a/tests/tests/test-xcm/test-mock-hrmp.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp.ts
@@ -2281,7 +2281,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal suspend", (context) => {
     await context.createBlock();
 
     // assert channel with para 2023 is suspended
-    let status = await context.polkadotApi.query.xcmpQueue.outboundXcmpStatus();
+    const status = await context.polkadotApi.query.xcmpQueue.outboundXcmpStatus();
     expect(status[0].state.isSuspended).to.be.true;
   });
 
@@ -2321,10 +2321,10 @@ describeDevMoonbeam("Mock XCM - receive horizontal suspend", (context) => {
     // For channel params, we set the default in all of them except for the maxMessageSize
     // We select MaxMessageSize = 4 because ClearOrigin involves 4 bytes
     // This makes sure that each message is enqued in a different page
-    let paraHrmpMockerTx = mockHrmpChannelExistanceTx(context, suspendedPara, 8, 8192, 4);
+    const paraHrmpMockerTx = mockHrmpChannelExistanceTx(context, suspendedPara, 8, 8192, 4);
 
     // Test for numMessages
-    let numMessages = 100;
+    const numMessages = 100;
 
     for (let i = 0; i < numMessages; i++) {
       await context.createBlock(
@@ -2338,7 +2338,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal suspend", (context) => {
     }
 
     // expect that queued messages is equal to the number of sent messages
-    let queuedMessages =
+    const queuedMessages =
       await await context.polkadotApi.query.xcmpQueue.outboundXcmpMessages.entries();
     expect(queuedMessages.length).to.eq(numMessages);
   });

--- a/tests/tests/test-xcm/test-mock-hrmp.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp.ts
@@ -2341,6 +2341,6 @@ describeDevMoonbeam("Mock XCM - receive horizontal suspend", (context) => {
     // expect that queued messages is equal to the number of sent messages
     const queuedMessages =
       await await context.polkadotApi.query.xcmpQueue.outboundXcmpMessages.entries();
-    expect(queuedMessages.length).to.eq(numMessages);
+    expect(queuedMessages).to.have.lengthOf(numMessages);
   });
 });

--- a/tests/tests/test-xcm/test-mock-hrmp.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp.ts
@@ -2294,7 +2294,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal suspend", (context) => {
     expect(status[0].state.isSuspended).to.be.true;
   });
 
-  it.only("It should push messages, and should enqueue them in xcmp outbound queue", async function () {
+  it("It should push messages, and should enqueue them in xcmp outbound queue", async function () {
     // TARGET 100 messages
     // We want to check there is no visible limit on these
 

--- a/tests/tests/test-xcm/test-mock-hrmp.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp.ts
@@ -2292,7 +2292,8 @@ describeDevMoonbeam("Mock XCM - receive horizontal suspend", (context) => {
 
     // Fragments are grouped together and stored in a message
     // It is this message that we are going to store
-    // The easiest way to test it create a single message every block, with no other messages to append
+    // The easiest way to test it create a single message every block,
+    // with no other messages to append
 
     // We can create these with sudo
     // The simplest message should do it
@@ -2328,14 +2329,16 @@ describeDevMoonbeam("Mock XCM - receive horizontal suspend", (context) => {
     const numMessages = 100;
 
     for (let i = 0; i < numMessages; i++) {
-      await expectOk(context.createBlock(
-        context.polkadotApi.tx.sudo.sudo(
-          context.polkadotApi.tx.utility.batchAll([
-            paraHrmpMockerTx,
-            context.polkadotApi.tx.polkadotXcm.send(versionedMult, messageToSend),
-          ])
+      await expectOk(
+        context.createBlock(
+          context.polkadotApi.tx.sudo.sudo(
+            context.polkadotApi.tx.utility.batchAll([
+              paraHrmpMockerTx,
+              context.polkadotApi.tx.polkadotXcm.send(versionedMult, messageToSend),
+            ])
+          )
         )
-      ));
+      );
     }
 
     // expect that queued messages is equal to the number of sent messages

--- a/tests/tests/test-xcm/test-mock-hrmp.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp.ts
@@ -2282,7 +2282,6 @@ describeDevMoonbeam("Mock XCM - receive horizontal suspend", (context) => {
     ) as any;
     const receivedMessage = context.polkadotApi.createType("u8", 0) as any;
     const totalMessage = [...xcmpFormat.toU8a(), ...receivedMessage.toU8a()];
-    console.log(totalMessage);
     // Send RPC call to inject XCM message
     // We will set a specific message knowing that it should mint the statemint asset
     await customWeb3Request(context.web3, "xcm_injectHrmpMessage", [2023, totalMessage]);

--- a/tests/tests/test-xcm/test-mock-hrmp.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp.ts
@@ -16,6 +16,7 @@ import { describeDevMoonbeam, DevTestContext } from "../../util/setup-dev-tests"
 import type { XcmVersionedXcm, XcmVersionedMultiLocation } from "@polkadot/types/lookup";
 
 import { createContract } from "../../util/transactions";
+import { expectOk } from "../../util/expect";
 
 const FOREIGN_TOKEN = 1_000_000_000_000n;
 
@@ -2327,14 +2328,14 @@ describeDevMoonbeam("Mock XCM - receive horizontal suspend", (context) => {
     const numMessages = 100;
 
     for (let i = 0; i < numMessages; i++) {
-      await context.createBlock(
+      await expectOk(context.createBlock(
         context.polkadotApi.tx.sudo.sudo(
           context.polkadotApi.tx.utility.batchAll([
             paraHrmpMockerTx,
             context.polkadotApi.tx.polkadotXcm.send(versionedMult, messageToSend),
           ])
         )
-      );
+      ));
     }
 
     // expect that queued messages is equal to the number of sent messages

--- a/tests/tests/test-xcm/test-mock-hrmp.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp.ts
@@ -4,13 +4,10 @@ import { KeyringPair } from "@polkadot/keyring/types";
 import {
   ParaId,
   XcmpMessageFormat,
-  MessagingStateSnapshot,
-  H256,
 } from "@polkadot/types/interfaces";
-import { BN, u8aToHex, hexToU8a } from "@polkadot/util";
+import { BN, u8aToHex} from "@polkadot/util";
 import { expect } from "chai";
 import { ChaChaRng } from "randchacha";
-import { xxhashAsU8a } from "@polkadot/util-crypto";
 
 import { alith, baltathar, generateKeyringPair } from "../../util/accounts";
 import { PARA_2000_SOURCE_LOCATION } from "../../util/assets";
@@ -22,7 +19,6 @@ import { describeDevMoonbeam, DevTestContext } from "../../util/setup-dev-tests"
 import type {
   XcmVersionedXcm,
   XcmVersionedMultiLocation,
-  CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot,
 } from "@polkadot/types/lookup";
 
 import { createContract } from "../../util/transactions";
@@ -2306,10 +2302,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal suspend", (context) => {
     const xcmMessage = {
       V2: [{ ClearOrigin: null as any }],
     };
-    const xcmpFormat: XcmpMessageFormat = context.polkadotApi.createType(
-      "XcmpMessageFormat",
-      "ConcatenatedVersionedXcm"
-    ) as any;
+
     const messageToSend: XcmVersionedXcm = context.polkadotApi.createType(
       "XcmVersionedXcm",
       xcmMessage

--- a/tests/tests/test-xcm/test-mock-hrmp.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp.ts
@@ -2342,8 +2342,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal suspend", (context) => {
     }
 
     // expect that queued messages is equal to the number of sent messages
-    const queuedMessages =
-      await await context.polkadotApi.query.xcmpQueue.outboundXcmpMessages.entries();
+    const queuedMessages = await context.polkadotApi.query.xcmpQueue.outboundXcmpMessages.entries();
     expect(queuedMessages).to.have.lengthOf(numMessages);
   });
 });

--- a/tests/tests/test-xcm/test-mock-hrmp.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp.ts
@@ -2285,7 +2285,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal suspend", (context) => {
     expect(status[0].state.isSuspended).to.be.true;
   });
 
-  it("It should push messages, and should enqueue them in xcmp outbound queue", async function () {
+  it("should push messages, and enqueue them in xcmp outbound queue", async function () {
     // TARGET 100 messages
     // We want to check there is no visible limit on these
 

--- a/tests/util/xcm.ts
+++ b/tests/util/xcm.ts
@@ -4,6 +4,7 @@ import { xxhashAsU8a } from "@polkadot/util-crypto";
 import { DevTestContext } from "./setup-dev-tests";
 import {
   CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot,
+  XcmVersionedXcm,
 } from "@polkadot/types/lookup";
 
 // Creates and returns the tx that overrides the paraHRMP existence

--- a/tests/util/xcm.ts
+++ b/tests/util/xcm.ts
@@ -1,0 +1,65 @@
+import { u8aToHex } from "@polkadot/util";
+import { xxhashAsU8a } from "@polkadot/util-crypto";
+
+import { DevTestContext } from "./setup-dev-tests";
+
+import type { CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot } from "@polkadot/types/lookup";
+
+// Creates and returns the tx that overrides the paraHRMP existance
+// This needs to be inserted at every block in which you are willing to test
+// state changes
+// The reason is that set_validation_data inherent overrides it
+export function mockHrmpChannelExistanceTx(
+  context: DevTestContext,
+  para: Number,
+  maxCapacity: Number,
+  maxTotalSize: Number,
+  maxMessageSize: Number
+) {
+  const relevantMessageState = {
+    dmqMqcHead: "0x0000000000000000000000000000000000000000000000000000000000000000",
+    relayDispatchQueueSize: [0, 0],
+    egressChannels: [
+      [
+        para,
+        {
+          maxCapacity,
+          maxTotalSize,
+          maxMessageSize,
+          msgCount: 0,
+          totalSize: 0,
+          mqcHead: null,
+        },
+      ],
+    ],
+    ingressChannels: [
+      [
+        para,
+        {
+          maxCapacity,
+          maxTotalSize,
+          maxMessageSize,
+          msgCount: 0,
+          totalSize: 0,
+          mqcHead: null,
+        },
+      ],
+    ],
+  };
+
+  const stateToInsert: CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot =
+    context.polkadotApi.createType(
+      "CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot",
+      relevantMessageState
+    ) as any;
+
+  // Get keys to modify balance
+  let module = xxhashAsU8a(new TextEncoder().encode("ParachainSystem"), 128);
+  let account_key = xxhashAsU8a(new TextEncoder().encode("RelevantMessagingState"), 128);
+
+  let overallKey = new Uint8Array([...module, ...account_key]);
+
+  return context.polkadotApi.tx.system.setStorage([
+    [u8aToHex(overallKey), u8aToHex(stateToInsert.toU8a())],
+  ]);
+}

--- a/tests/util/xcm.ts
+++ b/tests/util/xcm.ts
@@ -2,8 +2,9 @@ import { u8aToHex } from "@polkadot/util";
 import { xxhashAsU8a } from "@polkadot/util-crypto";
 
 import { DevTestContext } from "./setup-dev-tests";
-
-import type { CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot } from "@polkadot/types/lookup";
+import {
+  CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot,
+} from "@polkadot/types/lookup";
 
 // Creates and returns the tx that overrides the paraHRMP existence
 // This needs to be inserted at every block in which you are willing to test

--- a/tests/util/xcm.ts
+++ b/tests/util/xcm.ts
@@ -16,6 +16,7 @@ export function mockHrmpChannelExistanceTx(
   maxTotalSize: Number,
   maxMessageSize: Number
 ) {
+  // This constructs the relevant state to be inserted
   const relevantMessageState = {
     dmqMqcHead: "0x0000000000000000000000000000000000000000000000000000000000000000",
     relayDispatchQueueSize: [0, 0],
@@ -53,7 +54,7 @@ export function mockHrmpChannelExistanceTx(
       relevantMessageState
     ) as any;
 
-  // Get keys to modify balance
+  // Get keys to modify state
   let module = xxhashAsU8a(new TextEncoder().encode("ParachainSystem"), 128);
   let account_key = xxhashAsU8a(new TextEncoder().encode("RelevantMessagingState"), 128);
 

--- a/tests/util/xcm.ts
+++ b/tests/util/xcm.ts
@@ -5,7 +5,7 @@ import { DevTestContext } from "./setup-dev-tests";
 
 import type { CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot } from "@polkadot/types/lookup";
 
-// Creates and returns the tx that overrides the paraHRMP existance
+// Creates and returns the tx that overrides the paraHRMP existence
 // This needs to be inserted at every block in which you are willing to test
 // state changes
 // The reason is that set_validation_data inherent overrides it
@@ -55,10 +55,10 @@ export function mockHrmpChannelExistanceTx(
     ) as any;
 
   // Get keys to modify state
-  let module = xxhashAsU8a(new TextEncoder().encode("ParachainSystem"), 128);
-  let account_key = xxhashAsU8a(new TextEncoder().encode("RelevantMessagingState"), 128);
+  const module = xxhashAsU8a(new TextEncoder().encode("ParachainSystem"), 128);
+  const account_key = xxhashAsU8a(new TextEncoder().encode("RelevantMessagingState"), 128);
 
-  let overallKey = new Uint8Array([...module, ...account_key]);
+  const overallKey = new Uint8Array([...module, ...account_key]);
 
   return context.polkadotApi.tx.system.setStorage([
     [u8aToHex(overallKey), u8aToHex(stateToInsert.toU8a())],


### PR DESCRIPTION
### What does it do?
Adds tests testing the limits of the outbound queue. In order to test this, we needed to do the following pre-steps:

- Reception of a `Suspend` message from the suspended parachain. We do this through the mock xcm.
- Mock the existence HRMP channel with the suspended parachain. This is needed because otherwise sending the XCM fails before queuing the messages. This needs to be done at every block in which we try to send a message, as otherwise it is overriden by `set_validation_data`

Since the test requires to create a block with each of the inserted messages, I tested for 100 messages enqueued. We can easily change this
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
