### PR TITLE
Ethereum xcm suspend switch

### DIFF
--- a/pallets/ethereum-xcm/src/lib.rs
+++ b/pallets/ethereum-xcm/src/lib.rs
@@ -135,6 +135,7 @@ pub mod pallet {
 		OriginFor<T>: Into<Result<RawOrigin, OriginFor<T>>>,
 	{
 		/// Xcm Transact an Ethereum transaction.
+		/// Weight: Gas limit plus the db read involving the suspension check
 		#[pallet::weight(<T as pallet_evm::Config>::GasWeightMapping::gas_to_weight({
 			match xcm_transaction {
 				EthereumXcmTransaction::V1(v1_tx) =>  v1_tx.gas_limit.unique_saturated_into(),
@@ -160,6 +161,7 @@ pub mod pallet {
 		}
 
 		/// Xcm Transact an Ethereum transaction through proxy.
+		/// Weight: Gas limit plus the db reads involving the suspension and proxy checks
 		#[pallet::weight(<T as pallet_evm::Config>::GasWeightMapping::gas_to_weight({
 			match xcm_transaction {
 				EthereumXcmTransaction::V1(v1_tx) =>  v1_tx.gas_limit.unique_saturated_into(),

--- a/pallets/ethereum-xcm/src/lib.rs
+++ b/pallets/ethereum-xcm/src/lib.rs
@@ -117,6 +117,7 @@ pub mod pallet {
 
 	/// Whether or not Ethereum-XCM is suspended from executing
 	#[pallet::storage]
+	#[pallet::getter(fn ethereum_xcm_suspended)]
 	pub(super) type EthereumXcmSuspended<T: Config> = StorageValue<_, bool, ValueQuery>;
 
 	#[pallet::origin]

--- a/pallets/ethereum-xcm/src/mock.rs
+++ b/pallets/ethereum-xcm/src/mock.rs
@@ -23,6 +23,7 @@ use frame_support::{
 	weights::Weight,
 	ConsensusEngineId, PalletId,
 };
+use frame_system::EnsureRoot;
 use pallet_evm::{AddressMapping, EnsureAddressTruncated, FeeCalculator};
 use rlp::RlpStream;
 use sp_core::{hashing::keccak_256, H160, H256, U256};
@@ -250,6 +251,7 @@ impl crate::Config for Test {
 	type XcmEthereumOrigin = crate::EnsureXcmEthereumTransaction;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
 	type EnsureProxy = EthereumXcmEnsureProxy;
+	type ControllerOrigin = EnsureRoot<AccountId32>;
 }
 
 impl fp_self_contained::SelfContainedCall for Call {

--- a/pallets/ethereum-xcm/src/tests/v2.rs
+++ b/pallets/ethereum-xcm/src/tests/v2.rs
@@ -13,10 +13,11 @@
 
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
-use crate::{mock::*, RawOrigin};
+use crate::{mock::*, Error, RawOrigin};
 use ethereum_types::{H160, U256};
 use frame_support::{
 	assert_noop, assert_ok,
+	traits::Get,
 	weights::{Pays, PostDispatchInfo},
 };
 use sp_runtime::{DispatchError, DispatchErrorWithPostInfo};
@@ -385,5 +386,32 @@ fn test_transaction_hash_collision() {
 
 		// Still holds two transactions hashes after removing potential consecutive repeated values.
 		assert_eq!(hashes.len(), 2);
+	});
+}
+
+#[test]
+fn check_suspend_ethereum_to_xcm_works() {
+	let (pairs, mut ext) = new_test_ext(2);
+	let alice = &pairs[0];
+	let bob = &pairs[1];
+
+	let db_weights: frame_support::weights::RuntimeDbWeight =
+		<Test as frame_system::Config>::DbWeight::get();
+
+	ext.execute_with(|| {
+		assert_ok!(EthereumXcm::suspend_ethereum_xcm_execution(Origin::root(),));
+		assert_noop!(
+			EthereumXcm::transact(
+				RawOrigin::XcmEthereumTransaction(alice.address).into(),
+				xcm_evm_transfer_eip_1559_transaction(bob.address, U256::from(100)),
+			),
+			DispatchErrorWithPostInfo {
+				error: Error::<Test>::EthereumXcmExecutionSuspended.into(),
+				post_info: PostDispatchInfo {
+					actual_weight: Some(db_weights.reads(1)),
+					pays_fee: Pays::Yes
+				}
+			}
+		);
 	});
 }

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -702,6 +702,7 @@ impl pallet_ethereum_xcm::Config for Runtime {
 	type XcmEthereumOrigin = pallet_ethereum_xcm::EnsureXcmEthereumTransaction;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
 	type EnsureProxy = EthereumXcmEnsureProxy;
+	type ControllerOrigin = EnsureRoot<AccountId>;
 }
 
 parameter_types! {
@@ -973,6 +974,7 @@ impl Contains<Call> for MaintenanceFilter {
 			Call::PolkadotXcm(_) => false,
 			Call::Treasury(_) => false,
 			Call::XcmTransactor(_) => false,
+			Call::EthereumXcm(_) => false,
 			_ => true,
 		}
 	}

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1271,7 +1271,7 @@ construct_runtime! {
 		BaseFee: pallet_base_fee::{Pallet, Call, Storage, Config<T>, Event} = 35,
 		LocalAssets: pallet_assets::<Instance1>::{Pallet, Call, Storage, Event<T>} = 36,
 		MoonbeamOrbiters: pallet_moonbeam_orbiters::{Pallet, Call, Storage, Event<T>} = 37,
-		EthereumXcm: pallet_ethereum_xcm::{Pallet, Call, Origin} = 38,
+		EthereumXcm: pallet_ethereum_xcm::{Pallet, Call, Storage, Origin} = 38,
 		Randomness: pallet_randomness::{Pallet, Call, Storage, Event<T>, Inherent} = 39,
 		TreasuryCouncilCollective:
 			pallet_collective::<Instance3>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>} = 40,

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -1029,6 +1029,7 @@ impl pallet_ethereum_xcm::Config for Runtime {
 	type XcmEthereumOrigin = pallet_ethereum_xcm::EnsureXcmEthereumTransaction;
 	type ReservedXcmpWeight = ReservedXcmpWeight;
 	type EnsureProxy = EthereumXcmEnsureProxy;
+	type ControllerOrigin = EnsureRoot<AccountId>;
 }
 
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;

--- a/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
@@ -121,7 +121,8 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (transfer)"
         .push_any({
           Transact: {
             originType: "SovereignAccount",
-            requireWeightAtMost: new BN(525_000_000).add(new BN(25_000_000)), // 21_000 gas limit + db read
+            // 21_000 gas limit + db read
+            requireWeightAtMost: new BN(525_000_000).add(new BN(25_000_000)),
             call: {
               encoded: transferCallEncoded,
             },
@@ -412,7 +413,8 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (asset fee)
         .push_any({
           Transact: {
             originType: "SovereignAccount",
-            requireWeightAtMost: new BN(2_500_000_000).add(new BN(25_000_000)), // 100_000 gas + 1 db read
+            // 100_000 gas + 1 db read
+            requireWeightAtMost: new BN(2_500_000_000).add(new BN(25_000_000)),
             call: {
               encoded: transferCallEncoded,
             },
@@ -546,7 +548,8 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
         .push_any({
           Transact: {
             originType: "SovereignAccount",
-            requireWeightAtMost: new BN(525_000_000).add(new BN(50_000_000)), // 100_000 gas + 2 db read
+            // 100_000 gas + 2 db read
+            requireWeightAtMost: new BN(525_000_000).add(new BN(50_000_000)),
             call: {
               encoded: transferCallEncoded,
             },
@@ -685,7 +688,8 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
         .push_any({
           Transact: {
             originType: "SovereignAccount",
-            requireWeightAtMost: new BN(525_000_000).add(new BN(50_000_000)), // 100_000 gas + 2 reads
+            // 100_000 gas + 2 reads
+            requireWeightAtMost: new BN(525_000_000).add(new BN(50_000_000)),
             call: {
               encoded: transferCallEncoded,
             },
@@ -840,7 +844,8 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
         .push_any({
           Transact: {
             originType: "SovereignAccount",
-            requireWeightAtMost: new BN(525_000_000).add(new BN(50_000_000)), // 100_000 gas + 2db reads
+            // 100_000 gas + 2db reads
+            requireWeightAtMost: new BN(525_000_000).add(new BN(50_000_000)),
             call: {
               encoded: transferCallEncoded,
             },
@@ -1017,7 +1022,8 @@ describeDevMoonbeam("Mock XCM - transact ETHEREUM (proxy) disabled switch", (con
         .push_any({
           Transact: {
             originType: "SovereignAccount",
-            requireWeightAtMost: new BN(525_000_000).add(new BN(50_000_000)), // 100_000 gas + 2db reads
+            // 100_000 gas + 2db reads
+            requireWeightAtMost: new BN(525_000_000).add(new BN(50_000_000)),
             call: {
               encoded: transferCallEncoded,
             },
@@ -1166,7 +1172,8 @@ describeDevMoonbeam("Mock XCM - transact ETHEREUM (non-proxy) disabled switch", 
         .push_any({
           Transact: {
             originType: "SovereignAccount",
-            requireWeightAtMost: new BN(525_000_000).add(new BN(25_000_000)), // 21_000 gas limit + db read
+            // 21_000 gas limit + db read
+            requireWeightAtMost: new BN(525_000_000).add(new BN(25_000_000)),
             call: {
               encoded: transferCallEncoded,
             },

--- a/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
@@ -141,7 +141,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (transfer)"
       ).data.free.toBigInt();
       expect(testAccountBalance).to.eq(expectedTransferredAmount);
 
-      // Make sure descend addres has been deducted fees once (in xcm-executor) and balance 
+      // Make sure descend addres has been deducted fees once (in xcm-executor) and balance
       // has been transfered through evm.
       const descendAccountBalance = await context.web3.eth.getBalance(descendAddress);
       expect(BigInt(descendAccountBalance)).to.eq(
@@ -932,8 +932,8 @@ describeDevMoonbeam("Mock XCM - transact ETHEREUM (proxy) disabled switch", (con
     // We activate the suspension switch
     await context.createBlock(
       context.polkadotApi.tx.sudo
-      .sudo(context.polkadotApi.tx.ethereumXcm.suspendEthereumXcmExecution())
-      .signAsync(alith)
+        .sudo(context.polkadotApi.tx.ethereumXcm.suspendEthereumXcmExecution())
+        .signAsync(alith)
     );
   });
 
@@ -1082,12 +1082,12 @@ describeDevMoonbeam("Mock XCM - transact ETHEREUM (non-proxy) disabled switch", 
       (await context.polkadotApi.query.system.account(descendOriginAddress)) as any
     ).data.free.toBigInt();
     expect(balance).to.eq(transferredBalance);
-     
+
     // We activate the suspension switch
     await context.createBlock(
       context.polkadotApi.tx.sudo
-      .sudo(context.polkadotApi.tx.ethereumXcm.suspendEthereumXcmExecution())
-      .signAsync(alith)
+        .sudo(context.polkadotApi.tx.ethereumXcm.suspendEthereumXcmExecution())
+        .signAsync(alith)
     );
   });
 

--- a/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
@@ -1186,8 +1186,7 @@ describeDevMoonbeam("Mock XCM - transact ETHEREUM (non-proxy) disabled switch", 
       ).data.free.toBigInt();
       expect(testAccountBalance).to.eq(0n);
 
-      // Make sure descend address has been deducted fees once (in xcm-executor) and balance has been
-      // transfered through evm.
+      // Make sure descend address has been deducted fees once (in xcm-executor)
       const descendAddressBalance = await context.web3.eth.getBalance(descendAddress);
       expect(BigInt(descendAddressBalance)).to.eq(
         transferredBalance - expectedTransferredAmountPlusFees

--- a/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
@@ -88,7 +88,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (transfer)"
     let expectedTransferredAmount = 0n;
     let expectedTransferredAmountPlusFees = 0n;
 
-    const targetXcmWeight = 1_325_000_000n;
+    const targetXcmWeight = 1_325_000_000n + 25_000_000n;
     const targetXcmFee = targetXcmWeight * 50_000n;
 
     for (const xcmTransaction of xcmTransactions) {
@@ -121,7 +121,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (transfer)"
         .push_any({
           Transact: {
             originType: "SovereignAccount",
-            requireWeightAtMost: new BN(525_000_000), // 21_000 gas limit
+            requireWeightAtMost: new BN(525_000_000).add(new BN(25_000_000)), // 21_000 gas limit + db read
             call: {
               encoded: transferCallEncoded,
             },
@@ -141,10 +141,10 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (transfer)"
       ).data.free.toBigInt();
       expect(testAccountBalance).to.eq(expectedTransferredAmount);
 
-      // Make sure ALITH has been deducted fees once (in xcm-executor) and balance has been
-      // transfered through evm.
-      const alithAccountBalance = await context.web3.eth.getBalance(descendAddress);
-      expect(BigInt(alithAccountBalance)).to.eq(
+      // Make sure descend addres has been deducted fees once (in xcm-executor) and balance 
+      // has been transfered through evm.
+      const descendAccountBalance = await context.web3.eth.getBalance(descendAddress);
+      expect(BigInt(descendAccountBalance)).to.eq(
         transferredBalance - expectedTransferredAmountPlusFees
       );
     }
@@ -301,7 +301,8 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (asset fee)
   let random: KeyringPair;
   let contractDeployed;
 
-  const assetsToTransfer = 3_300_000_000n * 2n;
+  // Gas limit + one db read
+  const assetsToTransfer = (3_300_000_000n + 25_000_000n) * 2n;
 
   before("should Register an asset and set unit per sec", async function () {
     const { contract, rawTx } = await createContract(context, "Incrementor");
@@ -411,7 +412,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (asset fee)
         .push_any({
           Transact: {
             originType: "SovereignAccount",
-            requireWeightAtMost: new BN(2_500_000_000), // 100_000 gas
+            requireWeightAtMost: new BN(2_500_000_000).add(new BN(25_000_000)), // 100_000 gas + 1 db read
             call: {
               encoded: transferCallEncoded,
             },
@@ -509,7 +510,8 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
 
     let feeAmount = 0n;
 
-    const targetXcmWeight = 1_325_000_000n;
+    // Gas limit + 2 db reads
+    const targetXcmWeight = 1_325_000_000n + 100_000_000n;
     const targetXcmFee = targetXcmWeight * 50_000n;
 
     for (const xcmTransaction of xcmTransactions) {
@@ -544,7 +546,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
         .push_any({
           Transact: {
             originType: "SovereignAccount",
-            requireWeightAtMost: new BN(525_000_000), // 100_000 gas
+            requireWeightAtMost: new BN(525_000_000).add(new BN(50_000_000)), // 100_000 gas + 2 db read
             call: {
               encoded: transferCallEncoded,
             },
@@ -648,7 +650,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
 
     let feeAmount = 0n;
 
-    const targetXcmWeight = 1_325_000_000n;
+    const targetXcmWeight = 1_325_000_000n + 100_000_000n;
     const targetXcmFee = targetXcmWeight * 50_000n;
 
     for (const xcmTransaction of xcmTransactions) {
@@ -683,7 +685,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
         .push_any({
           Transact: {
             originType: "SovereignAccount",
-            requireWeightAtMost: new BN(525_000_000), // 100_000 gas
+            requireWeightAtMost: new BN(525_000_000).add(new BN(50_000_000)), // 100_000 gas + 2 reads
             call: {
               encoded: transferCallEncoded,
             },
@@ -802,7 +804,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
     let expectedTransferredAmount = 0n;
     let expectedTransferredAmountPlusFees = 0n;
 
-    const targetXcmWeight = 1_325_000_000n;
+    const targetXcmWeight = 1_325_000_000n + 100_000_000n;
     const targetXcmFee = targetXcmWeight * 50_000n;
 
     for (const xcmTransaction of xcmTransactions) {
@@ -838,7 +840,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
         .push_any({
           Transact: {
             originType: "SovereignAccount",
-            requireWeightAtMost: new BN(525_000_000), // 100_000 gas
+            requireWeightAtMost: new BN(525_000_000).add(new BN(50_000_000)), // 100_000 gas + 2db reads
             call: {
               encoded: transferCallEncoded,
             },
@@ -877,6 +879,319 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
       // Make sure derived / descended account nonce still zero.
       const derivedAccountNonce = await context.web3.eth.getTransactionCount(descendAddress);
       expect(derivedAccountNonce).to.eq(0);
+    }
+  });
+});
+
+describeDevMoonbeam("Mock XCM - transact ETHEREUM (proxy) disabled switch", (context) => {
+  let charlethBalance;
+  let charlethNonce;
+  let transferredBalance;
+  let sendingAddress;
+  let descendAddress;
+  let random: KeyringPair;
+
+  before("Should receive transact action with DescendOrigin", async function () {
+    const { originAddress, descendOriginAddress } = descendOriginFromAddress(
+      context,
+      charleth.address
+    );
+    sendingAddress = originAddress;
+    descendAddress = descendOriginAddress;
+    random = generateKeyringPair();
+    transferredBalance = 10_000_000_000_000_000_000n;
+
+    // We fund the Delegatee, which will send the xcm and pay fees
+    await expectOk(
+      context.createBlock(
+        context.polkadotApi.tx.balances.transfer(descendAddress, transferredBalance)
+      )
+    );
+
+    // Ensure funded
+    const balance_delegatee = (
+      (await context.polkadotApi.query.system.account(descendAddress)) as any
+    ).data.free.toBigInt();
+    expect(balance_delegatee).to.eq(transferredBalance);
+
+    // Add proxy
+    await context.createBlock(
+      context.polkadotApi.tx.proxy.addProxy(descendAddress, "Any" as any, 0).signAsync(charleth)
+    );
+
+    // Charleth balance after creating the proxy
+    charlethBalance = (
+      (await context.polkadotApi.query.system.account(sendingAddress)) as any
+    ).data.free.toBigInt();
+
+    // Charleth nonce
+    charlethNonce = parseInt(
+      ((await context.polkadotApi.query.system.account(sendingAddress)) as any).nonce
+    );
+
+    // We activate the suspension switch
+    await context.createBlock(
+      context.polkadotApi.tx.sudo
+      .sudo(context.polkadotApi.tx.ethereumXcm.suspendEthereumXcmExecution())
+      .signAsync(alith)
+    );
+  });
+
+  it("should fail to transact_through_proxy with proxy when disabled", async function () {
+    // Get Pallet balances index
+    const metadata = await context.polkadotApi.rpc.state.getMetadata();
+    const balancesPalletIndex = (metadata.asLatest.toHuman().pallets as Array<any>).find(
+      (pallet) => {
+        return pallet.name === "Balances";
+      }
+    ).index;
+
+    const amountToTransfer = transferredBalance / 10n;
+
+    const xcmTransactions = [
+      {
+        V1: {
+          gas_limit: 21000,
+          fee_payment: {
+            Auto: {
+              Low: null,
+            },
+          },
+          action: {
+            Call: random.address,
+          },
+          value: amountToTransfer,
+          input: [],
+          access_list: null,
+        },
+      },
+      {
+        V2: {
+          gas_limit: 21000,
+          action: {
+            Call: random.address,
+          },
+          value: amountToTransfer,
+          input: [],
+          access_list: null,
+        },
+      },
+    ];
+
+    let expectedTransferredAmount = 0n;
+    let expectedTransferredAmountPlusFees = 0n;
+
+    const targetXcmWeight = 1_325_000_000n + 100_000_000n;
+    const targetXcmFee = targetXcmWeight * 50_000n;
+
+    for (const xcmTransaction of xcmTransactions) {
+      expectedTransferredAmount += amountToTransfer;
+      expectedTransferredAmountPlusFees += amountToTransfer + targetXcmFee;
+      // TODO need to update lookup types for xcm ethereum transaction V2
+      const transferCall = context.polkadotApi.tx.ethereumXcm.transactThroughProxy(
+        sendingAddress,
+        xcmTransaction
+      );
+      const transferCallEncoded = transferCall?.method.toHex();
+
+      // We are going to test that we can receive a transact operation from parachain 1
+      // using descendOrigin first
+      const xcmMessage = new XcmFragment({
+        fees: {
+          multilocation: [
+            {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
+              },
+            },
+          ],
+          fungible: targetXcmFee,
+        },
+        weight_limit: new BN(targetXcmWeight.toString()),
+        descend_origin: sendingAddress,
+      })
+        .descend_origin()
+        .withdraw_asset()
+        .buy_execution()
+        .push_any({
+          Transact: {
+            originType: "SovereignAccount",
+            requireWeightAtMost: new BN(525_000_000).add(new BN(50_000_000)), // 100_000 gas + 2db reads
+            call: {
+              encoded: transferCallEncoded,
+            },
+          },
+        })
+        .as_v2();
+
+      // Send an XCM and create block to execute it
+      await injectHrmpMessageAndSeal(context, 1, {
+        type: "XcmVersionedXcm",
+        payload: xcmMessage,
+      } as RawXcmMessage);
+
+      // The transfer destination
+      // Make sure the destination address did not receive the funds
+      const testAccountBalance = (
+        await context.polkadotApi.query.system.account(random.address)
+      ).data.free.toBigInt();
+      expect(testAccountBalance).to.eq(0n);
+
+      // The EVM caller (proxy delegator)
+      // Make sure CHARLETH balance was not deducted.
+      const charlethAccountBalance = await context.web3.eth.getBalance(sendingAddress);
+      expect(BigInt(charlethAccountBalance)).to.eq(charlethBalance);
+      // Make sure CHARLETH nonce did not increase.
+      const charlethAccountNonce = await context.web3.eth.getTransactionCount(sendingAddress);
+      expect(charlethAccountNonce).to.eq(charlethNonce);
+
+      // The XCM sender (proxy delegatee)
+      // Make sure derived / descended account paid the xcm fees only.
+      const derivedAccountBalance = await context.web3.eth.getBalance(descendAddress);
+      expect(BigInt(derivedAccountBalance)).to.eq(
+        transferredBalance - (expectedTransferredAmountPlusFees - expectedTransferredAmount)
+      );
+      // Make sure derived / descended account nonce still zero.
+      const derivedAccountNonce = await context.web3.eth.getTransactionCount(descendAddress);
+      expect(derivedAccountNonce).to.eq(0);
+    }
+  });
+});
+
+describeDevMoonbeam("Mock XCM - transact ETHEREUM (non-proxy) disabled switch", (context) => {
+  let transferredBalance;
+  let sendingAddress;
+  let descendAddress;
+  let random: KeyringPair;
+
+  before("should receive transact action with DescendOrigin", async function () {
+    const { originAddress, descendOriginAddress } = descendOriginFromAddress(context);
+    sendingAddress = originAddress;
+    descendAddress = descendOriginAddress;
+    random = generateKeyringPair();
+    transferredBalance = 10_000_000_000_000_000_000n;
+
+    // We first fund parachain 2000 sovreign account
+    await expectOk(
+      context.createBlock(
+        context.polkadotApi.tx.balances.transfer(descendOriginAddress, transferredBalance)
+      )
+    );
+    const balance = (
+      (await context.polkadotApi.query.system.account(descendOriginAddress)) as any
+    ).data.free.toBigInt();
+    expect(balance).to.eq(transferredBalance);
+     
+    // We activate the suspension switch
+    await context.createBlock(
+      context.polkadotApi.tx.sudo
+      .sudo(context.polkadotApi.tx.ethereumXcm.suspendEthereumXcmExecution())
+      .signAsync(alith)
+    );
+  });
+
+  it("should receive transact and should not be able to execute", async function () {
+    // Get Pallet balances index
+    const metadata = await context.polkadotApi.rpc.state.getMetadata();
+    const balancesPalletIndex = (metadata.asLatest.toHuman().pallets as Array<any>).find(
+      (pallet) => {
+        return pallet.name === "Balances";
+      }
+    ).index;
+
+    const amountToTransfer = transferredBalance / 10n;
+
+    const xcmTransactions = [
+      {
+        V1: {
+          gas_limit: 21000,
+          fee_payment: {
+            Auto: {
+              Low: null,
+            },
+          },
+          action: {
+            Call: random.address,
+          },
+          value: amountToTransfer,
+          input: [],
+          access_list: null,
+        },
+      },
+      {
+        V2: {
+          gas_limit: 21000,
+          action: {
+            Call: random.address,
+          },
+          value: amountToTransfer,
+          input: [],
+          access_list: null,
+        },
+      },
+    ];
+
+    let expectedTransferredAmountPlusFees = 0n;
+
+    const targetXcmWeight = 1_325_000_000n + 25_000_000n;
+    const targetXcmFee = targetXcmWeight * 50_000n;
+
+    for (const xcmTransaction of xcmTransactions) {
+      expectedTransferredAmountPlusFees += targetXcmFee;
+      // TODO need to update lookup types for xcm ethereum transaction V2
+      const transferCall = context.polkadotApi.tx.ethereumXcm.transact(xcmTransaction as any);
+      const transferCallEncoded = transferCall?.method.toHex();
+
+      // We are going to test that we can receive a transact operation from parachain 1
+      // using descendOrigin first
+      const xcmMessage = new XcmFragment({
+        fees: {
+          multilocation: [
+            {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
+              },
+            },
+          ],
+          fungible: targetXcmFee,
+        },
+        weight_limit: new BN(targetXcmWeight.toString()),
+        descend_origin: sendingAddress,
+      })
+        .descend_origin()
+        .withdraw_asset()
+        .buy_execution()
+        .push_any({
+          Transact: {
+            originType: "SovereignAccount",
+            requireWeightAtMost: new BN(525_000_000).add(new BN(25_000_000)), // 21_000 gas limit + db read
+            call: {
+              encoded: transferCallEncoded,
+            },
+          },
+        })
+        .as_v2();
+
+      // Send an XCM and create block to execute it
+      await injectHrmpMessageAndSeal(context, 1, {
+        type: "XcmVersionedXcm",
+        payload: xcmMessage,
+      } as RawXcmMessage);
+
+      // Make sure tokens have not bein transferred
+      const testAccountBalance = (
+        await context.polkadotApi.query.system.account(random.address)
+      ).data.free.toBigInt();
+      expect(testAccountBalance).to.eq(0n);
+
+      // Make sure descend address has been deducted fees once (in xcm-executor) and balance has been
+      // transfered through evm.
+      const descendAddressBalance = await context.web3.eth.getBalance(descendAddress);
+      expect(BigInt(descendAddressBalance)).to.eq(
+        transferredBalance - expectedTransferredAmountPlusFees
+      );
     }
   });
 });


### PR DESCRIPTION
### What does it do?
Adds suspension switch to ethereumXcm pallet. This switch prevents any call to EthereumXCM when enabled.

Two new extrinsics that are root callable have been added, to be able to control the switch.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
