### PR TITLE
fix bug in calculation of totalBondReward

### DIFF
--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -222,10 +222,14 @@ async function assertRewardsAt(api: ApiPromise, nowBlockNumber: number) {
   ).to.be.true;
 
   debug(`totalRoundIssuance            ${totalRoundIssuance.toString()}
-reservedForParachainBond      ${reservedForParachainBond} (${parachainBondPercent} * totalRoundIssuance)
-totalCollatorCommissionReward ${totalCollatorCommissionReward.toString()} (${collatorCommissionRate} * totalRoundIssuance)
-totalStakingReward            ${totalStakingReward} (totalRoundIssuance - reservedForParachainBond)
-totalBondReward               ${totalBondReward} (totalStakingReward - totalCollatorCommissionReward)`);
+reservedForParachainBond      ${reservedForParachainBond} \
+(${parachainBondPercent} * totalRoundIssuance)
+totalCollatorCommissionReward ${totalCollatorCommissionReward.toString()} \
+(${collatorCommissionRate} * totalRoundIssuance)
+totalStakingReward            ${totalStakingReward} \
+(totalRoundIssuance - reservedForParachainBond)
+totalBondReward               ${totalBondReward} \
+(totalStakingReward - totalCollatorCommissionReward)`);
 
   // get the collators to be awarded via `awardedPts` storage
   const awardedCollators = (


### PR DESCRIPTION
### What does it do?
fixes bug in calculation of `totalBondReward` where it was calculated from `totalIssuance` instead of `totalStakingReward`.

```
totalStakingReward = totalIssuance - reservedForParachainBond
totalBondReward    = totalStakingReward - totalCollatorCommissionReward
```
As a result the test would fail when `reservedForParachainBond` would be non zero.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
