### PR TITLE
Add identity judgement reserves

### DIFF
--- a/tests/smoke-tests/test-balances-consistency.ts
+++ b/tests/smoke-tests/test-balances-consistency.ts
@@ -75,7 +75,7 @@ describeSmokeSuite(`Verify balances consistency`, { wssUrl, relayWssUrl }, (cont
       candidateInfo,
       delegatorState,
       identities,
-      subItentities,
+      subIdentities,
       democracyDeposits,
       democracyVotes,
       preimages,
@@ -195,19 +195,18 @@ describeSmokeSuite(`Verify balances consistency`, { wssUrl, relayWssUrl }, (cont
         accountId: `0x${identity[0].toHex().slice(-40)}`,
         reserved: {
           identity: identity[1].unwrap().deposit.toBigInt(),
-          judgements: identity[1].unwrap().judgements.map((judgement) => {
-              return judgement[1].isFeePaid ? judgement[1].asFeePaid.toBigInt() : 0n;
-            })
-            .reduce((prev, curr) => {
-              return prev ? prev + curr : curr;
-            }, undefined)
+          requestJudgements: identity[1]
+            .unwrap()
+            .judgements.reduce(
+              (acc, value) => acc + ((value[1].isFeePaid && value[1].asFeePaid.toBigInt()) || 0n),
+              0n
+            ),
         },
       })),
-      subItentities.map((subIdentity) => ({
+      subIdentities.map((subIdentity) => ({
         accountId: `0x${subIdentity[0].toHex().slice(-40)}`,
         reserved: {
           identity: subIdentity[1][0].toBigInt(),
-          // TODO: judgements here too?
         },
       })),
       Object.values(

--- a/tests/smoke-tests/test-balances-consistency.ts
+++ b/tests/smoke-tests/test-balances-consistency.ts
@@ -195,12 +195,19 @@ describeSmokeSuite(`Verify balances consistency`, { wssUrl, relayWssUrl }, (cont
         accountId: `0x${identity[0].toHex().slice(-40)}`,
         reserved: {
           identity: identity[1].unwrap().deposit.toBigInt(),
+          judgements: identity[1].unwrap().judgements.map((judgement) => {
+              return judgement[1].isFeePaid ? judgement[1].asFeePaid.toBigInt() : 0n;
+            })
+            .reduce((prev, curr) => {
+              return prev ? prev + curr : curr;
+            }, undefined)
         },
       })),
       subItentities.map((subIdentity) => ({
         accountId: `0x${subIdentity[0].toHex().slice(-40)}`,
         reserved: {
           identity: subIdentity[1][0].toBigInt(),
+          // TODO: judgements here too?
         },
       })),
       Object.values(


### PR DESCRIPTION
### What does it do?

Adds identity judgement reserves to the `balance-consistency` test.

I believe this is working except that when an identity is encountered with anything other than a `FeePaid(_)`, the object's `judgements` property is set to `undefined` (because of the second arg passed to `reduce()`). Someone with better js/ts skills than mine will have no problem sorting that out :)