### PR TITLE
use read_args in author mapping precompile (fix master)

### DIFF
--- a/precompiles/author-mapping/src/lib.rs
+++ b/precompiles/author-mapping/src/lib.rs
@@ -164,10 +164,7 @@ where
 	}
 
 	fn set_keys(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
-		let mut input = handle.read_input()?;
-		input.expect_arguments(1)?;
-
-		let keys: Bytes = input.read()?;
+		read_args!(handle, { keys: Bytes });
 
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
 		let call = AuthorMappingCall::<Runtime>::set_keys { keys: keys.into() };

--- a/tests/tests/test-precompile/test-precompile-author-mapping-keys.ts
+++ b/tests/tests/test-precompile/test-precompile-author-mapping-keys.ts
@@ -43,7 +43,7 @@ const setKeysThroughPrecompile = async (
       from: account,
       privateKey: private_key,
       to: PRECOMPILE_AUTHOR_MAPPING_ADDRESS,
-      data: AUTHOR_MAPPING_INTERFACE.encodeFunctionData("set_keys", [keys]),
+      data: AUTHOR_MAPPING_INTERFACE.encodeFunctionData("setKeys", [keys]),
     })
   );
 };


### PR DESCRIPTION
### What does it do?

Forgot to merge master in #1746, which changed how arguments are read in precompiles.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
