### PR TITLE
`EthereumXcm` limit input size

### DIFF
--- a/pallets/ethereum-xcm/src/tests/v1/eip1559.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/eip1559.rs
@@ -17,7 +17,9 @@
 use super::*;
 use frame_support::{
 	assert_noop,
+	traits::ConstU32,
 	weights::{Pays, PostDispatchInfo},
+	BoundedVec,
 };
 use sp_runtime::{DispatchError, DispatchErrorWithPostInfo};
 use xcm_primitives::{EthereumXcmFee, EthereumXcmTransaction, EthereumXcmTransactionV1};
@@ -47,7 +49,8 @@ fn xcm_evm_transfer_eip_1559_transaction(destination: H160, value: U256) -> Ethe
 		gas_limit: U256::from(0x5208),
 		action: ethereum::TransactionAction::Call(destination),
 		value,
-		input: vec![],
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+			.unwrap(),
 		access_list: None,
 	})
 }
@@ -58,7 +61,8 @@ fn xcm_evm_call_eip_1559_transaction(destination: H160, input: Vec<u8>) -> Ether
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value: U256::zero(),
-		input,
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(input)
+			.unwrap(),
 		access_list: None,
 	})
 }
@@ -70,7 +74,10 @@ fn xcm_erc20_creation_eip_1559_transaction() -> EthereumXcmTransaction {
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
-		input: hex::decode(CONTRACT).unwrap(),
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+			hex::decode(CONTRACT).unwrap(),
+		)
+		.unwrap(),
 		access_list: None,
 	})
 }
@@ -198,7 +205,11 @@ fn test_transact_xcm_validation_works() {
 					gas_limit: U256::from(0x5207),
 					action: ethereum::TransactionAction::Call(bob.address),
 					value: U256::from(1),
-					input: vec![],
+					input:
+						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+							vec![]
+						)
+						.unwrap(),
 					access_list: None,
 				}),
 			),
@@ -348,7 +359,8 @@ fn test_global_nonce_not_incr() {
 			gas_limit: U256::one(),
 			action: ethereum::TransactionAction::Call(bob.address),
 			value: U256::one(),
-			input: vec![],
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+				.unwrap(),
 			access_list: None,
 		});
 

--- a/pallets/ethereum-xcm/src/tests/v1/eip1559.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/eip1559.rs
@@ -49,7 +49,7 @@ fn xcm_evm_transfer_eip_1559_transaction(destination: H160, value: U256) -> Ethe
 		gas_limit: U256::from(0x5208),
 		action: ethereum::TransactionAction::Call(destination),
 		value,
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
 			.unwrap(),
 		access_list: None,
 	})
@@ -61,7 +61,7 @@ fn xcm_evm_call_eip_1559_transaction(destination: H160, input: Vec<u8>) -> Ether
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(input)
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(input)
 			.unwrap(),
 		access_list: None,
 	})
@@ -74,7 +74,7 @@ fn xcm_erc20_creation_eip_1559_transaction() -> EthereumXcmTransaction {
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
 			hex::decode(CONTRACT).unwrap(),
 		)
 		.unwrap(),
@@ -206,7 +206,7 @@ fn test_transact_xcm_validation_works() {
 					action: ethereum::TransactionAction::Call(bob.address),
 					value: U256::from(1),
 					input:
-						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
 							vec![]
 						)
 						.unwrap(),
@@ -359,7 +359,7 @@ fn test_global_nonce_not_incr() {
 			gas_limit: U256::one(),
 			action: ethereum::TransactionAction::Call(bob.address),
 			value: U256::one(),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
 				.unwrap(),
 			access_list: None,
 		});

--- a/pallets/ethereum-xcm/src/tests/v1/eip1559.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/eip1559.rs
@@ -49,7 +49,10 @@ fn xcm_evm_transfer_eip_1559_transaction(destination: H160, value: U256) -> Ethe
 		gas_limit: U256::from(0x5208),
 		action: ethereum::TransactionAction::Call(destination),
 		value,
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
+		input:
+			BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
+				vec![],
+			)
 			.unwrap(),
 		access_list: None,
 	})
@@ -61,7 +64,10 @@ fn xcm_evm_call_eip_1559_transaction(destination: H160, input: Vec<u8>) -> Ether
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(input)
+		input:
+			BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
+				input,
+			)
 			.unwrap(),
 		access_list: None,
 	})
@@ -74,10 +80,11 @@ fn xcm_erc20_creation_eip_1559_transaction() -> EthereumXcmTransaction {
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
-			hex::decode(CONTRACT).unwrap(),
-		)
-		.unwrap(),
+		input:
+			BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
+				hex::decode(CONTRACT).unwrap(),
+			)
+			.unwrap(),
 		access_list: None,
 	})
 }
@@ -205,11 +212,11 @@ fn test_transact_xcm_validation_works() {
 					gas_limit: U256::from(0x5207),
 					action: ethereum::TransactionAction::Call(bob.address),
 					value: U256::from(1),
-					input:
-						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
-							vec![]
-						)
-						.unwrap(),
+					input: BoundedVec::<
+						u8,
+						ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>,
+					>::try_from(vec![])
+					.unwrap(),
 					access_list: None,
 				}),
 			),
@@ -354,15 +361,21 @@ fn test_global_nonce_not_incr() {
 	ext.execute_with(|| {
 		assert_eq!(EthereumXcm::nonce(), U256::zero());
 
-		let invalid_transaction_cost = EthereumXcmTransaction::V1(EthereumXcmTransactionV1 {
-			fee_payment: EthereumXcmFee::Auto,
-			gas_limit: U256::one(),
-			action: ethereum::TransactionAction::Call(bob.address),
-			value: U256::one(),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
-				.unwrap(),
-			access_list: None,
-		});
+		let invalid_transaction_cost =
+			EthereumXcmTransaction::V1(
+				EthereumXcmTransactionV1 {
+					fee_payment: EthereumXcmFee::Auto,
+					gas_limit: U256::one(),
+					action: ethereum::TransactionAction::Call(bob.address),
+					value: U256::one(),
+					input: BoundedVec::<
+						u8,
+						ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>,
+					>::try_from(vec![])
+					.unwrap(),
+					access_list: None,
+				},
+			);
 
 		EthereumXcm::transact(
 			RawOrigin::XcmEthereumTransaction(alice.address).into(),

--- a/pallets/ethereum-xcm/src/tests/v1/eip2930.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/eip2930.rs
@@ -53,7 +53,10 @@ fn xcm_evm_transfer_eip_2930_transaction(destination: H160, value: U256) -> Ethe
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value,
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
+		input:
+			BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
+				vec![],
+			)
 			.unwrap(),
 		access_list,
 	})
@@ -70,7 +73,10 @@ fn xcm_evm_call_eip_2930_transaction(destination: H160, input: Vec<u8>) -> Ether
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(input)
+		input:
+			BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
+				input,
+			)
 			.unwrap(),
 		access_list,
 	})
@@ -87,10 +93,11 @@ fn xcm_erc20_creation_eip_2930_transaction() -> EthereumXcmTransaction {
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
-			hex::decode(CONTRACT).unwrap(),
-		)
-		.unwrap(),
+		input:
+			BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
+				hex::decode(CONTRACT).unwrap(),
+			)
+			.unwrap(),
 		access_list,
 	})
 }
@@ -217,11 +224,11 @@ fn test_transact_xcm_validation_works() {
 					gas_limit: U256::from(0x5207),
 					action: ethereum::TransactionAction::Call(bob.address),
 					value: U256::from(1),
-					input:
-						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
-							vec![]
-						)
-						.unwrap(),
+					input: BoundedVec::<
+						u8,
+						ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>,
+					>::try_from(vec![])
+					.unwrap(),
 					access_list: Some(vec![(H160::default(), vec![H256::default()])]),
 				}),
 			),
@@ -368,15 +375,21 @@ fn test_global_nonce_not_incr() {
 
 		let access_list = Some(vec![(H160::default(), vec![H256::default()])]);
 
-		let invalid_transaction_cost = EthereumXcmTransaction::V1(EthereumXcmTransactionV1 {
-			fee_payment: EthereumXcmFee::Auto,
-			gas_limit: U256::one(),
-			action: ethereum::TransactionAction::Call(bob.address),
-			value: U256::one(),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
-				.unwrap(),
-			access_list,
-		});
+		let invalid_transaction_cost =
+			EthereumXcmTransaction::V1(
+				EthereumXcmTransactionV1 {
+					fee_payment: EthereumXcmFee::Auto,
+					gas_limit: U256::one(),
+					action: ethereum::TransactionAction::Call(bob.address),
+					value: U256::one(),
+					input: BoundedVec::<
+						u8,
+						ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>,
+					>::try_from(vec![])
+					.unwrap(),
+					access_list,
+				},
+			);
 
 		EthereumXcm::transact(
 			RawOrigin::XcmEthereumTransaction(alice.address).into(),

--- a/pallets/ethereum-xcm/src/tests/v1/eip2930.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/eip2930.rs
@@ -53,7 +53,7 @@ fn xcm_evm_transfer_eip_2930_transaction(destination: H160, value: U256) -> Ethe
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value,
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
 			.unwrap(),
 		access_list,
 	})
@@ -70,7 +70,7 @@ fn xcm_evm_call_eip_2930_transaction(destination: H160, input: Vec<u8>) -> Ether
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(input)
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(input)
 			.unwrap(),
 		access_list,
 	})
@@ -87,7 +87,7 @@ fn xcm_erc20_creation_eip_2930_transaction() -> EthereumXcmTransaction {
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
 			hex::decode(CONTRACT).unwrap(),
 		)
 		.unwrap(),
@@ -218,7 +218,7 @@ fn test_transact_xcm_validation_works() {
 					action: ethereum::TransactionAction::Call(bob.address),
 					value: U256::from(1),
 					input:
-						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
 							vec![]
 						)
 						.unwrap(),
@@ -373,7 +373,7 @@ fn test_global_nonce_not_incr() {
 			gas_limit: U256::one(),
 			action: ethereum::TransactionAction::Call(bob.address),
 			value: U256::one(),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
 				.unwrap(),
 			access_list,
 		});

--- a/pallets/ethereum-xcm/src/tests/v1/eip2930.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/eip2930.rs
@@ -17,7 +17,9 @@
 use super::*;
 use frame_support::{
 	assert_noop,
+	traits::ConstU32,
 	weights::{Pays, PostDispatchInfo},
+	BoundedVec,
 };
 use sp_runtime::{DispatchError, DispatchErrorWithPostInfo};
 use xcm_primitives::{
@@ -51,7 +53,8 @@ fn xcm_evm_transfer_eip_2930_transaction(destination: H160, value: U256) -> Ethe
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value,
-		input: vec![],
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+			.unwrap(),
 		access_list,
 	})
 }
@@ -67,7 +70,8 @@ fn xcm_evm_call_eip_2930_transaction(destination: H160, input: Vec<u8>) -> Ether
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value: U256::zero(),
-		input,
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(input)
+			.unwrap(),
 		access_list,
 	})
 }
@@ -83,7 +87,10 @@ fn xcm_erc20_creation_eip_2930_transaction() -> EthereumXcmTransaction {
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
-		input: hex::decode(CONTRACT).unwrap(),
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+			hex::decode(CONTRACT).unwrap(),
+		)
+		.unwrap(),
 		access_list,
 	})
 }
@@ -210,7 +217,11 @@ fn test_transact_xcm_validation_works() {
 					gas_limit: U256::from(0x5207),
 					action: ethereum::TransactionAction::Call(bob.address),
 					value: U256::from(1),
-					input: vec![],
+					input:
+						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+							vec![]
+						)
+						.unwrap(),
 					access_list: Some(vec![(H160::default(), vec![H256::default()])]),
 				}),
 			),
@@ -362,7 +373,8 @@ fn test_global_nonce_not_incr() {
 			gas_limit: U256::one(),
 			action: ethereum::TransactionAction::Call(bob.address),
 			value: U256::one(),
-			input: vec![],
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+				.unwrap(),
 			access_list,
 		});
 

--- a/pallets/ethereum-xcm/src/tests/v1/legacy.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/legacy.rs
@@ -51,7 +51,7 @@ fn xcm_evm_transfer_legacy_transaction(destination: H160, value: U256) -> Ethere
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value,
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
 			.unwrap(),
 		access_list: None,
 	})
@@ -69,7 +69,7 @@ fn xcm_evm_call_eip_legacy_transaction(
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(input)
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(input)
 			.unwrap(),
 		access_list: None,
 	})
@@ -84,7 +84,7 @@ fn xcm_erc20_creation_legacy_transaction() -> EthereumXcmTransaction {
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
 			hex::decode(CONTRACT).unwrap(),
 		)
 		.unwrap(),
@@ -215,7 +215,7 @@ fn test_transact_xcm_validation_works() {
 					action: ethereum::TransactionAction::Call(bob.address),
 					value: U256::from(1),
 					input:
-						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
 							vec![]
 						)
 						.unwrap(),
@@ -368,7 +368,7 @@ fn test_global_nonce_not_incr() {
 			gas_limit: U256::one(),
 			action: ethereum::TransactionAction::Call(bob.address),
 			value: U256::one(),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
 				.unwrap(),
 			access_list: None,
 		});

--- a/pallets/ethereum-xcm/src/tests/v1/legacy.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/legacy.rs
@@ -51,7 +51,10 @@ fn xcm_evm_transfer_legacy_transaction(destination: H160, value: U256) -> Ethere
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value,
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
+		input:
+			BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
+				vec![],
+			)
 			.unwrap(),
 		access_list: None,
 	})
@@ -69,7 +72,10 @@ fn xcm_evm_call_eip_legacy_transaction(
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(input)
+		input:
+			BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
+				input,
+			)
 			.unwrap(),
 		access_list: None,
 	})
@@ -84,10 +90,11 @@ fn xcm_erc20_creation_legacy_transaction() -> EthereumXcmTransaction {
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
-			hex::decode(CONTRACT).unwrap(),
-		)
-		.unwrap(),
+		input:
+			BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
+				hex::decode(CONTRACT).unwrap(),
+			)
+			.unwrap(),
 		access_list: None,
 	})
 }
@@ -214,11 +221,11 @@ fn test_transact_xcm_validation_works() {
 					gas_limit: U256::from(0x5207),
 					action: ethereum::TransactionAction::Call(bob.address),
 					value: U256::from(1),
-					input:
-						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
-							vec![]
-						)
-						.unwrap(),
+					input: BoundedVec::<
+						u8,
+						ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>,
+					>::try_from(vec![])
+					.unwrap(),
 					access_list: None,
 				}),
 			),
@@ -363,15 +370,21 @@ fn test_global_nonce_not_incr() {
 	ext.execute_with(|| {
 		assert_eq!(EthereumXcm::nonce(), U256::zero());
 
-		let invalid_transaction_cost = EthereumXcmTransaction::V1(EthereumXcmTransactionV1 {
-			fee_payment: EthereumXcmFee::Auto,
-			gas_limit: U256::one(),
-			action: ethereum::TransactionAction::Call(bob.address),
-			value: U256::one(),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
-				.unwrap(),
-			access_list: None,
-		});
+		let invalid_transaction_cost =
+			EthereumXcmTransaction::V1(
+				EthereumXcmTransactionV1 {
+					fee_payment: EthereumXcmFee::Auto,
+					gas_limit: U256::one(),
+					action: ethereum::TransactionAction::Call(bob.address),
+					value: U256::one(),
+					input: BoundedVec::<
+						u8,
+						ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>,
+					>::try_from(vec![])
+					.unwrap(),
+					access_list: None,
+				},
+			);
 
 		EthereumXcm::transact(
 			RawOrigin::XcmEthereumTransaction(alice.address).into(),

--- a/pallets/ethereum-xcm/src/tests/v1/legacy.rs
+++ b/pallets/ethereum-xcm/src/tests/v1/legacy.rs
@@ -17,7 +17,9 @@
 use super::*;
 use frame_support::{
 	assert_noop,
+	traits::ConstU32,
 	weights::{Pays, PostDispatchInfo},
+	BoundedVec,
 };
 use sp_runtime::{DispatchError, DispatchErrorWithPostInfo};
 use xcm_primitives::{
@@ -49,7 +51,8 @@ fn xcm_evm_transfer_legacy_transaction(destination: H160, value: U256) -> Ethere
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value,
-		input: vec![],
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+			.unwrap(),
 		access_list: None,
 	})
 }
@@ -66,7 +69,8 @@ fn xcm_evm_call_eip_legacy_transaction(
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value: U256::zero(),
-		input,
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(input)
+			.unwrap(),
 		access_list: None,
 	})
 }
@@ -80,7 +84,10 @@ fn xcm_erc20_creation_legacy_transaction() -> EthereumXcmTransaction {
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
-		input: hex::decode(CONTRACT).unwrap(),
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+			hex::decode(CONTRACT).unwrap(),
+		)
+		.unwrap(),
 		access_list: None,
 	})
 }
@@ -207,7 +214,11 @@ fn test_transact_xcm_validation_works() {
 					gas_limit: U256::from(0x5207),
 					action: ethereum::TransactionAction::Call(bob.address),
 					value: U256::from(1),
-					input: vec![],
+					input:
+						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+							vec![]
+						)
+						.unwrap(),
 					access_list: None,
 				}),
 			),
@@ -357,7 +368,8 @@ fn test_global_nonce_not_incr() {
 			gas_limit: U256::one(),
 			action: ethereum::TransactionAction::Call(bob.address),
 			value: U256::one(),
-			input: vec![],
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+				.unwrap(),
 			access_list: None,
 		});
 

--- a/pallets/ethereum-xcm/src/tests/v2.rs
+++ b/pallets/ethereum-xcm/src/tests/v2.rs
@@ -17,7 +17,9 @@ use crate::{mock::*, RawOrigin};
 use ethereum_types::{H160, U256};
 use frame_support::{
 	assert_noop, assert_ok,
+	traits::ConstU32,
 	weights::{Pays, PostDispatchInfo},
+	BoundedVec,
 };
 use sp_runtime::{DispatchError, DispatchErrorWithPostInfo};
 use xcm_primitives::{EthereumXcmTransaction, EthereumXcmTransactionV2};
@@ -46,7 +48,8 @@ fn xcm_evm_transfer_eip_1559_transaction(destination: H160, value: U256) -> Ethe
 		gas_limit: U256::from(0x5208),
 		action: ethereum::TransactionAction::Call(destination),
 		value,
-		input: vec![],
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+			.unwrap(),
 		access_list: None,
 	})
 }
@@ -56,7 +59,8 @@ fn xcm_evm_call_eip_1559_transaction(destination: H160, input: Vec<u8>) -> Ether
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value: U256::zero(),
-		input,
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(input)
+			.unwrap(),
 		access_list: None,
 	})
 }
@@ -66,7 +70,10 @@ fn xcm_erc20_creation_eip_1559_transaction() -> EthereumXcmTransaction {
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
-		input: hex::decode(CONTRACT).unwrap(),
+		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+			hex::decode(CONTRACT).unwrap(),
+		)
+		.unwrap(),
 		access_list: None,
 	})
 }
@@ -190,7 +197,11 @@ fn test_transact_xcm_validation_works() {
 					gas_limit: U256::from(0x5207),
 					action: ethereum::TransactionAction::Call(bob.address),
 					value: U256::one(),
-					input: vec![],
+					input:
+						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
+							vec![]
+						)
+						.unwrap(),
 					access_list: None,
 				}),
 			),
@@ -339,7 +350,8 @@ fn test_global_nonce_not_incr() {
 			gas_limit: U256::one(),
 			action: ethereum::TransactionAction::Call(bob.address),
 			value: U256::one(),
-			input: vec![],
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+				.unwrap(),
 			access_list: None,
 		});
 

--- a/pallets/ethereum-xcm/src/tests/v2.rs
+++ b/pallets/ethereum-xcm/src/tests/v2.rs
@@ -48,7 +48,10 @@ fn xcm_evm_transfer_eip_1559_transaction(destination: H160, value: U256) -> Ethe
 		gas_limit: U256::from(0x5208),
 		action: ethereum::TransactionAction::Call(destination),
 		value,
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+		input:
+			BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
+				vec![],
+			)
 			.unwrap(),
 		access_list: None,
 	})
@@ -59,7 +62,10 @@ fn xcm_evm_call_eip_1559_transaction(destination: H160, input: Vec<u8>) -> Ether
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Call(destination),
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(input)
+		input:
+			BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
+				input,
+			)
 			.unwrap(),
 		access_list: None,
 	})
@@ -70,10 +76,11 @@ fn xcm_erc20_creation_eip_1559_transaction() -> EthereumXcmTransaction {
 		gas_limit: U256::from(0x100000),
 		action: ethereum::TransactionAction::Create,
 		value: U256::zero(),
-		input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
-			hex::decode(CONTRACT).unwrap(),
-		)
-		.unwrap(),
+		input:
+			BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(
+				hex::decode(CONTRACT).unwrap(),
+			)
+			.unwrap(),
 		access_list: None,
 	})
 }
@@ -197,11 +204,11 @@ fn test_transact_xcm_validation_works() {
 					gas_limit: U256::from(0x5207),
 					action: ethereum::TransactionAction::Call(bob.address),
 					value: U256::one(),
-					input:
-						BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(
-							vec![]
-						)
-						.unwrap(),
+					input: BoundedVec::<
+						u8,
+						ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>,
+					>::try_from(vec![])
+					.unwrap(),
 					access_list: None,
 				}),
 			),
@@ -346,14 +353,20 @@ fn test_global_nonce_not_incr() {
 	ext.execute_with(|| {
 		assert_eq!(EthereumXcm::nonce(), U256::zero());
 
-		let invalid_transaction_cost = EthereumXcmTransaction::V2(EthereumXcmTransactionV2 {
-			gas_limit: U256::one(),
-			action: ethereum::TransactionAction::Call(bob.address),
-			value: U256::one(),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
-				.unwrap(),
-			access_list: None,
-		});
+		let invalid_transaction_cost =
+			EthereumXcmTransaction::V2(
+				EthereumXcmTransactionV2 {
+					gas_limit: U256::one(),
+					action: ethereum::TransactionAction::Call(bob.address),
+					value: U256::one(),
+					input: BoundedVec::<
+						u8,
+						ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>,
+					>::try_from(vec![])
+					.unwrap(),
+					access_list: None,
+				},
+			);
 
 		EthereumXcm::transact(
 			RawOrigin::XcmEthereumTransaction(alice.address).into(),

--- a/primitives/xcm/src/ethereum_xcm.rs
+++ b/primitives/xcm/src/ethereum_xcm.rs
@@ -19,10 +19,10 @@ use ethereum::{
 	TransactionAction, TransactionSignature, TransactionV2,
 };
 use ethereum_types::{H160, H256, U256};
+use frame_support::{traits::ConstU32, BoundedVec};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_std::vec::Vec;
-use frame_support::{BoundedVec, traits::ConstU32};
 
 /// Max. allowed size of 65_536 bytes.
 pub const MAX_INPUT_SIZE: u32 = 2u32.pow(16);
@@ -74,7 +74,7 @@ pub struct EthereumXcmTransactionV1 {
 	pub action: TransactionAction,
 	/// Value to be transfered.
 	pub value: U256,
-	/// Input data for a contract call. 
+	/// Input data for a contract call.
 	pub input: BoundedVec<u8, ConstU32<MAX_INPUT_SIZE>>,
 	/// Map of addresses to be pre-paid to warm storage.
 	pub access_list: Option<Vec<(H160, Vec<H256>)>>,

--- a/primitives/xcm/src/ethereum_xcm.rs
+++ b/primitives/xcm/src/ethereum_xcm.rs
@@ -22,6 +22,10 @@ use ethereum_types::{H160, H256, U256};
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sp_std::vec::Vec;
+use frame_support::{BoundedVec, traits::ConstU32};
+
+/// Max. allowed size of 65_536 bytes.
+pub const MAX_INPUT_SIZE: u32 = 2u32.pow(16);
 
 /// Ensure that a proxy between `delegator` and `delegatee` exists in order to deny or grant
 /// permission to do xcm-transact to `transact_through_proxy`.
@@ -70,8 +74,8 @@ pub struct EthereumXcmTransactionV1 {
 	pub action: TransactionAction,
 	/// Value to be transfered.
 	pub value: U256,
-	/// Input data for a contract call.
-	pub input: Vec<u8>,
+	/// Input data for a contract call. 
+	pub input: BoundedVec<u8, ConstU32<MAX_INPUT_SIZE>>,
 	/// Map of addresses to be pre-paid to warm storage.
 	pub access_list: Option<Vec<(H160, Vec<H256>)>>,
 }
@@ -84,8 +88,8 @@ pub struct EthereumXcmTransactionV2 {
 	pub action: TransactionAction,
 	/// Value to be transfered.
 	pub value: U256,
-	/// Input data for a contract call.
-	pub input: Vec<u8>,
+	/// Input data for a contract call. Max. size 65_536 bytes.
+	pub input: BoundedVec<u8, ConstU32<MAX_INPUT_SIZE>>,
 	/// Map of addresses to be pre-paid to warm storage.
 	pub access_list: Option<Vec<(H160, Vec<H256>)>>,
 }
@@ -136,7 +140,7 @@ impl XcmToEthereum for EthereumXcmTransactionV1 {
 						gas_limit: self.gas_limit,
 						action: self.action,
 						value: self.value,
-						input: self.input.clone(),
+						input: self.input.to_vec(),
 						access_list: from_tuple_to_access_list(access_list),
 						odd_y_parity: true,
 						r: rs_id(),
@@ -150,7 +154,7 @@ impl XcmToEthereum for EthereumXcmTransactionV1 {
 						gas_limit: self.gas_limit,
 						action: self.action,
 						value: self.value,
-						input: self.input.clone(),
+						input: self.input.to_vec(),
 						signature: TransactionSignature::new(42, rs_id(), rs_id())?,
 					}))
 				}
@@ -165,7 +169,7 @@ impl XcmToEthereum for EthereumXcmTransactionV1 {
 					gas_limit: self.gas_limit,
 					action: self.action,
 					value: self.value,
-					input: self.input.clone(),
+					input: self.input.to_vec(),
 					access_list: if let Some(ref access_list) = self.access_list {
 						from_tuple_to_access_list(access_list)
 					} else {
@@ -204,7 +208,7 @@ impl XcmToEthereum for EthereumXcmTransactionV2 {
 			gas_limit: self.gas_limit,
 			action: self.action,
 			value: self.value,
-			input: self.input.clone(),
+			input: self.input.to_vec(),
 			access_list: if let Some(ref access_list) = self.access_list {
 				from_tuple_to_access_list(access_list)
 			} else {
@@ -227,7 +231,7 @@ mod tests {
 			fee_payment: EthereumXcmFee::Auto,
 			action: TransactionAction::Call(H160::default()),
 			value: U256::zero(),
-			input: vec![1u8],
+			input: BoundedVec::<u8, ConstU32<MAX_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
 			access_list: None,
 		};
 		let nonce = U256::zero();
@@ -259,7 +263,7 @@ mod tests {
 			}),
 			action: TransactionAction::Call(H160::default()),
 			value: U256::zero(),
-			input: vec![1u8],
+			input: BoundedVec::<u8, ConstU32<MAX_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
 			access_list: None,
 		};
 		let nonce = U256::zero();
@@ -295,7 +299,7 @@ mod tests {
 			}),
 			action: TransactionAction::Call(H160::default()),
 			value: U256::zero(),
-			input: vec![1u8],
+			input: BoundedVec::<u8, ConstU32<MAX_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
 			access_list: access_list.clone(),
 		};
 
@@ -323,7 +327,7 @@ mod tests {
 			gas_limit: U256::one(),
 			action: TransactionAction::Call(H160::default()),
 			value: U256::zero(),
-			input: vec![1u8],
+			input: BoundedVec::<u8, ConstU32<MAX_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
 			access_list: None,
 		};
 		let nonce = U256::zero();

--- a/primitives/xcm/src/ethereum_xcm.rs
+++ b/primitives/xcm/src/ethereum_xcm.rs
@@ -231,7 +231,8 @@ mod tests {
 			fee_payment: EthereumXcmFee::Auto,
 			action: TransactionAction::Call(H160::default()),
 			value: U256::zero(),
-			input: BoundedVec::<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
+			input: BoundedVec::<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>::try_from(vec![1u8])
+				.unwrap(),
 			access_list: None,
 		};
 		let nonce = U256::zero();
@@ -263,7 +264,8 @@ mod tests {
 			}),
 			action: TransactionAction::Call(H160::default()),
 			value: U256::zero(),
-			input: BoundedVec::<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
+			input: BoundedVec::<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>::try_from(vec![1u8])
+				.unwrap(),
 			access_list: None,
 		};
 		let nonce = U256::zero();
@@ -299,7 +301,8 @@ mod tests {
 			}),
 			action: TransactionAction::Call(H160::default()),
 			value: U256::zero(),
-			input: BoundedVec::<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
+			input: BoundedVec::<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>::try_from(vec![1u8])
+				.unwrap(),
 			access_list: access_list.clone(),
 		};
 
@@ -327,7 +330,8 @@ mod tests {
 			gas_limit: U256::one(),
 			action: TransactionAction::Call(H160::default()),
 			value: U256::zero(),
-			input: BoundedVec::<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
+			input: BoundedVec::<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>::try_from(vec![1u8])
+				.unwrap(),
 			access_list: None,
 		};
 		let nonce = U256::zero();

--- a/primitives/xcm/src/ethereum_xcm.rs
+++ b/primitives/xcm/src/ethereum_xcm.rs
@@ -25,7 +25,7 @@ use scale_info::TypeInfo;
 use sp_std::vec::Vec;
 
 /// Max. allowed size of 65_536 bytes.
-pub const MAX_INPUT_SIZE: u32 = 2u32.pow(16);
+pub const MAX_ETHEREUM_XCM_INPUT_SIZE: u32 = 2u32.pow(16);
 
 /// Ensure that a proxy between `delegator` and `delegatee` exists in order to deny or grant
 /// permission to do xcm-transact to `transact_through_proxy`.
@@ -75,7 +75,7 @@ pub struct EthereumXcmTransactionV1 {
 	/// Value to be transfered.
 	pub value: U256,
 	/// Input data for a contract call.
-	pub input: BoundedVec<u8, ConstU32<MAX_INPUT_SIZE>>,
+	pub input: BoundedVec<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>,
 	/// Map of addresses to be pre-paid to warm storage.
 	pub access_list: Option<Vec<(H160, Vec<H256>)>>,
 }
@@ -89,7 +89,7 @@ pub struct EthereumXcmTransactionV2 {
 	/// Value to be transfered.
 	pub value: U256,
 	/// Input data for a contract call. Max. size 65_536 bytes.
-	pub input: BoundedVec<u8, ConstU32<MAX_INPUT_SIZE>>,
+	pub input: BoundedVec<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>,
 	/// Map of addresses to be pre-paid to warm storage.
 	pub access_list: Option<Vec<(H160, Vec<H256>)>>,
 }
@@ -231,7 +231,7 @@ mod tests {
 			fee_payment: EthereumXcmFee::Auto,
 			action: TransactionAction::Call(H160::default()),
 			value: U256::zero(),
-			input: BoundedVec::<u8, ConstU32<MAX_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
+			input: BoundedVec::<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
 			access_list: None,
 		};
 		let nonce = U256::zero();
@@ -263,7 +263,7 @@ mod tests {
 			}),
 			action: TransactionAction::Call(H160::default()),
 			value: U256::zero(),
-			input: BoundedVec::<u8, ConstU32<MAX_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
+			input: BoundedVec::<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
 			access_list: None,
 		};
 		let nonce = U256::zero();
@@ -299,7 +299,7 @@ mod tests {
 			}),
 			action: TransactionAction::Call(H160::default()),
 			value: U256::zero(),
-			input: BoundedVec::<u8, ConstU32<MAX_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
+			input: BoundedVec::<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
 			access_list: access_list.clone(),
 		};
 
@@ -327,7 +327,7 @@ mod tests {
 			gas_limit: U256::one(),
 			action: TransactionAction::Call(H160::default()),
 			value: U256::zero(),
-			input: BoundedVec::<u8, ConstU32<MAX_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
+			input: BoundedVec::<u8, ConstU32<MAX_ETHEREUM_XCM_INPUT_SIZE>>::try_from(vec![1u8]).unwrap(),
 			access_list: None,
 		};
 		let nonce = U256::zero();

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -19,7 +19,7 @@
 mod xcm_mock;
 use frame_support::{
 	assert_ok,
-	traits::{PalletInfo, PalletInfoAccess, ConstU32},
+	traits::{ConstU32, PalletInfo, PalletInfoAccess},
 	weights::constants::WEIGHT_PER_SECOND,
 	BoundedVec,
 };
@@ -2870,7 +2870,8 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 			fee_payment: xcm_primitives::EthereumXcmFee::Auto,
 			action: pallet_ethereum::TransactionAction::Call(PARAALICE.into()),
 			value: U256::from(100),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![]).unwrap(),
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+				.unwrap(),
 			access_list: None,
 		});
 
@@ -2993,7 +2994,8 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 			fee_payment: xcm_primitives::EthereumXcmFee::Auto,
 			action: pallet_ethereum::TransactionAction::Call(PARAALICE.into()),
 			value: U256::from(100),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![]).unwrap(),
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+				.unwrap(),
 			access_list: None,
 		});
 
@@ -3120,7 +3122,8 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 			gas_limit: U256::from(21000),
 			action: pallet_ethereum::TransactionAction::Call(transfer_recipient.into()),
 			value: U256::from(100),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![]).unwrap(),
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+				.unwrap(),
 			access_list: None,
 		});
 

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -2870,7 +2870,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 			fee_payment: xcm_primitives::EthereumXcmFee::Auto,
 			action: pallet_ethereum::TransactionAction::Call(PARAALICE.into()),
 			value: U256::from(100),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
 				.unwrap(),
 			access_list: None,
 		});
@@ -2994,7 +2994,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 			fee_payment: xcm_primitives::EthereumXcmFee::Auto,
 			action: pallet_ethereum::TransactionAction::Call(PARAALICE.into()),
 			value: U256::from(100),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
 				.unwrap(),
 			access_list: None,
 		});
@@ -3122,7 +3122,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 			gas_limit: U256::from(21000),
 			action: pallet_ethereum::TransactionAction::Call(transfer_recipient.into()),
 			value: U256::from(100),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![])
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
 				.unwrap(),
 			access_list: None,
 		});

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -2870,8 +2870,10 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 			fee_payment: xcm_primitives::EthereumXcmFee::Auto,
 			action: pallet_ethereum::TransactionAction::Call(PARAALICE.into()),
 			value: U256::from(100),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
-				.unwrap(),
+			input: BoundedVec::<
+				u8,
+				ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>
+			>::try_from(vec![]).unwrap(),
 			access_list: None,
 		});
 
@@ -2994,8 +2996,10 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 			fee_payment: xcm_primitives::EthereumXcmFee::Auto,
 			action: pallet_ethereum::TransactionAction::Call(PARAALICE.into()),
 			value: U256::from(100),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
-				.unwrap(),
+			input: BoundedVec::<
+				u8,
+				ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>
+			>::try_from(vec![]).unwrap(),
 			access_list: None,
 		});
 
@@ -3122,8 +3126,10 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 			gas_limit: U256::from(21000),
 			action: pallet_ethereum::TransactionAction::Call(transfer_recipient.into()),
 			value: U256::from(100),
-			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>>::try_from(vec![])
-				.unwrap(),
+			input: BoundedVec::<
+				u8,
+				ConstU32<{ xcm_primitives::MAX_ETHEREUM_XCM_INPUT_SIZE }>
+			>::try_from(vec![]).unwrap(),
 			access_list: None,
 		});
 

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -19,8 +19,9 @@
 mod xcm_mock;
 use frame_support::{
 	assert_ok,
-	traits::{PalletInfo, PalletInfoAccess},
+	traits::{PalletInfo, PalletInfoAccess, ConstU32},
 	weights::constants::WEIGHT_PER_SECOND,
+	BoundedVec,
 };
 use pallet_asset_manager::LocalAssetIdCreator;
 use pallet_xcm_transactor::{Currency, CurrencyPayment, TransactWeights};
@@ -2869,7 +2870,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum() {
 			fee_payment: xcm_primitives::EthereumXcmFee::Auto,
 			action: pallet_ethereum::TransactionAction::Call(PARAALICE.into()),
 			value: U256::from(100),
-			input: vec![],
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![]).unwrap(),
 			access_list: None,
 		});
 
@@ -2992,7 +2993,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_no_proxy_fails() 
 			fee_payment: xcm_primitives::EthereumXcmFee::Auto,
 			action: pallet_ethereum::TransactionAction::Call(PARAALICE.into()),
 			value: U256::from(100),
-			input: vec![],
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![]).unwrap(),
 			access_list: None,
 		});
 
@@ -3119,7 +3120,7 @@ fn transact_through_signed_multilocation_para_to_para_ethereum_proxy_succeeds() 
 			gas_limit: U256::from(21000),
 			action: pallet_ethereum::TransactionAction::Call(transfer_recipient.into()),
 			value: U256::from(100),
-			input: vec![],
+			input: BoundedVec::<u8, ConstU32<{ xcm_primitives::MAX_INPUT_SIZE }>>::try_from(vec![]).unwrap(),
 			access_list: None,
 		});
 

--- a/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
@@ -3,8 +3,10 @@ import "@moonbeam-network/api-augment";
 import { KeyringPair } from "@polkadot/keyring/types";
 import { BN } from "@polkadot/util";
 import { expect } from "chai";
+import { ethers } from "ethers";
 
 import { alith, charleth, generateKeyringPair } from "../../util/accounts";
+import { getCompiled } from "../../util/contracts";
 import {
   descendOriginFromAddress,
   registerForeignAsset,
@@ -877,6 +879,254 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
       // Make sure derived / descended account nonce still zero.
       const derivedAccountNonce = await context.web3.eth.getTransactionCount(descendAddress);
       expect(derivedAccountNonce).to.eq(0);
+    }
+  });
+});
+
+describeDevMoonbeam("Mock XCM - transact ETHEREUM input size check succeeds", (context) => {
+  let transferredBalance;
+  let sendingAddress;
+  let contractDeployed;
+
+  before("should deploy CallForwarder contract and fund", async function () {
+    const { contract, rawTx } = await createContract(context, "CallForwarder");
+    await expectOk(context.createBlock(rawTx));
+
+    contractDeployed = contract;
+
+    const { originAddress, descendOriginAddress } = descendOriginFromAddress(context);
+    sendingAddress = originAddress;
+    transferredBalance = 10_000_000_000_000_000_000n;
+
+    // We first fund parachain 2000 sovreign account
+    await expectOk(
+      context.createBlock(
+        context.polkadotApi.tx.balances.transfer(descendOriginAddress, transferredBalance)
+      )
+    );
+    const balance = (
+      (await context.polkadotApi.query.system.account(descendOriginAddress)) as any
+    ).data.free.toBigInt();
+    expect(balance).to.eq(transferredBalance);
+  });
+
+  it("should succeed to call the contract", async function () {
+    // Get Pallet balances index
+    const metadata = await context.polkadotApi.rpc.state.getMetadata();
+    const balancesPalletIndex = (metadata.asLatest.toHuman().pallets as Array<any>).find(
+      (pallet) => {
+        return pallet.name === "Balances";
+      }
+    ).index;
+
+    const proxyInterface = new ethers.utils.Interface(getCompiled("CallForwarder").contract.abi);
+    // Matches the BoundedVec limit in the runtime.
+    const CALL_INPUT_SIZE_LIMIT = Math.pow(2, 16);
+
+    const xcmTransactions = [
+      {
+        V1: {
+          gas_limit: 1000000,
+          fee_payment: {
+            Auto: {
+              Low: null,
+            },
+          },
+          action: {
+            Call: contractDeployed.options.address,
+          },
+          value: 0n,
+          input: proxyInterface.encodeFunctionData("call", [
+            "0x0000000000000000000000000000000000000001",
+            context.web3.utils.bytesToHex(new Array(CALL_INPUT_SIZE_LIMIT - 128).fill(0)),
+          ]),
+          access_list: null,
+        },
+      },
+      {
+        V2: {
+          gas_limit: 1000000,
+          action: {
+            Call: contractDeployed.options.address,
+          },
+          value: 0n,
+          input: proxyInterface.encodeFunctionData("call", [
+            "0x0000000000000000000000000000000000000001",
+            context.web3.utils.bytesToHex(new Array(CALL_INPUT_SIZE_LIMIT - 128).fill(0)),
+          ]),
+          access_list: null,
+        },
+      },
+    ];
+
+    for (const xcmTransaction of xcmTransactions) {
+      const transferCall = context.polkadotApi.tx.ethereumXcm.transact(xcmTransaction as any);
+      const transferCallEncoded = transferCall?.method.toHex();
+      // We are going to test that we can receive a transact operation from parachain 1
+      // using descendOrigin first
+      const xcmMessage = new XcmFragment({
+        fees: {
+          multilocation: [
+            {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
+              },
+            },
+          ],
+          fungible: transferredBalance / 2n,
+        },
+        weight_limit: new BN(40000000000),
+        descend_origin: sendingAddress,
+      })
+        .descend_origin()
+        .withdraw_asset()
+        .buy_execution()
+        .push_any({
+          Transact: {
+            originType: "SovereignAccount",
+            requireWeightAtMost: new BN(30000000000),
+            call: {
+              encoded: transferCallEncoded,
+            },
+          },
+        })
+        .as_v2();
+
+      // Send an XCM and create block to execute it
+      await injectHrmpMessageAndSeal(context, 1, {
+        type: "XcmVersionedXcm",
+        payload: xcmMessage,
+      } as RawXcmMessage);
+
+      const block = await context.web3.eth.getBlock("latest");
+      // Input size is valid - on the limit -, expect block to include a transaction.
+      // That means the pallet-ethereum-xcm decoded the provided input to a BoundedVec.
+      expect(block.transactions.length).to.be.eq(1);
+    }
+  });
+});
+
+describeDevMoonbeam("Mock XCM - transact ETHEREUM input size check fails", (context) => {
+  let transferredBalance;
+  let sendingAddress;
+  let contractDeployed;
+
+  before("should deploy CallForwarder contract and fund", async function () {
+    const { contract, rawTx } = await createContract(context, "CallForwarder");
+    await expectOk(context.createBlock(rawTx));
+
+    contractDeployed = contract;
+
+    const { originAddress, descendOriginAddress } = descendOriginFromAddress(context);
+    sendingAddress = originAddress;
+    transferredBalance = 10_000_000_000_000_000_000n;
+
+    // We first fund parachain 2000 sovreign account
+    await expectOk(
+      context.createBlock(
+        context.polkadotApi.tx.balances.transfer(descendOriginAddress, transferredBalance)
+      )
+    );
+    const balance = (
+      (await context.polkadotApi.query.system.account(descendOriginAddress)) as any
+    ).data.free.toBigInt();
+    expect(balance).to.eq(transferredBalance);
+  });
+
+  it("should fail to call the contract due to BoundedVec restriction", async function () {
+    // Get Pallet balances index
+    const metadata = await context.polkadotApi.rpc.state.getMetadata();
+    const balancesPalletIndex = (metadata.asLatest.toHuman().pallets as Array<any>).find(
+      (pallet) => {
+        return pallet.name === "Balances";
+      }
+    ).index;
+
+    const proxyInterface = new ethers.utils.Interface(getCompiled("CallForwarder").contract.abi);
+    // Matches the BoundedVec limit in the runtime.
+    const CALL_INPUT_SIZE_LIMIT = Math.pow(2, 16);
+
+    const xcmTransactions = [
+      {
+        V1: {
+          gas_limit: 1000000,
+          fee_payment: {
+            Auto: {
+              Low: null,
+            },
+          },
+          action: {
+            Call: contractDeployed.options.address,
+          },
+          value: 0n,
+          input: proxyInterface.encodeFunctionData("call", [
+            "0x0000000000000000000000000000000000000001",
+            context.web3.utils.bytesToHex(new Array(CALL_INPUT_SIZE_LIMIT - 127).fill(0)),
+          ]),
+          access_list: null,
+        },
+      },
+      {
+        V2: {
+          gas_limit: 1000000,
+          action: {
+            Call: contractDeployed.options.address,
+          },
+          value: 0n,
+          input: proxyInterface.encodeFunctionData("call", [
+            "0x0000000000000000000000000000000000000001",
+            context.web3.utils.bytesToHex(new Array(CALL_INPUT_SIZE_LIMIT - 127).fill(0)),
+          ]),
+          access_list: null,
+        },
+      },
+    ];
+
+    for (const xcmTransaction of xcmTransactions) {
+      const transferCall = context.polkadotApi.tx.ethereumXcm.transact(xcmTransaction as any);
+      const transferCallEncoded = transferCall?.method.toHex();
+      // We are going to test that we can receive a transact operation from parachain 1
+      // using descendOrigin first
+      const xcmMessage = new XcmFragment({
+        fees: {
+          multilocation: [
+            {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
+              },
+            },
+          ],
+          fungible: transferredBalance / 2n,
+        },
+        weight_limit: new BN(40000000000),
+        descend_origin: sendingAddress,
+      })
+        .descend_origin()
+        .withdraw_asset()
+        .buy_execution()
+        .push_any({
+          Transact: {
+            originType: "SovereignAccount",
+            requireWeightAtMost: new BN(30000000000),
+            call: {
+              encoded: transferCallEncoded,
+            },
+          },
+        })
+        .as_v2();
+
+      // Send an XCM and create block to execute it
+      await injectHrmpMessageAndSeal(context, 1, {
+        type: "XcmVersionedXcm",
+        payload: xcmMessage,
+      } as RawXcmMessage);
+
+      const block = await context.web3.eth.getBlock("latest");
+      // Input size is invalid by 1 byte, expect block to not include a transaction.
+      // That means the pallet-ethereum-xcm couldn't decode the provided input to a BoundedVec.
+      expect(block.transactions.length).to.be.eq(0);
     }
   });
 });


### PR DESCRIPTION
### What does it do?

This PR substitutes the `EthereumXcmTransaction` `input` field type from `Vec` to `BoundedVec` to limit the call data allowed size.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
