### PR TITLE
Improve frontier weight test

### DIFF
--- a/tests/tests/test-eth-fee/test-eth-txn-weights.ts
+++ b/tests/tests/test-eth-fee/test-eth-txn-weights.ts
@@ -1,44 +1,45 @@
 import "@moonbeam-network/api-augment";
 
 import { expect } from "chai";
-import { ethers } from "ethers";
 
-import { alith, ALITH_PRIVATE_KEY } from "../../util/accounts";
+import { alith, ALITH_PRIVATE_KEY, baltathar } from "../../util/accounts";
 import { getCompiled } from "../../util/contracts";
 import { customWeb3Request } from "../../util/providers";
-import { describeDevMoonbeamAllEthTxTypes, DevTestContext } from "../../util/setup-dev-tests";
-import { EXTRINSIC_GAS_LIMIT } from "../../util/constants";
+import { describeDevMoonbeam, DevTestContext } from "../../util/setup-dev-tests";
+import { EXTRINSIC_GAS_LIMIT, EXTRINSIC_BASE_WEIGHT, WEIGHT_PER_GAS } from "../../util/constants";
+import { createTransaction, ALITH_TRANSACTION_TEMPLATE } from "../../util/transactions";
 
 // This tests an issue where pallet Ethereum in Frontier does not properly account for weight after
 // transaction application. Specifically, it accounts for weight before a transaction by multiplying
 // GasToWeight by gas_price, but does not adjust this afterwards. This leads to accounting for too
 // much weight in a block.
-describeDevMoonbeamAllEthTxTypes("Ethereum Weight Accounting", (context) => {
+describeDevMoonbeam("Ethereum Weight Accounting", (context) => {
   it("should account for weight used", async function () {
     this.timeout(10000);
 
-    let signer = new ethers.Wallet(ALITH_PRIVATE_KEY, context.ethers);
+    const { block, result } = await context.createBlock(
+      createTransaction(context, {
+        ...ALITH_TRANSACTION_TEMPLATE,
+        gas: EXTRINSIC_GAS_LIMIT,
+        maxFeePerGas: 1_000_000_000,
+        maxPriorityFeePerGas: 0,
+        to: baltathar.address,
+        data: null,
+      })
+    );
 
-    let tx = await signer.signTransaction({
-      from: alith.address,
-      to: null,
-      value: "0x0",
-      gasLimit: EXTRINSIC_GAS_LIMIT,
-      gasPrice: 1_000_000_000,
-      data: null,
-      nonce: await context.web3.eth.getTransactionCount(alith.address),
-    });
+    const EXPECTED_GAS_USED = 21_000n;
+    const EXPECTED_WEIGHT = EXPECTED_GAS_USED * WEIGHT_PER_GAS + BigInt(EXTRINSIC_BASE_WEIGHT);
 
-    // TODO: tweak: this includes some priority fee. it would be more clear without this.
-    const expected_weight = 1_575_000_000;
+    const receipt = await context.web3.eth.getTransactionReceipt(result.hash);
+    expect(BigInt(receipt.gasUsed)).to.equal(EXPECTED_GAS_USED);
 
-    const { block } = await context.createBlock(tx);
-
+    // query the block's weight, whose normal portion should reflect only this txn
     const apiAt = await context.polkadotApi.at(block.hash);
 
     let blockWeightsUsed = await apiAt.query.system.blockWeight();
     let normalWeight = blockWeightsUsed.normal;
 
-    expect(normalWeight.toNumber()).to.equal(expected_weight);
+    expect(normalWeight.toBigInt()).to.equal(EXPECTED_WEIGHT);
   });
 });

--- a/tests/util/constants.ts
+++ b/tests/util/constants.ts
@@ -40,8 +40,8 @@ export const BLOCK_TX_LIMIT = GAS_PER_SECOND * 0.5;
 
 // Current implementation is limiting block transactions to 75% of the block gas limit
 export const BLOCK_TX_GAS_LIMIT = BLOCK_TX_LIMIT * 0.75;
-// 400_000_000 Weight per extrinsics
-export const EXTRINSIC_BASE_COST = 250_000_000 / GAS_PER_WEIGHT;
+export const EXTRINSIC_BASE_WEIGHT = 250_000_000;
+export const EXTRINSIC_BASE_COST = EXTRINSIC_BASE_WEIGHT / GAS_PER_WEIGHT;
 
 // Maximum extrinsic weight is taken from the max allowed transaction weight per block,
 // minus the block initialization (10%) and minus the extrinsic base cost.


### PR DESCRIPTION
### What does it do?

Improves the Frontier weight test from #1807, mostly by removing magic numbers.

Note also, though, that it demonstrates that we are including Substrate's `extrinsic_base_weight` to the transaction, which we don't want to do.