### PR TITLE
Frontier db v2 migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2439,7 +2439,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "async-trait",
  "fc-db",
@@ -2458,14 +2458,16 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "fp-storage",
  "kvdb-rocksdb",
+ "log",
  "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-client-db",
+ "sp-blockchain",
  "sp-core",
  "sp-database",
  "sp-runtime",
@@ -2474,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "fc-db",
  "fp-consensus",
@@ -2491,7 +2493,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2534,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2673,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2685,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2700,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "evm",
  "frame-support",
@@ -2713,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2730,7 +2732,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "ethereum",
  "frame-support",
@@ -2744,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6644,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6828,7 +6830,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -6896,7 +6898,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "environmental",
  "evm",
@@ -7004,7 +7006,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "fp-evm",
 ]
@@ -7012,7 +7014,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7139,7 +7141,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7149,7 +7151,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "fp-evm",
  "num",
@@ -7270,7 +7272,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -7279,7 +7281,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#db02ba00697c3eb9247670c656d61faa85f515f9"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.29#c2403138010641be9a226fbdd9a5729174bdd07e"
 dependencies = [
  "fp-evm",
  "ripemd",

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -303,7 +303,11 @@ where
 				Err(internal_err("'pending' blocks are not supported"))
 			}
 			RequestBlockId::Hash(eth_hash) => {
-				match frontier_backend_client::load_hash::<B>(frontier_backend.as_ref(), eth_hash) {
+				match frontier_backend_client::load_hash::<B, C>(
+					client.as_ref(),
+					frontier_backend.as_ref(),
+					eth_hash,
+				) {
 					Ok(Some(id)) => Ok(id),
 					Ok(_) => Err(internal_err("Block hash not found".to_string())),
 					Err(e) => Err(e),
@@ -434,12 +438,15 @@ where
 			Err(e) => return Err(e),
 		};
 
-		let reference_id =
-			match frontier_backend_client::load_hash::<B>(frontier_backend.as_ref(), hash) {
-				Ok(Some(hash)) => hash,
-				Ok(_) => return Err(internal_err("Block hash not found".to_string())),
-				Err(e) => return Err(e),
-			};
+		let reference_id = match frontier_backend_client::load_hash::<B, C>(
+			client.as_ref(),
+			frontier_backend.as_ref(),
+			hash,
+		) {
+			Ok(Some(hash)) => hash,
+			Ok(_) => return Err(internal_err("Block hash not found".to_string())),
+			Err(e) => return Err(e),
+		};
 		// Get ApiRef. This handle allow to keep changes between txs in an internal buffer.
 		let api = client.runtime_api();
 		// Get Blockchain backend

--- a/client/rpc/finality/src/lib.rs
+++ b/client/rpc/finality/src/lib.rs
@@ -87,13 +87,14 @@ fn is_block_finalized_inner<B: Block<Hash = H256>, C: HeaderBackend<B> + 'static
 	client: &C,
 	raw_hash: H256,
 ) -> RpcResult<bool> {
-	let substrate_hash = match frontier_backend_client::load_hash::<B>(backend, raw_hash)? {
-		// If we find this hash in the frontier data base, we know it is an eth hash
-		Some(BlockId::Hash(hash)) => hash,
-		Some(BlockId::Number(_)) => panic!("is_canon test only works with hashes."),
-		// Otherwise, we assume this is a Substrate hash.
-		None => raw_hash,
-	};
+	let substrate_hash =
+		match frontier_backend_client::load_hash::<B, C>(client, backend, raw_hash)? {
+			// If we find this hash in the frontier data base, we know it is an eth hash
+			Some(BlockId::Hash(hash)) => hash,
+			Some(BlockId::Number(_)) => panic!("is_canon test only works with hashes."),
+			// Otherwise, we assume this is a Substrate hash.
+			None => raw_hash,
+		};
 
 	// First check whether the block is in the best chain
 	if !is_canon(client, substrate_hash) {

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -200,8 +200,15 @@ pub fn frontier_database_dir(config: &Configuration, path: &str) -> std::path::P
 
 // TODO This is copied from frontier. It should be imported instead after
 // https://github.com/paritytech/frontier/issues/333 is solved
-pub fn open_frontier_backend(config: &Configuration) -> Result<Arc<fc_db::Backend<Block>>, String> {
+pub fn open_frontier_backend<C>(
+	client: Arc<C>,
+	config: &Configuration,
+) -> Result<Arc<fc_db::Backend<Block>>, String>
+where
+	C: sp_blockchain::HeaderBackend<Block>,
+{
 	Ok(Arc::new(fc_db::Backend::<Block>::new(
+		client,
 		&fc_db::DatabaseSettings {
 			source: match config.database {
 				DatabaseSource::RocksDb { .. } => DatabaseSource::RocksDb {
@@ -401,7 +408,7 @@ where
 	let filter_pool: Option<FilterPool> = Some(Arc::new(Mutex::new(BTreeMap::new())));
 	let fee_history_cache: FeeHistoryCache = Arc::new(Mutex::new(BTreeMap::new()));
 
-	let frontier_backend = open_frontier_backend(config)?;
+	let frontier_backend = open_frontier_backend(client.clone(), config)?;
 
 	let frontier_block_import =
 		FrontierBlockImport::new(client.clone(), client.clone(), frontier_backend.clone());

--- a/tests/para-tests/moonbase/test-runtime-upgrade.ts
+++ b/tests/para-tests/moonbase/test-runtime-upgrade.ts
@@ -98,8 +98,6 @@ describeParachain(
         );
 
         await context.upgradeRuntime({ runtimeName: "moonbase", runtimeTag: RUNTIME_VERSION });
-        process.stdout.write("Waiting extra block for storage values to update...\n");
-        await context.waitBlocks(1);
 
         process.stdout.write(`Checking on-chain runtime version ${localVersion}...`);
         expect(

--- a/tests/para-tests/moonbase/test-runtime-upgrade.ts
+++ b/tests/para-tests/moonbase/test-runtime-upgrade.ts
@@ -98,7 +98,7 @@ describeParachain(
         );
 
         await context.upgradeRuntime({ runtimeName: "moonbase", runtimeTag: RUNTIME_VERSION });
-        process.stdout.write("Waiting extra block for storage values to update...");
+        process.stdout.write("Waiting extra block for storage values to update...\n");
         await context.waitBlocks(1);
 
         process.stdout.write(`Checking on-chain runtime version ${localVersion}...`);

--- a/tests/para-tests/moonbase/test-runtime-upgrade.ts
+++ b/tests/para-tests/moonbase/test-runtime-upgrade.ts
@@ -98,6 +98,8 @@ describeParachain(
         );
 
         await context.upgradeRuntime({ runtimeName: "moonbase", runtimeTag: RUNTIME_VERSION });
+        process.stdout.write("Waiting extra block for storage values to update...");
+        await context.waitBlocks(1);
 
         process.stdout.write(`Checking on-chain runtime version ${localVersion}...`);
         expect(

--- a/tests/util/upgrade.ts
+++ b/tests/util/upgrade.ts
@@ -119,11 +119,13 @@ export async function upgradeRuntime(api: ApiPromise, preferences: UpgradePrefer
           }
           if (options.waitMigration) {
             const blockToWait = (await api.rpc.chain.getHeader()).number.toNumber() + 1;
-            const subBlocks = await api.rpc.chain.subscribeNewHeads(async (header) => {
-              if (header.number.toNumber() == blockToWait) {
-                subBlocks();
-                resolve(blockToWait);
-              }
+            await new Promise(async (resolve) => {
+              const subBlocks = await api.rpc.chain.subscribeNewHeads(async (header) => {
+                if (header.number.toNumber() == blockToWait) {
+                  subBlocks();
+                  resolve(blockToWait);
+                }
+              });
             });
           }
           resolve(blockNumber);


### PR DESCRIPTION
### What does it do?

Details in https://github.com/paritytech/frontier/pull/862

- This migration moves to a new schema that supports equivocation in the Frontier offchain DB and it also replaces eventual orphan block hashes found for its canonical counterparts.
- Migration time will be heavily affected by `db-cache` cli arg, obviously the more the better.
- A more detailed migration progress can be enabled including `-lfc-db-upgrade=debug`.
- If the process is closed before finishing the migration it will resume when starting the process again, but is highly recommended to not kill the process.

### What important points reviewers should know?

`parity-db` is not compatible with the migration, there is no clear Api to achieve it. Nodes using `parity-db` will need to re-sync.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
