### PR TITLE
Add non-sc proxy account smoke test

### DIFF
--- a/tests/smoke-tests/test-proxy-consistency.ts
+++ b/tests/smoke-tests/test-proxy-consistency.ts
@@ -71,17 +71,18 @@ describeSmokeSuite(`Verify account proxies created`, { wssUrl, relayWssUrl }, (c
       }
       count += query.length;
 
-      let delegates = [];
+      // let delegates = [];
       // TEMPLATE: convert the data into the format you want (usually a dictionary per account)
       for (const proxyData of query) {
         let accountId = `0x${proxyData[0].toHex().slice(-40)}`;
         last_key = proxyData[0].toString();
         proxiesPerAccount[accountId] = proxyData[1][0].toArray();
-        proxyData[1][0].forEach((item) => delegates.push(item.delegate.toHuman()));
+        // proxyData[1][0].forEach((item) => delegates.push(item.delegate.toHuman()));
+        proxyAccList.push(accountId);
       }
 
       // Remove duplicates
-      proxyAccList = [...new Set(delegates)];
+      // proxyAccList = [...new Set(delegates)];
 
       // Debug logs to make sure it keeps progressing
       // TEMPLATE: Adapt log line
@@ -113,7 +114,7 @@ describeSmokeSuite(`Verify account proxies created`, { wssUrl, relayWssUrl }, (c
     }
 
     // TEMPLATE: Write nice logging for your test if it fails :)
-    if (failedProxies.length > 0){
+    if (failedProxies.length > 0) {
       debug("Failed accounts with too many proxies:");
       debug(
         failedProxies
@@ -125,7 +126,6 @@ describeSmokeSuite(`Verify account proxies created`, { wssUrl, relayWssUrl }, (c
           .join(`\n`)
       );
     }
-  
 
     // Make sure the test fails after we print the errors
     // TEMPLATE: Adapt variable & text
@@ -178,10 +178,10 @@ describeSmokeSuite(`Verify account proxies created`, { wssUrl, relayWssUrl }, (c
     debug(`Verified maximum allowed proxies constant`);
   });
 
-  it("should only be delegated to non-smart contract accounts", async function () {
+  it("should only be possible for proxies of non-smart contract accounts", async function () {
     this.timeout(60000);
 
-    // For each account with a registered proxy, lookup whether its delegates are smart contracts or not
+    // For each account with a registered proxy, check whether it is a non-SC address
     await Promise.all(
       proxyAccList.map(async (address) => {
         const resp = await apiAt.query.evm.accountCodes(address);
@@ -192,7 +192,8 @@ describeSmokeSuite(`Verify account proxies created`, { wssUrl, relayWssUrl }, (c
     ).then((results) => {
       results.forEach((item) => {
         // External accounts aka wallet account aka non-contract address
-        if (item.contract) debug(`Non-external proxy account detected: ${item.address} `);
+        if (item.contract)
+          debug(`Proxy account for non-external address detected: ${item.address} `);
       });
       expect(results.every((item) => item.contract == false)).to.be.true;
     });

--- a/tests/smoke-tests/test-proxy-consistency.ts
+++ b/tests/smoke-tests/test-proxy-consistency.ts
@@ -1,7 +1,7 @@
 import "@moonbeam-network/api-augment";
 import { ApiDecoration } from "@polkadot/api/types";
 import chalk from "chalk";
-import { expect, should } from "chai";
+import { expect } from "chai";
 import { printTokens } from "../util/logging";
 import { describeSmokeSuite } from "../util/setup-smoke-tests";
 
@@ -176,7 +176,7 @@ describeSmokeSuite(`Verify account proxies created`, { wssUrl, relayWssUrl }, (c
     await Promise.all(
       proxyAccList.map(async (address) => {
         const resp = await apiAt.query.evm.accountCodes(address);
-        const contract = resp.toJSON() == "0xX" ? false : true;
+        const contract = resp.toJSON() == "0x" ? false : true;
         // create results array of whether account is contract or not
         return { address, contract };
       })

--- a/tests/smoke-tests/test-proxy-consistency.ts
+++ b/tests/smoke-tests/test-proxy-consistency.ts
@@ -7,7 +7,6 @@ import { describeSmokeSuite } from "../util/setup-smoke-tests";
 
 // TEMPLATE: Remove useless types at the end
 import type { PalletProxyProxyDefinition } from "@polkadot/types/lookup";
-import { ed25519PairFromRandom } from "@polkadot/util-crypto";
 
 // TEMPLATE: Replace debug name
 const debug = require("debug")("smoke:proxy");

--- a/tests/smoke-tests/test-proxy-consistency.ts
+++ b/tests/smoke-tests/test-proxy-consistency.ts
@@ -16,7 +16,7 @@ const wssUrl = process.env.WSS_URL || null;
 const relayWssUrl = process.env.RELAY_WSS_URL || null;
 
 // TEMPLATE: Give suitable name
-describeSmokeSuite(`Verify created account proxy`, { wssUrl, relayWssUrl }, (context) => {
+describeSmokeSuite(`Verify account proxies created`, { wssUrl, relayWssUrl }, (context) => {
   // TEMPLATE: Declare variables representing the state to inspect
   //           To know the type of the variable, type the query and the highlight
   //           it to see
@@ -176,7 +176,7 @@ describeSmokeSuite(`Verify created account proxy`, { wssUrl, relayWssUrl }, (con
     await Promise.all(
       proxyAccList.map(async (address) => {
         const resp = await apiAt.query.evm.accountCodes(address);
-        const contract = resp.toJSON() == "0x" ? false : true;
+        const contract = resp.toJSON() == "0xX" ? false : true;
         // create results array of whether account is contract or not
         return { address, contract };
       })


### PR DESCRIPTION
### What does it do?
As part of [MOON-1931](https://purestake.atlassian.net/browse/MOON-1931), extends the `test-proxy-consistency.ts` smoke test to include a check that none of the proxies already created are for smart contract addresses.

### What important points reviewers should know?
1. Is the requirement:
`no proxy accounts can exist for a smart contract address`
OR
`accounts cannot have a smart contract as a delegate` 
OR
`both above`

2. Is there a better way of determining whether a H160 address is a contract address or not other than checking `evm.accountCodes == "0x"` ?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
Ensure data consistency on live networks
