### PR TITLE
`EthereumXcm` tracing support

### DIFF
--- a/primitives/xcm/src/ethereum_xcm.rs
+++ b/primitives/xcm/src/ethereum_xcm.rs
@@ -217,6 +217,21 @@ impl XcmToEthereum for EthereumXcmTransactionV2 {
 	}
 }
 
+/// The EthereumXcmTracingStatus storage key.
+pub const ETHEREUM_XCM_TRACING_STORAGE_KEY: &[u8] = b":ethereum_xcm_tracing";
+
+/// The current EthereumXcmTransaction trace status.
+#[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
+pub enum EthereumXcmTracingStatus {
+	/// A full block trace.
+	Block,
+	/// A specific transaction trace over an intermediate state.
+	Transaction(TransactionV2),
+	/// A status indicating it is safe to stop runtime work, as all data has been collected.
+	TransactionExited,
+}
+
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/primitives/xcm/src/ethereum_xcm.rs
+++ b/primitives/xcm/src/ethereum_xcm.rs
@@ -225,12 +225,11 @@ pub const ETHEREUM_XCM_TRACING_STORAGE_KEY: &[u8] = b":ethereum_xcm_tracing";
 pub enum EthereumXcmTracingStatus {
 	/// A full block trace.
 	Block,
-	/// A specific transaction trace over an intermediate state.
-	Transaction(TransactionV2),
-	/// A status indicating it is safe to stop runtime work, as all data has been collected.
+	/// A single transaction.
+	Transaction(H256),
+	/// Exit signal.
 	TransactionExited,
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -98,6 +98,15 @@ macro_rules! impl_runtime_apis_plus_common {
 					#[cfg(feature = "evm-tracing")]
 					{
 						use moonbeam_evm_tracer::tracer::EvmTracer;
+						use xcm_primitives::EthereumXcmTracingStatus;
+						
+						// Store the target transaction in a storage helper to identify EthereumXcm
+						// in the runtime CallDispatcher.
+						frame_support::storage::unhashed::put::<EthereumXcmTracingStatus>(
+							xcm_primitives::ETHEREUM_XCM_TRACING_STORAGE_KEY,
+							&EthereumXcmTracingStatus::Transaction(traced_transaction.clone()),
+						);
+
 						// Apply the a subset of extrinsics: all the substrate-specific or ethereum
 						// transactions that preceded the requested transaction.
 						for ext in extrinsics.into_iter() {
@@ -112,6 +121,7 @@ macro_rules! impl_runtime_apis_plus_common {
 								}
 								_ => Executive::apply_extrinsic(ext),
 							};
+							// TODO check if EthereumXcmTracingStatus is exited, then panic to exit
 						}
 
 						Err(sp_runtime::DispatchError::Other(

--- a/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
+++ b/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
@@ -18,7 +18,8 @@
 macro_rules! impl_moonbeam_xcm_call_tracing {
 	{} => {
 
-		type CallResult = Result<PostDispatchInfoOf<Call>, DispatchErrorWithPostInfo<PostDispatchInfoOf<Call>>>;
+		type CallResult =
+			Result<PostDispatchInfoOf<Call>, DispatchErrorWithPostInfo<PostDispatchInfoOf<Call>>>;
 
 		pub struct MoonbeamCall;
 		impl CallDispatcher<Call> for MoonbeamCall {
@@ -37,7 +38,11 @@ macro_rules! impl_moonbeam_xcm_call_tracing {
 						) => {
 							use crate::EthereumXcm;
 							use moonbeam_evm_tracer::tracer::EvmTracer;
-							use xcm_primitives::{XcmToEthereum, EthereumXcmTracingStatus, ETHEREUM_XCM_TRACING_STORAGE_KEY};
+							use xcm_primitives::{
+								XcmToEthereum,
+								EthereumXcmTracingStatus,
+								ETHEREUM_XCM_TRACING_STORAGE_KEY
+							};
 							use frame_support::storage::unhashed;
 
 							let dispatch_call = || {

--- a/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
+++ b/runtime/common/src/impl_moonbeam_xcm_call_tracing.rs
@@ -1,0 +1,100 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+#[macro_export]
+macro_rules! impl_moonbeam_xcm_call_tracing {
+	{} => {
+
+		type CallResult = Result<PostDispatchInfoOf<Call>, DispatchErrorWithPostInfo<PostDispatchInfoOf<Call>>>;
+
+		pub struct MoonbeamCall;
+		impl CallDispatcher<Call> for MoonbeamCall {
+			fn dispatch(
+				call: Call,
+				origin: Origin,
+			) -> CallResult {
+				if let Ok(raw_origin) = TryInto::<RawOrigin<AccountId>>::try_into(origin.clone().caller) {
+					match (call.clone(), raw_origin) {
+						(
+							Call::EthereumXcm(pallet_ethereum_xcm::Call::transact { xcm_transaction }) |
+							Call::EthereumXcm(pallet_ethereum_xcm::Call::transact_through_proxy { 
+								xcm_transaction, ..
+							 }),
+							RawOrigin::Signed(account_id)
+						) => {
+							use crate::EthereumXcm;
+							use moonbeam_evm_tracer::tracer::EvmTracer;
+							use xcm_primitives::{XcmToEthereum, EthereumXcmTracingStatus, ETHEREUM_XCM_TRACING_STORAGE_KEY};
+							// In the evm-tracing context, we always expect to hold some value for the
+							// EthereumXcm well known key.
+							if let Some(transaction) = frame_support::storage::unhashed::get(
+								ETHEREUM_XCM_TRACING_STORAGE_KEY
+							) {
+								let dispatch_call = || {
+									Call::dispatch(
+										call,
+										pallet_ethereum_xcm::Origin::XcmEthereumTransaction(
+											account_id.into()
+										).into()
+									)
+								};
+								return match transaction {
+									// When tracing a block, all calls are done using environmental.
+									EthereumXcmTracingStatus::Block => {
+										let mut res: Option<CallResult> = None;
+										EvmTracer::new().trace(|| {
+											res = Some(dispatch_call());
+										});
+										res.expect("Invalid dispatch result")
+									},
+									// When tracing a transaction, the one matching the trace request
+									// is done using environmental, the rest simply dispatched.
+									EthereumXcmTracingStatus::Transaction(traced_transaction) => {
+										let transaction_hash = xcm_transaction.into_transaction_v2(
+											EthereumXcm::nonce()
+										)
+										.expect("Invalid transaction conversion")
+										.hash();
+										if transaction_hash == traced_transaction.hash() {
+											// Exit after a single matching trace.
+											frame_support::storage::unhashed::put::<EthereumXcmTracingStatus>(
+												ETHEREUM_XCM_TRACING_STORAGE_KEY,
+												&EthereumXcmTracingStatus::TransactionExited,
+											);
+											let mut res: Option<CallResult> = None;
+											EvmTracer::new().trace(|| {
+												res = Some(dispatch_call());
+											});
+											res.expect("Invalid dispatch result")
+										} else {
+											dispatch_call()
+										}
+									},
+									// Tracing runtime work is done, just exit.
+									// We can panic here because all the tracing data was already
+									// collected by the host.
+									EthereumXcmTracingStatus::TransactionExited => panic!()
+								};
+							}
+						},
+						_ => {}
+					}
+				}
+				Call::dispatch(call, origin)
+			}
+		}
+	}
+}

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -20,6 +20,7 @@ use sp_core::H160;
 
 mod apis;
 mod impl_moonbeam_xcm_call;
+mod impl_moonbeam_xcm_call_tracing;
 mod impl_on_charge_evm_transaction;
 mod impl_self_contained_call;
 pub mod migrations;

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -254,7 +254,10 @@ pub type XcmFeesToAccount = xcm_primitives::XcmFeesToAccount<
 
 // Our implementation of the Moonbeam Call
 // Attachs the right origin in case the call is made to pallet-ethereum-xcm
+#[cfg(not(feature = "evm-tracing"))]
 moonbeam_runtime_common::impl_moonbeam_xcm_call!();
+#[cfg(feature = "evm-tracing")]
+moonbeam_runtime_common::impl_moonbeam_xcm_call_tracing!();
 
 pub struct XcmExecutorConfig;
 impl xcm_executor::Config for XcmExecutorConfig {

--- a/tests/tracing-tests/test-trace-ethereum-xcm.ts
+++ b/tests/tracing-tests/test-trace-ethereum-xcm.ts
@@ -1,0 +1,133 @@
+import "@moonbeam-network/api-augment";
+
+import { KeyringPair } from "@polkadot/keyring/types";
+import { BN } from "@polkadot/util";
+import { expect } from "chai";
+
+import { generateKeyringPair } from "../util/accounts";
+import {
+  descendOriginFromAddress,
+  injectHrmpMessageAndSeal,
+  RawXcmMessage,
+  XcmFragment,
+} from "../util/xcm";
+
+import { describeDevMoonbeam } from "../util/setup-dev-tests";
+
+import { createContract } from "../util/transactions";
+import { customWeb3Request } from "../util/providers";
+
+import { expectOk } from "../util/expect";
+
+describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (transfer)", (context) => {
+  let transactionHashes = [];
+
+  before("should receive transact action with DescendOrigin", async function () {
+    const { contract, rawTx } = await createContract(context, "Incrementor");
+    await expectOk(context.createBlock(rawTx));
+
+    const { originAddress, descendOriginAddress } = descendOriginFromAddress(context);
+    const sendingAddress = originAddress;
+    const random = generateKeyringPair();
+    const transferredBalance = 10_000_000_000_000_000_000n;
+
+    // We first fund parachain 2000 sovreign account
+    await expectOk(
+      context.createBlock(
+        context.polkadotApi.tx.balances.transfer(descendOriginAddress, transferredBalance)
+      )
+    );
+    // Get Pallet balances index
+    const metadata = await context.polkadotApi.rpc.state.getMetadata();
+    const balancesPalletIndex = (metadata.asLatest.toHuman().pallets as Array<any>).find(
+      (pallet) => {
+        return pallet.name === "Balances";
+      }
+    ).index;
+
+    const xcmTransactions = [
+      {
+        V1: {
+          gas_limit: 100000,
+          fee_payment: {
+            Auto: {
+              Low: null,
+            },
+          },
+          action: {
+            Call: contract.options.address,
+          },
+          value: 0n,
+          input: contract.methods.incr().encodeABI().toString(),
+          access_list: null,
+        },
+      },
+      {
+        V2: {
+          gas_limit: 100000,
+          action: {
+            Call: contract.options.address,
+          },
+          value: 0n,
+          input: contract.methods.incr().encodeABI().toString(),
+          access_list: null,
+        },
+      },
+    ];
+
+    for (const xcmTransaction of xcmTransactions) {
+      const transferCall = context.polkadotApi.tx.ethereumXcm.transact(xcmTransaction as any);
+      const transferCallEncoded = transferCall?.method.toHex();
+      const xcmMessage = new XcmFragment({
+        fees: {
+          multilocation: [
+            {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
+              },
+            },
+          ],
+          fungible: transferredBalance / 2n,
+        },
+        weight_limit: new BN(4000000000),
+        descend_origin: sendingAddress,
+      })
+        .descend_origin()
+        .withdraw_asset()
+        .buy_execution()
+        .push_any({
+          Transact: {
+            originType: "SovereignAccount",
+            requireWeightAtMost: new BN(3000000000),
+            call: {
+              encoded: transferCallEncoded,
+            },
+          },
+        })
+        .as_v2();
+
+      // Send an XCM and create block to execute it
+      await injectHrmpMessageAndSeal(context, 1, {
+        type: "XcmVersionedXcm",
+        payload: xcmMessage,
+      } as RawXcmMessage);
+
+      // Retrieve the stored ethereum transaction hash
+      transactionHashes.push((await context.web3.eth.getBlock("latest")).transactions[0]);
+    }
+  });
+
+  it("should trace ethereum xcm transactions", async function () {
+    for (const hash of transactionHashes) {
+      const receipt = await context.web3.eth.getTransactionReceipt(hash);
+      const trace = await customWeb3Request(context.web3, "debug_traceTransaction", [
+        hash,
+        { tracer: "callTracer" },
+      ]);
+      // We traced the transaction, and the traced gas used matches the one recorded
+      // in the ethereum transaction receipt.
+      expect(receipt.gasUsed).to.eq(context.web3.utils.hexToNumber(trace.result.gasUsed));
+    }
+  });
+});


### PR DESCRIPTION
### What does it do?

This PR adds support for requesting traces for ethereum transactions sent through `pallet-ethereum-xcm`.

## Problem

Current tracing implementation applies block extrinsics to a parent state until the target `Ethereum::transact` transaction is found. `EthereumXcm` transactions are part of `parachainSystem.setValidationData` XCM messages, not individual block body extrinsics so they are supported.

## Proposal

When a `debug_traceTransaction` request is received for a hash corresponding to a `EthereumXcm` transaction: 

- The request handling remains unchanged, calling the existing runtime api.
- The target transaction hash will be stored to later retrieve it in a `evm-tracing` custom `CallDispatcher`.
- If an `EthereumXcm` is about to be dispatched and it matches the initially stored target transaction hash, it will now be wrapped it in our `EvmTracer`. 
- Exit the runtime instance when the trace is done.

`debug_traceBlock` is identical, except it will now wrap any `EthereumXcm` transaction in the `EvmTracer`. 

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
