### PR TITLE
Remove extra round whitelist

### DIFF
--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -533,10 +533,6 @@ macro_rules! impl_runtime_apis_plus_common {
 											"6d6f646c70632f747273727900000000"
 											"00000000"
 						).to_vec().into(),
-						// ParachainStaking Round
-						hex_literal::hex!(  "a686a3043d0adcf2fa655e57bc595a78"
-											"13792e785168f725b60e2969c7fc2552")
-							.to_vec().into(),
 						// ParachainInfo ParachainId
 						hex_literal::hex!(  "0d715f2646c8f85767b5d2764bb27826"
 											"04a74d81251e398fd8a0a4d55023bb3f")


### PR DESCRIPTION
Benchmarking previously whitelisted the `ParachainStaking::round` storage item twice, this PR removes the 2nd

The first place it is whitelisted is L518-521 in the same file. It seems hard for me to comment and show this, but it can be seen by clicking the up arrow once when reviewing the file.