### PR TITLE
use u32 as BlockNumber in mocks

### DIFF
--- a/pallets/asset-manager/src/mock.rs
+++ b/pallets/asset-manager/src/mock.rs
@@ -60,7 +60,7 @@ impl frame_system::Config for Test {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;

--- a/pallets/asset-manager/src/mock.rs
+++ b/pallets/asset-manager/src/mock.rs
@@ -25,11 +25,8 @@ use frame_system::EnsureRoot;
 use scale_info::TypeInfo;
 use sp_core::H256;
 use sp_runtime::traits::Hash as THash;
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 use sp_runtime::DispatchError;
-use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-};
 use xcm::latest::prelude::*;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
@@ -37,6 +34,7 @@ type Block = frame_system::mocking::MockBlock<Test>;
 
 pub type AccountId = u64;
 pub type Balance = u64;
+pub type BlockNumber = u32;
 
 construct_runtime!(
 	pub enum Test where
@@ -51,7 +49,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 }
 impl frame_system::Config for Test {
 	type BaseCallFilter = Everything;
@@ -60,12 +58,12 @@ impl frame_system::Config for Test {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u32;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type DbWeight = ();

--- a/pallets/author-mapping/src/mock.rs
+++ b/pallets/author-mapping/src/mock.rs
@@ -59,7 +59,7 @@ impl Into<NimbusId> for TestAuthor {
 
 pub type AccountId = u64;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/pallets/author-mapping/src/mock.rs
+++ b/pallets/author-mapping/src/mock.rs
@@ -29,7 +29,6 @@ use serde::{Deserialize, Serialize};
 use sp_core::{ByteArray, H256};
 use sp_io;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill, RuntimeDebug,
 };
@@ -78,7 +77,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
@@ -94,7 +93,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/pallets/ethereum-xcm/src/mock.rs
+++ b/pallets/ethereum-xcm/src/mock.rs
@@ -27,7 +27,6 @@ use pallet_evm::{AddressMapping, EnsureAddressTruncated, FeeCalculator};
 use rlp::RlpStream;
 use sp_core::{hashing::keccak_256, H160, H256, U256};
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	AccountId32,
 };
@@ -40,6 +39,7 @@ use sp_runtime::{
 };
 
 pub type SignedExtra = (frame_system::CheckSpecVersion<Test>,);
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test, (), SignedExtra>;
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -61,7 +61,7 @@ frame_support::construct_runtime! {
 }
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub BlockWeights: frame_system::limits::BlockWeights =
 		frame_system::limits::BlockWeights::simple_max(1024);
 }
@@ -73,13 +73,13 @@ impl frame_system::Config for Test {
 	type DbWeight = ();
 	type Origin = Origin;
 	type Index = u64;
-	type BlockNumber = u32;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Call = Call;
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId32;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -232,7 +232,7 @@ impl pallet_proxy::Config for Test {
 pub struct EthereumXcmEnsureProxy;
 impl xcm_primitives::EnsureProxy<AccountId32> for EthereumXcmEnsureProxy {
 	fn ensure_ok(delegator: AccountId32, delegatee: AccountId32) -> Result<(), &'static str> {
-		let f = |x: &pallet_proxy::ProxyDefinition<AccountId32, ProxyType, u64>| -> bool {
+		let f = |x: &pallet_proxy::ProxyDefinition<AccountId32, ProxyType, u32>| -> bool {
 			x.delegate == delegatee && (x.proxy_type == ProxyType::Any)
 		};
 		Proxy::proxies(delegator)

--- a/pallets/ethereum-xcm/src/mock.rs
+++ b/pallets/ethereum-xcm/src/mock.rs
@@ -73,7 +73,7 @@ impl frame_system::Config for Test {
 	type DbWeight = ();
 	type Origin = Origin;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Call = Call;
 	type Hashing = BlakeTwo256;

--- a/pallets/ethereum-xcm/src/mock.rs
+++ b/pallets/ethereum-xcm/src/mock.rs
@@ -233,7 +233,7 @@ impl pallet_proxy::Config for Test {
 pub struct EthereumXcmEnsureProxy;
 impl xcm_primitives::EnsureProxy<AccountId32> for EthereumXcmEnsureProxy {
 	fn ensure_ok(delegator: AccountId32, delegatee: AccountId32) -> Result<(), &'static str> {
-		let f = |x: &pallet_proxy::ProxyDefinition<AccountId32, ProxyType, u32>| -> bool {
+		let f = |x: &pallet_proxy::ProxyDefinition<AccountId32, ProxyType, BlockNumber>| -> bool {
 			x.delegate == delegatee && (x.proxy_type == ProxyType::Any)
 		};
 		Proxy::proxies(delegator)

--- a/pallets/maintenance-mode/src/mock.rs
+++ b/pallets/maintenance-mode/src/mock.rs
@@ -36,7 +36,7 @@ use sp_runtime::{
 
 //TODO use TestAccount once it is in a common place (currently it lives with democracy precompiles)
 pub type AccountId = u64;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;

--- a/pallets/maintenance-mode/src/mock.rs
+++ b/pallets/maintenance-mode/src/mock.rs
@@ -29,7 +29,6 @@ use frame_support::{
 use frame_system::EnsureRoot;
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill,
 };
@@ -55,7 +54,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
@@ -72,7 +71,7 @@ impl frame_system::Config for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/pallets/migrations/src/mock.rs
+++ b/pallets/migrations/src/mock.rs
@@ -316,7 +316,7 @@ pub(crate) fn invoke_all_upgrade_hooks() -> Weight {
 	weight
 }
 
-pub(crate) fn roll_to(block_number: u32, invoke_on_runtime_upgrade_first: bool) {
+pub(crate) fn roll_to(block_number: BlockNumber, invoke_on_runtime_upgrade_first: bool) {
 	if invoke_on_runtime_upgrade_first {
 		Migrations::on_runtime_upgrade();
 	}

--- a/pallets/migrations/src/mock.rs
+++ b/pallets/migrations/src/mock.rs
@@ -33,7 +33,7 @@ use sp_runtime::{
 };
 
 pub type AccountId = u64;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;

--- a/pallets/migrations/src/mock.rs
+++ b/pallets/migrations/src/mock.rs
@@ -27,7 +27,6 @@ use frame_support::{
 };
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill,
 };
@@ -51,7 +50,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
@@ -68,7 +67,7 @@ impl frame_system::Config for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -317,7 +316,7 @@ pub(crate) fn invoke_all_upgrade_hooks() -> Weight {
 	weight
 }
 
-pub(crate) fn roll_to(block_number: u64, invoke_on_runtime_upgrade_first: bool) {
+pub(crate) fn roll_to(block_number: u32, invoke_on_runtime_upgrade_first: bool) {
 	if invoke_on_runtime_upgrade_first {
 		Migrations::on_runtime_upgrade();
 	}

--- a/pallets/moonbeam-orbiters/src/mock.rs
+++ b/pallets/moonbeam-orbiters/src/mock.rs
@@ -24,7 +24,6 @@ use frame_system::EnsureRoot;
 use nimbus_primitives::{AccountLookup, NimbusId};
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill,
 };
@@ -52,7 +51,7 @@ construct_runtime!(
 // Pallet system configuration
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
@@ -70,7 +69,7 @@ impl frame_system::Config for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -188,7 +187,7 @@ impl ExtBuilder {
 }
 
 /// Rolls to the desired block. Returns the number of blocks played.
-pub(crate) fn roll_to(n: u64) -> u64 {
+pub(crate) fn roll_to(n: u32) -> u32 {
 	let mut num_blocks = 0;
 	let mut block = System::block_number();
 	while block < n {
@@ -199,7 +198,7 @@ pub(crate) fn roll_to(n: u64) -> u64 {
 }
 
 // Rolls forward one block. Returns the new block number.
-fn roll_one_block() -> u64 {
+fn roll_one_block() -> u32 {
 	MoonbeamOrbiters::on_finalize(System::block_number());
 	Balances::on_finalize(System::block_number());
 	System::on_finalize(System::block_number());

--- a/pallets/moonbeam-orbiters/src/mock.rs
+++ b/pallets/moonbeam-orbiters/src/mock.rs
@@ -31,7 +31,7 @@ use sp_runtime::{
 
 pub type AccountId = u64;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;

--- a/pallets/moonbeam-orbiters/src/mock.rs
+++ b/pallets/moonbeam-orbiters/src/mock.rs
@@ -187,7 +187,7 @@ impl ExtBuilder {
 }
 
 /// Rolls to the desired block. Returns the number of blocks played.
-pub(crate) fn roll_to(n: u32) -> u32 {
+pub(crate) fn roll_to(n: BlockNumber) -> BlockNumber {
 	let mut num_blocks = 0;
 	let mut block = System::block_number();
 	while block < n {
@@ -198,7 +198,7 @@ pub(crate) fn roll_to(n: u32) -> u32 {
 }
 
 // Rolls forward one block. Returns the new block number.
-fn roll_one_block() -> u32 {
+fn roll_one_block() -> BlockNumber {
 	MoonbeamOrbiters::on_finalize(System::block_number());
 	Balances::on_finalize(System::block_number());
 	System::on_finalize(System::block_number());

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -403,7 +403,7 @@ macro_rules! assert_event_not_emitted {
 }
 
 // Same storage changes as ParachainStaking::on_finalize
-pub(crate) fn set_author(round: u32, acc: u64, pts: u32) {
+pub(crate) fn set_author(round: BlockNumber, acc: u64, pts: u32) {
 	<Points<Test>>::mutate(round, |p| *p += pts);
 	<AwardedPts<Test>>::mutate(round, acc, |p| *p += pts);
 }

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -237,7 +237,7 @@ impl ExtBuilder {
 }
 
 /// Rolls forward one block. Returns the new block number.
-pub(crate) fn roll_one_block() -> u32 {
+pub(crate) fn roll_one_block() -> BlockNumber {
 	Balances::on_finalize(System::block_number());
 	System::on_finalize(System::block_number());
 	System::set_block_number(System::block_number() + 1);
@@ -248,7 +248,7 @@ pub(crate) fn roll_one_block() -> u32 {
 }
 
 /// Rolls to the desired block. Returns the number of blocks played.
-pub(crate) fn roll_to(n: u32) -> u32 {
+pub(crate) fn roll_to(n: BlockNumber) -> BlockNumber {
 	let mut num_blocks = 0;
 	let mut block = System::block_number();
 	while block < n {
@@ -261,14 +261,14 @@ pub(crate) fn roll_to(n: u32) -> u32 {
 /// Rolls block-by-block to the beginning of the specified round.
 /// This will complete the block in which the round change occurs.
 /// Returns the number of blocks played.
-pub(crate) fn roll_to_round_begin(round: u32) -> u32 {
+pub(crate) fn roll_to_round_begin(round: BlockNumber) -> BlockNumber {
 	let block = (round - 1) * DefaultBlocksPerRound::get();
 	roll_to(block)
 }
 
 /// Rolls block-by-block to the end of the specified round.
 /// The block following will be the one in which the specified round change occurs.
-pub(crate) fn roll_to_round_end(round: u32) -> u32 {
+pub(crate) fn roll_to_round_end(round: BlockNumber) -> BlockNumber {
 	let block = round * DefaultBlocksPerRound::get() - 1;
 	roll_to(block)
 }

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -34,7 +34,7 @@ use sp_runtime::{
 
 pub type AccountId = u64;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -27,7 +27,6 @@ use frame_support::{
 use sp_core::H256;
 use sp_io;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill, Percent,
 };
@@ -54,7 +53,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
@@ -71,7 +70,7 @@ impl frame_system::Config for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -238,7 +237,7 @@ impl ExtBuilder {
 }
 
 /// Rolls forward one block. Returns the new block number.
-pub(crate) fn roll_one_block() -> u64 {
+pub(crate) fn roll_one_block() -> u32 {
 	Balances::on_finalize(System::block_number());
 	System::on_finalize(System::block_number());
 	System::set_block_number(System::block_number() + 1);
@@ -249,7 +248,7 @@ pub(crate) fn roll_one_block() -> u64 {
 }
 
 /// Rolls to the desired block. Returns the number of blocks played.
-pub(crate) fn roll_to(n: u64) -> u64 {
+pub(crate) fn roll_to(n: u32) -> u32 {
 	let mut num_blocks = 0;
 	let mut block = System::block_number();
 	while block < n {
@@ -262,15 +261,15 @@ pub(crate) fn roll_to(n: u64) -> u64 {
 /// Rolls block-by-block to the beginning of the specified round.
 /// This will complete the block in which the round change occurs.
 /// Returns the number of blocks played.
-pub(crate) fn roll_to_round_begin(round: u64) -> u64 {
-	let block = (round - 1) * DefaultBlocksPerRound::get() as u64;
+pub(crate) fn roll_to_round_begin(round: u32) -> u32 {
+	let block = (round - 1) * DefaultBlocksPerRound::get();
 	roll_to(block)
 }
 
 /// Rolls block-by-block to the end of the specified round.
 /// The block following will be the one in which the specified round change occurs.
-pub(crate) fn roll_to_round_end(round: u64) -> u64 {
-	let block = round * DefaultBlocksPerRound::get() as u64 - 1;
+pub(crate) fn roll_to_round_end(round: u32) -> u32 {
+	let block = round * DefaultBlocksPerRound::get() - 1;
 	roll_to(block)
 }
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -6916,7 +6916,7 @@ fn deferred_payment_storage_items_are_cleaned_up() {
 		.with_candidates(vec![(1, 20), (2, 20)])
 		.build()
 		.execute_with(|| {
-			let mut round: u32 = 1;
+			let mut round: BlockNumber = 1;
 			set_author(round, 1, 1);
 			set_author(round, 2, 1);
 
@@ -7121,11 +7121,11 @@ fn deferred_payment_steady_state_event_flow() {
 		.build()
 		.execute_with(|| {
 			// convenience to set the round points consistently
-			let set_round_points = |round: u32| {
-				set_author(round as u32, 1, 1);
-				set_author(round as u32, 2, 1);
-				set_author(round as u32, 3, 1);
-				set_author(round as u32, 4, 1);
+			let set_round_points = |round: BlockNumber| {
+				set_author(round as BlockNumber, 1, 1);
+				set_author(round as BlockNumber, 2, 1);
+				set_author(round as BlockNumber, 3, 1);
+				set_author(round as BlockNumber, 4, 1);
 			};
 
 			// grab initial issuance -- we will reset it before round issuance is calculated so that
@@ -7145,7 +7145,7 @@ fn deferred_payment_steady_state_event_flow() {
 			};
 
 			// fn to roll through the first RewardPaymentDelay rounds. returns new round index
-			let roll_through_initial_rounds = |mut round: u32| -> u32 {
+			let roll_through_initial_rounds = |mut round: BlockNumber| -> BlockNumber {
 				while round < crate::mock::RewardPaymentDelay::get() + 1 {
 					set_round_points(round);
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -24,7 +24,7 @@
 use crate::delegation_requests::{CancelledScheduledRequest, DelegationAction, ScheduledRequest};
 use crate::mock::{
 	roll_one_block, roll_to, roll_to_round_begin, roll_to_round_end, set_author, Balances,
-	Event as MetaEvent, ExtBuilder, Origin, ParachainStaking, Test,
+	BlockNumber, Event as MetaEvent, ExtBuilder, Origin, ParachainStaking, Test,
 };
 use crate::{
 	assert_eq_events, assert_eq_last_events, assert_event_emitted, assert_last_event,
@@ -7160,7 +7160,7 @@ fn deferred_payment_steady_state_event_flow() {
 
 			// roll through a "steady state" round and make all of our assertions
 			// returns new round index
-			let roll_through_steady_state_round = |round: u32| -> u32 {
+			let roll_through_steady_state_round = |round: BlockNumber| -> BlockNumber {
 				let num_rounds_rolled = roll_to_round_begin(round);
 				assert_eq!(
 					num_rounds_rolled, 1,

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -7121,7 +7121,7 @@ fn deferred_payment_steady_state_event_flow() {
 		.build()
 		.execute_with(|| {
 			// convenience to set the round points consistently
-			let set_round_points = |round: u64| {
+			let set_round_points = |round: u32| {
 				set_author(round as u32, 1, 1);
 				set_author(round as u32, 2, 1);
 				set_author(round as u32, 3, 1);
@@ -7145,8 +7145,8 @@ fn deferred_payment_steady_state_event_flow() {
 			};
 
 			// fn to roll through the first RewardPaymentDelay rounds. returns new round index
-			let roll_through_initial_rounds = |mut round: u64| -> u64 {
-				while round < crate::mock::RewardPaymentDelay::get() as u64 + 1 {
+			let roll_through_initial_rounds = |mut round: u32| -> u32 {
+				while round < crate::mock::RewardPaymentDelay::get() + 1 {
 					set_round_points(round);
 
 					roll_to_round_end(round);
@@ -7160,7 +7160,7 @@ fn deferred_payment_steady_state_event_flow() {
 
 			// roll through a "steady state" round and make all of our assertions
 			// returns new round index
-			let roll_through_steady_state_round = |round: u64| -> u64 {
+			let roll_through_steady_state_round = |round: u32| -> u32 {
 				let num_rounds_rolled = roll_to_round_begin(round);
 				assert_eq!(
 					num_rounds_rolled, 1,

--- a/pallets/proxy-genesis-companion/src/mock.rs
+++ b/pallets/proxy-genesis-companion/src/mock.rs
@@ -25,7 +25,6 @@ use frame_support::{
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill,
 };
@@ -53,7 +52,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
@@ -70,7 +69,7 @@ impl frame_system::Config for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/pallets/proxy-genesis-companion/src/mock.rs
+++ b/pallets/proxy-genesis-companion/src/mock.rs
@@ -33,7 +33,7 @@ use sp_runtime::{
 //TODO use TestAccount once it is in a common place (currently it lives with democracy precompiles)
 pub type AccountId = u64;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;

--- a/pallets/randomness/src/mock.rs
+++ b/pallets/randomness/src/mock.rs
@@ -27,7 +27,6 @@ use pallet_evm::IdentityAddressMapping;
 use session_keys_primitives::VrfId;
 use sp_core::{H160, H256};
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill,
 };
@@ -55,7 +54,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
@@ -72,7 +71,7 @@ impl frame_system::Config for Test {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/pallets/randomness/src/mock.rs
+++ b/pallets/randomness/src/mock.rs
@@ -35,7 +35,7 @@ use sp_std::convert::{TryFrom, TryInto};
 
 pub type AccountId = H160;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;

--- a/pallets/randomness/src/tests.rs
+++ b/pallets/randomness/src/tests.rs
@@ -42,7 +42,7 @@ fn cannot_make_local_request_already_fulfillable() {
 		.with_balances(vec![(ALICE, 15)])
 		.build()
 		.execute_with(|| {
-			let request = build_default_request(RequestType::Local(0u64));
+			let request = build_default_request(RequestType::Local(0));
 			assert_noop!(
 				Randomness::request_randomness(request),
 				Error::<Test>::CannotRequestRandomnessBeforeMinDelay
@@ -56,7 +56,7 @@ fn cannot_make_request_fulfillable_past_expiry() {
 		.with_balances(vec![(ALICE, 15)])
 		.build()
 		.execute_with(|| {
-			let request = build_default_request(RequestType::Local(22u64));
+			let request = build_default_request(RequestType::Local(22));
 			assert_noop!(
 				Randomness::request_randomness(request),
 				Error::<Test>::CannotRequestRandomnessAfterMaxDelay
@@ -70,7 +70,7 @@ fn cannot_make_request_with_less_than_deposit() {
 		.with_balances(vec![(ALICE, 9)])
 		.build()
 		.execute_with(|| {
-			let request = build_default_request(RequestType::BabeEpoch(16u64));
+			let request = build_default_request(RequestType::BabeEpoch(16));
 			assert_noop!(
 				Randomness::request_randomness(request),
 				sp_runtime::DispatchError::Module(sp_runtime::ModuleError {
@@ -79,7 +79,7 @@ fn cannot_make_request_with_less_than_deposit() {
 					message: Some("InsufficientBalance")
 				})
 			);
-			let request = build_default_request(RequestType::Local(16u64));
+			let request = build_default_request(RequestType::Local(16));
 			assert_noop!(
 				Randomness::request_randomness(request),
 				sp_runtime::DispatchError::Module(sp_runtime::ModuleError {
@@ -97,7 +97,7 @@ fn cannot_make_request_with_less_than_deposit_plus_fee() {
 		.with_balances(vec![(ALICE, 14)])
 		.build()
 		.execute_with(|| {
-			let request = build_default_request(RequestType::BabeEpoch(16u64));
+			let request = build_default_request(RequestType::BabeEpoch(16));
 			assert_noop!(
 				Randomness::request_randomness(request),
 				sp_runtime::DispatchError::Module(sp_runtime::ModuleError {
@@ -106,7 +106,7 @@ fn cannot_make_request_with_less_than_deposit_plus_fee() {
 					message: Some("InsufficientBalance")
 				})
 			);
-			let request = build_default_request(RequestType::Local(16u64));
+			let request = build_default_request(RequestType::Local(16));
 			assert_noop!(
 				Randomness::request_randomness(request),
 				sp_runtime::DispatchError::Module(sp_runtime::ModuleError {
@@ -126,11 +126,11 @@ fn request_reserves_deposit_and_fee() {
 		.execute_with(|| {
 			assert_eq!(Randomness::total_locked(), 0);
 			assert_eq!(Balances::free_balance(&ALICE), 30);
-			let request = build_default_request(RequestType::BabeEpoch(16u64));
+			let request = build_default_request(RequestType::BabeEpoch(16));
 			assert_ok!(Randomness::request_randomness(request));
 			assert_eq!(Randomness::total_locked(), 15);
 			assert_eq!(Balances::free_balance(&ALICE), 15);
-			let request = build_default_request(RequestType::Local(16u64));
+			let request = build_default_request(RequestType::Local(16));
 			assert_ok!(Randomness::request_randomness(request));
 			assert_eq!(Randomness::total_locked(), 30);
 			assert_eq!(Balances::free_balance(&ALICE), 0);
@@ -144,10 +144,10 @@ fn request_babe_current_block_randomness_increments_request_counter() {
 		.build()
 		.execute_with(|| {
 			assert_eq!(Randomness::request_count(), 0);
-			let request = build_default_request(RequestType::BabeEpoch(16u64));
+			let request = build_default_request(RequestType::BabeEpoch(16));
 			assert_ok!(Randomness::request_randomness(request));
 			assert_eq!(Randomness::request_count(), 1);
-			let request = build_default_request(RequestType::Local(16u64));
+			let request = build_default_request(RequestType::Local(16));
 			assert_ok!(Randomness::request_randomness(request));
 			assert_eq!(Randomness::request_count(), 2);
 		});
@@ -159,7 +159,7 @@ fn request_babe_current_block_randomness_inserts_request_state() {
 		.with_balances(vec![(ALICE, 60)])
 		.build()
 		.execute_with(|| {
-			let request = build_default_request(RequestType::BabeEpoch(16u64));
+			let request = build_default_request(RequestType::BabeEpoch(16));
 			assert_eq!(Randomness::requests(0), None);
 			assert_ok!(Randomness::request_randomness(request.clone()));
 			assert_eq!(
@@ -169,7 +169,7 @@ fn request_babe_current_block_randomness_inserts_request_state() {
 					deposit: 10,
 				})
 			);
-			let request = build_default_request(RequestType::Local(16u64));
+			let request = build_default_request(RequestType::Local(16));
 			assert_eq!(Randomness::requests(1), None);
 			assert_ok!(Randomness::request_randomness(request.clone()));
 			assert_eq!(
@@ -197,7 +197,7 @@ fn request_babe_one_epoch_ago_randomness_emits_event() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::BabeEpoch(16u64),
+				info: RequestType::BabeEpoch(16),
 			};
 			assert_ok!(Randomness::request_randomness(request));
 			assert_event_emitted!(crate::Event::RandomnessRequestedBabeEpoch {
@@ -208,7 +208,7 @@ fn request_babe_one_epoch_ago_randomness_emits_event() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				earliest_epoch: 16u64,
+				earliest_epoch: 16,
 			});
 		});
 }
@@ -226,7 +226,7 @@ fn request_local_randomness_emits_event() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request));
 			assert_event_emitted!(crate::Event::RandomnessRequestedLocal {
@@ -237,7 +237,7 @@ fn request_local_randomness_emits_event() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				earliest_block: 16u64,
+				earliest_block: 16,
 			});
 		});
 }
@@ -255,10 +255,10 @@ fn request_randomness_adds_new_randomness_result() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request));
-			let result = Randomness::randomness_results(RequestType::Local(16u64)).unwrap();
+			let result = Randomness::randomness_results(RequestType::Local(16)).unwrap();
 			assert_eq!(result.request_count, 1u64);
 			assert!(result.randomness.is_none());
 		});
@@ -277,11 +277,11 @@ fn request_randomness_increments_randomness_result() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request.clone()));
 			assert_ok!(Randomness::request_randomness(request));
-			let result = Randomness::randomness_results(RequestType::Local(16u64)).unwrap();
+			let result = Randomness::randomness_results(RequestType::Local(16)).unwrap();
 			assert_eq!(result.request_count, 2u64);
 			assert!(result.randomness.is_none());
 		});
@@ -302,14 +302,14 @@ fn prepare_fulfillment_for_local_works() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request));
-			System::set_block_number(16u64);
+			System::set_block_number(16);
 			let mut result =
-				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16u64)).unwrap();
+				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16)).unwrap();
 			result.randomness = Some(H256::default());
-			crate::pallet::RandomnessResults::<Test>::insert(RequestType::Local(16u64), result);
+			crate::pallet::RandomnessResults::<Test>::insert(RequestType::Local(16), result);
 			assert_ok!(Randomness::prepare_fulfillment(0u64));
 		});
 }
@@ -327,7 +327,7 @@ fn prepare_fulfillment_fails_before_can_be_fulfilled() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request.clone()));
 			assert_ok!(Randomness::request_randomness(request));
@@ -361,17 +361,17 @@ fn prepare_fulfillment_uses_randomness_result_without_updating_count() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request));
-			System::set_block_number(16u64);
+			System::set_block_number(16);
 			let mut pre_result =
-				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16u64)).unwrap();
+				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16)).unwrap();
 			pre_result.randomness = Some(H256::default());
-			crate::pallet::RandomnessResults::<Test>::insert(RequestType::Local(16u64), pre_result);
+			crate::pallet::RandomnessResults::<Test>::insert(RequestType::Local(16), pre_result);
 			assert_ok!(Randomness::prepare_fulfillment(0u64));
 			let post_result =
-				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16u64)).unwrap();
+				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16)).unwrap();
 			assert_eq!(post_result.request_count, 1);
 		});
 }
@@ -391,15 +391,15 @@ fn finish_fulfillment_removes_request_from_storage() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request.clone()));
 			assert_ok!(Randomness::request_randomness(request));
-			System::set_block_number(16u64);
+			System::set_block_number(16);
 			let mut pre_result =
-				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16u64)).unwrap();
+				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16)).unwrap();
 			pre_result.randomness = Some(H256::default());
-			crate::pallet::RandomnessResults::<Test>::insert(RequestType::Local(16u64), pre_result);
+			crate::pallet::RandomnessResults::<Test>::insert(RequestType::Local(16), pre_result);
 			let fulfill_args = Randomness::prepare_fulfillment(0u64).unwrap();
 			Randomness::finish_fulfillment(
 				1u64,
@@ -425,14 +425,14 @@ fn finish_fulfillment_refunds_refund_address_with_excess_and_caller_with_cost_of
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request));
-			System::set_block_number(16u64);
+			System::set_block_number(16);
 			let mut pre_result =
-				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16u64)).unwrap();
+				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16)).unwrap();
 			pre_result.randomness = Some(H256::default());
-			crate::pallet::RandomnessResults::<Test>::insert(RequestType::Local(16u64), pre_result);
+			crate::pallet::RandomnessResults::<Test>::insert(RequestType::Local(16), pre_result);
 			let fulfill_args = Randomness::prepare_fulfillment(0u64).unwrap();
 			Randomness::finish_fulfillment(
 				1u64,
@@ -461,18 +461,18 @@ fn finish_fulfillment_decrements_randomness_result_and_keeps_in_storage_if_not_l
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request.clone()));
 			assert_ok!(Randomness::request_randomness(request));
-			System::set_block_number(16u64);
+			System::set_block_number(16);
 			let mut pre_result =
-				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16u64)).unwrap();
+				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16)).unwrap();
 			pre_result.randomness = Some(H256::default());
-			crate::pallet::RandomnessResults::<Test>::insert(RequestType::Local(16u64), pre_result);
+			crate::pallet::RandomnessResults::<Test>::insert(RequestType::Local(16), pre_result);
 			let fulfill_args = Randomness::prepare_fulfillment(0u64).unwrap();
 			assert_eq!(
-				Randomness::randomness_results(RequestType::Local(16u64))
+				Randomness::randomness_results(RequestType::Local(16))
 					.unwrap()
 					.request_count,
 				2
@@ -485,7 +485,7 @@ fn finish_fulfillment_decrements_randomness_result_and_keeps_in_storage_if_not_l
 				5,
 			);
 			assert_eq!(
-				Randomness::randomness_results(RequestType::Local(16u64))
+				Randomness::randomness_results(RequestType::Local(16))
 					.unwrap()
 					.request_count,
 				1
@@ -506,17 +506,17 @@ fn finish_fulfillment_decrements_randomness_result_and_removes_from_storage_if_l
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request));
-			System::set_block_number(16u64);
+			System::set_block_number(16);
 			let mut pre_result =
-				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16u64)).unwrap();
+				crate::pallet::RandomnessResults::<Test>::get(RequestType::Local(16)).unwrap();
 			pre_result.randomness = Some(H256::default());
-			crate::pallet::RandomnessResults::<Test>::insert(RequestType::Local(16u64), pre_result);
-			let fulfill_args = Randomness::prepare_fulfillment(0u64).unwrap();
+			crate::pallet::RandomnessResults::<Test>::insert(RequestType::Local(16), pre_result);
+			let fulfill_args = Randomness::prepare_fulfillment(0).unwrap();
 			assert_eq!(
-				Randomness::randomness_results(RequestType::Local(16u64))
+				Randomness::randomness_results(RequestType::Local(16))
 					.unwrap()
 					.request_count,
 				1
@@ -528,7 +528,7 @@ fn finish_fulfillment_decrements_randomness_result_and_removes_from_storage_if_l
 				&ALICE,
 				5,
 			);
-			assert!(Randomness::randomness_results(RequestType::Local(16u64)).is_none());
+			assert!(Randomness::randomness_results(RequestType::Local(16)).is_none());
 		});
 }
 
@@ -557,7 +557,7 @@ fn non_requester_cannot_increase_fee() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request));
 			assert_noop!(
@@ -580,7 +580,7 @@ fn increase_request_fee_transfers_from_caller_and_updates_request_state_fee() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request));
 			assert_ok!(Randomness::increase_request_fee(&ALICE, 0u64, 6));
@@ -604,7 +604,7 @@ fn increase_request_fee_fails_if_insufficient_balance() {
 				gas_limit: 100u64,
 				num_words: 1u8,
 				salt: H256::default(),
-				info: RequestType::Local(16u64),
+				info: RequestType::Local(16),
 			};
 			assert_ok!(Randomness::request_randomness(request));
 			assert_noop!(
@@ -637,7 +637,7 @@ fn execute_request_expiration_fails_before_request_expiration() {
 		.build()
 		.execute_with(|| {
 			assert_ok!(Randomness::request_randomness(build_default_request(
-				RequestType::BabeEpoch(16u64)
+				RequestType::BabeEpoch(16)
 			)));
 			assert_noop!(
 				Randomness::execute_request_expiration(&ALICE, 0u64),
@@ -653,7 +653,7 @@ fn execute_request_expiration_removes_request() {
 		.build()
 		.execute_with(|| {
 			assert_ok!(Randomness::request_randomness(build_default_request(
-				RequestType::BabeEpoch(16u64)
+				RequestType::BabeEpoch(16)
 			)));
 			// increase epoch to expiry
 			crate::pallet::RelayEpoch::<Test>::put(20u64);
@@ -671,14 +671,14 @@ fn execute_request_expiration_removes_result() {
 		.build()
 		.execute_with(|| {
 			assert_ok!(Randomness::request_randomness(build_default_request(
-				RequestType::BabeEpoch(16u64)
+				RequestType::BabeEpoch(16)
 			)));
 			// increase epoch to expiry
 			crate::pallet::RelayEpoch::<Test>::put(20u64);
-			assert!(Randomness::randomness_results(RequestType::BabeEpoch(16u64)).is_some());
+			assert!(Randomness::randomness_results(RequestType::BabeEpoch(16)).is_some());
 			// execute expiry
 			assert_ok!(Randomness::execute_request_expiration(&BOB, 0u64));
-			assert!(Randomness::randomness_results(RequestType::BabeEpoch(16u64)).is_none());
+			assert!(Randomness::randomness_results(RequestType::BabeEpoch(16)).is_none());
 		});
 }
 
@@ -689,7 +689,7 @@ fn execute_request_expiration_returns_deposit_to_contract_address_and_fees_to_ca
 		.build()
 		.execute_with(|| {
 			assert_ok!(Randomness::request_randomness(build_default_request(
-				RequestType::BabeEpoch(16u64)
+				RequestType::BabeEpoch(16)
 			)));
 			crate::pallet::RelayEpoch::<Test>::put(20u64);
 			assert_ok!(Randomness::execute_request_expiration(&BOB, 0u64));

--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -78,7 +78,7 @@ impl frame_system::Config for Test {
 	type Origin = Origin;
 	type Index = u64;
 	type Call = Call;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;

--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -25,10 +25,7 @@ use parity_scale_codec::{Decode, Encode};
 
 use sp_core::{H160, H256};
 use sp_io;
-use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-};
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 use xcm::latest::{
 	opaque, Error as XcmError, Instruction,
 	Junction::{AccountKey20, PalletInstance, Parachain},
@@ -59,14 +56,14 @@ construct_runtime!(
 );
 
 pub type Balance = u128;
-
+pub type BlockNumber = u32;
 pub type AccountId = u64;
 
 parameter_types! {
 	pub ParachainId: cumulus_primitives_core::ParaId = 100.into();
 }
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub BlockWeights: frame_system::limits::BlockWeights =
 		frame_system::limits::BlockWeights::simple_max(1024);
 }
@@ -78,12 +75,12 @@ impl frame_system::Config for Test {
 	type Origin = Origin;
 	type Index = u64;
 	type Call = Call;
-	type BlockNumber = u32;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type DbWeight = ();

--- a/precompiles/assets-erc20/src/mock.rs
+++ b/precompiles/assets-erc20/src/mock.rs
@@ -34,7 +34,7 @@ use sp_runtime::{
 pub type AccountId = Account;
 pub type AssetId = u128;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 pub type Block = frame_system::mocking::MockBlock<Runtime>;
 

--- a/precompiles/assets-erc20/src/mock.rs
+++ b/precompiles/assets-erc20/src/mock.rs
@@ -26,10 +26,7 @@ use pallet_evm::{AddressMapping, EnsureAddressNever, EnsureAddressRoot};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::{H160, H256};
-use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-};
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
 pub type AccountId = Account;
 pub type AssetId = u128;
@@ -171,7 +168,7 @@ impl From<Account> for H256 {
 }
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const SS58Prefix: u8 = 42;
 }
 
@@ -186,7 +183,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/precompiles/author-mapping/src/mock.rs
+++ b/precompiles/author-mapping/src/mock.rs
@@ -36,7 +36,7 @@ use sp_runtime::{
 
 pub type AccountId = Account;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/precompiles/author-mapping/src/mock.rs
+++ b/precompiles/author-mapping/src/mock.rs
@@ -29,10 +29,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::{H160, H256, U256};
 use sp_io;
-use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-};
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
 pub type AccountId = Account;
 pub type Balance = u128;
@@ -119,7 +116,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Runtime {
@@ -133,7 +130,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = Account;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -31,7 +31,7 @@ use sp_runtime::{
 
 pub type AccountId = Account;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 pub type Block = frame_system::mocking::MockBlock<Runtime>;
 

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -24,10 +24,7 @@ use pallet_evm::{AddressMapping, EnsureAddressNever, EnsureAddressRoot, Precompi
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::{H160, H256, U256};
-use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-};
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
 pub type AccountId = Account;
 pub type Balance = u128;
@@ -113,7 +110,7 @@ impl From<Account> for H256 {
 }
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const SS58Prefix: u8 = 42;
 }
 
@@ -128,7 +125,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/precompiles/batch/src/mock.rs
+++ b/precompiles/batch/src/mock.rs
@@ -26,7 +26,6 @@ use serde::{Deserialize, Serialize};
 use sp_core::H160;
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill,
 };
@@ -118,7 +117,7 @@ impl From<H160> for Account {
 }
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
@@ -136,7 +135,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/precompiles/batch/src/mock.rs
+++ b/precompiles/batch/src/mock.rs
@@ -33,7 +33,7 @@ use sp_runtime::{
 
 pub type AccountId = Account;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/precompiles/call-permit/src/mock.rs
+++ b/precompiles/call-permit/src/mock.rs
@@ -43,7 +43,7 @@ pub const ALICE_SECRET_KEY: [u8; 32] =
 
 pub type AccountId = Account;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/precompiles/call-permit/src/mock.rs
+++ b/precompiles/call-permit/src/mock.rs
@@ -28,7 +28,6 @@ use serde::{Deserialize, Serialize};
 use sp_core::H160;
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill,
 };
@@ -128,7 +127,7 @@ impl From<H160> for Account {
 }
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
@@ -146,7 +145,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/precompiles/collective/src/mock.rs
+++ b/precompiles/collective/src/mock.rs
@@ -342,7 +342,7 @@ impl ExtBuilder {
 }
 
 #[allow(unused)]
-pub(crate) fn roll_to(n: u32) {
+pub(crate) fn roll_to(n: BlockNumber) {
 	// We skip timestamp's on_finalize because it requires that the timestamp inherent be set
 	// We may be able to simulate this by poking its storage directly, but I don't see any value
 	// added from doing that.

--- a/precompiles/collective/src/mock.rs
+++ b/precompiles/collective/src/mock.rs
@@ -37,7 +37,7 @@ use sp_runtime::{
 
 pub type AccountId = Account;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/precompiles/collective/src/mock.rs
+++ b/precompiles/collective/src/mock.rs
@@ -19,7 +19,7 @@ use super::*;
 use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::{ConstU128, ConstU64, Everything, GenesisBuild, MapSuccess, OnFinalize, OnInitialize},
+	traits::{ConstU128, Everything, GenesisBuild, MapSuccess, OnFinalize, OnInitialize},
 	PalletId,
 };
 use pallet_evm::{
@@ -30,7 +30,6 @@ use serde::{Deserialize, Serialize};
 use sp_core::{H160, H256, U256};
 use sp_io;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup, Replace},
 	Permill,
 };
@@ -121,7 +120,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Runtime {
@@ -135,7 +134,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = Account;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -229,7 +228,7 @@ impl pallet_treasury::Config for Runtime {
 	type OnSlash = Treasury;
 	type ProposalBond = ProposalBond;
 	type ProposalBondMinimum = ConstU128<1>;
-	type SpendPeriod = ConstU64<1>;
+	type SpendPeriod = ConstU32<1>;
 	type Burn = ();
 	type BurnDestination = ();
 	type MaxApprovals = ConstU32<100>;
@@ -248,7 +247,7 @@ impl pallet_collective::Config<pallet_collective::Instance1> for Runtime {
 	type Proposal = Call;
 	/// The maximum amount of time (in blocks) for council members to vote on motions.
 	/// Motions may end in fewer blocks if enough votes are cast to determine the result.
-	type MotionDuration = ConstU64<2>;
+	type MotionDuration = ConstU32<2>;
 	/// The maximum number of Proposlas that can be open in the council at once.
 	type MaxProposals = ConstU32<100>;
 	/// The maximum number of council members.
@@ -343,7 +342,7 @@ impl ExtBuilder {
 }
 
 #[allow(unused)]
-pub(crate) fn roll_to(n: u64) {
+pub(crate) fn roll_to(n: u32) {
 	// We skip timestamp's on_finalize because it requires that the timestamp inherent be set
 	// We may be able to simulate this by poking its storage directly, but I don't see any value
 	// added from doing that.

--- a/precompiles/crowdloan-rewards/src/mock.rs
+++ b/precompiles/crowdloan-rewards/src/mock.rs
@@ -307,7 +307,7 @@ impl ExtBuilder {
 }
 
 //TODO Add pallets here if necessary
-pub(crate) fn roll_to(n: u32) {
+pub(crate) fn roll_to(n: BlockNumber) {
 	while System::block_number() < n {
 		// Relay chain Stuff. I might actually set this to a number different than N
 		let sproof_builder = RelayStateSproofBuilder::default();

--- a/precompiles/crowdloan-rewards/src/mock.rs
+++ b/precompiles/crowdloan-rewards/src/mock.rs
@@ -35,7 +35,6 @@ use serde::{Deserialize, Serialize};
 use sp_core::{H256, U256};
 use sp_io;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill,
 };
@@ -135,7 +134,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 }
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Runtime {
@@ -149,7 +148,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = H160;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -308,14 +307,14 @@ impl ExtBuilder {
 }
 
 //TODO Add pallets here if necessary
-pub(crate) fn roll_to(n: u64) {
+pub(crate) fn roll_to(n: u32) {
 	while System::block_number() < n {
 		// Relay chain Stuff. I might actually set this to a number different than N
 		let sproof_builder = RelayStateSproofBuilder::default();
 		let (relay_parent_storage_root, relay_chain_state) =
 			sproof_builder.into_state_root_and_proof();
 		let vfp = PersistedValidationData {
-			relay_parent_number: (System::block_number() + 1u64) as RelayChainBlockNumber,
+			relay_parent_number: (System::block_number() + 1) as RelayChainBlockNumber,
 			relay_parent_storage_root,
 			..Default::default()
 		};

--- a/precompiles/crowdloan-rewards/src/mock.rs
+++ b/precompiles/crowdloan-rewards/src/mock.rs
@@ -42,7 +42,7 @@ use sp_runtime::{
 
 pub type AccountId = H160;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub const PRECOMPILE_ADDRESS: u64 = 1;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/precompiles/pallet-democracy/src/mock.rs
+++ b/precompiles/pallet-democracy/src/mock.rs
@@ -37,7 +37,7 @@ use sp_runtime::{
 
 pub type AccountId = Account;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/precompiles/pallet-democracy/src/mock.rs
+++ b/precompiles/pallet-democracy/src/mock.rs
@@ -334,7 +334,7 @@ impl ExtBuilder {
 	}
 }
 
-pub(crate) fn roll_to(n: u32) {
+pub(crate) fn roll_to(n: BlockNumber) {
 	// We skip timestamp's on_finalize because it requires that the timestamp inherent be set
 	// We may be able to simulate this by poking its storage directly, but I don't see any value
 	// added from doing that.

--- a/precompiles/pallet-democracy/src/mock.rs
+++ b/precompiles/pallet-democracy/src/mock.rs
@@ -30,10 +30,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::{H256, U256};
 use sp_io;
-use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-};
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
 pub type AccountId = Account;
 pub type Balance = u128;
@@ -120,7 +117,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Runtime {
@@ -134,7 +131,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = Account;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -337,7 +334,7 @@ impl ExtBuilder {
 	}
 }
 
-pub(crate) fn roll_to(n: u64) {
+pub(crate) fn roll_to(n: u32) {
 	// We skip timestamp's on_finalize because it requires that the timestamp inherent be set
 	// We may be able to simulate this by poking its storage directly, but I don't see any value
 	// added from doing that.

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -37,7 +37,7 @@ use sp_runtime::{
 
 pub type AccountId = Account;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -363,7 +363,7 @@ pub(crate) fn set_points(round: u32, acc: Account, pts: u32) {
 	<AwardedPts<Runtime>>::mutate(round, acc, |p| *p += pts);
 }
 
-pub(crate) fn roll_to(n: u32) {
+pub(crate) fn roll_to(n: BlockNumber) {
 	while System::block_number() < n {
 		ParachainStaking::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());
@@ -377,7 +377,7 @@ pub(crate) fn roll_to(n: u32) {
 
 /// Rolls block-by-block to the beginning of the specified round.
 /// This will complete the block in which the round change occurs.
-pub(crate) fn roll_to_round_begin(round: u32) {
+pub(crate) fn roll_to_round_begin(round: BlockNumber) {
 	let block = (round - 1) * DefaultBlocksPerRound::get();
 	roll_to(block)
 }

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -30,7 +30,6 @@ use serde::{Deserialize, Serialize};
 use sp_core::{H160, H256, U256};
 use sp_io;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill, Percent,
 };
@@ -117,7 +116,7 @@ impl From<H160> for Account {
 }
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
@@ -134,7 +133,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();
@@ -364,7 +363,7 @@ pub(crate) fn set_points(round: u32, acc: Account, pts: u32) {
 	<AwardedPts<Runtime>>::mutate(round, acc, |p| *p += pts);
 }
 
-pub(crate) fn roll_to(n: u64) {
+pub(crate) fn roll_to(n: u32) {
 	while System::block_number() < n {
 		ParachainStaking::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());
@@ -378,8 +377,8 @@ pub(crate) fn roll_to(n: u64) {
 
 /// Rolls block-by-block to the beginning of the specified round.
 /// This will complete the block in which the round change occurs.
-pub(crate) fn roll_to_round_begin(round: u64) {
-	let block = (round - 1) * DefaultBlocksPerRound::get() as u64;
+pub(crate) fn roll_to_round_begin(round: u32) {
+	let block = (round - 1) * DefaultBlocksPerRound::get();
 	roll_to(block)
 }
 

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -358,7 +358,7 @@ impl ExtBuilder {
 }
 
 // Sets the same storage changes as EventHandler::note_author impl
-pub(crate) fn set_points(round: u32, acc: Account, pts: u32) {
+pub(crate) fn set_points(round: BlockNumber, acc: Account, pts: u32) {
 	<Points<Runtime>>::mutate(round, |p| *p += pts);
 	<AwardedPts<Runtime>>::mutate(round, acc, |p| *p += pts);
 }

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -177,8 +177,8 @@ fn round_works() {
 			.execute_returns(EvmDataWriter::new().write(1u32).build());
 
 		// test next `ROUNDS_TO_TEST` rounds
-		const ROUNDS_TO_TEST: u64 = 10;
-		let mut current_round: u64 = 1;
+		const ROUNDS_TO_TEST: u32 = 10;
+		let mut current_round: u32 = 1;
 		while current_round < ROUNDS_TO_TEST {
 			current_round += 1;
 			roll_to_round_begin(current_round);

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -178,7 +178,7 @@ fn round_works() {
 
 		// test next `ROUNDS_TO_TEST` rounds
 		const ROUNDS_TO_TEST: u32 = 10;
-		let mut current_round: u32 = 1;
+		let mut current_round: BlockNumber = 1;
 		while current_round < ROUNDS_TO_TEST {
 			current_round += 1;
 			roll_to_round_begin(current_round);

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -178,7 +178,7 @@ fn round_works() {
 
 		// test next `ROUNDS_TO_TEST` rounds
 		const ROUNDS_TO_TEST: u32 = 10;
-		let mut current_round: BlockNumber = 1;
+		let mut current_round = 1;
 		while current_round < ROUNDS_TO_TEST {
 			current_round += 1;
 			roll_to_round_begin(current_round);

--- a/precompiles/proxy/src/mock.rs
+++ b/precompiles/proxy/src/mock.rs
@@ -38,7 +38,7 @@ use sp_runtime::{
 
 pub type AccountId = Account;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/precompiles/proxy/src/mock.rs
+++ b/precompiles/proxy/src/mock.rs
@@ -31,10 +31,7 @@ use serde::{Deserialize, Serialize};
 use sp_core::{H160, H256, U256};
 use sp_io;
 use sp_runtime::codec::{Decode, Encode, MaxEncodedLen};
-use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-};
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 
 pub type AccountId = Account;
 pub type Balance = u128;
@@ -119,7 +116,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Runtime {
@@ -133,7 +130,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = Account;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/precompiles/proxy/src/tests.rs
+++ b/precompiles/proxy/src/tests.rs
@@ -87,7 +87,7 @@ fn test_add_proxy_fails_if_duplicate_proxy() {
 			assert_ok!(Call::Proxy(ProxyCall::add_proxy {
 				delegate: Bob,
 				proxy_type: ProxyType::Something,
-				delay: 0u64,
+				delay: 0,
 			})
 			.dispatch(Origin::signed(Alice)));
 
@@ -115,7 +115,7 @@ fn test_add_proxy_fails_if_less_permissive_proxy() {
 			assert_ok!(Call::Proxy(ProxyCall::add_proxy {
 				delegate: Bob,
 				proxy_type: ProxyType::Something,
-				delay: 0u64,
+				delay: 0,
 			})
 			.dispatch(Origin::signed(Alice)));
 
@@ -143,7 +143,7 @@ fn test_add_proxy_fails_if_more_permissive_proxy() {
 			assert_ok!(Call::Proxy(ProxyCall::add_proxy {
 				delegate: Bob,
 				proxy_type: ProxyType::Something,
-				delay: 0u64,
+				delay: 0,
 			})
 			.dispatch(Origin::signed(Alice)));
 
@@ -208,7 +208,7 @@ fn test_remove_proxy_fails_if_invalid_value_for_proxy_type() {
 			assert_ok!(Call::Proxy(ProxyCall::add_proxy {
 				delegate: Bob,
 				proxy_type: ProxyType::Something,
-				delay: 0u64,
+				delay: 0,
 			})
 			.dispatch(Origin::signed(Alice)));
 
@@ -257,7 +257,7 @@ fn test_remove_proxy_succeeds() {
 			assert_ok!(Call::Proxy(ProxyCall::add_proxy {
 				delegate: Bob,
 				proxy_type: ProxyType::Something,
-				delay: 0u64,
+				delay: 0,
 			})
 			.dispatch(Origin::signed(Alice)));
 
@@ -294,13 +294,13 @@ fn test_remove_proxies_succeeds() {
 			assert_ok!(Call::Proxy(ProxyCall::add_proxy {
 				delegate: Bob,
 				proxy_type: ProxyType::Something,
-				delay: 0u64,
+				delay: 0,
 			})
 			.dispatch(Origin::signed(Alice)));
 			assert_ok!(Call::Proxy(ProxyCall::add_proxy {
 				delegate: Charlie,
 				proxy_type: ProxyType::Any,
-				delay: 0u64,
+				delay: 0,
 			})
 			.dispatch(Origin::signed(Alice)));
 
@@ -368,7 +368,7 @@ fn test_is_proxy_returns_false_if_proxy_type_incorrect() {
 			assert_ok!(Call::Proxy(ProxyCall::add_proxy {
 				delegate: Bob,
 				proxy_type: ProxyType::Something,
-				delay: 0u64,
+				delay: 0,
 			})
 			.dispatch(Origin::signed(Alice)));
 
@@ -398,7 +398,7 @@ fn test_is_proxy_returns_false_if_proxy_delay_incorrect() {
 			assert_ok!(Call::Proxy(ProxyCall::add_proxy {
 				delegate: Bob,
 				proxy_type: ProxyType::Something,
-				delay: 1u64,
+				delay: 1,
 			})
 			.dispatch(Origin::signed(Alice)));
 
@@ -428,7 +428,7 @@ fn test_is_proxy_returns_true_if_proxy() {
 			assert_ok!(Call::Proxy(ProxyCall::add_proxy {
 				delegate: Bob,
 				proxy_type: ProxyType::Something,
-				delay: 1u64,
+				delay: 1,
 			})
 			.dispatch(Origin::signed(Alice)));
 
@@ -486,7 +486,7 @@ fn test_nested_evm_bypass_proxy_should_allow_elevating_proxy_type() {
 			assert_ok!(Call::Proxy(ProxyCall::add_proxy {
 				delegate: Bob,
 				proxy_type: ProxyType::Something,
-				delay: 0u64,
+				delay: 0,
 			})
 			.dispatch(Origin::signed(Alice)));
 

--- a/precompiles/randomness/src/mock.rs
+++ b/precompiles/randomness/src/mock.rs
@@ -41,7 +41,7 @@ use precompile_utils::precompile_set::*;
 
 pub type AccountId = H160;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/precompiles/randomness/src/mock.rs
+++ b/precompiles/randomness/src/mock.rs
@@ -32,7 +32,6 @@ use session_keys_primitives::VrfId;
 use sp_consensus_babe::Slot;
 use sp_core::{H160, H256};
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill,
 };
@@ -63,7 +62,7 @@ construct_runtime!(
 );
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
@@ -80,7 +79,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/precompiles/relay-encoder/src/mock.rs
+++ b/precompiles/relay-encoder/src/mock.rs
@@ -34,7 +34,7 @@ use sp_runtime::{
 
 pub type AccountId = Account;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/precompiles/relay-encoder/src/mock.rs
+++ b/precompiles/relay-encoder/src/mock.rs
@@ -27,7 +27,6 @@ use serde::{Deserialize, Serialize};
 use sp_core::H160;
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill,
 };
@@ -115,7 +114,7 @@ impl From<H160> for Account {
 }
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Runtime {
@@ -129,7 +128,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = Account;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/precompiles/xcm-transactor/src/mock.rs
+++ b/precompiles/xcm-transactor/src/mock.rs
@@ -33,10 +33,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::{H160, H256, U256};
 use sp_io;
-use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-};
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 use sp_std::marker::PhantomData;
 use xcm::latest::{
 	Error as XcmError,
@@ -169,7 +166,7 @@ parameter_types! {
 }
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const SS58Prefix: u8 = 42;
 	pub const MockDbWeight: RuntimeDbWeight = RuntimeDbWeight {
 		read: 1,
@@ -188,7 +185,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = TestAccount;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/precompiles/xcm-transactor/src/mock.rs
+++ b/precompiles/xcm-transactor/src/mock.rs
@@ -52,7 +52,7 @@ use xcm_primitives::AccountIdToCurrencyId;
 
 pub type AccountId = TestAccount;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub const PRECOMPILE_ADDRESS: u64 = 1;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/precompiles/xcm-utils/src/mock.rs
+++ b/precompiles/xcm-utils/src/mock.rs
@@ -30,10 +30,7 @@ use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_core::{H256, U256};
 use sp_io;
-use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-};
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 use sp_std::borrow::Borrow;
 use xcm::latest::{
 	Error as XcmError,
@@ -232,7 +229,7 @@ parameter_types! {
 }
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const SS58Prefix: u8 = 42;
 	pub const MockDbWeight: RuntimeDbWeight = RuntimeDbWeight {
 		read: 1,
@@ -251,7 +248,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = TestAccount;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/precompiles/xcm-utils/src/mock.rs
+++ b/precompiles/xcm-utils/src/mock.rs
@@ -52,7 +52,7 @@ use Junctions::Here;
 
 pub type AccountId = TestAccount;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub const PRECOMPILE_ADDRESS: u64 = 1;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/precompiles/xtokens/src/mock.rs
+++ b/precompiles/xtokens/src/mock.rs
@@ -48,7 +48,7 @@ use xcm_executor::{
 
 pub type AccountId = TestAccount;
 pub type Balance = u128;
-pub type BlockNumber = u64;
+pub type BlockNumber = u32;
 pub const PRECOMPILE_ADDRESS: u64 = 1;
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/precompiles/xtokens/src/mock.rs
+++ b/precompiles/xtokens/src/mock.rs
@@ -27,10 +27,7 @@ use pallet_evm::{AddressMapping, EnsureAddressNever, EnsureAddressRoot, Precompi
 use serde::{Deserialize, Serialize};
 use sp_core::H256;
 use sp_io;
-use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-};
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
 use xcm::latest::{
 	Error as XcmError,
 	Junction::{AccountKey20, GeneralIndex, PalletInstance, Parachain},
@@ -158,7 +155,7 @@ parameter_types! {
 }
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 	pub const SS58Prefix: u8 = 42;
 }
 impl frame_system::Config for Runtime {
@@ -172,7 +169,7 @@ impl frame_system::Config for Runtime {
 	type Hashing = BlakeTwo256;
 	type AccountId = TestAccount;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type Version = ();

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -71,7 +71,7 @@ impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -28,7 +28,6 @@ use frame_system::EnsureRoot;
 use parity_scale_codec::{Decode, Encode};
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
 	traits::{BlakeTwo256, Hash, IdentityLookup, Zero},
 	Permill,
 };
@@ -62,21 +61,22 @@ use xcm_simulator::{
 pub type AccountId = moonbeam_core_primitives::AccountId;
 pub type Balance = u128;
 pub type AssetId = u128;
+pub type BlockNumber = u32;
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 }
 
 impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u32;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type BlockWeights = ();
@@ -450,7 +450,7 @@ impl orml_xtokens::Config for Runtime {
 parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 0;
-	pub const SpendPeriod: u64 = 0;
+	pub const SpendPeriod: u32 = 0;
 	pub const TreasuryId: PalletId = PalletId(*b"pc/trsry");
 	pub const MaxApprovals: u32 = 100;
 }
@@ -1010,7 +1010,7 @@ pub struct EthereumXcmEnsureProxy;
 impl xcm_primitives::EnsureProxy<AccountId> for EthereumXcmEnsureProxy {
 	fn ensure_ok(delegator: AccountId, delegatee: AccountId) -> Result<(), &'static str> {
 		// The EVM implicitely contains an Any proxy, so we only allow for "Any" proxies
-		let def: pallet_proxy::ProxyDefinition<AccountId, ProxyType, u64> =
+		let def: pallet_proxy::ProxyDefinition<AccountId, ProxyType, BlockNumber> =
 			pallet_proxy::Pallet::<Runtime>::find_proxy(
 				&delegator,
 				&delegatee,
@@ -1075,7 +1075,7 @@ pub(crate) fn on_runtime_upgrade() {
 	PolkadotXcm::on_runtime_upgrade();
 }
 
-pub(crate) fn para_roll_to(n: u64) {
+pub(crate) fn para_roll_to(n: u32) {
 	while System::block_number() < n {
 		PolkadotXcm::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -1076,7 +1076,7 @@ pub(crate) fn on_runtime_upgrade() {
 	PolkadotXcm::on_runtime_upgrade();
 }
 
-pub(crate) fn para_roll_to(n: u32) {
+pub(crate) fn para_roll_to(n: BlockNumber) {
 	while System::block_number() < n {
 		PolkadotXcm::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());

--- a/runtime/moonbase/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonbase/tests/xcm_mock/relay_chain.rs
@@ -46,7 +46,7 @@ impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;

--- a/runtime/moonbase/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonbase/tests/xcm_mock/relay_chain.rs
@@ -227,7 +227,7 @@ pub(crate) fn relay_events() -> Vec<Event> {
 }
 
 use frame_support::traits::{OnFinalize, OnInitialize};
-pub(crate) fn relay_roll_to(n: u32) {
+pub(crate) fn relay_roll_to(n: BlockNumber) {
 	while System::block_number() < n {
 		XcmPallet::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());

--- a/runtime/moonbase/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonbase/tests/xcm_mock/relay_chain.rs
@@ -22,7 +22,10 @@ use frame_support::{
 	weights::Weight,
 };
 use sp_core::H256;
-use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	AccountId32,
+};
 
 use polkadot_parachain::primitives::Id as ParaId;
 use polkadot_runtime_parachains::{configuration, origin, shared, ump};
@@ -37,21 +40,22 @@ use xcm_builder::{
 use xcm_executor::{Config, XcmExecutor};
 pub type AccountId = AccountId32;
 pub type Balance = u128;
+pub type BlockNumber = u32;
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 }
 
 impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u32;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type BlockWeights = ();
@@ -223,7 +227,7 @@ pub(crate) fn relay_events() -> Vec<Event> {
 }
 
 use frame_support::traits::{OnFinalize, OnInitialize};
-pub(crate) fn relay_roll_to(n: u64) {
+pub(crate) fn relay_roll_to(n: u32) {
 	while System::block_number() < n {
 		XcmPallet::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());

--- a/runtime/moonbase/tests/xcm_mock/statemint_like.rs
+++ b/runtime/moonbase/tests/xcm_mock/statemint_like.rs
@@ -62,7 +62,7 @@ impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;

--- a/runtime/moonbase/tests/xcm_mock/statemint_like.rs
+++ b/runtime/moonbase/tests/xcm_mock/statemint_like.rs
@@ -25,8 +25,7 @@ use frame_system::EnsureRoot;
 
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
-	traits::{Hash, IdentityLookup},
+	traits::{BlakeTwo256, Hash, IdentityLookup},
 	AccountId32,
 };
 
@@ -53,21 +52,22 @@ use xcm_simulator::{
 pub type AccountId = AccountId32;
 pub type Balance = u128;
 pub type AssetId = u128;
+pub type BlockNumber = u32;
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 }
 
 impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u32;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type BlockWeights = ();

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -28,8 +28,7 @@ use orml_traits::parameter_type_with_key;
 use parity_scale_codec::{Decode, Encode};
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
-	traits::{Hash, IdentityLookup},
+	traits::{BlakeTwo256, Hash, IdentityLookup},
 	Permill,
 };
 use sp_std::{convert::TryFrom, prelude::*};
@@ -61,21 +60,22 @@ use xcm_simulator::{
 pub type AccountId = moonbeam_core_primitives::AccountId;
 pub type Balance = u128;
 pub type AssetId = u128;
+pub type BlockNumber = u32;
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 }
 
 impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u32;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type BlockWeights = ();
@@ -422,7 +422,7 @@ impl orml_xtokens::Config for Runtime {
 parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 0;
-	pub const SpendPeriod: u64 = 0;
+	pub const SpendPeriod: u32 = 0;
 	pub const TreasuryId: PalletId = PalletId(*b"pc/trsry");
 	pub const MaxApprovals: u32 = 100;
 }
@@ -972,7 +972,7 @@ pub(crate) fn on_runtime_upgrade() {
 	PolkadotXcm::on_runtime_upgrade();
 }
 
-pub(crate) fn para_roll_to(n: u64) {
+pub(crate) fn para_roll_to(n: u32) {
 	while System::block_number() < n {
 		PolkadotXcm::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -70,7 +70,7 @@ impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -972,7 +972,7 @@ pub(crate) fn on_runtime_upgrade() {
 	PolkadotXcm::on_runtime_upgrade();
 }
 
-pub(crate) fn para_roll_to(n: u32) {
+pub(crate) fn para_roll_to(n: BlockNumber) {
 	while System::block_number() < n {
 		PolkadotXcm::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());

--- a/runtime/moonbeam/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/relay_chain.rs
@@ -22,7 +22,10 @@ use frame_support::{
 	weights::Weight,
 };
 use sp_core::H256;
-use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	AccountId32,
+};
 
 use polkadot_parachain::primitives::Id as ParaId;
 use polkadot_runtime_parachains::{configuration, origin, shared, ump};
@@ -37,21 +40,22 @@ use xcm_builder::{
 use xcm_executor::{Config, XcmExecutor};
 pub type AccountId = AccountId32;
 pub type Balance = u128;
+pub type BlockNumber = u32;
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 }
 
 impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u32;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type BlockWeights = ();
@@ -280,7 +284,7 @@ pub(crate) fn relay_events() -> Vec<Event> {
 }
 
 use frame_support::traits::{OnFinalize, OnInitialize};
-pub(crate) fn relay_roll_to(n: u64) {
+pub(crate) fn relay_roll_to(n: u32) {
 	while System::block_number() < n {
 		XcmPallet::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());

--- a/runtime/moonbeam/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/relay_chain.rs
@@ -284,7 +284,7 @@ pub(crate) fn relay_events() -> Vec<Event> {
 }
 
 use frame_support::traits::{OnFinalize, OnInitialize};
-pub(crate) fn relay_roll_to(n: u32) {
+pub(crate) fn relay_roll_to(n: BlockNumber) {
 	while System::block_number() < n {
 		XcmPallet::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());

--- a/runtime/moonbeam/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/relay_chain.rs
@@ -46,7 +46,7 @@ impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;

--- a/runtime/moonbeam/tests/xcm_mock/statemint_like.rs
+++ b/runtime/moonbeam/tests/xcm_mock/statemint_like.rs
@@ -62,7 +62,7 @@ impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;

--- a/runtime/moonbeam/tests/xcm_mock/statemint_like.rs
+++ b/runtime/moonbeam/tests/xcm_mock/statemint_like.rs
@@ -25,8 +25,7 @@ use frame_system::EnsureRoot;
 
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
-	traits::{Hash, IdentityLookup},
+	traits::{BlakeTwo256, Hash, IdentityLookup},
 	AccountId32,
 };
 
@@ -53,21 +52,22 @@ use xcm_simulator::{
 pub type AccountId = AccountId32;
 pub type Balance = u128;
 pub type AssetId = u128;
+pub type BlockNumber = u32;
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 }
 
 impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u32;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type BlockWeights = ();

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -983,7 +983,7 @@ pub(crate) fn on_runtime_upgrade() {
 	PolkadotXcm::on_runtime_upgrade();
 }
 
-pub(crate) fn para_roll_to(n: u32) {
+pub(crate) fn para_roll_to(n: BlockNumber) {
 	while System::block_number() < n {
 		PolkadotXcm::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -27,8 +27,7 @@ use frame_system::EnsureRoot;
 use parity_scale_codec::{Decode, Encode};
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
-	traits::{Hash, IdentityLookup},
+	traits::{BlakeTwo256, Hash, IdentityLookup},
 	Permill,
 };
 use sp_std::{convert::TryFrom, prelude::*};
@@ -61,21 +60,22 @@ use xcm_simulator::{
 pub type AccountId = moonbeam_core_primitives::AccountId;
 pub type Balance = u128;
 pub type AssetId = u128;
+pub type BlockNumber = u32;
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 }
 
 impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u32;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type BlockWeights = ();
@@ -435,7 +435,7 @@ impl orml_xtokens::Config for Runtime {
 parameter_types! {
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	pub const ProposalBondMinimum: Balance = 0;
-	pub const SpendPeriod: u64 = 0;
+	pub const SpendPeriod: u32 = 0;
 	pub const TreasuryId: PalletId = PalletId(*b"pc/trsry");
 	pub const MaxApprovals: u32 = 100;
 }
@@ -983,7 +983,7 @@ pub(crate) fn on_runtime_upgrade() {
 	PolkadotXcm::on_runtime_upgrade();
 }
 
-pub(crate) fn para_roll_to(n: u64) {
+pub(crate) fn para_roll_to(n: u32) {
 	while System::block_number() < n {
 		PolkadotXcm::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -70,7 +70,7 @@ impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;

--- a/runtime/moonriver/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonriver/tests/xcm_mock/relay_chain.rs
@@ -22,7 +22,10 @@ use frame_support::{
 	weights::Weight,
 };
 use sp_core::H256;
-use sp_runtime::{testing::Header, traits::IdentityLookup, AccountId32};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	AccountId32,
+};
 
 use polkadot_parachain::primitives::Id as ParaId;
 use polkadot_runtime_parachains::{configuration, origin, shared, ump};
@@ -37,21 +40,22 @@ use xcm_builder::{
 use xcm_executor::{Config, XcmExecutor};
 pub type AccountId = AccountId32;
 pub type Balance = u128;
+pub type BlockNumber = u32;
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 }
 
 impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u32;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type BlockWeights = ();
@@ -280,7 +284,7 @@ pub(crate) fn relay_events() -> Vec<Event> {
 }
 
 use frame_support::traits::{OnFinalize, OnInitialize};
-pub(crate) fn relay_roll_to(n: u64) {
+pub(crate) fn relay_roll_to(n: u32) {
 	while System::block_number() < n {
 		XcmPallet::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());

--- a/runtime/moonriver/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonriver/tests/xcm_mock/relay_chain.rs
@@ -284,7 +284,7 @@ pub(crate) fn relay_events() -> Vec<Event> {
 }
 
 use frame_support::traits::{OnFinalize, OnInitialize};
-pub(crate) fn relay_roll_to(n: u32) {
+pub(crate) fn relay_roll_to(n: BlockNumber) {
 	while System::block_number() < n {
 		XcmPallet::on_finalize(System::block_number());
 		Balances::on_finalize(System::block_number());

--- a/runtime/moonriver/tests/xcm_mock/relay_chain.rs
+++ b/runtime/moonriver/tests/xcm_mock/relay_chain.rs
@@ -46,7 +46,7 @@ impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;

--- a/runtime/moonriver/tests/xcm_mock/statemine_like.rs
+++ b/runtime/moonriver/tests/xcm_mock/statemine_like.rs
@@ -62,7 +62,7 @@ impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u64;
+	type BlockNumber = u32;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;

--- a/runtime/moonriver/tests/xcm_mock/statemine_like.rs
+++ b/runtime/moonriver/tests/xcm_mock/statemine_like.rs
@@ -25,8 +25,7 @@ use frame_system::EnsureRoot;
 
 use sp_core::H256;
 use sp_runtime::{
-	testing::Header,
-	traits::{Hash, IdentityLookup},
+	traits::{BlakeTwo256, Hash, IdentityLookup},
 	AccountId32,
 };
 
@@ -53,21 +52,22 @@ use xcm_simulator::{
 pub type AccountId = AccountId32;
 pub type Balance = u128;
 pub type AssetId = u128;
+pub type BlockNumber = u32;
 
 parameter_types! {
-	pub const BlockHashCount: u64 = 250;
+	pub const BlockHashCount: u32 = 250;
 }
 
 impl frame_system::Config for Runtime {
 	type Origin = Origin;
 	type Call = Call;
 	type Index = u64;
-	type BlockNumber = u32;
+	type BlockNumber = BlockNumber;
 	type Hash = H256;
 	type Hashing = ::sp_runtime::traits::BlakeTwo256;
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type Header = Header;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
 	type Event = Event;
 	type BlockHashCount = BlockHashCount;
 	type BlockWeights = ();


### PR DESCRIPTION
### What does it do?
fixes all our mocks to use `u32` as `BlockNumber`, matching the real chain type.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
