### PR TITLE
Add `XcmFragment` typescript test utilities

### DIFF
--- a/tests/tests/test-xcm/test-mock-dmp-error-and-appendix.ts
+++ b/tests/tests/test-xcm/test-mock-dmp-error-and-appendix.ts
@@ -5,7 +5,7 @@ import { expect } from "chai";
 
 import { alith } from "../../util/accounts";
 import { RELAY_SOURCE_LOCATION, relayAssetMetadata } from "../../util/assets";
-import { registerForeignAsset } from "../../util/xcm";
+import { registerForeignAsset, XcmFragment } from "../../util/xcm";
 import { customWeb3Request } from "../../util/providers";
 import { describeDevMoonbeam } from "../../util/setup-dev-tests";
 import type { XcmVersionedXcm } from "@polkadot/types/lookup";
@@ -32,66 +32,31 @@ describeDevMoonbeam("Mock XCM - downward transfer with non-triggered error handl
   });
 
   it("Should make sure that Alith does not receive 10 dot without error", async function () {
-    // BuyExecution does not charge for fees because we registered it for not doing so
-    // But since there is no error, and the deposit is on the error handler, the assets
-    // will be trapped
-    const xcmMessage = {
-      V2: [
-        // Pretend relay assets were transferred to the sovereign
-        {
-          ReserveAssetDeposited: [
-            {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    Here: null,
-                  },
-                },
-              },
-              fun: { Fungible: 10n * RELAY_TOKEN },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 1,
+            interior: {
+              Here: null,
             },
-          ],
-        },
-        // Buy execution power
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    Here: null,
-                  },
-                },
-              },
-              fun: { Fungible: 10n * RELAY_TOKEN },
-            },
-            weightLimit: { Limited: new BN(500000000) },
           },
-        },
-        // Set an error handler that fires if there is any error after setting the ErrorHandler
-        {
-          SetErrorHandler: [
-            {
-              // Deposit any existing asset in holding into alith
-              DepositAsset: {
-                assets: { Wild: "All" },
-                maxAssets: new BN(1),
-                beneficiary: {
-                  parents: 0,
-                  interior: { X1: { AccountKey20: { network: "Any", key: alith.address } } },
-                },
-              },
-            },
-          ],
-        },
-        // Execute an arbitrary valid instruction that would trigger the ErrorHandler otherwise
-        {
-          ClearOrigin: null,
-        },
-      ],
-    };
+        ],
+        fungible: 10n * RELAY_TOKEN,
+      },
+      weight_limit: new BN(500000000),
+      beneficiary: alith.address,
+    })
+      .reserve_asset_deposited()
+      .buy_execution()
+      // BuyExecution does not charge for fees because we registered it for not doing so
+      // But since there is no error, and the deposit is on the error handler, the assets
+      // will be trapped
+      .with(function () {
+        return this.set_error_handler_with([this.deposit_asset]);
+      })
+      .clear_origin()
+      .as_v2();
 
     const receivedMessage: XcmVersionedXcm = context.polkadotApi.createType(
       "XcmVersionedXcm",
@@ -131,65 +96,30 @@ describeDevMoonbeam("Mock XCM - downward transfer with triggered error handler",
   });
 
   it("Should make sure that Alith does receive 10 dot because there is error", async function () {
-    // BuyExecution does not charge for fees because we registered it for not doing so
-    // As a consequence the trapped assets will be entirely credited
-    const xcmMessage = {
-      V2: [
-        // Pretend relay assets were transferred to the sovereign
-        {
-          ReserveAssetDeposited: [
-            {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    Here: null,
-                  },
-                },
-              },
-              fun: { Fungible: 10n * RELAY_TOKEN },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 1,
+            interior: {
+              Here: null,
             },
-          ],
-        },
-        // Buy execution power
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    Here: null,
-                  },
-                },
-              },
-              fun: { Fungible: 10n * RELAY_TOKEN },
-            },
-            weightLimit: { Limited: new BN(1000000000) },
           },
-        },
-        // Set an error handler that fires if there is any error during the execution
-        {
-          SetErrorHandler: [
-            {
-              // Deposit any existing asset in holding into alith
-              DepositAsset: {
-                assets: { Wild: "All" },
-                maxAssets: new BN(1),
-                beneficiary: {
-                  parents: 0,
-                  interior: { X1: { AccountKey20: { network: "Any", key: alith.address } } },
-                },
-              },
-            },
-          ],
-        },
-        // Fire the error handler. This forces an error
-        {
-          Trap: 0,
-        },
-      ],
-    };
+        ],
+        fungible: 10n * RELAY_TOKEN,
+      },
+      weight_limit: new BN(1000000000),
+      beneficiary: alith.address,
+    })
+      .reserve_asset_deposited()
+      .buy_execution()
+      // BuyExecution does not charge for fees because we registered it for not doing so
+      // As a consequence the trapped assets will be entirely credited
+      .with(function () {
+        return this.set_error_handler_with([this.deposit_asset]);
+      })
+      .trap()
+      .as_v2();
 
     const receivedMessage: XcmVersionedXcm = context.polkadotApi.createType(
       "XcmVersionedXcm",
@@ -231,61 +161,28 @@ describeDevMoonbeam("Mock XCM - downward transfer with always triggered appendix
   });
 
   it("Should make sure Alith receives 10 dot with appendix and without error", async function () {
-    // BuyExecution does not charge for fees because we registered it for not doing so
-    // As a consequence the trapped assets will be entirely credited
-    const xcmMessage = {
-      V2: [
-        // Pretend relay assets were transferred to the sovereign
-        {
-          ReserveAssetDeposited: [
-            {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    Here: null,
-                  },
-                },
-              },
-              fun: { Fungible: 10n * RELAY_TOKEN },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 1,
+            interior: {
+              Here: null,
             },
-          ],
-        },
-        // Buy execution power
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    Here: null,
-                  },
-                },
-              },
-              fun: { Fungible: 10n * RELAY_TOKEN },
-            },
-            weightLimit: { Limited: new BN(800000000) },
           },
-        },
-        // Set an appendix to be executed after the XCM message is executed. No matter if errors
-        {
-          SetAppendix: [
-            // Deposit any existing asset in holding into alith
-            {
-              DepositAsset: {
-                assets: { Wild: "All" },
-                maxAssets: new BN(1),
-                beneficiary: {
-                  parents: 0,
-                  interior: { X1: { AccountKey20: { network: "Any", key: alith.address } } },
-                },
-              },
-            },
-          ],
-        },
-      ],
-    };
+        ],
+        fungible: 10n * RELAY_TOKEN,
+      },
+      weight_limit: new BN(800000000),
+      beneficiary: alith.address,
+    })
+      .reserve_asset_deposited()
+      .buy_execution()
+      // Set an appendix to be executed after the XCM message is executed. No matter if errors
+      .with(function () {
+        return this.set_appendix_with([this.deposit_asset]);
+      })
+      .as_v2();
 
     const receivedMessage: XcmVersionedXcm = context.polkadotApi.createType(
       "XcmVersionedXcm",
@@ -326,66 +223,31 @@ describeDevMoonbeam("Mock XCM - downward transfer with always triggered appendix
   });
 
   it("Should make sure Alith receives 10 dot with appendix and without error", async function () {
-    // BuyExecution does not charge for fees because we registered it for not doing so
-    // As a consequence the trapped assets will be entirely credited
-    // The goal is to show appendix runs even if there is an error
-    const xcmMessage = {
-      V2: [
-        // Pretend relay assets were transferred to the sovereign
-        {
-          ReserveAssetDeposited: [
-            {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    Here: null,
-                  },
-                },
-              },
-              fun: { Fungible: 10n * RELAY_TOKEN },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 1,
+            interior: {
+              Here: null,
             },
-          ],
-        },
-        // Buy execution power
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    Here: null,
-                  },
-                },
-              },
-              fun: { Fungible: 10n * RELAY_TOKEN },
-            },
-            weightLimit: { Limited: new BN(1000000000) },
           },
-        },
-        // Set an appendix to be executed after the XCM message is executed. No matter if errors
-        {
-          SetAppendix: [
-            {
-              // Deposit any existing asset in holding into alith
-              DepositAsset: {
-                assets: { Wild: "All" },
-                maxAssets: new BN(1),
-                beneficiary: {
-                  parents: 0,
-                  interior: { X1: { AccountKey20: { network: "Any", key: alith.address } } },
-                },
-              },
-            },
-          ],
-        },
-        // Fire the error handler. This forces an error
-        {
-          Trap: 0,
-        },
-      ],
-    };
+        ],
+        fungible: 10n * RELAY_TOKEN,
+      },
+      weight_limit: new BN(1000000000),
+      beneficiary: alith.address,
+    })
+      .reserve_asset_deposited()
+      .buy_execution()
+      // BuyExecution does not charge for fees because we registered it for not doing so
+      // As a consequence the trapped assets will be entirely credited
+      // The goal is to show appendix runs even if there is an error
+      .with(function () {
+        return this.set_appendix_with([this.deposit_asset]);
+      })
+      .trap()
+      .as_v2();
 
     const receivedMessage: XcmVersionedXcm = context.polkadotApi.createType(
       "XcmVersionedXcm",
@@ -430,43 +292,23 @@ describeDevMoonbeam("Mock XCM - downward transfer claim trapped assets", (contex
     // Goal is to trapp assets, so that later can be claimed
     // Since we only BuyExecution, but we do not do anything with the assets after that,
     // they are trapped
-    const xcmMessage = {
-      V2: [
-        // Pretend relay assets were transferred to the sovereign
-        {
-          ReserveAssetDeposited: [
-            {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    Here: null,
-                  },
-                },
-              },
-              fun: { Fungible: 10n * RELAY_TOKEN },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 1,
+            interior: {
+              Here: null,
             },
-          ],
-        },
-        // Buy execution power
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    Here: null,
-                  },
-                },
-              },
-              fun: { Fungible: 10n * RELAY_TOKEN },
-            },
-            weightLimit: { Limited: new BN(400000000) },
           },
-        },
-      ],
-    };
+        ],
+        fungible: 10n * RELAY_TOKEN,
+      },
+      weight_limit: new BN(400000000),
+    })
+      .reserve_asset_deposited()
+      .buy_execution()
+      .as_v2();
 
     const receivedMessage: XcmVersionedXcm = context.polkadotApi.createType(
       "XcmVersionedXcm",
@@ -490,65 +332,29 @@ describeDevMoonbeam("Mock XCM - downward transfer claim trapped assets", (contex
   });
 
   it("Should make sure that Alith receives claimed assets", async function () {
-    // BuyExecution does not charge for fees because we registered it for not doing so
-    // As a consequence the trapped assets will be entirely credited
-    const xcmMessage = {
-      V2: [
-        // Claim assets that were previously trapped
-        // assets: the assets that were trapped
-        // ticket: the version of the assets (xcm version)
-        {
-          ClaimAsset: {
-            assets: [
-              {
-                id: {
-                  Concrete: {
-                    parents: 1,
-                    interior: {
-                      Here: null,
-                    },
-                  },
-                },
-                fun: { Fungible: 10n * RELAY_TOKEN },
-              },
-            ],
-            // Ticket seems to indicate the version of the assets
-            ticket: {
-              parents: 0,
-              interior: { X1: { GeneralIndex: 2 } },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 1,
+            interior: {
+              Here: null,
             },
           },
-        },
-        // Buy execution power
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    Here: null,
-                  },
-                },
-              },
-              fun: { Fungible: 10n * RELAY_TOKEN },
-            },
-            weightLimit: { Limited: new BN(600000000) },
-          },
-        },
-        // Deposit assets, this time correctly, on Alith
-        {
-          DepositAsset: {
-            assets: { Wild: "All" },
-            maxAssets: new BN(1),
-            beneficiary: {
-              parents: 0,
-              interior: { X1: { AccountKey20: { network: "Any", key: alith.address } } },
-            },
-          },
-        },
-      ],
-    };
+        ],
+        fungible: 10n * RELAY_TOKEN,
+      },
+      weight_limit: new BN(1000000000),
+      beneficiary: alith.address,
+    })
+      // Claim assets that were previously trapped
+      // assets: the assets that were trapped
+      // ticket: the version of the assets (xcm version)
+      .claim_asset()
+      .buy_execution()
+      // Deposit assets, this time correctly, on Alith
+      .deposit_asset()
+      .as_v2();
 
     const receivedMessage: XcmVersionedXcm = context.polkadotApi.createType(
       "XcmVersionedXcm",

--- a/tests/tests/test-xcm/test-mock-dmp-queue.ts
+++ b/tests/tests/test-xcm/test-mock-dmp-queue.ts
@@ -6,6 +6,7 @@ import { describeDevMoonbeam } from "../../util/setup-dev-tests";
 
 import type { XcmVersionedXcm } from "@polkadot/types/lookup";
 import { expectOk } from "../../util/expect";
+import { XcmFragment } from "../../util/xcm";
 
 describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
   it("Should test DMP on_initialization and on_idle", async function () {
@@ -39,46 +40,24 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
     // for that reason, we multiply times 2
     const clearOriginsPerMessage = (weightPerMessage - weightPerXcmInst * 2n) / weightPerXcmInst;
 
-    const instructions = [
-      {
-        WithdrawAsset: [
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
           {
-            id: {
-              Concrete: {
-                parents: 0,
-                interior: {
-                  X1: { PalletInstance: balancesPalletIndex },
-                },
-              },
+            parents: 0,
+            interior: {
+              X1: { PalletInstance: balancesPalletIndex },
             },
-            fun: { Fungible: 1 },
           },
         ],
+        fungible: 1n,
       },
-      ...Array(Number(clearOriginsPerMessage)).fill({
-        ClearOrigin: null,
-      }),
-      {
-        BuyExecution: {
-          fees: {
-            id: {
-              Concrete: {
-                parents: 0,
-                interior: {
-                  X1: { PalletInstance: balancesPalletIndex },
-                },
-              },
-            },
-            fun: { Fungible: 1 },
-          },
-          weightLimit: { Limited: new BN(20000000000) },
-        },
-      },
-    ];
-
-    const xcmMessage = {
-      V2: instructions,
-    };
+      weight_limit: new BN(20000000000),
+    })
+      .withdraw_asset()
+      .clear_origin(clearOriginsPerMessage)
+      .buy_execution()
+      .as_v2();
 
     const receivedMessage: XcmVersionedXcm = context.polkadotApi.createType(
       "XcmVersionedXcm",

--- a/tests/tests/test-xcm/test-mock-hrmp-asset-transfer.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp-asset-transfer.ts
@@ -7,7 +7,12 @@ import { expect } from "chai";
 
 import { alith, baltathar, generateKeyringPair } from "../../util/accounts";
 import { PARA_2000_SOURCE_LOCATION } from "../../util/assets";
-import { registerForeignAsset, injectHrmpMessageAndSeal, RawXcmMessage } from "../../util/xcm";
+import {
+  registerForeignAsset,
+  injectHrmpMessageAndSeal,
+  RawXcmMessage,
+  XcmFragment,
+} from "../../util/xcm";
 import { customWeb3Request } from "../../util/providers";
 
 import { describeDevMoonbeam } from "../../util/setup-dev-tests";
@@ -111,48 +116,24 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     // Old prefix:
     // Parachain(Statemint parachain)
     // GeneralIndex(assetId being transferred)
-    let xcmMessage = {
-      V2: [
-        {
-          ReserveAssetDeposited: [
-            {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: { X2: [{ Parachain: statemint_para_id }, { GeneralIndex: 0 }] },
-                },
-              },
-              fun: { Fungible: new BN(10000000000000) },
-            },
-          ],
-        },
-        { ClearOrigin: null as any },
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: new BN(1),
-                  interior: { X2: [{ Parachain: statemint_para_id }, { GeneralIndex: 0 }] },
-                },
-              },
-              fun: { Fungible: new BN(10000000000000) },
-            },
-            weightLimit: { Limited: new BN(4000000000) },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 1,
+            interior: { X2: [{ Parachain: statemint_para_id }, { GeneralIndex: 0 }] },
           },
-        },
-        {
-          DepositAsset: {
-            assets: { Wild: "All" },
-            maxAssets: new BN(1),
-            beneficiary: {
-              parents: 0,
-              interior: { X1: { AccountKey20: { network: "Any", key: alith.address } } },
-            },
-          },
-        },
-      ],
-    };
+        ],
+        fungible: 10000000000000n,
+      },
+      weight_limit: new BN(4000000000),
+      beneficiary: alith.address,
+    })
+      .reserve_asset_deposited()
+      .clear_origin()
+      .buy_execution()
+      .deposit_asset()
+      .as_v2();
 
     // Send an XCM and create block to execute it
     await injectHrmpMessageAndSeal(context, statemint_para_id, {
@@ -196,60 +177,30 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     // Parachain(Statemint parachain)
     // PalletInstance(Statemint assets pallet instance)
     // GeneralIndex(assetId being transferred)
-    let xcmMessage = {
-      V2: [
-        {
-          ReserveAssetDeposited: [
-            {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    X3: [
-                      { Parachain: statemint_para_id },
-                      { PalletInstance: statemint_assets_pallet_instance },
-                      { GeneralIndex: 0 },
-                    ],
-                  },
-                },
-              },
-              fun: { Fungible: new BN(10000000000000) },
-            },
-          ],
-        },
-        { ClearOrigin: null as any },
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: new BN(1),
-                  interior: {
-                    X3: [
-                      { Parachain: statemint_para_id },
-                      { PalletInstance: statemint_assets_pallet_instance },
-                      { GeneralIndex: 0 },
-                    ],
-                  },
-                },
-              },
-              fun: { Fungible: new BN(10000000000000) },
-            },
-            weightLimit: { Limited: new BN(4000000000) },
-          },
-        },
-        {
-          DepositAsset: {
-            assets: { Wild: "All" },
-            maxAssets: new BN(1),
-            beneficiary: {
-              parents: 0,
-              interior: { X1: { AccountKey20: { network: "Any", key: alith.address } } },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 1,
+            interior: {
+              X3: [
+                { Parachain: statemint_para_id },
+                { PalletInstance: statemint_assets_pallet_instance },
+                { GeneralIndex: 0 },
+              ],
             },
           },
-        },
-      ],
-    };
+        ],
+        fungible: 10000000000000n,
+      },
+      weight_limit: new BN(4000000000),
+      beneficiary: alith.address,
+    })
+      .reserve_asset_deposited()
+      .clear_origin()
+      .buy_execution()
+      .deposit_asset()
+      .as_v2();
 
     // Send an XCM and create block to execute it
     await injectHrmpMessageAndSeal(context, statemint_para_id, {
@@ -298,57 +249,32 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer of DEV", (context) =
     const balancesPalletIndex = (metadata.asLatest.toHuman().pallets as Array<any>).find(
       (pallet) => pallet.name === "Balances"
     ).index;
+
     // We are charging 100_000_000 weight for every XCM instruction
     // We are executing 4 instructions
     // 100_000_000 * 4 * 50000 = 20000000000000
     // We are charging 20 micro DEV for this operation
     // The rest should be going to the deposit account
-    let xcmMessage = {
-      V2: [
-        {
-          WithdrawAsset: [
-            {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    X2: [{ Parachain: ownParaId }, { PalletInstance: balancesPalletIndex }],
-                  },
-                },
-              },
-              fun: { Fungible: transferredBalance },
-            },
-          ],
-        },
-        { ClearOrigin: null as any },
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    X2: [{ Parachain: ownParaId }, { PalletInstance: balancesPalletIndex }],
-                  },
-                },
-              },
-              fun: { Fungible: transferredBalance },
-            },
-            weightLimit: { Limited: new BN(4000000000) },
-          },
-        },
-        {
-          DepositAsset: {
-            assets: { Wild: "All" },
-            maxAssets: new BN(1),
-            beneficiary: {
-              parents: 0,
-              interior: { X1: { AccountKey20: { network: "Any", key: random.address } } },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 1,
+            interior: {
+              X2: [{ Parachain: ownParaId }, { PalletInstance: balancesPalletIndex }],
             },
           },
-        },
-      ],
-    };
+        ],
+        fungible: transferredBalance,
+      },
+      weight_limit: new BN(4000000000),
+      beneficiary: random.address,
+    })
+      .withdraw_asset()
+      .clear_origin()
+      .buy_execution()
+      .deposit_asset()
+      .as_v2();
 
     // Send an XCM and create block to execute it
     await injectHrmpMessageAndSeal(context, foreign_para_id, {
@@ -411,54 +337,26 @@ describeDevMoonbeam(
       // 200_000_000 * 4 * 50000 = 40000000000000
       // We are charging 40 micro DEV for this operation
       // The rest should be going to the deposit account
-      let xcmMessage = {
-        V2: [
-          {
-            WithdrawAsset: [
-              {
-                // This is the new reanchored logic
-                id: {
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X1: { PalletInstance: balancesPalletIndex },
-                    },
-                  },
-                },
-                fun: { Fungible: transferredBalance },
-              },
-            ],
-          },
-          { ClearOrigin: null as any },
-          {
-            BuyExecution: {
-              fees: {
-                id: {
-                  // This is the new reanchored logic
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X1: { PalletInstance: balancesPalletIndex },
-                    },
-                  },
-                },
-                fun: { Fungible: transferredBalance },
-              },
-              weightLimit: { Limited: new BN(8000000000) },
-            },
-          },
-          {
-            DepositAsset: {
-              assets: { Wild: "All" },
-              maxAssets: new BN(1),
-              beneficiary: {
-                parents: 0,
-                interior: { X1: { AccountKey20: { network: "Any", key: random.address } } },
+      const xcmMessage = new XcmFragment({
+        fees: {
+          multilocation: [
+            {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          },
-        ],
-      };
+          ],
+          fungible: transferredBalance,
+        },
+        weight_limit: new BN(8000000000),
+        beneficiary: random.address,
+      })
+        .withdraw_asset()
+        .clear_origin()
+        .buy_execution()
+        .deposit_asset()
+        .as_v2();
 
       // Send an XCM and create block to execute it
       await injectHrmpMessageAndSeal(context, foreign_para_id, {
@@ -557,66 +455,32 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     // 100_000_000 * 4 * 50000 = 20000000000000
     // We are charging 20 micro DEV for this operation
     // The rest should be going to the deposit account
-    let xcmMessage = {
-      V2: [
-        {
-          WithdrawAsset: [
-            {
-              // This is the new reanchored logic
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: transferredBalance },
-            },
-            {
-              // This is the new reanchored logic
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X2: [{ PalletInstance: localAssetsPalletIndex }, { GeneralIndex: assetId }],
-                  },
-                },
-              },
-              fun: { Fungible: transferredBalance },
-            },
-          ],
-        },
-        { ClearOrigin: null as any },
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                // This is the new reanchored logic
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: transferredBalance },
-            },
-            weightLimit: { Limited: new BN(4000000000) },
-          },
-        },
-        {
-          DepositAsset: {
-            assets: { Wild: "All" },
-            maxAssets: new BN(2),
-            beneficiary: {
-              parents: 0,
-              interior: { X1: { AccountKey20: { network: "Any", key: alith.address } } },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 0,
+            interior: {
+              X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        },
-      ],
-    };
+          {
+            parents: 0,
+            interior: {
+              X2: [{ PalletInstance: localAssetsPalletIndex }, { GeneralIndex: assetId }],
+            },
+          },
+        ],
+        fungible: transferredBalance,
+      },
+      weight_limit: new BN(4000000000),
+      beneficiary: alith.address,
+    })
+      .withdraw_asset()
+      .clear_origin()
+      .buy_execution()
+      .deposit_asset(2n)
+      .as_v2();
 
     // Send an XCM and create block to execute it
     await injectHrmpMessageAndSeal(context, foreign_para_id, {
@@ -664,75 +528,40 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
   it("Should receive 10 asset 0 tokens using statemint asset 1 as fee ", async function () {
     // We are going to test that, using one of them as fee payment (assetOne),
     // we can receive the other
-    let xcmMessage = {
-      V2: [
-        {
-          ReserveAssetDeposited: [
-            {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    X3: [
-                      { Parachain: statemint_para_id },
-                      { PalletInstance: statemint_assets_pallet_instance },
-                      { GeneralIndex: 0 },
-                    ],
-                  },
-                },
-              },
-              fun: { Fungible: new BN(10000000000000) },
-            },
-            {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    X3: [
-                      { Parachain: statemint_para_id },
-                      { PalletInstance: statemint_assets_pallet_instance },
-                      { GeneralIndex: 1 },
-                    ],
-                  },
-                },
-              },
-              fun: { Fungible: new BN(10000000000000) },
-            },
-          ],
-        },
-        { ClearOrigin: null as any },
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: new BN(1),
-                  interior: {
-                    X3: [
-                      { Parachain: statemint_para_id },
-                      { PalletInstance: statemint_assets_pallet_instance },
-                      { GeneralIndex: 1 },
-                    ],
-                  },
-                },
-              },
-              fun: { Fungible: new BN(10000000000000) },
-            },
-            weightLimit: { Limited: new BN(4000000000) },
-          },
-        },
-        {
-          DepositAsset: {
-            assets: { Wild: "All" },
-            maxAssets: new BN(2),
-            beneficiary: {
-              parents: 0,
-              interior: { X1: { AccountKey20: { network: "Any", key: alith.address } } },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 1,
+            interior: {
+              X3: [
+                { Parachain: statemint_para_id },
+                { PalletInstance: statemint_assets_pallet_instance },
+                { GeneralIndex: 0 },
+              ],
             },
           },
-        },
-      ],
-    };
+          {
+            parents: 1,
+            interior: {
+              X3: [
+                { Parachain: statemint_para_id },
+                { PalletInstance: statemint_assets_pallet_instance },
+                { GeneralIndex: 1 },
+              ],
+            },
+          },
+        ],
+        fungible: 10000000000000n,
+      },
+      weight_limit: new BN(4000000000),
+      beneficiary: alith.address,
+    })
+      .reserve_asset_deposited()
+      .clear_origin()
+      .buy_execution(1) // buy execution with asset at index 1
+      .deposit_asset(2n)
+      .as_v2();
 
     // Send an XCM and create block to execute it
     await injectHrmpMessageAndSeal(context, statemint_para_id, {
@@ -827,70 +656,36 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     // 100_000_000 * 4 * 50000 = 20000000000000
     // We are charging 20 micro DEV for this operation
     // The rest should be going to the deposit account
-    let xcmMessage = {
-      V2: [
-        {
-          WithdrawAsset: [
-            {
-              // This is the new reanchored logic
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    X2: [{ Parachain: ownParaId }, { PalletInstance: balancesPalletIndex }],
-                  },
-                },
-              },
-              fun: { Fungible: transferredBalance },
-            },
-            {
-              // This is the new reanchored logic
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    X3: [
-                      { Parachain: ownParaId },
-                      { PalletInstance: localAssetsPalletIndex },
-                      { GeneralIndex: assetId },
-                    ],
-                  },
-                },
-              },
-              fun: { Fungible: transferredBalance },
-            },
-          ],
-        },
-        { ClearOrigin: null as any },
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                // This is the new reanchored logic
-                Concrete: {
-                  parents: 1,
-                  interior: {
-                    X2: [{ Parachain: ownParaId }, { PalletInstance: balancesPalletIndex }],
-                  },
-                },
-              },
-              fun: { Fungible: transferredBalance },
-            },
-            weightLimit: { Limited: new BN(4000000000) },
-          },
-        },
-        {
-          DepositAsset: {
-            assets: { Wild: "All" },
-            maxAssets: new BN(2),
-            beneficiary: {
-              parents: 0,
-              interior: { X1: { AccountKey20: { network: "Any", key: baltathar.address } } },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 1,
+            interior: {
+              X2: [{ Parachain: ownParaId }, { PalletInstance: balancesPalletIndex }],
             },
           },
-        },
-      ],
-    };
+          {
+            parents: 1,
+            interior: {
+              X3: [
+                { Parachain: ownParaId },
+                { PalletInstance: localAssetsPalletIndex },
+                { GeneralIndex: assetId },
+              ],
+            },
+          },
+        ],
+        fungible: transferredBalance,
+      },
+      weight_limit: new BN(4000000000),
+      beneficiary: baltathar.address,
+    })
+      .withdraw_asset()
+      .clear_origin()
+      .buy_execution()
+      .deposit_asset(2n)
+      .as_v2();
 
     // Send an XCM and create block to execute it
     await injectHrmpMessageAndSeal(context, foreign_para_id, {
@@ -925,48 +720,24 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
   it("Should not receive 10 asset 0 tokens because fee not supported ", async function () {
     // We are going to test that, using one of them as fee payment (assetOne),
     // we can receive the other
-    let xcmMessage = {
-      V2: [
-        {
-          ReserveAssetDeposited: [
-            {
-              id: {
-                Concrete: {
-                  parents: 1,
-                  interior: { X2: [{ Parachain: statemint_para_id }, { GeneralIndex: 0 }] },
-                },
-              },
-              fun: { Fungible: new BN(10000000000000) },
-            },
-          ],
-        },
-        { ClearOrigin: null as any },
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: new BN(1),
-                  interior: { X2: [{ Parachain: statemint_para_id }, { GeneralIndex: 0 }] },
-                },
-              },
-              fun: { Fungible: new BN(10000000000000) },
-            },
-            weightLimit: { Limited: new BN(4000000000) },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 1,
+            interior: { X2: [{ Parachain: statemint_para_id }, { GeneralIndex: 0 }] },
           },
-        },
-        {
-          DepositAsset: {
-            assets: { Wild: "All" },
-            maxAssets: new BN(2),
-            beneficiary: {
-              parents: 0,
-              interior: { X1: { AccountKey20: { network: "Any", key: alith.address } } },
-            },
-          },
-        },
-      ],
-    };
+        ],
+        fungible: 10000000000000n,
+      },
+      weight_limit: new BN(4000000000),
+      beneficiary: alith.address,
+    })
+      .reserve_asset_deposited()
+      .clear_origin()
+      .buy_execution()
+      .deposit_asset(2n)
+      .as_v2();
 
     // Send an XCM and create block to execute it
     await injectHrmpMessageAndSeal(context, statemint_para_id, {

--- a/tests/tests/test-xcm/test-mock-hrmp-queue.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp-queue.ts
@@ -4,7 +4,6 @@ import { BN, u8aToHex } from "@polkadot/util";
 import { expect } from "chai";
 import { ChaChaRng } from "randchacha";
 
-import { customWeb3Request } from "../../util/providers";
 import {
   mockHrmpChannelExistanceTx,
   injectHrmpMessageAndSeal,
@@ -17,6 +16,7 @@ import { describeDevMoonbeam, DevTestContext } from "../../util/setup-dev-tests"
 import type { XcmVersionedXcm, XcmVersionedMultiLocation } from "@polkadot/types/lookup";
 
 import { expectOk } from "../../util/expect";
+import { XcmFragment } from "../../util/xcm";
 
 // enum to mark how xcmp execution went
 enum XcmpExecution {
@@ -124,44 +124,24 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
     // single messages.
     const clearOriginsPerMessage = (weightPerMessage - weightPerXcmInst) / weightPerXcmInst;
 
-    const xcmMessage = {
-      V2: [
-        {
-          WithdrawAsset: [
-            {
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: 1 },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 0,
+            interior: {
+              X1: { PalletInstance: balancesPalletIndex },
             },
-          ],
-        },
-        ...Array(Number(clearOriginsPerMessage)).fill({
-          ClearOrigin: null,
-        }),
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: 1 },
-            },
-            weightLimit: { Limited: new BN(20000000000) },
           },
-        },
-      ],
-    };
+        ],
+        fungible: 1n,
+      },
+      weight_limit: new BN(20000000000),
+    })
+      .withdraw_asset()
+      .clear_origin(clearOriginsPerMessage)
+      .buy_execution()
+      .as_v2();
 
     // We want these isntructions to fail in BuyExecution. That means
     // WithdrawAsset needs to work. The only way for this to work
@@ -268,44 +248,24 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
     // for that reason, we multiply times 2
     const clearOriginsPerMessage = (weightPerMessage - weightPerXcmInst * 2n) / weightPerXcmInst;
 
-    let xcmMessage = {
-      V2: [
-        {
-          WithdrawAsset: [
-            {
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: 1 },
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 0,
+            interior: {
+              X1: { PalletInstance: balancesPalletIndex },
             },
-          ],
-        },
-        ...Array(Number(clearOriginsPerMessage)).fill({
-          ClearOrigin: null,
-        }),
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: 1 },
-            },
-            weightLimit: { Limited: new BN(20000000000) },
           },
-        },
-      ],
-    };
+        ],
+        fungible: 1n,
+      },
+      weight_limit: new BN(20000000000),
+    })
+      .withdraw_asset()
+      .clear_origin(clearOriginsPerMessage)
+      .buy_execution()
+      .as_v2();
 
     // We want these isntructions to fail in BuyExecution. That means
     // WithdrawAsset needs to work. The only way for this to work
@@ -389,76 +349,41 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
       (pallet) => pallet.name === "Balances"
     ).index;
 
-    const xcmMessageNotExecuted = {
-      V2: [
-        {
-          WithdrawAsset: [
-            {
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: 1 },
+    const xcmMessageNotExecuted = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 0,
+            interior: {
+              X1: { PalletInstance: balancesPalletIndex },
             },
-          ],
-        },
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: 1 },
-            },
-            weightLimit: { Limited: new BN(20000000000) },
           },
-        },
-      ],
-    };
-    const xcmMessageExecuted = {
-      V2: [
-        {
-          WithdrawAsset: [
-            {
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: 2 },
+        ],
+        fungible: 1n,
+      },
+      weight_limit: new BN(20000000000),
+    })
+      .withdraw_asset()
+      .buy_execution()
+      .as_v2();
+
+    const xcmMessageExecuted = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 0,
+            interior: {
+              X1: { PalletInstance: balancesPalletIndex },
             },
-          ],
-        },
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: 2 },
-            },
-            weightLimit: { Limited: new BN(20000000000) },
           },
-        },
-      ],
-    };
+        ],
+        fungible: 2n,
+      },
+      weight_limit: new BN(20000000000),
+    })
+      .withdraw_asset()
+      .buy_execution()
+      .as_v2();
 
     const paraId = context.polkadotApi.createType("ParaId", 1) as any;
     const sovereignAddress = u8aToHex(
@@ -497,41 +422,23 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
       (pallet) => pallet.name === "Balances"
     ).index;
 
-    const xcmMessageNotExecuted = {
-      V2: [
-        {
-          WithdrawAsset: [
-            {
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: 1 },
+    const xcmMessageNotExecuted = new XcmFragment({
+      fees: {
+        multilocation: [
+          {
+            parents: 0,
+            interior: {
+              X1: { PalletInstance: balancesPalletIndex },
             },
-          ],
-        },
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: {
-                  parents: 0,
-                  interior: {
-                    X1: { PalletInstance: balancesPalletIndex },
-                  },
-                },
-              },
-              fun: { Fungible: 1 },
-            },
-            weightLimit: { Limited: new BN(20000000000) },
           },
-        },
-      ],
-    };
+        ],
+        fungible: 1n,
+      },
+      weight_limit: new BN(20000000000),
+    })
+      .withdraw_asset()
+      .buy_execution()
+      .as_v2();
 
     const paraId = context.polkadotApi.createType("ParaId", 1) as any;
     const sovereignAddress = u8aToHex(

--- a/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
@@ -10,6 +10,7 @@ import {
   registerForeignAsset,
   injectHrmpMessageAndSeal,
   RawXcmMessage,
+  XcmFragment,
 } from "../../util/xcm";
 
 import { describeDevMoonbeam } from "../../util/setup-dev-tests";
@@ -99,60 +100,34 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (transfer)"
 
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
-      const xcmMessage = {
-        V2: [
-          {
-            DescendOrigin: {
-              X1: {
-                AccountKey20: {
-                  network: "Any",
-                  key: sendingAddress,
-                },
+      const xcmMessage = new XcmFragment({
+        fees: {
+          multilocation: [
+            {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          },
-          {
-            WithdrawAsset: [
-              {
-                id: {
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X1: { PalletInstance: balancesPalletIndex },
-                    },
-                  },
-                },
-                fun: { Fungible: targetXcmFee },
-              },
-            ],
-          },
-          {
-            BuyExecution: {
-              fees: {
-                id: {
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X1: { PalletInstance: balancesPalletIndex },
-                    },
-                  },
-                },
-                fun: { Fungible: targetXcmFee },
-              },
-              weightLimit: { Limited: targetXcmWeight },
+          ],
+          fungible: targetXcmFee,
+        },
+        weight_limit: new BN(targetXcmWeight.toString()),
+        descend_origin: sendingAddress,
+      })
+        .descend_origin()
+        .withdraw_asset()
+        .buy_execution()
+        .push_any({
+          Transact: {
+            originType: "SovereignAccount",
+            requireWeightAtMost: new BN(525_000_000), // 21_000 gas limit
+            call: {
+              encoded: transferCallEncoded,
             },
           },
-          {
-            Transact: {
-              originType: "SovereignAccount",
-              requireWeightAtMost: new BN(525_000_000), // 21_000 gas limit
-              call: {
-                encoded: transferCallEncoded,
-              },
-            },
-          },
-        ],
-      };
+        })
+        .as_v2();
 
       // Send an XCM and create block to execute it
       await injectHrmpMessageAndSeal(context, 1, {
@@ -254,60 +229,34 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (call)", (c
       const transferCallEncoded = transferCall?.method.toHex();
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
-      const xcmMessage = {
-        V2: [
-          {
-            DescendOrigin: {
-              X1: {
-                AccountKey20: {
-                  network: "Any",
-                  key: sendingAddress,
-                },
+      const xcmMessage = new XcmFragment({
+        fees: {
+          multilocation: [
+            {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          },
-          {
-            WithdrawAsset: [
-              {
-                id: {
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X1: { PalletInstance: balancesPalletIndex },
-                    },
-                  },
-                },
-                fun: { Fungible: transferredBalance / 2n },
-              },
-            ],
-          },
-          {
-            BuyExecution: {
-              fees: {
-                id: {
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X1: { PalletInstance: balancesPalletIndex },
-                    },
-                  },
-                },
-                fun: { Fungible: transferredBalance / 2n },
-              },
-              weightLimit: { Limited: new BN(4000000000) },
+          ],
+          fungible: transferredBalance / 2n,
+        },
+        weight_limit: new BN(4000000000),
+        descend_origin: sendingAddress,
+      })
+        .descend_origin()
+        .withdraw_asset()
+        .buy_execution()
+        .push_any({
+          Transact: {
+            originType: "SovereignAccount",
+            requireWeightAtMost: new BN(3000000000),
+            call: {
+              encoded: transferCallEncoded,
             },
           },
-          {
-            Transact: {
-              originType: "SovereignAccount",
-              requireWeightAtMost: new BN(3000000000),
-              call: {
-                encoded: transferCallEncoded,
-              },
-            },
-          },
-        ],
-      };
+        })
+        .as_v2();
 
       // Send an XCM and create block to execute it
       await injectHrmpMessageAndSeal(context, 1, {
@@ -378,42 +327,19 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (asset fee)
     expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
 
     // Deposit asset
-    let xcmMessage = {
-      V2: [
-        {
-          ReserveAssetDeposited: [
-            {
-              id: {
-                Concrete: ASSET_MULTILOCATION,
-              },
-              fun: { Fungible: assetsToTransfer + 800_000_000n },
-            },
-          ],
-        },
-        { ClearOrigin: null as any },
-        {
-          BuyExecution: {
-            fees: {
-              id: {
-                Concrete: ASSET_MULTILOCATION,
-              },
-              fun: { Fungible: assetsToTransfer + 800_000_000n },
-            },
-            weightLimit: { Limited: new BN(800_000_000) },
-          },
-        },
-        {
-          DepositAsset: {
-            assets: { Wild: "All" },
-            maxAssets: new BN(1),
-            beneficiary: {
-              parents: 0,
-              interior: { X1: { AccountKey20: { network: "Any", key: descendOriginAddress } } },
-            },
-          },
-        },
-      ],
-    };
+    const xcmMessage = new XcmFragment({
+      fees: {
+        multilocation: [ASSET_MULTILOCATION],
+        fungible: assetsToTransfer + 800_000_000n,
+      },
+      weight_limit: new BN(800_000_000),
+      beneficiary: descendOriginAddress,
+    })
+      .reserve_asset_deposited()
+      .clear_origin()
+      .buy_execution()
+      .deposit_asset()
+      .as_v2();
 
     // Send an XCM and create block to execute it
     await injectHrmpMessageAndSeal(context, statemint_para_id, {
@@ -468,52 +394,30 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (asset fee)
       // TODO need to update lookup types for xcm ethereum transaction V2
       const transferCall = context.polkadotApi.tx.ethereumXcm.transact(xcmTransaction as any);
       const transferCallEncoded = transferCall?.method.toHex();
+
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
-      const xcmMessage = {
-        V2: [
-          {
-            DescendOrigin: {
-              X1: {
-                AccountKey20: {
-                  network: "Any",
-                  key: sendingAddress,
-                },
-              },
+      const xcmMessage = new XcmFragment({
+        fees: {
+          multilocation: [ASSET_MULTILOCATION],
+          fungible: assetsToTransfer / 2n,
+        },
+        weight_limit: new BN((assetsToTransfer / 2n).toString()),
+        descend_origin: sendingAddress,
+      })
+        .descend_origin()
+        .withdraw_asset()
+        .buy_execution()
+        .push_any({
+          Transact: {
+            originType: "SovereignAccount",
+            requireWeightAtMost: new BN(2_500_000_000), // 100_000 gas
+            call: {
+              encoded: transferCallEncoded,
             },
           },
-          {
-            WithdrawAsset: [
-              {
-                id: {
-                  Concrete: ASSET_MULTILOCATION,
-                },
-                fun: { Fungible: assetsToTransfer / 2n },
-              },
-            ],
-          },
-          {
-            BuyExecution: {
-              fees: {
-                id: {
-                  Concrete: ASSET_MULTILOCATION,
-                },
-                fun: { Fungible: assetsToTransfer / 2n },
-              },
-              weightLimit: { Limited: assetsToTransfer / 2n },
-            },
-          },
-          {
-            Transact: {
-              originType: "SovereignAccount",
-              requireWeightAtMost: new BN(2_500_000_000), // 100_000 gas
-              call: {
-                encoded: transferCallEncoded,
-              },
-            },
-          },
-        ],
-      };
+        })
+        .as_v2();
 
       // Send an XCM and create block to execute it
       await injectHrmpMessageAndSeal(context, 1, {
@@ -619,60 +523,34 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
 
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
-      const xcmMessage = {
-        V2: [
-          {
-            DescendOrigin: {
-              X1: {
-                AccountKey20: {
-                  network: "Any",
-                  key: sendingAddress,
-                },
+      const xcmMessage = new XcmFragment({
+        fees: {
+          multilocation: [
+            {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          },
-          {
-            WithdrawAsset: [
-              {
-                id: {
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X1: { PalletInstance: balancesPalletIndex },
-                    },
-                  },
-                },
-                fun: { Fungible: targetXcmFee },
-              },
-            ],
-          },
-          {
-            BuyExecution: {
-              fees: {
-                id: {
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X1: { PalletInstance: balancesPalletIndex },
-                    },
-                  },
-                },
-                fun: { Fungible: targetXcmFee },
-              },
-              weightLimit: { Limited: targetXcmWeight },
+          ],
+          fungible: targetXcmFee,
+        },
+        weight_limit: new BN(targetXcmWeight.toString()),
+        descend_origin: sendingAddress,
+      })
+        .descend_origin()
+        .withdraw_asset()
+        .buy_execution()
+        .push_any({
+          Transact: {
+            originType: "SovereignAccount",
+            requireWeightAtMost: new BN(525_000_000), // 100_000 gas
+            call: {
+              encoded: transferCallEncoded,
             },
           },
-          {
-            Transact: {
-              originType: "SovereignAccount",
-              requireWeightAtMost: new BN(525_000_000), // 21_000 gas limit
-              call: {
-                encoded: transferCallEncoded,
-              },
-            },
-          },
-        ],
-      };
+        })
+        .as_v2();
 
       // Send an XCM and create block to execute it
       await injectHrmpMessageAndSeal(context, 1, {
@@ -784,60 +662,34 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
 
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
-      const xcmMessage = {
-        V2: [
-          {
-            DescendOrigin: {
-              X1: {
-                AccountKey20: {
-                  network: "Any",
-                  key: sendingAddress,
-                },
+      const xcmMessage = new XcmFragment({
+        fees: {
+          multilocation: [
+            {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          },
-          {
-            WithdrawAsset: [
-              {
-                id: {
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X1: { PalletInstance: balancesPalletIndex },
-                    },
-                  },
-                },
-                fun: { Fungible: targetXcmFee },
-              },
-            ],
-          },
-          {
-            BuyExecution: {
-              fees: {
-                id: {
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X1: { PalletInstance: balancesPalletIndex },
-                    },
-                  },
-                },
-                fun: { Fungible: targetXcmFee },
-              },
-              weightLimit: { Limited: targetXcmWeight },
+          ],
+          fungible: targetXcmFee,
+        },
+        weight_limit: new BN(targetXcmWeight.toString()),
+        descend_origin: sendingAddress,
+      })
+        .descend_origin()
+        .withdraw_asset()
+        .buy_execution()
+        .push_any({
+          Transact: {
+            originType: "SovereignAccount",
+            requireWeightAtMost: new BN(525_000_000), // 100_000 gas
+            call: {
+              encoded: transferCallEncoded,
             },
           },
-          {
-            Transact: {
-              originType: "SovereignAccount",
-              requireWeightAtMost: new BN(525_000_000), // 21_000 gas limit
-              call: {
-                encoded: transferCallEncoded,
-              },
-            },
-          },
-        ],
-      };
+        })
+        .as_v2();
 
       // Send an XCM and create block to execute it
       await injectHrmpMessageAndSeal(context, 1, {
@@ -965,60 +817,34 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
 
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
-      const xcmMessage = {
-        V2: [
-          {
-            DescendOrigin: {
-              X1: {
-                AccountKey20: {
-                  network: "Any",
-                  key: sendingAddress,
-                },
+      const xcmMessage = new XcmFragment({
+        fees: {
+          multilocation: [
+            {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          },
-          {
-            WithdrawAsset: [
-              {
-                id: {
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X1: { PalletInstance: balancesPalletIndex },
-                    },
-                  },
-                },
-                fun: { Fungible: targetXcmFee },
-              },
-            ],
-          },
-          {
-            BuyExecution: {
-              fees: {
-                id: {
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X1: { PalletInstance: balancesPalletIndex },
-                    },
-                  },
-                },
-                fun: { Fungible: targetXcmFee },
-              },
-              weightLimit: { Limited: targetXcmWeight },
+          ],
+          fungible: targetXcmFee,
+        },
+        weight_limit: new BN(targetXcmWeight.toString()),
+        descend_origin: sendingAddress,
+      })
+        .descend_origin()
+        .withdraw_asset()
+        .buy_execution()
+        .push_any({
+          Transact: {
+            originType: "SovereignAccount",
+            requireWeightAtMost: new BN(525_000_000), // 100_000 gas
+            call: {
+              encoded: transferCallEncoded,
             },
           },
-          {
-            Transact: {
-              originType: "SovereignAccount",
-              requireWeightAtMost: new BN(525_000_000), // 21_000 gas limit
-              call: {
-                encoded: transferCallEncoded,
-              },
-            },
-          },
-        ],
-      };
+        })
+        .as_v2();
 
       // Send an XCM and create block to execute it
       await injectHrmpMessageAndSeal(context, 1, {

--- a/tests/util/xcm.ts
+++ b/tests/util/xcm.ts
@@ -187,3 +187,190 @@ export async function injectHrmpMessageAndSeal(
   // Create a block in which the XCM will be executed
   await context.createBlock();
 }
+
+interface XcmFragmentConfig {
+  fees: {
+    multilocation: any[];
+    fungible: bigint;
+  };
+  weight_limit: BN;
+  descend_origin?: string;
+  beneficiary?: string;
+}
+
+export class XcmFragment {
+  config: XcmFragmentConfig;
+  instructions: any[];
+
+  constructor(config: XcmFragmentConfig) {
+    this.config = config;
+    this.instructions = [];
+  }
+
+  // Add a `ReserveAssetDeposited` instruction
+  reserve_asset_deposited(): this {
+    this.instructions.push({
+      ReserveAssetDeposited: this.config.fees.multilocation.map((multilocation) => {
+        return {
+          id: {
+            Concrete: multilocation,
+          },
+          fun: { Fungible: this.config.fees.fungible },
+        };
+      }, this),
+    });
+    return this;
+  }
+
+  // Add a `WithdrawAsset` instruction
+  withdraw_asset(): this {
+    this.instructions.push({
+      WithdrawAsset: this.config.fees.multilocation.map((multilocation) => {
+        return {
+          id: {
+            Concrete: multilocation,
+          },
+          fun: { Fungible: this.config.fees.fungible },
+        };
+      }, this),
+    });
+    return this;
+  }
+
+  // Add a `BuyExecution` instruction
+  buy_execution(multilocation_index: number = 0): this {
+    this.instructions.push({
+      BuyExecution: {
+        fees: {
+          id: {
+            Concrete: this.config.fees.multilocation[multilocation_index],
+          },
+          fun: { Fungible: this.config.fees.fungible },
+        },
+        weightLimit: { Limited: this.config.weight_limit },
+      },
+    });
+    return this;
+  }
+
+  // Add a `ClaimAsset` instruction
+  claim_asset(): this {
+    this.instructions.push({
+      ClaimAsset: {
+        assets: [
+          {
+            id: {
+              Concrete: this.config.fees.multilocation[0],
+            },
+            fun: { Fungible: this.config.fees.fungible },
+          },
+        ],
+        // Ticket seems to indicate the version of the assets
+        ticket: {
+          parents: 0,
+          interior: { X1: { GeneralIndex: 2 } },
+        },
+      },
+    });
+    return this;
+  }
+
+  // Add a `ClearOrigin` instruction
+  clear_origin(repeat: bigint = 1n): this {
+    for (var i = 0; i < repeat; i++) {
+      this.instructions.push({ ClearOrigin: null as any });
+    }
+    return this;
+  }
+
+  // Add a `DescendOrigin` instruction
+  descend_origin(): this {
+    if (this.config.descend_origin != null) {
+      this.instructions.push({
+        DescendOrigin: {
+          X1: {
+            AccountKey20: {
+              network: "Any",
+              key: this.config.descend_origin,
+            },
+          },
+        },
+      });
+    } else {
+      console.warn("!Building a DescendOrigin instruction without a configured descend_origin");
+    }
+    return this;
+  }
+
+  // Add a `DepositAsset` instruction
+  deposit_asset(max_assets: bigint = 1n): this {
+    if (this.config.beneficiary == null) {
+      console.warn("!Building a DepositAsset instruction without a configured beneficiary");
+    }
+    this.instructions.push({
+      DepositAsset: {
+        assets: { Wild: "All" },
+        maxAssets: max_assets,
+        beneficiary: {
+          parents: 0,
+          interior: { X1: { AccountKey20: { network: "Any", key: this.config.beneficiary } } },
+        },
+      },
+    });
+    return this;
+  }
+
+  // Add a `SetErrorHandler` instruction, appending all the nested instructions
+  set_error_handler_with(callbacks: Function[]): this {
+    let error_instructions = [];
+    callbacks.forEach((cb) => {
+      cb.call(this);
+      // As each method in the class pushes to the instruction stack, we pop
+      error_instructions.push(this.instructions.pop());
+    });
+    this.instructions.push({
+      SetErrorHandler: error_instructions,
+    });
+    return this;
+  }
+
+  // Add a `SetAppendix` instruction, appending all the nested instructions
+  set_appendix_with(callbacks: Function[]): this {
+    let appendix_instructions = [];
+    callbacks.forEach((cb) => {
+      cb.call(this);
+      // As each method in the class pushes to the instruction stack, we pop
+      appendix_instructions.push(this.instructions.pop());
+    });
+    this.instructions.push({
+      SetAppendix: appendix_instructions,
+    });
+    return this;
+  }
+
+  // Add a `Trap` instruction, appending all the nested instructions
+  trap(): this {
+    this.instructions.push({
+      Trap: 0,
+    });
+    return this;
+  }
+
+  // Utility function to support functional style method call chaining bound to `this` context
+  with(callback: Function): this {
+    return callback.call(this);
+  }
+
+  // Pushes the given instruction
+  push_any(instruction: any): this {
+    this.instructions.push(instruction);
+    return this;
+  }
+
+  // Returns a V2 fragment payload
+  as_v2(): any {
+    return {
+      V2: this.instructions,
+    };
+  }
+}

--- a/tests/util/xcm.ts
+++ b/tests/util/xcm.ts
@@ -348,7 +348,7 @@ export class XcmFragment {
     return this;
   }
 
-  // Add a `Trap` instruction, appending all the nested instructions
+  // Add a `Trap` instruction
   trap(): this {
     this.instructions.push({
       Trap: 0,


### PR DESCRIPTION
### What does it do?

A typescript utility class that reduces the boilerplate when writting xcm fragments.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
