### PR TITLE
Add required deposit to randomness precompile

### DIFF
--- a/precompiles/randomness/Randomness.sol
+++ b/precompiles/randomness/Randomness.sol
@@ -74,6 +74,11 @@ interface Randomness {
     /// @custom:selector 81797566
     function relayEpochIndex() external view returns (uint64);
 
+    /// Return the deposit required to perform a request
+    /// @dev Each request will need a deposit.
+    /// @custom:selector fb7cfdd7
+    function requiredDeposit() external view returns (uint256);
+
     /// @notice Returns the request status
     /// @param requestId The id of the request to check (must be < 2**64)
     /// @return status Status of the request


### PR DESCRIPTION
Reported by @eshaben

I forgot to implement `requiredDeposit` in the precompile in #1376 , so it was removed from the solidity file in https://github.com/PureStake/moonbeam/pull/1647#discussion_r943695895

This PR implements it as originally intended and adds it back to the solidity file