### PR TITLE
Fix Ethereum post-dispatch weight

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,7 +2398,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "async-trait",
  "fc-db",
@@ -2417,7 +2417,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "fp-storage",
  "kvdb-rocksdb",
@@ -2433,7 +2433,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "fc-db",
  "fp-consensus",
@@ -2450,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2630,7 +2630,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "evm",
  "frame-support",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2686,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -2700,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6592,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6779,7 +6779,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -6848,7 +6848,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "evm",
  "fp-evm",
@@ -6955,7 +6955,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "fp-evm",
 ]
@@ -6963,7 +6963,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7090,7 +7090,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7100,7 +7100,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "fp-evm",
  "num",
@@ -7221,7 +7221,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -7230,7 +7230,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#80053f00081a8979ec65bc0c8eb98bb4810d4364"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.26#5b682d436b0484d63fe6cbd333af4094930c7c18"
 dependencies = [
  "fp-evm",
  "ripemd",

--- a/tests/tests/test-eth-fee/test-eth-txn-weights.ts
+++ b/tests/tests/test-eth-fee/test-eth-txn-weights.ts
@@ -29,8 +29,8 @@ describeDevMoonbeamAllEthTxTypes("Ethereum Weight Accounting", (context) => {
       nonce: await context.web3.eth.getTransactionCount(alith.address),
     });
 
-    // TODO: tweak, also derive from gas used * gas_to_weight
-    const expected_weight = 525_000_000;
+    // TODO: tweak: this includes some priority fee. it would be more clear without this.
+    const expected_weight = 1_575_000_000;
 
     const { block } = await context.createBlock(tx);
 

--- a/tests/tests/test-eth-fee/test-eth-txn-weights.ts
+++ b/tests/tests/test-eth-fee/test-eth-txn-weights.ts
@@ -1,0 +1,44 @@
+import "@moonbeam-network/api-augment";
+
+import { expect } from "chai";
+import { ethers } from "ethers";
+
+import { alith, ALITH_PRIVATE_KEY } from "../../util/accounts";
+import { getCompiled } from "../../util/contracts";
+import { customWeb3Request } from "../../util/providers";
+import { describeDevMoonbeamAllEthTxTypes, DevTestContext } from "../../util/setup-dev-tests";
+import { EXTRINSIC_GAS_LIMIT } from "../../util/constants";
+
+// This tests an issue where pallet Ethereum in Frontier does not properly account for weight after
+// transaction application. Specifically, it accounts for weight before a transaction by multiplying
+// GasToWeight by gas_price, but does not adjust this afterwards. This leads to accounting for too
+// much weight in a block.
+describeDevMoonbeamAllEthTxTypes("Ethereum Weight Accounting", (context) => {
+  it("should account for weight used", async function () {
+    this.timeout(10000);
+
+    let signer = new ethers.Wallet(ALITH_PRIVATE_KEY, context.ethers);
+
+    let tx = await signer.signTransaction({
+      from: alith.address,
+      to: null,
+      value: "0x0",
+      gasLimit: EXTRINSIC_GAS_LIMIT,
+      gasPrice: 1_000_000_000,
+      data: null,
+      nonce: await context.web3.eth.getTransactionCount(alith.address),
+    });
+
+    // TODO: tweak, also derive from gas used * gas_to_weight
+    const expected_weight = 525_000_000;
+
+    const { block } = await context.createBlock(tx);
+
+    const apiAt = await context.polkadotApi.at(block.hash);
+
+    let blockWeightsUsed = await apiAt.query.system.blockWeight();
+    let normalWeight = blockWeightsUsed.normal;
+
+    expect(normalWeight.toNumber()).to.equal(expected_weight);
+  });
+});


### PR DESCRIPTION
### What does it do?

Bumps frontier to include fixes for post-dispatch weight accounting. See the related upstream PR for more details: https://github.com/paritytech/frontier/pull/851

Also adds a typescript regression test.