### PR TITLE
[MOON-1885] fix staking rewards smoke test to account for Perbill arithmetic

### DIFF
--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -341,7 +341,7 @@ async function assertRewardsAt(api: ApiPromise, nowBlockNumber: number) {
   if (specVersion >= 1800) {
     expect(actualTotalRewardedWithLoss.toString()).to.equal(
       totalStakingReward.toString(),
-      `Total rewarded events did not match total expected issuance for collators + delegators, inflation was "${actualTotalRewardedWithLoss
+      `Total rewarded events did not match total expected issuance for collators + delegators, diff of "${actualTotalRewardedWithLoss
         .sub(totalStakingReward)
         .toString()}" for round ${originalRoundNumber}`
     );

--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -331,9 +331,6 @@ async function assertRewardsAt(api: ApiPromise, nowBlockNumber: number) {
   estimated ${estimatedBondRewardedLoss.toString()}, actual ${actualBondRewardedLoss.toString()}`
   ).to.be.lessThanOrEqual(maxDifference);
 
-  //   debug(`commission loss : ${actualCommissionRewardedLoss.toString()}
-  // bond reward loss: ${actualBondRewardedLoss.toString()}`);
-
   // calculate total rewarded amount including the amount lost to Perbill arithmetic
   const actualTotalRewardedWithLoss = totalRewardedAmount
     .add(actualCommissionRewardedLoss)
@@ -471,7 +468,6 @@ async function assertRewardedEventsAtBlock(
     bondReward
   );
   const actualBondRewardedLoss = bondReward.sub(rewarded.amount.bondReward);
-  // debug(`bond reward loss: ${actualBondRewardedLoss.toString()}`);
 
   // Perbill arithmetic can deviate at most ±1 per operation so we use the number of delegators
   // and the collator itself to compute the max deviation per billion

--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -325,8 +325,8 @@ got "${commissionRewardLoss}", estimated loss ${estimatedCommissionRewardedLoss.
 actual loss ${actualCommissionRewardedLoss.toString()}`
     ).to.be.true;
 
-    // we add the two estimated losses, since the totalBondReward is always split between N collators,
-    // which then split the reward again between the all the delegators
+    // we add the two estimated losses, since the totalBondReward is always split between N
+    // collators, which then split the reward again between the all the delegators
     const estimatedBondRewardedLoss = new Perbill(BN_BILLION.sub(totalCollatorShare))
       .of(totalBondReward)
       .add(totalBondRewardedLoss);
@@ -484,9 +484,9 @@ async function assertRewardedEventsAtBlock(
     const loss = estimatedBondRewardedLoss.sub(actualBondRewardedLoss).abs();
     expect(
       loss.lten(maxDifference),
-      `Total bond rewarded share loss for collator "${rewarded.collator}" was above ${maxDifference} \
-parts per billion, got diff "${loss}", estimated loss ${estimatedBondRewardedLoss}, \
-actual loss ${actualBondRewardedLoss}`
+      `Total bond rewarded share loss for collator "${rewarded.collator}" was above \
+${maxDifference} parts per billion, got diff "${loss}", estimated loss \
+${estimatedBondRewardedLoss}, actual loss ${actualBondRewardedLoss}`
     ).to.be.true;
 
     rewarded.amount.bondRewardLoss = actualBondRewardedLoss;

--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -315,7 +315,8 @@ async function assertRewardsAt(api: ApiPromise, nowBlockNumber: number) {
   expect(
     estimatedCommissionRewardedLoss.sub(actualCommissionRewardedLoss).abs().toNumber(),
     `Percentage share loss was above ${maxDifference} parts per billion, \
-  estimated ${estimatedCommissionRewardedLoss.toString()}, actual ${actualCommissionRewardedLoss.toString()}`
+  estimated ${estimatedCommissionRewardedLoss.toString()}, \
+  actual ${actualCommissionRewardedLoss.toString()}`
   ).to.be.lessThanOrEqual(maxDifference);
 
   // we add the two estimated losses, since the totalBondReward is always split between N collators,
@@ -342,7 +343,8 @@ async function assertRewardsAt(api: ApiPromise, nowBlockNumber: number) {
   if (specVersion >= 1800) {
     expect(actualTotalRewardedWithLoss.toString()).to.equal(
       totalStakingReward.toString(),
-      `Total rewarded events did not match total expected issuance for collators + delegators, diff of "${actualTotalRewardedWithLoss
+      `Total rewarded events did not match total expected issuance for collators & delegators, \
+      diff of "${actualTotalRewardedWithLoss
         .sub(totalStakingReward)
         .toString()}" for round ${originalRoundNumber}`
     );


### PR DESCRIPTION
### What does it do?
Fixes staking rewards smoke test to account for Perbill arithmetic. We currently distribute rewards in 3 areas:
* distribute commission among collators based on their points
* distribute rewards among collators based on their points
  *  distribute rewards among delegators (and self) based on their bonded value
 
At each stage, due to `Perbill` precision the indvidual shares usually do not add up to 100% (rather `1,000,000,000`) this is usually found to be lower (e.g. `999,999,998`, `999,999,999`, etc.)

This PR fixes the expectation to account for the missing value with a delta of `N` parts per billion where `N` is the number of ways an amount is split, since each operation can introduce a deviation of `±1`.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
