### PR TITLE
Increase randomness recursion limit to 1

### DIFF
--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -115,7 +115,7 @@ pub type MoonbasePrecompiles<R> = PrecompileSetBuilder<
 				PrecompileAt<AddressU64<2054>, XcmTransactorWrapper<R>>,
 				PrecompileAt<AddressU64<2055>, AuthorMappingWrapper<R>>,
 				PrecompileAt<AddressU64<2056>, BatchPrecompile<R>, LimitRecursionTo<2>>,
-				PrecompileAt<AddressU64<2057>, RandomnessWrapper<R>, LimitRecursionTo<2>>,
+				PrecompileAt<AddressU64<2057>, RandomnessWrapper<R>, LimitRecursionTo<1>>,
 				PrecompileAt<AddressU64<2058>, CallPermitPrecompile<R>>,
 			),
 		>,

--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -115,7 +115,7 @@ pub type MoonbasePrecompiles<R> = PrecompileSetBuilder<
 				PrecompileAt<AddressU64<2054>, XcmTransactorWrapper<R>>,
 				PrecompileAt<AddressU64<2055>, AuthorMappingWrapper<R>>,
 				PrecompileAt<AddressU64<2056>, BatchPrecompile<R>, LimitRecursionTo<2>>,
-				PrecompileAt<AddressU64<2057>, RandomnessWrapper<R>>,
+				PrecompileAt<AddressU64<2057>, RandomnessWrapper<R>, LimitRecursionTo<2>>,
 				PrecompileAt<AddressU64<2058>, CallPermitPrecompile<R>>,
 			),
 		>,

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -66,11 +66,6 @@ use sp_runtime::{
 use xcm::latest::prelude::*;
 
 #[test]
-fn verify_randomness_recursion_limit() {
-	// verify Randomness recursion limit is 2 for safety purposes
-}
-
-#[test]
 fn verify_randomness_precompile_gas_constants() {
 	let weight_to_gas = |weight| {
 		<moonbase_runtime::Runtime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(weight)

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -66,6 +66,11 @@ use sp_runtime::{
 use xcm::latest::prelude::*;
 
 #[test]
+fn verify_randomness_recursion_limit() {
+	// verify Randomness recursion limit is 2 for safety purposes
+}
+
+#[test]
 fn verify_randomness_precompile_gas_constants() {
 	let weight_to_gas = |weight| {
 		<moonbase_runtime::Runtime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(weight)


### PR DESCRIPTION
Increases randomness recursion limit to 1 so that users can request the next randomness via the fulfillment callback. It is a nice automatic way to make the next request upon fulfilling the last one.

Refactors `finish_fulfillment` so that, if it is ever called more than once, it will only do the storage/balance changes once. This makes it safe against recursive callbacks (review logic below).

For context, the `fulfill_request` precompile function calls `let result = prepare_fulfill()` then uses that result in the randomness callback before calling `finish_fulfillment`. The `prepare_fulfill` only reads storage and returns a result. It does not write to storage at all. This PR changes `finish_fulfillment` so that it only makes the storage changes associated with cleaning up the request once. If it was called a second time, it would do nothing the second time it is called.
