### PR TITLE
add over percent tests for auto-compound, return error in precompiles

### DIFF
--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -557,6 +557,14 @@ where
 		candidate_auto_compounding_delegation_count: SolidityConvert<U256, u32>,
 		delegator_delegation_count: SolidityConvert<U256, u32>,
 	) -> EvmResult {
+		if auto_compound > 100 {
+			return Err(
+				RevertReason::custom("Must be an integer between 0 and 100 included")
+					.in_field("auto_compound")
+					.into(),
+			);
+		}
+
 		let amount = Self::u256_to_amount(amount).in_field("amount")?;
 		let auto_compound = Percent::from_percent(auto_compound);
 		let candidate_delegation_count = candidate_delegation_count.converted();
@@ -749,6 +757,14 @@ where
 		candidate_auto_compounding_delegation_count: SolidityConvert<U256, u32>,
 		delegator_delegation_count: SolidityConvert<U256, u32>,
 	) -> EvmResult {
+		if value > 100 {
+			return Err(
+				RevertReason::custom("Must be an integer between 0 and 100 included")
+					.in_field("value")
+					.into(),
+			);
+		}
+
 		let value = Percent::from_percent(value);
 		let candidate_auto_compounding_delegation_count_hint =
 			candidate_auto_compounding_delegation_count.converted();

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -1207,44 +1207,7 @@ fn cancel_delegator_bonded_less_works() {
 
 #[test]
 fn delegate_with_auto_compound_works() {
-	ExtBuilder::default()
-		.with_balances(vec![(Alice, 1_000), (Bob, 1_000)])
-		.with_candidates(vec![(Alice, 1_000)])
-		.build()
-		.execute_with(|| {
-			let input_data = PCall::delegate_with_auto_compound {
-				candidate: Address(Alice.into()),
-				amount: 1_000.into(),
-				auto_compound: 50,
-				candidate_delegation_count: 0.into(),
-				candidate_auto_compounding_delegation_count: 0.into(),
-				delegator_delegation_count: 0.into(),
-			}
-			.into();
-
-			// Make sure the call goes through successfully
-			assert_ok!(Call::Evm(evm_call(Bob, input_data)).dispatch(Origin::root()));
-
-			assert!(ParachainStaking::is_delegator(&Bob));
-
-			let expected: crate::mock::Event = StakingEvent::Delegation {
-				delegator: Bob,
-				locked_amount: 1_000,
-				candidate: Alice,
-				delegator_position: pallet_parachain_staking::DelegatorAdded::AddedToTop {
-					new_total: 2_000,
-				},
-				auto_compound: Percent::from_percent(50),
-			}
-			.into();
-			// Assert that the events vector contains the one expected
-			assert!(events().contains(&expected));
-		});
-}
-
-#[test]
-fn delegate_with_auto_compound_cap_hundred_percent_if_above() {
-	for auto_compound_percent in [100, 101, 255] {
+	for auto_compound_percent in [0, 50, 100] {
 		ExtBuilder::default()
 			.with_balances(vec![(Alice, 1_000), (Bob, 1_000)])
 			.with_candidates(vec![(Alice, 1_000)])
@@ -1253,7 +1216,7 @@ fn delegate_with_auto_compound_cap_hundred_percent_if_above() {
 				let input_data = PCall::delegate_with_auto_compound {
 					candidate: Address(Alice.into()),
 					amount: 1_000.into(),
-					auto_compound: auto_compound_percent.clone(),
+					auto_compound: auto_compound_percent,
 					candidate_delegation_count: 0.into(),
 					candidate_auto_compounding_delegation_count: 0.into(),
 					delegator_delegation_count: 0.into(),
@@ -1264,12 +1227,6 @@ fn delegate_with_auto_compound_cap_hundred_percent_if_above() {
 				assert_ok!(Call::Evm(evm_call(Bob, input_data)).dispatch(Origin::root()));
 
 				assert!(ParachainStaking::is_delegator(&Bob));
-				assert_eq!(
-					ParachainStaking::delegation_auto_compound(&Alice, &Bob),
-					Percent::from_percent(100),
-					"The auto-compound value was not 100% for input '{}'",
-					auto_compound_percent,
-				);
 
 				let expected: crate::mock::Event = StakingEvent::Delegation {
 					delegator: Bob,
@@ -1278,57 +1235,48 @@ fn delegate_with_auto_compound_cap_hundred_percent_if_above() {
 					delegator_position: pallet_parachain_staking::DelegatorAdded::AddedToTop {
 						new_total: 2_000,
 					},
-					auto_compound: Percent::from_percent(100),
+					auto_compound: Percent::from_percent(auto_compound_percent),
 				}
 				.into();
 				// Assert that the events vector contains the one expected
-				assert!(
-					events().contains(&expected),
-					"The auto-compound event was not 100% for input '{}'",
-					auto_compound_percent,
-				);
+				assert!(events().contains(&expected));
+			});
+	}
+}
+
+#[test]
+fn delegate_with_auto_compound_returns_error_if_percent_above_hundred() {
+	for auto_compound_percent in [101, 255] {
+		ExtBuilder::default()
+			.with_balances(vec![(Alice, 1_000), (Bob, 1_000)])
+			.with_candidates(vec![(Alice, 1_000)])
+			.build()
+			.execute_with(|| {
+				PrecompilesValue::get()
+					.prepare_test(
+						Bob,
+						Precompile,
+						PCall::delegate_with_auto_compound {
+							candidate: Address(Alice.into()),
+							amount: 1_000.into(),
+							auto_compound: auto_compound_percent,
+							candidate_delegation_count: 0.into(),
+							candidate_auto_compounding_delegation_count: 0.into(),
+							delegator_delegation_count: 0.into(),
+						},
+					)
+					.execute_reverts(|output| {
+						from_utf8(&output).unwrap().contains(
+							"auto_compound: Must be an integer between 0 and 100 included",
+						)
+					});
 			});
 	}
 }
 
 #[test]
 fn set_auto_compound_works_if_delegation() {
-	ExtBuilder::default()
-		.with_balances(vec![(Alice, 1_000), (Bob, 1_000)])
-		.with_candidates(vec![(Alice, 1_000)])
-		.with_delegations(vec![(Bob, Alice, 1_000)])
-		.build()
-		.execute_with(|| {
-			let input_data = PCall::set_auto_compound {
-				candidate: Address(Alice.into()),
-				value: 50,
-				candidate_auto_compounding_delegation_count: 0.into(),
-				delegator_delegation_count: 1.into(),
-			}
-			.into();
-
-			// Make sure the call goes through successfully
-			assert_ok!(Call::Evm(evm_call(Bob, input_data)).dispatch(Origin::root()));
-
-			assert_eq!(
-				ParachainStaking::delegation_auto_compound(&Alice, &Bob),
-				Percent::from_percent(50)
-			);
-
-			let expected: crate::mock::Event = StakingEvent::AutoCompoundSet {
-				candidate: Alice,
-				delegator: Bob,
-				value: Percent::from_percent(50),
-			}
-			.into();
-			// Assert that the events vector contains the one expected
-			assert!(events().contains(&expected));
-		});
-}
-
-#[test]
-fn set_auto_compound_percent_cap_hundred_percent_if_above() {
-	for auto_compound_percent in [100, 101, 255] {
+	for auto_compound_percent in [0, 50, 100] {
 		ExtBuilder::default()
 			.with_balances(vec![(Alice, 1_000), (Bob, 1_000)])
 			.with_candidates(vec![(Alice, 1_000)])
@@ -1337,7 +1285,7 @@ fn set_auto_compound_percent_cap_hundred_percent_if_above() {
 			.execute_with(|| {
 				let input_data = PCall::set_auto_compound {
 					candidate: Address(Alice.into()),
-					value: auto_compound_percent.clone(),
+					value: auto_compound_percent,
 					candidate_auto_compounding_delegation_count: 0.into(),
 					delegator_delegation_count: 1.into(),
 				}
@@ -1348,23 +1296,46 @@ fn set_auto_compound_percent_cap_hundred_percent_if_above() {
 
 				assert_eq!(
 					ParachainStaking::delegation_auto_compound(&Alice, &Bob),
-					Percent::from_percent(100),
-					"The auto-compound value was not 100% for input '{}'",
-					auto_compound_percent,
+					Percent::from_percent(auto_compound_percent)
 				);
 
 				let expected: crate::mock::Event = StakingEvent::AutoCompoundSet {
 					candidate: Alice,
 					delegator: Bob,
-					value: Percent::from_percent(100),
+					value: Percent::from_percent(auto_compound_percent),
 				}
 				.into();
 				// Assert that the events vector contains the one expected
-				assert!(
-					events().contains(&expected),
-					"The auto-compound event was not 100% for input '{}'",
-					auto_compound_percent,
-				);
+				assert!(events().contains(&expected));
+			});
+	}
+}
+
+#[test]
+fn set_auto_compound_returns_error_if_value_above_hundred_percent() {
+	for auto_compound_percent in [101, 255] {
+		ExtBuilder::default()
+			.with_balances(vec![(Alice, 1_000), (Bob, 1_000)])
+			.with_candidates(vec![(Alice, 1_000)])
+			.with_delegations(vec![(Bob, Alice, 1_000)])
+			.build()
+			.execute_with(|| {
+				PrecompilesValue::get()
+					.prepare_test(
+						Bob,
+						Precompile,
+						PCall::set_auto_compound {
+							candidate: Address(Alice.into()),
+							value: auto_compound_percent,
+							candidate_auto_compounding_delegation_count: 0.into(),
+							delegator_delegation_count: 1.into(),
+						},
+					)
+					.execute_reverts(|output| {
+						from_utf8(&output)
+							.unwrap()
+							.contains("value: Must be an integer between 0 and 100 included")
+					});
 			});
 	}
 }

--- a/tests/tests/test-staking/test-delegate-with-auto-compound.ts
+++ b/tests/tests/test-staking/test-delegate-with-auto-compound.ts
@@ -1,10 +1,13 @@
 import "@polkadot/api-augment";
 import "@moonbeam-network/api-augment";
-import { expect } from "chai";
+import { expect, use as chaiUse } from "chai";
+import chaiAsPromised from "chai-as-promised";
 import { MIN_GLMR_STAKING, MIN_GLMR_DELEGATOR } from "../../util/constants";
 import { describeDevMoonbeam } from "../../util/setup-dev-tests";
 import { alith, baltathar, charleth, ethan } from "../../util/accounts";
 import { expectOk } from "../../util/expect";
+
+chaiUse(chaiAsPromised);
 
 describeDevMoonbeam("Staking - Delegate With Auto-Compound - bond less than min", (context) => {
   it("should fail", async () => {
@@ -169,6 +172,18 @@ describeDevMoonbeam("Staking - Delegate With Auto-Compound - wrong delegation hi
     );
     expect(block.result.successful).to.be.false;
     expect(block.result.error.name).to.equal("TooLowDelegationCountToDelegate");
+  });
+});
+
+describeDevMoonbeam("Staking - Delegate With Auto-Compound - 101%", (context) => {
+  it("should fail", async () => {
+    await expect(
+      context.createBlock(
+        context.polkadotApi.tx.parachainStaking
+          .delegateWithAutoCompound(alith.address, MIN_GLMR_DELEGATOR, 101, 0, 0, 0)
+          .signAsync(ethan)
+      )
+    ).to.eventually.be.rejectedWith("Value is greater than allowed maximum!");
   });
 });
 

--- a/tests/tests/test-staking/test-set-auto-compound.ts
+++ b/tests/tests/test-staking/test-set-auto-compound.ts
@@ -1,10 +1,13 @@
 import "@polkadot/api-augment";
 import "@moonbeam-network/api-augment";
-import { expect } from "chai";
+import { expect, use as chaiUse } from "chai";
+import chaiAsPromised from "chai-as-promised";
 import { MIN_GLMR_STAKING, MIN_GLMR_DELEGATOR } from "../../util/constants";
 import { describeDevMoonbeam } from "../../util/setup-dev-tests";
 import { alith, baltathar, charleth, ethan } from "../../util/accounts";
 import { expectOk } from "../../util/expect";
+
+chaiUse(chaiAsPromised);
 
 describeDevMoonbeam("Staking - Set Auto-Compound - delegator not exists", (context) => {
   it("should fail", async () => {
@@ -92,6 +95,28 @@ describeDevMoonbeam(
     });
   }
 );
+
+describeDevMoonbeam("Staking - Set Auto-Compound - new config 101%", (context) => {
+  before("setup delegate", async () => {
+    await expectOk(
+      context.createBlock(
+        context.polkadotApi.tx.parachainStaking
+          .delegate(alith.address, MIN_GLMR_DELEGATOR, 0, 0)
+          .signAsync(ethan)
+      )
+    );
+  });
+
+  it("should fail", async () => {
+    await expect(
+      context.createBlock(
+        context.polkadotApi.tx.parachainStaking
+          .setAutoCompound(alith.address, 101, 0, 1)
+          .signAsync(ethan)
+      )
+    ).to.eventually.be.rejectedWith("Value is greater than allowed maximum!");
+  });
+});
 
 describeDevMoonbeam("Staking - Set Auto-Compound - insert new config", (context) => {
   before("setup delegate", async () => {


### PR DESCRIPTION
### What does it do?
* returns error in precompiles, if auto-compound above 100%
* adds over percent tests, where raw unsigned integers are accepted.


#### Breaking change
:warning: Previously precompiles would silently cap the `autoCompound` percent in the range `[0, 100]`. With this change it will now return an error to be consistent with the behavior seen in extrinsics.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
