### PR TITLE
Forbid recursion in randomness precompile

### DIFF
--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -115,7 +115,7 @@ pub type MoonbasePrecompiles<R> = PrecompileSetBuilder<
 				PrecompileAt<AddressU64<2054>, XcmTransactorWrapper<R>>,
 				PrecompileAt<AddressU64<2055>, AuthorMappingWrapper<R>>,
 				PrecompileAt<AddressU64<2056>, BatchPrecompile<R>, LimitRecursionTo<2>>,
-				PrecompileAt<AddressU64<2057>, RandomnessWrapper<R>>,
+				PrecompileAt<AddressU64<2057>, RandomnessWrapper<R>, ForbidRecursion>,
 				PrecompileAt<AddressU64<2058>, CallPermitPrecompile<R>>,
 			),
 		>,


### PR DESCRIPTION
To prevent some edge case related to recursively calling `fulfill`

