### PR TITLE
Decode Solidity bytes in precompile AuthorMapping::setKey

### DIFF
--- a/precompiles/author-mapping/src/lib.rs
+++ b/precompiles/author-mapping/src/lib.rs
@@ -173,11 +173,13 @@ where
 	}
 
 	fn set_keys(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
+		let mut input = handle.read_input()?;
+		input.expect_arguments(1)?;
+
+		let keys: Bytes = input.read()?;
+
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
-		let call = AuthorMappingCall::<Runtime>::set_keys {
-			// Taking all input minus selector (4 bytes)
-			keys: handle.input()[4..].to_vec(),
-		};
+		let call = AuthorMappingCall::<Runtime>::set_keys { keys: keys.into() };
 
 		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
 

--- a/precompiles/author-mapping/src/tests.rs
+++ b/precompiles/author-mapping/src/tests.rs
@@ -299,9 +299,14 @@ fn set_keys_works() {
 			})
 			.dispatch(Origin::signed(Alice)));
 
+			// Create input with keys inside a Solidity bytes.
 			let input = EvmDataWriter::new_with_selector(Action::SetKeys)
-				.write(sp_core::H256::from([2u8; 32]))
-				.write(sp_core::H256::from([4u8; 32]))
+				.write(Bytes(
+					EvmDataWriter::new()
+						.write(sp_core::H256::from([2u8; 32]))
+						.write(sp_core::H256::from([4u8; 32]))
+						.build(),
+				))
 				.build();
 
 			// Make sure the call goes through successfully

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -2520,8 +2520,12 @@ fn author_mapping_register_and_set_keys() {
 					ALICE,
 					author_mapping_precompile_address,
 					EvmDataWriter::new_with_selector(AuthorMappingAction::SetKeys)
-						.write(sp_core::H256::from([2u8; 32]))
-						.write(sp_core::H256::from([4u8; 32]))
+						.write(Bytes(
+							EvmDataWriter::new()
+								.write(sp_core::H256::from([2u8; 32]))
+								.write(sp_core::H256::from([4u8; 32]))
+								.build(),
+						))
 						.build(),
 				)
 				.expect_cost(16280)

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -2494,8 +2494,12 @@ fn author_mapping_register_and_set_keys() {
 					ALICE,
 					author_mapping_precompile_address,
 					EvmDataWriter::new_with_selector(AuthorMappingAction::SetKeys)
-						.write(sp_core::H256::from([1u8; 32]))
-						.write(sp_core::H256::from([3u8; 32]))
+						.write(Bytes(
+							EvmDataWriter::new()
+								.write(sp_core::H256::from([1u8; 32]))
+								.write(sp_core::H256::from([3u8; 32]))
+								.build(),
+						))
 						.build(),
 				)
 				.expect_cost(16280)

--- a/tests/tests/test-precompile/test-precompile-author-mapping-keys.ts
+++ b/tests/tests/test-precompile/test-precompile-author-mapping-keys.ts
@@ -1,14 +1,22 @@
 import "@moonbeam-network/api-augment";
 
 import { expect } from "chai";
+import { ethers } from "ethers";
 
 import { ethan, ETHAN_PRIVATE_KEY, faith, FAITH_PRIVATE_KEY } from "../../util/accounts";
 import { getBlockExtrinsic } from "../../util/block";
 import { PRECOMPILE_AUTHOR_MAPPING_ADDRESS } from "../../util/constants";
+import { getCompiled } from "../../util/contracts";
 import { describeDevMoonbeam, DevTestContext } from "../../util/setup-dev-tests";
-import { sendPrecompileTx } from "../../util/transactions";
+import {
+  ALITH_TRANSACTION_TEMPLATE,
+  createTransaction,
+  sendPrecompileTx,
+} from "../../util/transactions";
 
 const debug = require("debug")("test-precompile:author-mapping");
+const AUTHOR_MAPPING_CONTRACT = getCompiled("AuthorMapping");
+const AUTHOR_MAPPING_INTERFACE = new ethers.utils.Interface(AUTHOR_MAPPING_CONTRACT.contract.abi);
 
 // Keys used to set author-mapping in the tests
 const originalKeys = [
@@ -29,14 +37,14 @@ const setKeysThroughPrecompile = async (
   private_key: string,
   keys: string
 ) => {
-  await sendPrecompileTx(
-    context,
-    PRECOMPILE_AUTHOR_MAPPING_ADDRESS,
-    SELECTORS,
-    account,
-    private_key,
-    "set_keys",
-    [keys]
+  await context.createBlock(
+    createTransaction(context, {
+      ...ALITH_TRANSACTION_TEMPLATE,
+      from: account,
+      privateKey: private_key,
+      to: PRECOMPILE_AUTHOR_MAPPING_ADDRESS,
+      data: AUTHOR_MAPPING_INTERFACE.encodeFunctionData("set_keys", [keys]),
+    })
   );
 };
 
@@ -400,7 +408,7 @@ describeDevMoonbeam("Precompile Author Mapping - Set Faith only 1 key", (context
 
 describeDevMoonbeam("Precompile Author Mapping - Set Faith mapping with 0 keys", (context) => {
   it("should fail", async function () {
-    await setKeysThroughPrecompile(context, faith.address, FAITH_PRIVATE_KEY, "");
+    await setKeysThroughPrecompile(context, faith.address, FAITH_PRIVATE_KEY, "0x");
     const { extrinsic, events, resultEvent } = await getBlockExtrinsic(
       context.polkadotApi,
       await context.polkadotApi.rpc.chain.getBlockHash(),


### PR DESCRIPTION
### What does it do?

Currently arguments of `setKey` in `AuthorMapping` precompile are not properly decoded and don't match what what is generated from Ethereum tools with the Solidity interface.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
