### PR TITLE
Fix chi squared test

### DIFF
--- a/tests/smoke-tests/test-randomness-consistency.ts
+++ b/tests/smoke-tests/test-randomness-consistency.ts
@@ -350,7 +350,7 @@ function chiSquareTest(bytes: Uint8Array) {
   // chi.pdf(31, 0.05) = 44.985
   // https://en.wikibooks.org/wiki/Engineering_Tables/Chi-Squared_Distibution
   const pValue = 44.985;
-  bytes.forEach((a) => (chiSquared += ((a - expectedValue) ^ 2) / expectedValue));
+  bytes.forEach((a) => (chiSquared += ((a - expectedValue) ** 2) / expectedValue));
   expect(chiSquared < pValue).to.equal(
     true,
     `Chi square value greater than or equal to expected so bytes in output appear related` +

--- a/tests/smoke-tests/test-randomness-consistency.ts
+++ b/tests/smoke-tests/test-randomness-consistency.ts
@@ -345,9 +345,8 @@ function isRandom(bytes: Uint8Array) {
 function chiSquareTest(bytes: Uint8Array) {
   let chiSquared = 0.0;
   let numOnes = 0;
-  // expected value is expected average of [u8; 32]
+  // expected value of 256 coin flips:
   const expectedValue = 256 / 2;
-  console.log(`expectedValue: ${expectedValue}`);
   // degrees of freedom is 256 - 1 = 255, alpha is 0.05
   // chi.pdf(31, 0.05) = 287.882 (TODO: use precise value; this is from 250 in following table)
   // https://en.wikibooks.org/wiki/Engineering_Tables/Chi-Squared_Distibution
@@ -362,8 +361,7 @@ function chiSquareTest(bytes: Uint8Array) {
   let numZeroes = 256 - numOnes;
   chiSquared += (numZeroes - expectedValue) ** 2.0 / expectedValue;
 
-  console.log(`zeroes: ${numZeroes} ones: ${numOnes}`);
-  console.log(`final chiSquared: ${chiSquared}`);
+  expect(numOnes + numZeroes).to.equal(256, "Data should produce exactly 256 bits");
 
   expect(chiSquared < pValue).to.equal(
     true,

--- a/tests/smoke-tests/test-randomness-consistency.ts
+++ b/tests/smoke-tests/test-randomness-consistency.ts
@@ -344,30 +344,25 @@ function isRandom(bytes: Uint8Array) {
 // Tests if byte output is independent
 function chiSquareTest(bytes: Uint8Array) {
   let chiSquared = 0.0;
-  let occurences: number[] = new Array(256);
-  occurences.fill(0, 0, 256);
+  let numOnes = 0;
   // expected value is expected average of [u8; 32]
-  const expectedValue = 32 / 256;
+  const expectedValue = 256 / 2;
   console.log(`expectedValue: ${expectedValue}`);
-  // degrees of freedom is 32 - 1 = 31, alpha is 0.05
-  // chi.pdf(31, 0.05) = 44.985
+  // degrees of freedom is 256 - 1 = 255, alpha is 0.05
+  // chi.pdf(31, 0.05) = 287.882 (TODO: use precise value; this is from 250 in following table)
   // https://en.wikibooks.org/wiki/Engineering_Tables/Chi-Squared_Distibution
 
-  // count occurences of each byte
-  const pValue = 44.985;
+  // count occurences of ones
+  const pValue = 286.882;
   bytes.forEach((a) => {
-    occurences[a] += 1;
+    numOnes += [...a.toString(2)].filter(x => x === '1').length;
   });
 
-  occurences.forEach((o) => {
-    // console.log(`o: ${o}`);
-    // const prev = chiSquared;
-    // const diff = (o - expectedValue);
-    // const diffSquared = diff ** 2.0;
-    chiSquared += (o - expectedValue) ** 2.0 / expectedValue;
-    // console.log(`chiSquared ${prev} -> ${chiSquared} (diff: ${diff}, diffSquared: ${diffSquared}`);
-  });
+  chiSquared += (numOnes - expectedValue) ** 2.0 / expectedValue;
+  let numZeroes = 256 - numOnes;
+  chiSquared += (numZeroes - expectedValue) ** 2.0 / expectedValue;
 
+  console.log(`zeroes: ${numZeroes} ones: ${numOnes}`);
   console.log(`final chiSquared: ${chiSquared}`);
 
   expect(chiSquared < pValue).to.equal(

--- a/tests/smoke-tests/test-randomness-consistency.ts
+++ b/tests/smoke-tests/test-randomness-consistency.ts
@@ -354,7 +354,7 @@ function chiSquareTest(bytes: Uint8Array) {
   // count occurences of ones
   const pValue = 286.882;
   bytes.forEach((a) => {
-    numOnes += [...a.toString(2)].filter(x => x === '1').length;
+    numOnes += [...a.toString(2)].filter((x) => x === "1").length;
   });
 
   chiSquared += (numOnes - expectedValue) ** 2.0 / expectedValue;

--- a/tests/smoke-tests/test-randomness-consistency.ts
+++ b/tests/smoke-tests/test-randomness-consistency.ts
@@ -348,7 +348,7 @@ function chiSquareTest(bytes: Uint8Array) {
   // expected value of 256 coin flips:
   const expectedValue = 256 / 2;
   // degrees of freedom is 256 - 1 = 255, alpha is 0.05
-  // chi.pdf(31, 0.05) = 287.882 (TODO: use precise value; this is from 250 in following table)
+  // chi.pdf(250, 0.05) = 287.882 (TODO: use precise value; this is from 250 in following table)
   // https://en.wikibooks.org/wiki/Engineering_Tables/Chi-Squared_Distibution
 
   // count occurences of ones

--- a/tests/smoke-tests/test-randomness-consistency.ts
+++ b/tests/smoke-tests/test-randomness-consistency.ts
@@ -363,8 +363,8 @@ function chiSquareTest(bytes: Uint8Array) {
     // console.log(`o: ${o}`);
     // const prev = chiSquared;
     // const diff = (o - expectedValue);
-    const diffSquared = diff ** 2.0;
-    chiSquared += (o - expectedValue) ** 2.0;
+    // const diffSquared = diff ** 2.0;
+    chiSquared += (o - expectedValue) ** 2.0 / expectedValue;
     // console.log(`chiSquared ${prev} -> ${chiSquared} (diff: ${diff}, diffSquared: ${diffSquared}`);
   });
 

--- a/tests/smoke-tests/test-randomness-consistency.ts
+++ b/tests/smoke-tests/test-randomness-consistency.ts
@@ -354,6 +354,8 @@ function chiSquareTest(bytes: Uint8Array) {
   // count occurences of ones
   const pValue = 286.882;
   bytes.forEach((a) => {
+    // convert to a binary text string, e.g. "101101", then count the ones.
+    // note that this string excluded insignificant digits, which is why we count ones
     numOnes += [...a.toString(2)].filter((x) => x === "1").length;
   });
 

--- a/tests/smoke-tests/test-randomness-consistency.ts
+++ b/tests/smoke-tests/test-randomness-consistency.ts
@@ -343,14 +343,33 @@ function isRandom(bytes: Uint8Array) {
 
 // Tests if byte output is independent
 function chiSquareTest(bytes: Uint8Array) {
-  let chiSquared = 0;
+  let chiSquared = 0.0;
+  let occurences: number[] = new Array(256);
+  occurences.fill(0, 0, 256);
   // expected value is expected average of [u8; 32]
-  const expectedValue = 128;
+  const expectedValue = 32 / 256;
+  console.log(`expectedValue: ${expectedValue}`);
   // degrees of freedom is 32 - 1 = 31, alpha is 0.05
   // chi.pdf(31, 0.05) = 44.985
   // https://en.wikibooks.org/wiki/Engineering_Tables/Chi-Squared_Distibution
+
+  // count occurences of each byte
   const pValue = 44.985;
-  bytes.forEach((a) => (chiSquared += ((a - expectedValue) ** 2) / expectedValue));
+  bytes.forEach((a) => {
+    occurences[a] += 1;
+  });
+
+  occurences.forEach((o) => {
+    // console.log(`o: ${o}`);
+    // const prev = chiSquared;
+    // const diff = (o - expectedValue);
+    const diffSquared = diff ** 2.0;
+    chiSquared += (o - expectedValue) ** 2.0;
+    // console.log(`chiSquared ${prev} -> ${chiSquared} (diff: ${diff}, diffSquared: ${diffSquared}`);
+  });
+
+  console.log(`final chiSquared: ${chiSquared}`);
+
   expect(chiSquared < pValue).to.equal(
     true,
     `Chi square value greater than or equal to expected so bytes in output appear related` +


### PR DESCRIPTION
### What does it do?

Reimplements chiSquared test to count bits with a different algorithm. Actually, I think this PR is close to what the original intended to do except:

* pValue is different (reflects 256 degrees of freedom since we are counting 256 bits)
* uses `**` operator for exponentiation
* rewrites to count bits instead of trying to shortcut through bytes

Another implementation for reference: https://github.com/chipbell4/chi-squared-test/blob/811ce7213d40077d8ca404c6d6adfa1769cba529/index.js#L9