### PR TITLE
Updates polkadot api for moonbeam type bundle

### DIFF
--- a/moonbeam-types-bundle/package.json
+++ b/moonbeam-types-bundle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moonbeam-types-bundle",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Bundled types to instantiate the Polkadot JS api with a Moonbeam network",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
It had a different version that other packages.
I also published to NPM