### PR TITLE
Allows publish runtime to run on master branch

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -26,11 +26,12 @@ jobs:
     steps:
       - name: Get Timestamp
         run: echo "TMSP=$(date '+%Y%m%d_%H%M%S')" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
       - name: Copy scripts
         run: |
           ls -la scripts/
           cp -R scripts /tmp/original-scripts
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.to }}
       - name: Login to DockerHub

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Get Timestamp
         run: echo "TMSP=$(date '+%Y%m%d_%H%M%S')" >> $GITHUB_ENV
+      - name: Copy scripts
+        run: cp -R scripts original-scripts
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.to }}
@@ -58,7 +60,7 @@ jobs:
           GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE: ${{ matrix.srtool_image }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE_TAG: ${{ matrix.srtool_image_tag }}
-        run: ./scripts/build-runtime-srtool.sh
+        run: ./original-scripts/build-runtime-srtool.sh
       - name: Summary
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain }}-srtool-digest.json

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get Timestamp
         run: echo "TMSP=$(date '+%Y%m%d_%H%M%S')" >> $GITHUB_ENV
       - name: Copy scripts
-        run: cp -R scripts original-scripts
+        run: cp -R scripts /tmp/original-scripts
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.to }}
@@ -60,7 +60,7 @@ jobs:
           GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE: ${{ matrix.srtool_image }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE_TAG: ${{ matrix.srtool_image_tag }}
-        run: ./original-scripts/build-runtime-srtool.sh
+        run: /tmp/original-scripts/build-runtime-srtool.sh
       - name: Summary
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain }}-srtool-digest.json

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -81,7 +81,9 @@ jobs:
           GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE: ${{ matrix.srtool_image }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE_TAG: ${{ matrix.srtool_image_tag }}
-        run: ./original-scripts/build-runtime-srtool.sh
+        run: |
+          chmod u+x ./original-scripts/build-runtime-srtool.sh
+          ./original-scripts/build-runtime-srtool.sh
       - name: Summary
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain }}-srtool-digest.json

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Get Timestamp
         run: echo "TMSP=$(date '+%Y%m%d_%H%M%S')" >> $GITHUB_ENV
       - name: Copy scripts
-        run: cp -R scripts /tmp/original-scripts
+        run: |
+          ls -la scripts/
+          cp -R scripts /tmp/original-scripts
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.to }}

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -14,7 +14,20 @@ on:
 jobs:
   ####### Build runtimes with srtool #######
 
+  setup-scripts:
+    runs-on: self-hosted
+    steps:
+      - name: Get Timestamp
+        run: echo "TMSP=$(date '+%Y%m%d_%H%M%S')" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+      - name: Upload scripts
+        uses: actions/upload-artifact@v3
+          with:
+            name: original-scripts
+            path: scripts
+
   build-srtool-runtimes:
+    needs: ["setup-scripts"]
     runs-on: self-hosted
     strategy:
       matrix:
@@ -27,11 +40,6 @@ jobs:
       - name: Get Timestamp
         run: echo "TMSP=$(date '+%Y%m%d_%H%M%S')" >> $GITHUB_ENV
       - uses: actions/checkout@v3
-      - name: Copy scripts
-        run: |
-          ls -la scripts/
-          cp -R scripts /tmp/original-scripts
-      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.to }}
       - name: Login to DockerHub
@@ -40,6 +48,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Download original scripts
+        uses: actions/download-artifact@v3
+        with:
+          name: original-scripts
+          path: original-scripts
       - name: Build & Push purestake/srtool image
         if: github.repository == 'purestake/moonbeam'
         run: |
@@ -63,7 +76,7 @@ jobs:
           GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE: ${{ matrix.srtool_image }}
           GH_WORKFLOW_MATRIX_SRTOOL_IMAGE_TAG: ${{ matrix.srtool_image_tag }}
-        run: /tmp/original-scripts/build-runtime-srtool.sh
+        run: ./original-scripts/build-runtime-srtool.sh
       - name: Summary
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq . > ${{ matrix.chain }}-srtool-digest.json

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -22,9 +22,14 @@ jobs:
       - uses: actions/checkout@v3
       - name: Upload scripts
         uses: actions/upload-artifact@v3
-          with:
-            name: original-scripts
-            path: scripts
+        with:
+          name: original-scripts
+          path: scripts
+      - name: Upload tools
+        uses: actions/upload-artifact@v3
+        with:
+          name: original-tools
+          path: tools
 
   build-srtool-runtimes:
     needs: ["setup-scripts"]
@@ -94,7 +99,7 @@ jobs:
 
   publish-draft-release:
     runs-on: ubuntu-latest
-    needs: ["build-srtool-runtimes"]
+    needs: ["setup-scripts", "build-srtool-runtimes"]
     outputs:
       release_url: ${{ steps.create-release.outputs.html_url }}
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
@@ -123,12 +128,17 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+      - name: Download Original Tools
+        uses: actions/download-artifact@v3
+        with:
+          name: original-tools
+          path: original-tools
       - name: Generate release body
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: generate-release-body
+        working-directory: original-tools
         run: |
-          cd tools
           yarn
           yarn -s run ts-node github/generate-runtimes-body.ts --owner "${{ github.repository_owner }}" --repo "$(basename ${{ github.repository }})" --from "${{ github.event.inputs.from }}" --to "${{ github.event.inputs.to }}" --srtool-report-folder '../build/' > ../body.md
       - name: Get runtime version


### PR DESCRIPTION
The Github Action `publish runtime draft` is now triggering scripts and tools from the workflow branch instead of the runtime branch.
It allows to benefit from recent changes and building previous runtimes