### PR TITLE
Add back authorMapping old events so indexers can decode them

### DIFF
--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -117,6 +117,22 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
 	pub enum Event<T: Config> {
+		// DEPRECATED EVENTS, added for indexers to decode old events
+		AuthorRegistered {
+			author_id: NimbusId,
+			account_id: T::AccountId,
+		},
+		AuthorDeRegistered {
+			author_id: NimbusId,
+		},
+		AuthorRotated {
+			new_author_id: NimbusId,
+			account_id: T::AccountId,
+		},
+		DefunctAuthorBusted {
+			author_id: NimbusId,
+			account_id: T::AccountId,
+		},
 		/// A NimbusId has been registered and mapped to an AccountId.
 		KeysRegistered {
 			nimbus_id: NimbusId,


### PR DESCRIPTION
Indexers are having trouble decoding AuthorMapping events that were removed/changed in #1407 . See the events not decoded here https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/explorer/query/6600

The tracking issue for this is MOON-1860.

Is there a way to fix this decoding without adding these events back?

- [ ] verify adding old events back fixes decoding issue