### PR TITLE
Fix blockWeights access in smoke test

### DIFF
--- a/tests/smoke-tests/test-relay-xcm-fees.ts
+++ b/tests/smoke-tests/test-relay-xcm-fees.ts
@@ -75,8 +75,12 @@ describeSmokeSuite(`Verify XCM weight fees for relay`, { wssUrl, relayWssUrl }, 
         : units / 100n;
     const coef = cent / 10n;
 
-    const relayBaseWeight =
-        relayApiAt.consts.system.blockWeights.perClass.normal.baseExtrinsic.toBigInt();
+    // the blockWeights structure has been modified around 9300 to include reftime.
+    const relayBaseExtrinsic = relayApiAt.consts.system.blockWeights.perClass.normal
+      .baseExtrinsic as any;
+    const relayBaseWeight = relayBaseExtrinsic.refTime
+      ? relayBaseExtrinsic.refTime.toBigInt()
+      : relayBaseExtrinsic.toBigInt();
 
     const expectedFeePerSecond = (coef * seconds) / relayBaseWeight;
 

--- a/tests/smoke-tests/test-relay-xcm-fees.ts
+++ b/tests/smoke-tests/test-relay-xcm-fees.ts
@@ -76,11 +76,7 @@ describeSmokeSuite(`Verify XCM weight fees for relay`, { wssUrl, relayWssUrl }, 
     const coef = cent / 10n;
 
     const relayBaseWeight =
-      relayVersion >= 9290
-        ? (
-            relayApiAt.consts.system.blockWeights.perClass.normal.baseExtrinsic as any
-          ).refTime.toBigInt()
-        : relayApiAt.consts.system.blockWeights.perClass.normal.baseExtrinsic.toBigInt();
+        relayApiAt.consts.system.blockWeights.perClass.normal.baseExtrinsic.toBigInt();
 
     const expectedFeePerSecond = (coef * seconds) / relayBaseWeight;
 

--- a/tests/util/common.ts
+++ b/tests/util/common.ts
@@ -4,3 +4,12 @@ export function sortObjectByKeys(o) {
     .sort()
     .reduce((r, k) => ((r[k] = o[k]), r), {});
 }
+
+export function getObjectMethods(obj) {
+  let properties = new Set();
+  let currentObj = obj;
+  do {
+    Object.getOwnPropertyNames(currentObj).map((item) => properties.add(item));
+  } while ((currentObj = Object.getPrototypeOf(currentObj)));
+  return [...properties.keys()].filter((item: any) => typeof obj[item] === "function");
+}


### PR DESCRIPTION
### What does it do?

This is a very blind attempt to fix a smoke test failure related to relay runtimes 9290+.

It seems that after some change in https://github.com/PureStake/moonbeam/pull/1818 the `refTime` reference is no longer necessary.

Take this with a grain of salt: I don't understand the root cause here (yet).