### PR TITLE
Filter anonymous proxy

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -949,8 +949,8 @@ impl Contains<Call> for NormalFilter {
 			// We filter anonymous proxy as they make "reserve" inconsistent
 			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270 // editorconfig-checker-disable-line
 			Call::Proxy(method) => match method {
-				pallet_assets::Call::anonymous { .. } => false,
-				pallet_assets::Call::kill_anonymous { .. } => false,
+				pallet_proxy::Call::anonymous { .. } => false,
+				pallet_proxy::Call::kill_anonymous { .. } => false,
 				_ => true,
 			},
 			_ => true,

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -946,6 +946,12 @@ impl Contains<Call> for NormalFilter {
 				pallet_xcm::Call::force_default_xcm_version { .. } => true,
 				_ => false,
 			},
+			// We filter anonymous proxy as they make "reserve" inconsistent
+			Call::Proxy(method) => match method {
+				pallet_assets::Call::anonymous { .. } => false,
+				pallet_assets::Call::kill_anonymous { .. } => false,
+				_ => true,
+			},
 			_ => true,
 		}
 	}

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -947,7 +947,7 @@ impl Contains<Call> for NormalFilter {
 				_ => false,
 			},
 			// We filter anonymous proxy as they make "reserve" inconsistent
-			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270
+			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270 // editorconfig-checker-disable-line
 			Call::Proxy(method) => match method {
 				pallet_assets::Call::anonymous { .. } => false,
 				pallet_assets::Call::kill_anonymous { .. } => false,

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -947,6 +947,7 @@ impl Contains<Call> for NormalFilter {
 				_ => false,
 			},
 			// We filter anonymous proxy as they make "reserve" inconsistent
+			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270
 			Call::Proxy(method) => match method {
 				pallet_assets::Call::anonymous { .. } => false,
 				pallet_assets::Call::kill_anonymous { .. } => false,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -949,7 +949,7 @@ impl Contains<Call> for NormalFilter {
 				_ => false,
 			},
 			// We filter anonymous proxy as they make "reserve" inconsistent
-			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270
+			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270 // editorconfig-checker-disable-line
 			Call::Proxy(method) => match method {
 				pallet_assets::Call::anonymous { .. } => false,
 				pallet_assets::Call::kill_anonymous { .. } => false,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -948,6 +948,12 @@ impl Contains<Call> for NormalFilter {
 				pallet_xcm::Call::force_default_xcm_version { .. } => true,
 				_ => false,
 			},
+			// We filter anonymous proxy as they make "reserve" inconsistent
+			Call::Proxy(method) => match method {
+				pallet_assets::Call::anonymous { .. } => false,
+				pallet_assets::Call::kill_anonymous { .. } => false,
+				_ => true,
+			},
 			// We filter for now transact through signed
 			Call::XcmTransactor(method) => match method {
 				pallet_xcm_transactor::Call::transact_through_signed_multilocation { .. } => false,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -949,6 +949,7 @@ impl Contains<Call> for NormalFilter {
 				_ => false,
 			},
 			// We filter anonymous proxy as they make "reserve" inconsistent
+			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270
 			Call::Proxy(method) => match method {
 				pallet_assets::Call::anonymous { .. } => false,
 				pallet_assets::Call::kill_anonymous { .. } => false,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -951,8 +951,8 @@ impl Contains<Call> for NormalFilter {
 			// We filter anonymous proxy as they make "reserve" inconsistent
 			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270 // editorconfig-checker-disable-line
 			Call::Proxy(method) => match method {
-				pallet_assets::Call::anonymous { .. } => false,
-				pallet_assets::Call::kill_anonymous { .. } => false,
+				pallet_proxy::Call::anonymous { .. } => false,
+				pallet_proxy::Call::kill_anonymous { .. } => false,
 				_ => true,
 			},
 			// We filter for now transact through signed

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -957,8 +957,8 @@ impl Contains<Call> for NormalFilter {
 			// We filter anonymous proxy as they make "reserve" inconsistent
 			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270 // editorconfig-checker-disable-line
 			Call::Proxy(method) => match method {
-				pallet_assets::Call::anonymous { .. } => false,
-				pallet_assets::Call::kill_anonymous { .. } => false,
+				pallet_proxy::Call::anonymous { .. } => false,
+				pallet_proxy::Call::kill_anonymous { .. } => false,
 				_ => true,
 			},
 			// We filter for now transact through signed

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -955,6 +955,7 @@ impl Contains<Call> for NormalFilter {
 				_ => false,
 			},
 			// We filter anonymous proxy as they make "reserve" inconsistent
+			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270
 			Call::Proxy(method) => match method {
 				pallet_assets::Call::anonymous { .. } => false,
 				pallet_assets::Call::kill_anonymous { .. } => false,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -955,7 +955,7 @@ impl Contains<Call> for NormalFilter {
 				_ => false,
 			},
 			// We filter anonymous proxy as they make "reserve" inconsistent
-			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270
+			// See: https://github.com/paritytech/substrate/blob/37cca710eed3dadd4ed5364c7686608f5175cce1/frame/proxy/src/lib.rs#L270 // editorconfig-checker-disable-line
 			Call::Proxy(method) => match method {
 				pallet_assets::Call::anonymous { .. } => false,
 				pallet_assets::Call::kill_anonymous { .. } => false,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -954,6 +954,12 @@ impl Contains<Call> for NormalFilter {
 				pallet_xcm::Call::force_default_xcm_version { .. } => true,
 				_ => false,
 			},
+			// We filter anonymous proxy as they make "reserve" inconsistent
+			Call::Proxy(method) => match method {
+				pallet_assets::Call::anonymous { .. } => false,
+				pallet_assets::Call::kill_anonymous { .. } => false,
+				_ => true,
+			},
 			// We filter for now transact through signed
 			Call::XcmTransactor(method) => match method {
 				pallet_xcm_transactor::Call::transact_through_signed_multilocation { .. } => false,


### PR DESCRIPTION
Anonymous proxy are not well designed. Using them can lead to lost funds and unreserved balances. 
This PR prevents user to use those

See: https://github.com/paritytech/substrate/blob/master/frame/proxy/src/lib.rs#L270
