### PR TITLE
[MOON-1806] remove deprecated parachain-staking items

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -471,18 +471,6 @@ pub mod pallet {
 	pub(crate) type Round<T: Config> = StorageValue<_, RoundInfo<T::BlockNumber>, ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn nominator_state2)]
-	/// DEPRECATED in favor of DelegatorState
-	/// Get nominator state associated with an account if account is nominating else None
-	pub(crate) type NominatorState2<T: Config> = StorageMap<
-		_,
-		Twox64Concat,
-		T::AccountId,
-		Nominator2<T::AccountId, BalanceOf<T>>,
-		OptionQuery,
-	>;
-
-	#[pallet::storage]
 	#[pallet::getter(fn delegator_state)]
 	/// Get delegator state associated with an account if account is delegating else None
 	pub(crate) type DelegatorState<T: Config> = StorageMap<
@@ -490,18 +478,6 @@ pub mod pallet {
 		Twox64Concat,
 		T::AccountId,
 		Delegator<T::AccountId, BalanceOf<T>>,
-		OptionQuery,
-	>;
-
-	#[pallet::storage]
-	#[pallet::getter(fn candidate_state)]
-	/// DEPRECATED
-	/// Get collator candidate state associated with an account if account is a candidate else None
-	pub(crate) type CandidateState<T: Config> = StorageMap<
-		_,
-		Twox64Concat,
-		T::AccountId,
-		CollatorCandidate<T::AccountId, BalanceOf<T>>,
 		OptionQuery,
 	>;
 
@@ -551,18 +527,6 @@ pub mod pallet {
 		Twox64Concat,
 		T::AccountId,
 		Delegations<T::AccountId, BalanceOf<T>>,
-		OptionQuery,
-	>;
-
-	#[pallet::storage]
-	#[pallet::getter(fn collator_state2)]
-	/// DEPRECATED in favor of CandidateState
-	/// Get collator state associated with an account if account is collating else None
-	pub(crate) type CollatorState2<T: Config> = StorageMap<
-		_,
-		Twox64Concat,
-		T::AccountId,
-		Collator2<T::AccountId, BalanceOf<T>>,
 		OptionQuery,
 	>;
 

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -24,9 +24,8 @@ use crate::pallet::{DelegationScheduledRequests, DelegatorState, Total};
 use crate::types::deprecated::{DelegationChange, Delegator as OldDelegator};
 use crate::types::Delegator;
 use crate::{
-	BalanceOf, Bond, BottomDelegations, CandidateInfo, CandidateMetadata, CandidateState,
-	CapacityStatus, CollatorCandidate, Config, Delegations, Event, Pallet, Points, Round, Staked,
-	TopDelegations,
+	BalanceOf, Bond, BottomDelegations, CandidateInfo, CandidateMetadata, CapacityStatus,
+	CollatorCandidate, Config, Delegations, Event, Pallet, Points, Round, Staked, TopDelegations,
 };
 #[cfg(feature = "try-runtime")]
 use frame_support::traits::OnRuntimeUpgradeHelpersExt;
@@ -524,95 +523,6 @@ impl<T: Config> OnRuntimeUpgrade for SplitCandidateStateToDecreasePoV<T> {
 	}
 }
 */
-
-/// Migration to properly increase maximum delegations per collator
-/// The logic may be used to recompute the top and bottom delegations whenever
-/// MaxTopDelegationsPerCandidate changes (works for if decreases as well)
-pub struct IncreaseMaxDelegationsPerCandidate<T>(PhantomData<T>);
-impl<T: Config> OnRuntimeUpgrade for IncreaseMaxDelegationsPerCandidate<T> {
-	fn on_runtime_upgrade() -> Weight {
-		let (mut reads, mut writes) = (0u64, 0u64);
-		for (account, state) in <CandidateState<T>>::iter() {
-			reads = reads.saturating_add(1u64);
-			// 1. collect all delegations into single vec and order them
-			let mut all_delegations = state.top_delegations.clone();
-			let mut starting_bottom_delegations = state.bottom_delegations.clone();
-			all_delegations.append(&mut starting_bottom_delegations);
-			// sort all delegations from greatest to least
-			all_delegations.sort_unstable_by(|a, b| b.amount.cmp(&a.amount));
-			let top_n = T::MaxTopDelegationsPerCandidate::get() as usize;
-			// 2. split them into top and bottom using the T::MaxNominatorsPerCollator
-			let top_delegations: Vec<Bond<T::AccountId, BalanceOf<T>>> =
-				all_delegations.iter().take(top_n).cloned().collect();
-			let bottom_delegations = if all_delegations.len() > top_n {
-				let rest = all_delegations.len() - top_n;
-				let bottom: Vec<Bond<T::AccountId, BalanceOf<T>>> =
-					all_delegations.iter().rev().take(rest).cloned().collect();
-				bottom
-			} else {
-				// empty, all nominations are in top
-				Vec::new()
-			};
-			let (mut total_counted, mut total_backing): (BalanceOf<T>, BalanceOf<T>) =
-				(state.bond.into(), state.bond.into());
-			for Bond { amount, .. } in &top_delegations {
-				total_counted = total_counted.saturating_add(*amount);
-				total_backing = total_backing.saturating_add(*amount);
-			}
-			for Bond { amount, .. } in &bottom_delegations {
-				total_backing = total_backing.saturating_add(*amount);
-			}
-			// update candidate pool with new total counted if it changed
-			if state.total_counted != total_counted && state.is_active() {
-				reads = reads.saturating_add(1u64);
-				writes = writes.saturating_add(1u64);
-				<Pallet<T>>::update_active(account.clone(), total_counted);
-			}
-			<CandidateState<T>>::insert(
-				account,
-				CollatorCandidate {
-					top_delegations,
-					bottom_delegations,
-					total_counted,
-					total_backing,
-					..state
-				},
-			);
-			writes = writes.saturating_add(1u64);
-		}
-		let weight = T::DbWeight::get();
-		// 20% of the max block weight as safety margin for computation
-		weight.reads(reads) + weight.writes(writes) + 100_000_000_000
-	}
-	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade() -> Result<(), &'static str> {
-		// get delegation count for all candidates to check consistency
-		for (account, state) in <CandidateState<T>>::iter() {
-			// insert top + bottom into some temp map?
-			let total_delegation_count =
-				state.top_delegations.len() as u32 + state.bottom_delegations.len() as u32;
-			Self::set_temp_storage(
-				total_delegation_count,
-				&format!("Candidate{:?}DelegationCount", account)[..],
-			);
-		}
-		Ok(())
-	}
-
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade() -> Result<(), &'static str> {
-		// check that top + bottom are the same as the expected (stored in temp)
-		for (account, state) in <CandidateState<T>>::iter() {
-			let expected_count: u32 =
-				Self::get_temp_storage(&format!("Candidate{:?}DelegationCount", account)[..])
-					.expect("qed");
-			let actual_count =
-				state.top_delegations.len() as u32 + state.bottom_delegations.len() as u32;
-			assert_eq!(expected_count, actual_count);
-		}
-		Ok(())
-	}
-}
 
 /// Migration to replace the automatic ExitQueue with a manual exits API.
 /// This migration is idempotent so it can be run more than once without any risk.

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -1059,7 +1059,7 @@ fn execute_leave_candidates_removes_candidate_state() {
 				1,
 				0
 			));
-			assert!(ParachainStaking::candidate_state(1).is_none());
+			assert!(ParachainStaking::candidate_info(1).is_none());
 		});
 }
 
@@ -1099,7 +1099,7 @@ fn execute_leave_candidates_removes_pending_delegation_requests() {
 				1,
 				1
 			));
-			assert!(ParachainStaking::candidate_state(1).is_none());
+			assert!(ParachainStaking::candidate_info(1).is_none());
 			assert!(
 				!ParachainStaking::delegation_scheduled_requests(&1)
 					.iter()

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -39,21 +39,13 @@ type BalanceOf<Runtime> = <<Runtime as pallet_parachain_staking::Config>::Curren
 #[generate_function_selector]
 #[derive(Debug, PartialEq)]
 enum Action {
-	// DEPRECATED
-	MinNomination = "min_nomination()",
 	MinDelegation = "min_delegation()",
 	Points = "points(uint256)",
 	CandidateCount = "candidate_count()",
 	Round = "round()",
-	// DEPRECATED
-	CollatorNominationCount = "collator_nomination_count(address)",
-	// DEPRECATED
-	NominatorNominationCount = "nominator_nomination_count(address)",
 	CandidateDelegationCount = "candidate_delegation_count(address)",
 	DelegatorDelegationCount = "delegator_delegation_count(address)",
 	SelectedCandidates = "selected_candidates()",
-	// DEPRECATED
-	IsNominator = "is_nominator(address)",
 	IsDelegator = "is_delegator(address)",
 	IsCandidate = "is_candidate(address)",
 	IsSelectedCandidate = "is_selected_candidate(address)",
@@ -61,35 +53,21 @@ enum Action {
 	CandidateExitIsPending = "candidate_exit_is_pending(address)",
 	CandidateRequestIsPending = "candidate_request_is_pending(address)",
 	JoinCandidates = "join_candidates(uint256,uint256)",
-	// DEPRECATED
-	LeaveCandidates = "leave_candidates(uint256)",
 	ScheduleLeaveCandidates = "schedule_leave_candidates(uint256)",
 	ExecuteLeaveCandidates = "execute_leave_candidates(address,uint256)",
 	CancelLeaveCandidates = "cancel_leave_candidates(uint256)",
 	GoOffline = "go_offline()",
 	GoOnline = "go_online()",
-	// DEPRECATED
-	CandidateBondLess = "candidate_bond_less(uint256)",
 	ScheduleCandidateBondLess = "schedule_candidate_bond_less(uint256)",
 	CandidateBondMore = "candidate_bond_more(uint256)",
 	ExecuteCandidateBondLess = "execute_candidate_bond_less(address)",
 	CancelCandidateBondLess = "cancel_candidate_bond_less()",
-	// DEPRECATED
-	Nominate = "nominate(address,uint256,uint256,uint256)",
 	Delegate = "delegate(address,uint256,uint256,uint256)",
-	// DEPRECATED
-	LeaveNominators = "leave_nominators(uint256)",
 	ScheduleLeaveDelegators = "schedule_leave_delegators()",
 	ExecuteLeaveDelegators = "execute_leave_delegators(address,uint256)",
 	CancelLeaveDelegators = "cancel_leave_delegators()",
-	// DEPRECATED
-	RevokeNomination = "revoke_nomination(address)",
 	ScheduleRevokeDelegation = "schedule_revoke_delegation(address)",
-	// DEPRECATED
-	NominatorBondLess = "nominator_bond_less(address,uint256)",
 	ScheduleDelegatorBondLess = "schedule_delegator_bond_less(address,uint256)",
-	// DEPRECATED
-	NominatorBondMore = "nominator_bond_more(address,uint256)",
 	DelegatorBondMore = "delegator_bond_more(address,uint256)",
 	ExecuteDelegationRequest = "execute_delegation_request(address,address)",
 	CancelDelegationRequest = "cancel_delegation_request(address)",
@@ -119,17 +97,13 @@ where
 
 		handle.check_function_modifier(match selector {
 			// Views
-			Action::IsNominator
-			| Action::IsDelegator
+			Action::IsDelegator
 			| Action::IsCandidate
 			| Action::IsSelectedCandidate
-			| Action::MinNomination
 			| Action::MinDelegation
 			| Action::Points
 			| Action::CandidateCount
 			| Action::Round
-			| Action::CollatorNominationCount
-			| Action::NominatorNominationCount
 			| Action::CandidateDelegationCount
 			| Action::DelegatorDelegationCount
 			| Action::SelectedCandidates
@@ -138,28 +112,21 @@ where
 			| Action::CandidateRequestIsPending => FunctionModifier::View,
 			// Non-payables
 			Action::JoinCandidates
-			| Action::LeaveCandidates
 			| Action::ScheduleLeaveCandidates
 			| Action::ExecuteLeaveCandidates
 			| Action::CancelLeaveCandidates
 			| Action::GoOffline
 			| Action::GoOnline
-			| Action::CandidateBondLess
 			| Action::ScheduleCandidateBondLess
 			| Action::CandidateBondMore
 			| Action::ExecuteCandidateBondLess
 			| Action::CancelCandidateBondLess
-			| Action::Nominate
 			| Action::Delegate
-			| Action::LeaveNominators
 			| Action::ScheduleLeaveDelegators
 			| Action::ExecuteLeaveDelegators
 			| Action::CancelLeaveDelegators
-			| Action::RevokeNomination
 			| Action::ScheduleRevokeDelegation
-			| Action::NominatorBondLess
 			| Action::ScheduleDelegatorBondLess
-			| Action::NominatorBondMore
 			| Action::DelegatorBondMore
 			| Action::ExecuteDelegationRequest
 			| Action::CancelDelegationRequest => FunctionModifier::NonPayable,
@@ -167,21 +134,13 @@ where
 
 		// Return early if storage getter; return (origin, call) if dispatchable
 		let (origin, call) = match selector {
-			// DEPRECATED
-			Action::MinNomination => return Self::min_delegation(handle),
 			Action::MinDelegation => return Self::min_delegation(handle),
 			Action::Points => return Self::points(handle),
 			Action::CandidateCount => return Self::candidate_count(handle),
 			Action::Round => return Self::round(handle),
-			// DEPRECATED
-			Action::CollatorNominationCount => return Self::candidate_delegation_count(handle),
-			// DEPRECATED
-			Action::NominatorNominationCount => return Self::delegator_delegation_count(handle),
 			Action::CandidateDelegationCount => return Self::candidate_delegation_count(handle),
 			Action::DelegatorDelegationCount => return Self::delegator_delegation_count(handle),
 			Action::SelectedCandidates => return Self::selected_candidates(handle),
-			// DEPRECATED
-			Action::IsNominator => return Self::is_delegator(handle),
 			Action::IsDelegator => return Self::is_delegator(handle),
 			Action::IsCandidate => return Self::is_candidate(handle),
 			Action::IsSelectedCandidate => return Self::is_selected_candidate(handle),
@@ -192,35 +151,21 @@ where
 			Action::CandidateRequestIsPending => return Self::candidate_request_is_pending(handle),
 			// runtime methods (dispatchables)
 			Action::JoinCandidates => Self::join_candidates(handle)?,
-			// DEPRECATED
-			Action::LeaveCandidates => Self::schedule_leave_candidates(handle)?,
 			Action::ScheduleLeaveCandidates => Self::schedule_leave_candidates(handle)?,
 			Action::ExecuteLeaveCandidates => Self::execute_leave_candidates(handle)?,
 			Action::CancelLeaveCandidates => Self::cancel_leave_candidates(handle)?,
 			Action::GoOffline => Self::go_offline(handle)?,
 			Action::GoOnline => Self::go_online(handle)?,
-			// DEPRECATED
-			Action::CandidateBondLess => Self::schedule_candidate_bond_less(handle)?,
 			Action::ScheduleCandidateBondLess => Self::schedule_candidate_bond_less(handle)?,
 			Action::CandidateBondMore => Self::candidate_bond_more(handle)?,
 			Action::ExecuteCandidateBondLess => Self::execute_candidate_bond_less(handle)?,
 			Action::CancelCandidateBondLess => Self::cancel_candidate_bond_less(handle)?,
-			// DEPRECATED
-			Action::Nominate => Self::delegate(handle)?,
 			Action::Delegate => Self::delegate(handle)?,
-			// DEPRECATED
-			Action::LeaveNominators => Self::schedule_leave_delegators(handle)?,
 			Action::ScheduleLeaveDelegators => Self::schedule_leave_delegators(handle)?,
 			Action::ExecuteLeaveDelegators => Self::execute_leave_delegators(handle)?,
 			Action::CancelLeaveDelegators => Self::cancel_leave_delegators(handle)?,
-			// DEPRECATED
-			Action::RevokeNomination => Self::schedule_revoke_delegation(handle)?,
 			Action::ScheduleRevokeDelegation => Self::schedule_revoke_delegation(handle)?,
-			// DEPRECATED
-			Action::NominatorBondLess => Self::schedule_delegator_bond_less(handle)?,
 			Action::ScheduleDelegatorBondLess => Self::schedule_delegator_bond_less(handle)?,
-			// DEPRECATED
-			Action::NominatorBondMore => Self::delegator_bond_more(handle)?,
 			Action::DelegatorBondMore => Self::delegator_bond_more(handle)?,
 			Action::ExecuteDelegationRequest => Self::execute_delegation_request(handle)?,
 			Action::CancelDelegationRequest => Self::cancel_delegation_request(handle)?,

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -46,60 +46,38 @@ fn evm_call(source: Account, input: Vec<u8>) -> EvmCall<Runtime> {
 
 #[test]
 fn selectors() {
-	// DEPRECATED
-	assert_eq!(Action::IsNominator as u32, 0x8e5080e7);
 	assert_eq!(Action::IsDelegator as u32, 0x1f030587);
 	assert_eq!(Action::IsCandidate as u32, 0x8545c833);
 	assert_eq!(Action::IsSelectedCandidate as u32, 0x8f6d27c7);
 	assert_eq!(Action::Points as u32, 0x9799b4e7);
-	// DEPRECATED
-	assert_eq!(Action::MinNomination as u32, 0xc9f593b2);
 	assert_eq!(Action::MinDelegation as u32, 0x72ce8933);
 	assert_eq!(Action::CandidateCount as u32, 0x4b1c4c29);
 	assert_eq!(Action::Round as u32, 0x146ca531);
-	assert_eq!(Action::CollatorNominationCount as u32, 0x0ad6a7be);
 	assert_eq!(Action::CandidateDelegationCount as u32, 0x815b796c);
-	assert_eq!(Action::NominatorNominationCount as u32, 0xdae5659b);
 	assert_eq!(Action::DelegatorDelegationCount as u32, 0xfbc51bca);
 	assert_eq!(Action::SelectedCandidates as u32, 0x89f47a21);
 	assert_eq!(Action::DelegationRequestIsPending as u32, 0x192e1db3);
 	assert_eq!(Action::CandidateExitIsPending as u32, 0xeb613b8a);
 	assert_eq!(Action::CandidateRequestIsPending as u32, 0x26ab05fb);
 	assert_eq!(Action::JoinCandidates as u32, 0x0a1bff60);
-	// DEPRECATED
-	assert_eq!(Action::LeaveCandidates as u32, 0x72b02a31);
 	assert_eq!(Action::ScheduleLeaveCandidates as u32, 0x60afbac6);
 	assert_eq!(Action::ExecuteLeaveCandidates as u32, 0x3fdc4c30);
 	assert_eq!(Action::CancelLeaveCandidates as u32, 0x0880b3e2);
 	assert_eq!(Action::GoOffline as u32, 0x767e0450);
 	assert_eq!(Action::GoOnline as u32, 0xd2f73ceb);
 	assert_eq!(Action::CandidateBondMore as u32, 0xc57bd3a8);
-	// DEPRECATED
-	assert_eq!(Action::CandidateBondLess as u32, 0x289b6ba7);
 	assert_eq!(Action::ScheduleCandidateBondLess as u32, 0x034c47bc);
 	assert_eq!(Action::ExecuteCandidateBondLess as u32, 0xa9a2b8b7);
 	assert_eq!(Action::CancelCandidateBondLess as u32, 0x583d0fdc);
-	// DEPRECATED
-	assert_eq!(Action::Nominate as u32, 0x49df6eb3);
 	assert_eq!(Action::Delegate as u32, 0x829f5ee3);
-	// DEPRECATED
-	assert_eq!(Action::LeaveNominators as u32, 0xb71d2153);
 	assert_eq!(Action::ScheduleLeaveDelegators as u32, 0x65a5bbd0);
 	assert_eq!(Action::ExecuteLeaveDelegators as u32, 0xa84a7468);
 	assert_eq!(Action::CancelLeaveDelegators as u32, 0x2a987643);
-	// DEPRECATED
-	assert_eq!(Action::RevokeNomination as u32, 0x4b65c34b);
 	assert_eq!(Action::ScheduleRevokeDelegation as u32, 0x22266e75);
 	assert_eq!(Action::ExecuteLeaveDelegators as u32, 0xa84a7468);
 	assert_eq!(Action::CancelLeaveDelegators as u32, 0x2a987643);
-	// DEPRECATED
-	assert_eq!(Action::RevokeNomination as u32, 0x4b65c34b);
 	assert_eq!(Action::ScheduleRevokeDelegation as u32, 0x22266e75);
-	// DEPRECATED
-	assert_eq!(Action::NominatorBondMore as u32, 0x971d44c8);
 	assert_eq!(Action::DelegatorBondMore as u32, 0xf8331108);
-	// DEPRECATED
-	assert_eq!(Action::NominatorBondLess as u32, 0xf6a52569);
 	assert_eq!(Action::ScheduleDelegatorBondLess as u32, 0x00043acf);
 	assert_eq!(Action::ExecuteDelegationRequest as u32, 0xe42366a6);
 	assert_eq!(Action::CancelDelegationRequest as u32, 0x7284cf50);
@@ -120,22 +98,6 @@ fn no_selector_exists_but_length_is_right() {
 		precompiles()
 			.prepare_test(Alice, Precompile, vec![1u8, 2u8, 3u8, 4u8])
 			.execute_reverts(|output| output == b"unknown selector");
-	});
-}
-
-// DEPRECATED
-#[test]
-fn min_nomination_works() {
-	ExtBuilder::default().build().execute_with(|| {
-		precompiles()
-			.prepare_test(
-				Alice,
-				Precompile,
-				EvmDataWriter::new_with_selector(Action::MinNomination).build(),
-			)
-			.expect_cost(0) // TODO: Test db read/write costs
-			.expect_no_logs()
-			.execute_returns(EvmDataWriter::new().write(3u32).build())
 	});
 }
 
@@ -234,34 +196,6 @@ fn round_works() {
 	});
 }
 
-// DEPRECATED
-#[test]
-fn collator_nomination_count_works() {
-	ExtBuilder::default()
-		.with_balances(vec![(Alice, 1_000), (Bob, 50), (Charlie, 50), (Bogus, 50)])
-		.with_candidates(vec![(Alice, 1_000)])
-		.with_delegations(vec![
-			(Bob, Alice, 50),
-			(Charlie, Alice, 50),
-			(Bogus, Alice, 50),
-		])
-		.build()
-		.execute_with(|| {
-			// Assert that there 3 nominations for Alice
-			precompiles()
-				.prepare_test(
-					Alice,
-					Precompile,
-					EvmDataWriter::new_with_selector(Action::CollatorNominationCount)
-						.write(Address(Alice.into()))
-						.build(),
-				)
-				.expect_cost(0) // TODO: Test db read/write costs
-				.expect_no_logs()
-				.execute_returns(EvmDataWriter::new().write(3u32).build());
-		});
-}
-
 #[test]
 fn candidate_delegation_count_works() {
 	ExtBuilder::default()
@@ -289,30 +223,6 @@ fn candidate_delegation_count_works() {
 		});
 }
 
-// DEPRECATED
-#[test]
-fn nominator_nomination_count_works() {
-	ExtBuilder::default()
-		.with_balances(vec![(Alice, 1_000), (Bob, 1_000), (Charlie, 200)])
-		.with_candidates(vec![(Alice, 1_000), (Bob, 1_000)])
-		.with_delegations(vec![(Charlie, Alice, 100), (Charlie, Bob, 100)])
-		.build()
-		.execute_with(|| {
-			// Assert that Charlie has 2 outstanding delegations
-			precompiles()
-				.prepare_test(
-					Alice,
-					Precompile,
-					EvmDataWriter::new_with_selector(Action::NominatorNominationCount)
-						.write(Address(Charlie.into()))
-						.build(),
-				)
-				.expect_cost(0) // TODO: Test db read/write costs
-				.expect_no_logs()
-				.execute_returns(EvmDataWriter::new().write(2u32).build());
-		});
-}
-
 #[test]
 fn delegator_delegation_count_works() {
 	ExtBuilder::default()
@@ -333,43 +243,6 @@ fn delegator_delegation_count_works() {
 				.expect_cost(0) // TODO: Test db read/write costs
 				.expect_no_logs()
 				.execute_returns(EvmDataWriter::new().write(2u32).build());
-		});
-}
-
-// DEPRECATED
-#[test]
-fn is_nominator_true_false() {
-	ExtBuilder::default()
-		.with_balances(vec![(Alice, 1_000), (Bob, 50)])
-		.with_candidates(vec![(Alice, 1_000)])
-		.with_delegations(vec![(Bob, Alice, 50)])
-		.build()
-		.execute_with(|| {
-			// Assert that Charlie is not a delegator
-			precompiles()
-				.prepare_test(
-					Alice,
-					Precompile,
-					EvmDataWriter::new_with_selector(Action::IsNominator)
-						.write(Address(Charlie.into()))
-						.build(),
-				)
-				.expect_cost(0) // TODO: Test db read/write costs
-				.expect_no_logs()
-				.execute_returns(EvmDataWriter::new().write(false).build());
-
-			// Assert that Bob is a delegator
-			precompiles()
-				.prepare_test(
-					Alice,
-					Precompile,
-					EvmDataWriter::new_with_selector(Action::IsNominator)
-						.write(Address(Bob.into()))
-						.build(),
-				)
-				.expect_cost(0) // TODO: Test db read/write costs
-				.expect_no_logs()
-				.execute_returns(EvmDataWriter::new().write(true).build());
 		});
 }
 
@@ -745,32 +618,6 @@ fn join_candidates_works() {
 		});
 }
 
-// DEPRECATED
-#[test]
-fn leave_candidates_works() {
-	ExtBuilder::default()
-		.with_balances(vec![(Alice, 1_000)])
-		.with_candidates(vec![(Alice, 1_000)])
-		.build()
-		.execute_with(|| {
-			let input_data = EvmDataWriter::new_with_selector(Action::LeaveCandidates)
-				.write(U256::one())
-				.build();
-
-			// Make sure the call goes through successfully
-			assert_ok!(Call::Evm(evm_call(Alice, input_data)).dispatch(Origin::root()));
-
-			let expected: crate::mock::Event = StakingEvent::CandidateScheduledExit {
-				exit_allowed_round: 1,
-				candidate: Alice,
-				scheduled_exit: 3,
-			}
-			.into();
-			// Assert that the events vector contains the one expected
-			assert!(events().contains(&expected));
-		});
-}
-
 #[test]
 fn schedule_leave_candidates_works() {
 	ExtBuilder::default()
@@ -918,32 +765,6 @@ fn candidate_bond_more_works() {
 		});
 }
 
-// DEPRECATED
-#[test]
-fn candidate_bond_less_works() {
-	ExtBuilder::default()
-		.with_balances(vec![(Alice, 1_000)])
-		.with_candidates(vec![(Alice, 1_000)])
-		.build()
-		.execute_with(|| {
-			let input_data = EvmDataWriter::new_with_selector(Action::CandidateBondLess)
-				.write(U256::from(500))
-				.build();
-
-			// Make sure the call goes through successfully
-			assert_ok!(Call::Evm(evm_call(Alice, input_data)).dispatch(Origin::root()));
-
-			let expected: crate::mock::Event = StakingEvent::CandidateBondLessRequested {
-				candidate: Alice,
-				amount_to_decrease: 500,
-				execute_round: 3,
-			}
-			.into();
-			// Assert that the events vector contains the one expected
-			assert!(events().contains(&expected));
-		});
-}
-
 #[test]
 fn schedule_candidate_bond_less_works() {
 	ExtBuilder::default()
@@ -1029,40 +850,6 @@ fn cancel_candidate_bond_less_works() {
 		});
 }
 
-// DEPRECATED
-#[test]
-fn nominate_works() {
-	ExtBuilder::default()
-		.with_balances(vec![(Alice, 1_000), (Bob, 1_000)])
-		.with_candidates(vec![(Alice, 1_000)])
-		.build()
-		.execute_with(|| {
-			let input_data = EvmDataWriter::new_with_selector(Action::Nominate)
-				.write(Address(Alice.into()))
-				.write(U256::from(1_000))
-				.write(U256::zero())
-				.write(U256::zero())
-				.build();
-
-			// Make sure the call goes through successfully
-			assert_ok!(Call::Evm(evm_call(Bob, input_data)).dispatch(Origin::root()));
-
-			assert!(ParachainStaking::is_delegator(&Bob));
-
-			let expected: crate::mock::Event = StakingEvent::Delegation {
-				delegator: Bob,
-				locked_amount: 1_000,
-				candidate: Alice,
-				delegator_position: pallet_parachain_staking::DelegatorAdded::AddedToTop {
-					new_total: 2_000,
-				},
-			}
-			.into();
-			// Assert that the events vector contains the one expected
-			assert!(events().contains(&expected));
-		});
-}
-
 #[test]
 fn delegate_works() {
 	ExtBuilder::default()
@@ -1089,33 +876,6 @@ fn delegate_works() {
 				delegator_position: pallet_parachain_staking::DelegatorAdded::AddedToTop {
 					new_total: 2_000,
 				},
-			}
-			.into();
-			// Assert that the events vector contains the one expected
-			assert!(events().contains(&expected));
-		});
-}
-
-// DEPRECATED
-#[test]
-fn leave_nominators_works() {
-	ExtBuilder::default()
-		.with_balances(vec![(Alice, 1_000), (Bob, 1_000)])
-		.with_candidates(vec![(Alice, 1_000)])
-		.with_delegations(vec![(Bob, Alice, 1_000)])
-		.build()
-		.execute_with(|| {
-			let input_data = EvmDataWriter::new_with_selector(Action::LeaveNominators)
-				.write(U256::one())
-				.build();
-
-			// Make sure the call goes through successfully
-			assert_ok!(Call::Evm(evm_call(Bob, input_data)).dispatch(Origin::root()));
-
-			let expected: crate::mock::Event = StakingEvent::DelegatorExitScheduled {
-				round: 1,
-				delegator: Bob,
-				scheduled_exit: 3,
 			}
 			.into();
 			// Assert that the events vector contains the one expected
@@ -1204,34 +964,6 @@ fn cancel_leave_delegators_works() {
 		});
 }
 
-// DEPRECATED
-#[test]
-fn revoke_nomination_works() {
-	ExtBuilder::default()
-		.with_balances(vec![(Alice, 1_000), (Bob, 1_000)])
-		.with_candidates(vec![(Alice, 1_000)])
-		.with_delegations(vec![(Bob, Alice, 1_000)])
-		.build()
-		.execute_with(|| {
-			let input_data = EvmDataWriter::new_with_selector(Action::RevokeNomination)
-				.write(Address(Alice.into()))
-				.build();
-
-			// Make sure the call goes through successfully
-			assert_ok!(Call::Evm(evm_call(Bob, input_data)).dispatch(Origin::root()));
-
-			let expected: crate::mock::Event = StakingEvent::DelegationRevocationScheduled {
-				round: 1,
-				delegator: Bob,
-				candidate: Alice,
-				scheduled_exit: 3,
-			}
-			.into();
-			// Assert that the events vector contains the one expected
-			assert!(events().contains(&expected));
-		});
-}
-
 #[test]
 fn schedule_revoke_delegation_works() {
 	ExtBuilder::default()
@@ -1252,34 +984,6 @@ fn schedule_revoke_delegation_works() {
 				delegator: Bob,
 				candidate: Alice,
 				scheduled_exit: 3,
-			}
-			.into();
-			// Assert that the events vector contains the one expected
-			assert!(events().contains(&expected));
-		});
-}
-
-// DEPRECATED
-#[test]
-fn nominator_bond_more_works() {
-	ExtBuilder::default()
-		.with_balances(vec![(Alice, 1_000), (Bob, 1_500)])
-		.with_candidates(vec![(Alice, 1_000)])
-		.with_delegations(vec![(Bob, Alice, 500)])
-		.build()
-		.execute_with(|| {
-			let input_data = EvmDataWriter::new_with_selector(Action::NominatorBondMore)
-				.write(Address(Alice.into()))
-				.write(U256::from(500))
-				.build();
-
-			assert_ok!(Call::Evm(evm_call(Bob, input_data)).dispatch(Origin::root()));
-
-			let expected: crate::mock::Event = StakingEvent::DelegationIncreased {
-				delegator: Bob,
-				candidate: Alice,
-				amount: 500,
-				in_top: true,
 			}
 			.into();
 			// Assert that the events vector contains the one expected
@@ -1311,35 +1015,6 @@ fn delegator_bond_more_works() {
 			.into();
 			// Assert that the events vector contains the one expected
 			assert!(events().contains(&expected));
-		});
-}
-
-// DEPRECATED
-#[test]
-fn nominator_bond_less_works() {
-	ExtBuilder::default()
-		.with_balances(vec![(Alice, 1_000), (Bob, 1_500)])
-		.with_candidates(vec![(Alice, 1_000)])
-		.with_delegations(vec![(Bob, Alice, 1_500)])
-		.build()
-		.execute_with(|| {
-			let input_data = EvmDataWriter::new_with_selector(Action::NominatorBondLess)
-				.write(Address(Alice.into()))
-				.write(U256::from(500))
-				.build();
-
-			assert_ok!(Call::Evm(evm_call(Bob, input_data)).dispatch(Origin::root()));
-
-			// Check for the right events.
-			let expected_event: crate::mock::Event = StakingEvent::DelegationDecreaseScheduled {
-				delegator: Bob,
-				candidate: Alice,
-				amount_to_decrease: 500,
-				execute_round: 3,
-			}
-			.into();
-
-			assert!(events().contains(&expected_event));
 		});
 }
 

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -41,7 +41,7 @@ use pallet_base_fee::Config as BaseFeeConfig;
 use pallet_migrations::{GetMigrations, Migration};
 use pallet_parachain_staking::{
 	migrations::{
-		IncreaseMaxDelegationsPerCandidate, PatchIncorrectDelegationSums, PurgeStaleStorage,
+		PatchIncorrectDelegationSums, PurgeStaleStorage,
 		SplitDelegatorStateIntoDelegationScheduledRequests,
 	},
 	Config as ParachainStakingConfig,
@@ -151,32 +151,6 @@ impl<T: ParachainStakingConfig> Migration
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(&self) -> Result<(), &'static str> {
 		SplitDelegatorStateIntoDelegationScheduledRequests::<T>::post_upgrade()
-	}
-}
-
-/// Staking increase max counted delegations per collator candidate
-pub struct ParachainStakingIncreaseMaxDelegationsPerCandidate<T>(PhantomData<T>);
-impl<T: ParachainStakingConfig> Migration
-	for ParachainStakingIncreaseMaxDelegationsPerCandidate<T>
-{
-	fn friendly_name(&self) -> &str {
-		"MM_Parachain_Staking_IncreaseMaxDelegationsPerCandidate_v2"
-	}
-
-	fn migrate(&self, _available_weight: Weight) -> Weight {
-		IncreaseMaxDelegationsPerCandidate::<T>::on_runtime_upgrade()
-	}
-
-	/// Run a standard pre-runtime test. This works the same way as in a normal runtime upgrade.
-	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade(&self) -> Result<(), &'static str> {
-		IncreaseMaxDelegationsPerCandidate::<T>::pre_upgrade()
-	}
-
-	/// Run a standard post-runtime test. This works the same way as in a normal runtime upgrade.
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(&self) -> Result<(), &'static str> {
-		IncreaseMaxDelegationsPerCandidate::<T>::post_upgrade()
 	}
 }
 

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -2242,7 +2242,6 @@
       "resolved": "https://registry.npmjs.org/chacha/-/chacha-2.1.0.tgz",
       "integrity": "sha512-FhVtqaZOiHlOKUkAWfDlJ+oe/O8iPQbCC0pFXJqphr4YQBCZPXa8Mv3j35+W4eWFWCoTUcW2u5IWDDkknygvVA==",
       "dependencies": {
-        "chacha-native": "^2.0.0",
         "inherits": "^2.0.1",
         "readable-stream": "^1.0.33"
       },
@@ -2342,7 +2341,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -4512,9 +4510,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4564,9 +4559,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dependencies": {
-        "graceful-fs": "^4.1.9"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
       }
@@ -6821,9 +6813,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }

--- a/tests/tests/test-precompile/test-precompile-staking.ts
+++ b/tests/tests/test-precompile/test-precompile-staking.ts
@@ -1,127 +1,61 @@
 import "@moonbeam-network/api-augment";
 
-import { numberToHex } from "@polkadot/util";
 import { expect } from "chai";
 import { ethers } from "ethers";
 
-import { alith, ethan, ETHAN_PRIVATE_KEY } from "../../util/accounts";
+import { alith, ethan } from "../../util/accounts";
 import { verifyLatestBlockFees } from "../../util/block";
 import { MIN_GLMR_STAKING, PRECOMPILE_PARACHAIN_STAKING_ADDRESS } from "../../util/constants";
 import { getCompiled } from "../../util/contracts";
-import {
-  describeDevMoonbeam,
-  describeDevMoonbeamAllEthTxTypes,
-  DevTestContext,
-} from "../../util/setup-dev-tests";
-import {
-  callPrecompile,
-  createTransaction,
-  ETHAN_TRANSACTION_TEMPLATE,
-  sendPrecompileTx,
-} from "../../util/transactions";
+import { web3EthCall } from "../../util/providers";
+import { describeDevMoonbeam, describeDevMoonbeamAllEthTxTypes } from "../../util/setup-dev-tests";
+import { createTransaction, ETHAN_TRANSACTION_TEMPLATE } from "../../util/transactions";
 
 const PARACHAIN_STAKING_CONTRACT = getCompiled("ParachainStaking");
 const PARACHAIN_STAKING_INTERFACE = new ethers.utils.Interface(
   PARACHAIN_STAKING_CONTRACT.contract.abi
 );
 
-const SELECTORS = {
-  candidate_bond_less: "289b6ba7",
-  candidate_bond_more: "c57bd3a8",
-  go_offline: "767e0450",
-  go_online: "d2f73ceb",
-  is_candidate: "8545c833",
-  is_selected_candidate: "8f6d27c7",
-  is_delegator: "8e5080e7",
-  join_candidates: "0a1bff60",
-  leave_candidates: "72b02a31",
-  leave_delegators: "b71d2153",
-  min_delegation: "c9f593b2",
-  delegate: "829f5ee3",
-  points: "9799b4e7",
-  candidate_count: "4b1c4c29",
-  delegation_request_is_pending: "192e1db3",
-  candidate_exit_is_pending: "eb613b8a",
-};
-
-async function isSelectedCandidate(context: DevTestContext, address: string) {
-  return await callPrecompile(
-    context,
-    PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
-    SELECTORS,
-    "is_selected_candidate",
-    [address]
-  );
-}
-
-async function IsDelegator(context: DevTestContext, address: string) {
-  return await callPrecompile(
-    context,
-    PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
-    SELECTORS,
-    "is_delegator",
-    [address]
-  );
-}
-
-async function isCandidate(context: DevTestContext, address: string) {
-  return await callPrecompile(
-    context,
-    PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
-    SELECTORS,
-    "is_candidate",
-    [address]
-  );
-}
-
-async function candidateCount(context: DevTestContext) {
-  return await callPrecompile(
-    context,
-    PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
-    SELECTORS,
-    "candidate_count",
-    []
-  );
-}
-
-async function delegationRequestIsPending(
-  context: DevTestContext,
-  delegatorAddress: string,
-  collatorAddress: string
-) {
-  return await callPrecompile(
-    context,
-    PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
-    SELECTORS,
-    "delegation_request_is_pending",
-    [delegatorAddress, collatorAddress]
-  );
-}
-
-describeDevMoonbeam("Staking - Genesis", (context) => {
+describeDevMoonbeam("Precompiles - Staking - Genesis", (context) => {
   it("should include collator from the specs", async function () {
-    expect(Number((await isSelectedCandidate(context, alith.address)).result)).to.equal(1);
+    const { result } = await web3EthCall(context.web3, {
+      to: PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
+      data: PARACHAIN_STAKING_INTERFACE.encodeFunctionData("is_selected_candidate", [
+        alith.address,
+      ]),
+    });
+
+    expect(Number(result)).to.equal(1);
   });
+
   it("should have one collator", async function () {
-    expect(Number((await candidateCount(context)).result)).to.equal(1);
+    const { result } = await web3EthCall(context.web3, {
+      to: PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
+      data: PARACHAIN_STAKING_INTERFACE.encodeFunctionData("candidate_count"),
+    });
+
+    expect(Number(result)).to.equal(1);
   });
 });
 
-describeDevMoonbeamAllEthTxTypes("Staking - Join Candidates", (context) => {
-  it("should successfully call joinCandidates on ethan", async function () {
-    const { result } = await sendPrecompileTx(
-      context,
-      PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
-      SELECTORS,
-      ethan.address,
-      ETHAN_PRIVATE_KEY,
-      "join_candidates",
-      [numberToHex(Number(MIN_GLMR_STAKING)), numberToHex(1)]
+describeDevMoonbeamAllEthTxTypes("Precompiles - Staking - Join Candidates", (context) => {
+  before("add ethan as candidate", async function () {
+    const { result } = await context.createBlock(
+      createTransaction(context, {
+        ...ETHAN_TRANSACTION_TEMPLATE,
+        to: PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
+        data: PARACHAIN_STAKING_INTERFACE.encodeFunctionData("join_candidates", [
+          MIN_GLMR_STAKING,
+          1,
+        ]),
+      })
     );
 
     const receipt = await context.web3.eth.getTransactionReceipt(result.hash);
     expect(receipt.status).to.equal(true);
+  });
 
+  it("should successfully call joinCandidates on ethan", async function () {
     const candidatesAfter = await context.polkadotApi.query.parachainStaking.candidatePool();
     expect(candidatesAfter.length).to.equal(2, "New candidate should have been added");
     expect(candidatesAfter[1].owner.toString()).to.equal(
@@ -133,21 +67,27 @@ describeDevMoonbeamAllEthTxTypes("Staking - Join Candidates", (context) => {
       "new candidate ethan should have been added (wrong amount)"
     );
 
-    expect(Number((await isCandidate(context, ethan.address)).result)).to.equal(1);
+    const { result } = await web3EthCall(context.web3, {
+      to: PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
+      data: PARACHAIN_STAKING_INTERFACE.encodeFunctionData("is_candidate", [alith.address]),
+    });
+
+    expect(Number(result)).to.equal(1);
     await verifyLatestBlockFees(context, 0n);
   });
 });
 
-describeDevMoonbeamAllEthTxTypes("Staking - Collator Leaving", (context) => {
+describeDevMoonbeamAllEthTxTypes("Precompiles - Staking - Collator Leaving", (context) => {
   before("add ethan to candidates", async () => {
-    const { result } = await sendPrecompileTx(
-      context,
-      PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
-      SELECTORS,
-      ethan.address,
-      ETHAN_PRIVATE_KEY,
-      "join_candidates",
-      [numberToHex(Number(MIN_GLMR_STAKING)), numberToHex(1)]
+    const { result } = await context.createBlock(
+      createTransaction(context, {
+        ...ETHAN_TRANSACTION_TEMPLATE,
+        to: PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
+        data: PARACHAIN_STAKING_INTERFACE.encodeFunctionData("join_candidates", [
+          MIN_GLMR_STAKING,
+          1,
+        ]),
+      })
     );
 
     const receipt = await context.web3.eth.getTransactionReceipt(result.hash);
@@ -155,14 +95,14 @@ describeDevMoonbeamAllEthTxTypes("Staking - Collator Leaving", (context) => {
   });
 
   it("should successfully call candidate_exit_is_pending on ethan", async function () {
-    const { result } = await sendPrecompileTx(
-      context,
-      PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
-      SELECTORS,
-      ethan.address,
-      ETHAN_PRIVATE_KEY,
-      "candidate_exit_is_pending",
-      [ethan.address]
+    const { result } = await context.createBlock(
+      createTransaction(context, {
+        ...ETHAN_TRANSACTION_TEMPLATE,
+        to: PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
+        data: PARACHAIN_STAKING_INTERFACE.encodeFunctionData("candidate_exit_is_pending", [
+          ethan.address,
+        ]),
+      })
     );
 
     const receipt = await context.web3.eth.getTransactionReceipt(result.hash);
@@ -170,7 +110,7 @@ describeDevMoonbeamAllEthTxTypes("Staking - Collator Leaving", (context) => {
   });
 });
 
-describeDevMoonbeamAllEthTxTypes("Staking - Join Delegators", (context) => {
+describeDevMoonbeamAllEthTxTypes("Precompiles - Staking - Join Delegators", (context) => {
   beforeEach("should successfully call delegate for ethan.address to ALITH", async function () {
     await context.createBlock(
       createTransaction(context, {
@@ -201,7 +141,7 @@ describeDevMoonbeamAllEthTxTypes("Staking - Join Delegators", (context) => {
   });
 });
 
-describeDevMoonbeamAllEthTxTypes("Staking - Join Delegators", (context) => {
+describeDevMoonbeamAllEthTxTypes("Precompiles - Staking - Join Delegators", (context) => {
   before("should successfully call delegate for ethan.address to ALITH", async function () {
     // Delegate ethan.address->ALITH
     await context.createBlock(
@@ -216,13 +156,19 @@ describeDevMoonbeamAllEthTxTypes("Staking - Join Delegators", (context) => {
         ]),
       })
     );
+
+    const { result } = await web3EthCall(context.web3, {
+      to: PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
+      data: PARACHAIN_STAKING_INTERFACE.encodeFunctionData("delegation_request_is_pending", [
+        ethan.address,
+        alith.address,
+      ]),
+    });
+
+    expect(Number(result)).to.equal(0);
   });
 
   it("should verify delegation pending requests", async function () {
-    expect(
-      Number((await delegationRequestIsPending(context, ethan.address, alith.address)).result)
-    ).to.equal(0);
-
     // Schedule Revoke
     await context.createBlock(
       context.polkadotApi.tx.parachainStaking
@@ -231,8 +177,14 @@ describeDevMoonbeamAllEthTxTypes("Staking - Join Delegators", (context) => {
     );
 
     // Check that there exists a pending request
-    expect(
-      Number((await delegationRequestIsPending(context, ethan.address, alith.address)).result)
-    ).to.equal(1);
+    const { result } = await web3EthCall(context.web3, {
+      to: PRECOMPILE_PARACHAIN_STAKING_ADDRESS,
+      data: PARACHAIN_STAKING_INTERFACE.encodeFunctionData("delegation_request_is_pending", [
+        ethan.address,
+        alith.address,
+      ]),
+    });
+
+    expect(Number(result)).to.equal(1);
   });
 });

--- a/tests/util/transactions.ts
+++ b/tests/util/transactions.ts
@@ -4,7 +4,14 @@ import fetch from "node-fetch";
 import * as RLP from "rlp";
 import { Contract } from "web3-eth-contract";
 
-import { alith, ALITH_PRIVATE_KEY, baltathar, BALTATHAR_PRIVATE_KEY } from "./accounts";
+import {
+  alith,
+  ALITH_PRIVATE_KEY,
+  baltathar,
+  BALTATHAR_PRIVATE_KEY,
+  ethan,
+  ETHAN_PRIVATE_KEY,
+} from "./accounts";
 import { getCompiled } from "./contracts";
 import { customWeb3Request } from "./providers";
 import { DevTestContext } from "./setup-dev-tests";
@@ -45,6 +52,12 @@ export const BALTATHAR_TRANSACTION_TEMPLATE: TransactionOptions = {
   ...TRANSACTION_TEMPLATE,
   from: baltathar.address,
   privateKey: BALTATHAR_PRIVATE_KEY,
+};
+
+export const ETHAN_TRANSACTION_TEMPLATE: TransactionOptions = {
+  ...TRANSACTION_TEMPLATE,
+  from: ethan.address,
+  privateKey: ETHAN_PRIVATE_KEY,
 };
 
 export const createTransaction = async (


### PR DESCRIPTION
### What does it do?

:warning: Breaking Change :warning: 

Removes the following [deprecated](https://github.com/PureStake/moonbeam/pull/810) storage items:
* `NominatorState2`
* `CandidateState`
* `CollatorState2`

and the following precompiles associated with them:
* `min_nomination()`
* `collator_nomination_count(address)`
* `nominator_nomination_count(address)`
* `is_nominator(address)`
* `leave_candidates(uint256)`
* `candidate_bond_less(uint256)`
* `nominate(address,uint256,uint256,uint256)`
* `leave_nominators(uint256)`
* `revoke_nomination(address)`
* `nominator_bond_less(address,uint256)`
* `nominator_bond_more(address,uint256)`

The storage items were verified to be empty for our networks.

Also removes the already-performed `ParachainStakingIncreaseMaxDelegationsPerCandidate` migration.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
