### PR TITLE
Adds another missing type and bumps the version of Polkadot JS API in Moonbeam types bundle

### DIFF
--- a/moonbeam-types-bundle/index.ts
+++ b/moonbeam-types-bundle/index.ts
@@ -101,6 +101,7 @@ const TYPES_0_4: RegistryTypes = {
     balance: "u128",
   },
   EthTransaction: "LegacyTransaction",
+  DispatchErrorModule: "DispatchErrorModuleU8"
 };
 const { RefCount, ...TYPES_5_5 } = TYPES_0_4;
 

--- a/moonbeam-types-bundle/package.json
+++ b/moonbeam-types-bundle/package.json
@@ -26,7 +26,7 @@
     "url": "git+https://github.com/PureStake/moonbeam.git"
   },
   "dependencies": {
-    "@polkadot/api": "^8.8.2",
+    "@polkadot/api": "^9.2.1",
     "typescript": "^4.7.4"
   },
   "devDependencies": {


### PR DESCRIPTION
### What does it do?

This adds another missing type to the Moonbeam types bundle that was identified after @tgmichel created the original PR (https://github.com/PureStake/moonbeam/pull/1745).

And it also bumps the polkadot-js api version number of the Moonbeam types bundle to 9.2.1

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

This PR adds to this existing PR from @tgmichel 

https://github.com/PureStake/moonbeam/pull/1745

### What value does it bring to the blockchain users?

Allows older blocks and events in the blocks to be correctly decoded
