### PR TITLE
Drain all AwardedPts after payouts

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1532,6 +1532,9 @@ pub mod pallet {
 					// clean up storage items that we no longer need
 					<DelayedPayouts<T>>::remove(paid_for_round);
 					<Points<T>>::remove(paid_for_round);
+					// remove any AwardedPts entries that are left over. this will happen any time a
+					// selected collator produces no blocks for the entire round.
+					<AwardedPts<T>>::iter_prefix(paid_for_round).drain().collect();
 				}
 				result.1 // weight consumed by pay_one_collator_reward
 			} else {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1532,9 +1532,9 @@ pub mod pallet {
 					// clean up storage items that we no longer need
 					<DelayedPayouts<T>>::remove(paid_for_round);
 					<Points<T>>::remove(paid_for_round);
-					// remove any AwardedPts entries that are left over. this will happen any time a
+					// remove any AtStake entries that are left over. this will happen any time a
 					// selected collator produces no blocks for the entire round.
-					<AwardedPts<T>>::iter_prefix(paid_for_round).drain().collect();
+					<AtStake<T>>::iter_prefix(paid_for_round).drain().collect();
 				}
 				result.1 // weight consumed by pay_one_collator_reward
 			} else {


### PR DESCRIPTION
### What does it do?

Removes `AtStake` entries that didn't have a corresponding `AwardedPts` entry. This happens any time a collator produces no blocks for a round.

Note that this is done after the last payout is made.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
