### PR TITLE
fix tracing tests: 1000 loop require higher gas limit

### DIFF
--- a/tests/tracing-tests/test-trace-gas.ts
+++ b/tests/tracing-tests/test-trace-gas.ts
@@ -31,7 +31,7 @@ describeDevMoonbeam("Trace filter - Gas Loop", (context) => {
         createContractExecution(context, {
           contract,
           contractCall: contract.methods.incrementalLoop(loop.count),
-        })
+        }, { gas: 3_000_000 })
       );
       loop.txHash = result.hash;
       loop.blockNumber = i + 2;
@@ -74,7 +74,7 @@ describeDevMoonbeam("Trace filter - Gas Loop", (context) => {
 
   it("should return 2068654 gasUsed for 1000 loop", async function () {
     this.timeout(12000);
-    const { rawTx } = await createContract(context, "Looper");
+    const { rawTx } = await createContract(context, "Looper", { gas: 3_000_000 });
     await context.createBlock(rawTx);
 
     const trace = await customWeb3Request(context.web3, "trace_filter", [

--- a/tests/tracing-tests/test-trace-gas.ts
+++ b/tests/tracing-tests/test-trace-gas.ts
@@ -28,10 +28,14 @@ describeDevMoonbeam("Trace filter - Gas Loop", (context) => {
     for (let i = 0; i < testLoops.length; i++) {
       const loop = testLoops[i];
       const { result } = await context.createBlock(
-        createContractExecution(context, {
-          contract,
-          contractCall: contract.methods.incrementalLoop(loop.count),
-        }, { gas: 3_000_000 })
+        createContractExecution(
+          context,
+          {
+            contract,
+            contractCall: contract.methods.incrementalLoop(loop.count),
+          },
+          { gas: 3_000_000 }
+        )
       );
       loop.txHash = result.hash;
       loop.blockNumber = i + 2;


### PR DESCRIPTION
### What does it do?

Tracing tests was broken by commit 2e8425b054484f291b6eb81cbe372fe710374b8d.
This commit set the default gas limit to 500 000 instead of 12 000 000, but this is not enough for some cases in tracing tests. 

This PR just hardcode a higher gas limit for theses cases.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
