### PR TITLE
`EthereumXcm` global nonce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "async-trait",
  "fc-db",
@@ -2417,7 +2417,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "fp-storage",
  "kvdb-rocksdb",
@@ -2433,7 +2433,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "fc-db",
  "fp-consensus",
@@ -2450,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2630,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "evm",
  "frame-support",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2686,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -2700,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6590,7 +6590,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6777,7 +6777,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -6846,7 +6846,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "evm",
  "fp-evm",
@@ -6953,7 +6953,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "fp-evm",
 ]
@@ -6961,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7088,7 +7088,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7098,7 +7098,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "fp-evm",
  "num",
@@ -7219,7 +7219,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -7228,7 +7228,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#696a7a474f72e380d6f96e075351026d2928d409"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
 dependencies = [
  "fp-evm",
  "ripemd",

--- a/pallets/ethereum-xcm/src/tests/v1/eip2930.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/eip2930.rs
@@ -317,3 +317,96 @@ fn test_ensure_transact_xcm_trough_proxy_ok() {
 		});
 	}
 }
+
+#[test]
+fn test_global_nonce_incr() {
+	let (pairs, mut ext) = new_test_ext(3);
+	let alice = &pairs[0];
+	let bob = &pairs[1];
+	let charlie = &pairs[2];
+
+	ext.execute_with(|| {
+		assert_eq!(EthereumXcm::nonce(), U256::zero());
+
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(alice.address).into(),
+			xcm_evm_transfer_eip_2930_transaction(charlie.address, U256::one()),
+		)
+		.expect("Failed to execute transaction from Alice to Charlie");
+
+		assert_eq!(EthereumXcm::nonce(), U256::one());
+
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(bob.address).into(),
+			xcm_evm_transfer_eip_2930_transaction(charlie.address, U256::one()),
+		)
+		.expect("Failed to execute transaction from Bob to Charlie");
+
+		assert_eq!(EthereumXcm::nonce(), U256::from(2));
+	});
+}
+
+#[test]
+fn test_global_nonce_not_incr() {
+	let (pairs, mut ext) = new_test_ext(2);
+	let alice = &pairs[0];
+	let bob = &pairs[1];
+
+	ext.execute_with(|| {
+		assert_eq!(EthereumXcm::nonce(), U256::zero());
+
+		let access_list = Some(vec![(H160::default(), vec![H256::default()])]);
+
+		let invalid_transaction_cost = EthereumXcmTransaction::V1(EthereumXcmTransactionV1 {
+			fee_payment: EthereumXcmFee::Auto,
+			gas_limit: U256::one(),
+			action: ethereum::TransactionAction::Call(bob.address),
+			value: U256::one(),
+			input: vec![],
+			access_list,
+		});
+
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(alice.address).into(),
+			invalid_transaction_cost,
+		)
+		.expect_err("Failed to execute transaction from Alice to Bob");
+
+		assert_eq!(EthereumXcm::nonce(), U256::zero());
+	});
+}
+
+#[test]
+fn test_transaction_hash_collision() {
+	let (pairs, mut ext) = new_test_ext(3);
+	let alice = &pairs[0];
+	let bob = &pairs[1];
+	let charlie = &pairs[2];
+
+	ext.execute_with(|| {
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(alice.address).into(),
+			xcm_evm_transfer_eip_2930_transaction(charlie.address, U256::one()),
+		)
+		.expect("Failed to execute transaction from Alice to Charlie");
+
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(bob.address).into(),
+			xcm_evm_transfer_eip_2930_transaction(charlie.address, U256::one()),
+		)
+		.expect("Failed to execute transaction from Bob to Charlie");
+
+		let mut hashes = Ethereum::pending()
+			.iter()
+			.map(|(tx, _, _)| tx.hash())
+			.collect::<Vec<ethereum_types::H256>>();
+
+		// Holds two transactions hashes
+		assert_eq!(hashes.len(), 2);
+
+		hashes.dedup();
+
+		// Still holds two transactions hashes after removing potential consecutive repeated values.
+		assert_eq!(hashes.len(), 2);
+	});
+}

--- a/pallets/ethereum-xcm/src/tests/v1/legacy.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/legacy.rs
@@ -314,3 +314,94 @@ fn test_ensure_transact_xcm_trough_proxy_ok() {
 		});
 	}
 }
+
+#[test]
+fn test_global_nonce_incr() {
+	let (pairs, mut ext) = new_test_ext(3);
+	let alice = &pairs[0];
+	let bob = &pairs[1];
+	let charlie = &pairs[2];
+
+	ext.execute_with(|| {
+		assert_eq!(EthereumXcm::nonce(), U256::zero());
+
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(alice.address).into(),
+			xcm_evm_transfer_legacy_transaction(charlie.address, U256::one()),
+		)
+		.expect("Failed to execute transaction from Alice to Charlie");
+
+		assert_eq!(EthereumXcm::nonce(), U256::one());
+
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(bob.address).into(),
+			xcm_evm_transfer_legacy_transaction(charlie.address, U256::one()),
+		)
+		.expect("Failed to execute transaction from Bob to Charlie");
+
+		assert_eq!(EthereumXcm::nonce(), U256::from(2));
+	});
+}
+
+#[test]
+fn test_global_nonce_not_incr() {
+	let (pairs, mut ext) = new_test_ext(2);
+	let alice = &pairs[0];
+	let bob = &pairs[1];
+
+	ext.execute_with(|| {
+		assert_eq!(EthereumXcm::nonce(), U256::zero());
+
+		let invalid_transaction_cost = EthereumXcmTransaction::V1(EthereumXcmTransactionV1 {
+			fee_payment: EthereumXcmFee::Auto,
+			gas_limit: U256::one(),
+			action: ethereum::TransactionAction::Call(bob.address),
+			value: U256::one(),
+			input: vec![],
+			access_list: None,
+		});
+
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(alice.address).into(),
+			invalid_transaction_cost,
+		)
+		.expect_err("Failed to execute transaction from Alice to Bob");
+
+		assert_eq!(EthereumXcm::nonce(), U256::zero());
+	});
+}
+
+#[test]
+fn test_transaction_hash_collision() {
+	let (pairs, mut ext) = new_test_ext(3);
+	let alice = &pairs[0];
+	let bob = &pairs[1];
+	let charlie = &pairs[2];
+
+	ext.execute_with(|| {
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(alice.address).into(),
+			xcm_evm_transfer_legacy_transaction(charlie.address, U256::one()),
+		)
+		.expect("Failed to execute transaction from Alice to Charlie");
+
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(bob.address).into(),
+			xcm_evm_transfer_legacy_transaction(charlie.address, U256::one()),
+		)
+		.expect("Failed to execute transaction from Bob to Charlie");
+
+		let mut hashes = Ethereum::pending()
+			.iter()
+			.map(|(tx, _, _)| tx.hash())
+			.collect::<Vec<ethereum_types::H256>>();
+
+		// Holds two transactions hashes
+		assert_eq!(hashes.len(), 2);
+
+		hashes.dedup();
+
+		// Still holds two transactions hashes after removing potential consecutive repeated values.
+		assert_eq!(hashes.len(), 2);
+	});
+}

--- a/pallets/ethereum-xcm/src/tests/v2.rs
+++ b/pallets/ethereum-xcm/src/tests/v2.rs
@@ -123,8 +123,8 @@ fn test_transact_xcm_evm_call_works() {
 	ext.execute_with(|| {
 		let t = EIP1559UnsignedTransaction {
 			nonce: U256::zero(),
-			max_priority_fee_per_gas: U256::from(1),
-			max_fee_per_gas: U256::from(1),
+			max_priority_fee_per_gas: U256::one(),
+			max_fee_per_gas: U256::one(),
 			gas_limit: U256::from(0x100000),
 			action: ethereum::TransactionAction::Create,
 			value: U256::zero(),
@@ -189,7 +189,7 @@ fn test_transact_xcm_validation_works() {
 				EthereumXcmTransaction::V2(EthereumXcmTransactionV2 {
 					gas_limit: U256::from(0x5207),
 					action: ethereum::TransactionAction::Call(bob.address),
-					value: U256::from(1),
+					value: U256::one(),
 					input: vec![],
 					access_list: None,
 				}),
@@ -296,4 +296,94 @@ fn test_ensure_transact_xcm_trough_proxy_ok() {
 				Proxy::remove_proxy_delegate(&bob.account_id, alice.account_id.clone(), proxy, 0);
 		});
 	}
+}
+
+#[test]
+fn test_global_nonce_incr() {
+	let (pairs, mut ext) = new_test_ext(3);
+	let alice = &pairs[0];
+	let bob = &pairs[1];
+	let charlie = &pairs[2];
+
+	ext.execute_with(|| {
+		assert_eq!(EthereumXcm::nonce(), U256::zero());
+
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(alice.address).into(),
+			xcm_evm_transfer_eip_1559_transaction(charlie.address, U256::one()),
+		)
+		.expect("Failed to execute transaction from Alice to Charlie");
+
+		assert_eq!(EthereumXcm::nonce(), U256::one());
+
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(bob.address).into(),
+			xcm_evm_transfer_eip_1559_transaction(charlie.address, U256::one()),
+		)
+		.expect("Failed to execute transaction from Bob to Charlie");
+
+		assert_eq!(EthereumXcm::nonce(), U256::from(2));
+	});
+}
+
+#[test]
+fn test_global_nonce_not_incr() {
+	let (pairs, mut ext) = new_test_ext(2);
+	let alice = &pairs[0];
+	let bob = &pairs[1];
+
+	ext.execute_with(|| {
+		assert_eq!(EthereumXcm::nonce(), U256::zero());
+
+		let invalid_transaction_cost = EthereumXcmTransaction::V2(EthereumXcmTransactionV2 {
+			gas_limit: U256::one(),
+			action: ethereum::TransactionAction::Call(bob.address),
+			value: U256::one(),
+			input: vec![],
+			access_list: None,
+		});
+
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(alice.address).into(),
+			invalid_transaction_cost,
+		)
+		.expect_err("Failed to execute transaction from Alice to Bob");
+
+		assert_eq!(EthereumXcm::nonce(), U256::zero());
+	});
+}
+
+#[test]
+fn test_transaction_hash_collision() {
+	let (pairs, mut ext) = new_test_ext(3);
+	let alice = &pairs[0];
+	let bob = &pairs[1];
+	let charlie = &pairs[2];
+
+	ext.execute_with(|| {
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(alice.address).into(),
+			xcm_evm_transfer_eip_1559_transaction(charlie.address, U256::one()),
+		)
+		.expect("Failed to execute transaction from Alice to Charlie");
+
+		EthereumXcm::transact(
+			RawOrigin::XcmEthereumTransaction(bob.address).into(),
+			xcm_evm_transfer_eip_1559_transaction(charlie.address, U256::one()),
+		)
+		.expect("Failed to execute transaction from Bob to Charlie");
+
+		let mut hashes = Ethereum::pending()
+			.iter()
+			.map(|(tx, _, _)| tx.hash())
+			.collect::<Vec<ethereum_types::H256>>();
+
+		// Holds two transactions hashes
+		assert_eq!(hashes.len(), 2);
+
+		hashes.dedup();
+
+		// Still holds two transactions hashes after removing potential consecutive repeated values.
+		assert_eq!(hashes.len(), 2);
+	});
 }

--- a/primitives/xcm/src/ethereum_xcm.rs
+++ b/primitives/xcm/src/ethereum_xcm.rs
@@ -254,7 +254,7 @@ mod tests {
 		let xcm_transaction = EthereumXcmTransactionV1 {
 			gas_limit: U256::one(),
 			fee_payment: EthereumXcmFee::Manual(ManualEthereumXcmFee {
-				gas_price: Some(U256::one()),
+				gas_price: Some(U256::zero()),
 				max_fee_per_gas: None,
 			}),
 			action: TransactionAction::Call(H160::default()),
@@ -290,7 +290,7 @@ mod tests {
 		let xcm_transaction = EthereumXcmTransactionV1 {
 			gas_limit: U256::one(),
 			fee_payment: EthereumXcmFee::Manual(ManualEthereumXcmFee {
-				gas_price: Some(U256::one()),
+				gas_price: Some(U256::zero()),
 				max_fee_per_gas: None,
 			}),
 			action: TransactionAction::Call(H160::default()),


### PR DESCRIPTION
### What does it do?

Adds a `Nonce(U256)` storage value to `pallet-ethereum-xcm` that holds a pallet's owned global nonce used in xcm ethereum transactions.

### What important points reviewers should know?

Prevents ethereum tx hash collision when different callers provide identical transaction payload.

### Is there something left for follow-up PRs?

Depends on https://github.com/paritytech/frontier/pull/833

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
