### PR TITLE
add democracy enactment offset

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -492,11 +492,15 @@ impl pallet_collective::Config<TechCommitteeInstance> for Runtime {
 	type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
 }
 
+// The purpose of this offset is to ensure that a democratic proposal will not apply in the same
+// block as a round change.
+const ENACTMENT_OFFSET: u32 = 300;
+
 impl pallet_democracy::Config for Runtime {
 	type Proposal = Call;
 	type Event = Event;
 	type Currency = Balances;
-	type EnactmentPeriod = ConstU32<{ 1 * DAYS }>;
+	type EnactmentPeriod = ConstU32<{ 1 * DAYS + ENACTMENT_OFFSET }>;
 	type LaunchPeriod = ConstU32<{ 1 * DAYS }>;
 	type VotingPeriod = ConstU32<{ 5 * DAYS }>;
 	type VoteLockingPeriod = ConstU32<{ 1 * DAYS }>;

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -510,11 +510,15 @@ impl pallet_collective::Config<TechCommitteeInstance> for Runtime {
 	type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
 }
 
+// The purpose of this offset is to ensure that a democratic proposal will not apply in the same
+// block as a round change.
+const ENACTMENT_OFFSET: u32 = 900;
+
 impl pallet_democracy::Config for Runtime {
 	type Proposal = Call;
 	type Event = Event;
 	type Currency = Balances;
-	type EnactmentPeriod = ConstU32<{ 2 * DAYS }>;
+	type EnactmentPeriod = ConstU32<{ 2 * DAYS + ENACTMENT_OFFSET }>;
 	type LaunchPeriod = ConstU32<{ 7 * DAYS }>;
 	type VotingPeriod = ConstU32<{ 14 * DAYS }>;
 	type VoteLockingPeriod = ConstU32<{ 7 * DAYS }>;

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -484,11 +484,15 @@ impl pallet_collective::Config<TechCommitteeInstance> for Runtime {
 	type WeightInfo = pallet_collective::weights::SubstrateWeight<Runtime>;
 }
 
+// The purpose of this offset is to ensure that a democratic proposal will not apply in the same
+// block as a round change.
+const ENACTMENT_OFFSET: u32 = 300;
+
 impl pallet_democracy::Config for Runtime {
 	type Proposal = Call;
 	type Event = Event;
 	type Currency = Balances;
-	type EnactmentPeriod = ConstU32<{ 1 * DAYS }>;
+	type EnactmentPeriod = ConstU32<{ 1 * DAYS + ENACTMENT_OFFSET }>;
 	type LaunchPeriod = ConstU32<{ 1 * DAYS }>;
 	type VotingPeriod = ConstU32<{ 5 * DAYS }>;
 

--- a/tests/tests/test-democracy/test-democracy-genesis.ts
+++ b/tests/tests/test-democracy/test-democracy-genesis.ts
@@ -11,8 +11,8 @@ describeDevMoonbeam("Democracy - genesis", (context) => {
   it("should have no preimages", async function () {
     expect((await context.polkadotApi.query.democracy.preimages.entries()).length).to.equal(0);
   });
-  it("should have an enactment of 7200", async function () {
-    expect(context.polkadotApi.consts.democracy.enactmentPeriod.toNumber()).to.equal(7200);
+  it("should have an enactment of 7500", async function () {
+    expect(context.polkadotApi.consts.democracy.enactmentPeriod.toNumber()).to.equal(7500);
   });
   it("should have a voting period of 36000", async function () {
     expect(context.polkadotApi.consts.democracy.votingPeriod.toNumber()).to.equal(36000);


### PR DESCRIPTION
### What does it do?

Add an offset to enactment period to ensure that a democratic proposal will not apply in the same block as a staking round change.

This work because the `EnactmentPeriod` always start at round change because `LaunchPeriod` and `VotingPeriod` are multiples of round length (in number of blocks).

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
