### PR TITLE
Note author for next round if new round block

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1851,7 +1851,12 @@ pub mod pallet {
 	/// * 20 points to the block producer for producing a block in the chain
 	impl<T: Config> nimbus_primitives::EventHandler<T::AccountId> for Pallet<T> {
 		fn note_author(author: T::AccountId) {
-			let now = <Round<T>>::get().current;
+			let mut round = <Round<T>>::get();
+			let now = if round.should_update() {
+				round.current.saturating_add(1u64)
+			} else {
+				round.current
+			};
 			let score_plus_20 = <AwardedPts<T>>::get(now, &author).saturating_add(20);
 			<AwardedPts<T>>::insert(now, author, score_plus_20);
 			<Points<T>>::mutate(now, |x| *x = x.saturating_add(20));

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1851,9 +1851,9 @@ pub mod pallet {
 	/// * 20 points to the block producer for producing a block in the chain
 	impl<T: Config> nimbus_primitives::EventHandler<T::AccountId> for Pallet<T> {
 		fn note_author(author: T::AccountId) {
-			let mut round = <Round<T>>::get();
-			let now = if round.should_update() {
-				round.current.saturating_add(1u64)
+			let round = <Round<T>>::get();
+			let now = if round.should_update(frame_system::Pallet::<T>::block_number()) {
+				round.current.saturating_add(1u32)
 			} else {
 				round.current
 			};


### PR DESCRIPTION
For the block of a round change, we want the author of that block to get credit for the new round and not the previous round. So `ParachainStaking::note_author` has been changed s.t. we increment the round number used for tracking points iff the round is supposed to change this block but has not yet.

It was previously expected that the order of ParachainStaking above AuthorInherent in the runtimes would ensure that the round would change before `note_author`, but a real world scenario + smoke tests showed `note_author` was called before the round change in one such block. Therefore, we add this code which increments the round iff the round is supposed to change this block but has not yet.