### PR TITLE
Reduces gas limit in ethereum transaction for test

### DIFF
--- a/tests/tests/test-eth-tx/test-eth-tx-types.ts
+++ b/tests/tests/test-eth-tx/test-eth-tx-types.ts
@@ -19,14 +19,14 @@ describeDevMoonbeam(
       expect(extrinsic.asLegacy.toJSON()).to.deep.equal({
         nonce: 0,
         gasPrice: 1000000000,
-        gasLimit: 12000000,
+        gasLimit: 500000,
         action: { call: baltathar.address.toLowerCase() },
         value: 512,
         input: "0x",
         signature: {
           v: 2597,
-          r: "0x440c713c1ea8ced9edacac8a33baa89411dca31af33b5c6e2c8e4a3c95112ab4",
-          s: "0x17c303f32862b65034da593cc0fb1178c915ef7a0b9c221ff3b7d00647b208fb",
+          r: "0xcf557dd84876e395aa34349e050c72e4af7f18a3e1307f165883f909175ad9e4",
+          s: "0x67b34284e732937f030ddbf6ce0bdedea92f11c764b1b461167c890e661089cf",
         },
       });
     });

--- a/tests/tests/test-eth-tx/test-eth-tx-types.ts
+++ b/tests/tests/test-eth-tx/test-eth-tx-types.ts
@@ -2,15 +2,23 @@ import "@moonbeam-network/api-augment";
 
 import { expect } from "chai";
 
-import { baltathar } from "../../util/accounts";
+import { ALITH_PRIVATE_KEY, baltathar } from "../../util/accounts";
 import { describeDevMoonbeam } from "../../util/setup-dev-tests";
-import { createTransfer } from "../../util/transactions";
+import { createTransaction, createTransfer } from "../../util/transactions";
 
 describeDevMoonbeam(
   "Ethereum Transaction - Legacy",
   (context) => {
     it("should contain valid legacy Ethereum data", async function () {
-      await context.createBlock(createTransfer(context, baltathar.address, 512));
+      await context.createBlock(
+        createTransaction(context, {
+          privateKey: ALITH_PRIVATE_KEY,
+          to: baltathar.address,
+          gas: 12_000_000,
+          gasPrice: 1_000_000_000,
+          value: 512,
+        })
+      );
 
       const signedBlock = await context.polkadotApi.rpc.chain.getBlock();
       let extrinsic = signedBlock.block.extrinsics.find((ex) => ex.method.section == "ethereum")
@@ -19,14 +27,14 @@ describeDevMoonbeam(
       expect(extrinsic.asLegacy.toJSON()).to.deep.equal({
         nonce: 0,
         gasPrice: 1000000000,
-        gasLimit: 500000,
+        gasLimit: 12000000,
         action: { call: baltathar.address.toLowerCase() },
         value: 512,
         input: "0x",
         signature: {
           v: 2597,
-          r: "0xcf557dd84876e395aa34349e050c72e4af7f18a3e1307f165883f909175ad9e4",
-          s: "0x67b34284e732937f030ddbf6ce0bdedea92f11c764b1b461167c890e661089cf",
+          r: "0x440c713c1ea8ced9edacac8a33baa89411dca31af33b5c6e2c8e4a3c95112ab4",
+          s: "0x17c303f32862b65034da593cc0fb1178c915ef7a0b9c221ff3b7d00647b208fb",
         },
       });
     });

--- a/tests/tests/test-subscription/test-subscription.ts
+++ b/tests/tests/test-subscription/test-subscription.ts
@@ -29,7 +29,7 @@ describeDevMoonbeam("Subscription - Block headers", (context) => {
     const promise = new Promise<BlockHeader>((resolve) => {
       subscription.once("data", resolve);
     });
-    await context.createBlock(createTransfer(context, baltathar.address, 0));
+    await context.createBlock(createTransfer(context, baltathar.address, 0, { gas: 12000000 }));
     const data = await promise;
     subscription.unsubscribe();
 

--- a/tests/tests/test-txpool/test-txpool-pending.ts
+++ b/tests/tests/test-txpool/test-txpool-pending.ts
@@ -69,10 +69,14 @@ describeDevMoonbeam("TxPool - Ethereum Contract Call", (context) => {
 
     txHash = (
       await customWeb3Request(context.web3, "eth_sendRawTransaction", [
-        await createContractExecution(context, {
-          contract,
-          contractCall: contract.methods.multiply(5),
-        }),
+        await createContractExecution(
+          context,
+          {
+            contract,
+            contractCall: contract.methods.multiply(5),
+          },
+          { gas: 12000000 }
+        ),
       ])
     ).result;
   });

--- a/tests/util/transactions.ts
+++ b/tests/util/transactions.ts
@@ -170,7 +170,7 @@ export const createTransfer = async (
 export async function createContract(
   context: DevTestContext,
   contractName: string,
-  options: TransactionOptions = ALITH_TRANSACTION_TEMPLATE,
+  options: TransactionOptions = { ...ALITH_TRANSACTION_TEMPLATE, gas: 5_000_000 },
   contractArguments: any[] = []
 ): Promise<{ rawTx: string; contract: Contract; contractAddress: string }> {
   const contractCompiled = getCompiled(contractName);

--- a/tests/util/transactions.ts
+++ b/tests/util/transactions.ts
@@ -30,7 +30,7 @@ export interface TransactionOptions {
 
 export const TRANSACTION_TEMPLATE: TransactionOptions = {
   nonce: null,
-  gas: 12_000_000,
+  gas: 500_000,
   gasPrice: 1_000_000_000,
   value: "0x00",
 };


### PR DESCRIPTION
This prevents tests that are needing multiple ethereum transactions in a single block to fail.

The value has switched from 12_000_000 to 500_000 which I believe is enough for all the default transactions we do