### PR TITLE
Run MigrateAtStakeAutoCompound only for unpaid rounds

### DIFF
--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -55,7 +55,7 @@ impl<T: Config> MigrateAtStakeAutoCompound<T> {
 	/// Get keys for the `AtStake` storage for the rounds up to `RewardPaymentDelay` rounds ago.
 	/// We migrate only the last unpaid rounds due to the presence of stale entries in `AtStake`
 	/// which significantly increase the PoV size.
-	fn unpaid_rounds_keys() -> Vec<(RoundIndex, T::AccountId, Vec<u8>)> {
+	fn unpaid_rounds_keys() -> impl Iterator<Item = (RoundIndex, T::AccountId, Vec<u8>)> {
 		let current_round = <Round<T>>::get().current;
 		let max_unpaid_round = current_round.saturating_sub(T::RewardPaymentDelay::get());
 		(max_unpaid_round..=current_round)
@@ -66,7 +66,6 @@ impl<T: Config> MigrateAtStakeAutoCompound<T> {
 					(round, candidate, key)
 				})
 			})
-			.collect::<Vec<_>>()
 	}
 }
 impl<T: Config> OnRuntimeUpgrade for MigrateAtStakeAutoCompound<T> {

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -42,7 +42,7 @@ use pallet_migrations::{GetMigrations, Migration};
 use pallet_parachain_staking::{
 	migrations::{
 		MigrateAtStakeAutoCompound, PatchIncorrectDelegationSums, PurgeStaleStorage,
-		RemovePaidRoundsFromAtStake, SplitDelegatorStateIntoDelegationScheduledRequests,
+		SplitDelegatorStateIntoDelegationScheduledRequests,
 	},
 	Config as ParachainStakingConfig,
 };
@@ -149,30 +149,6 @@ impl<T: ParachainStakingConfig> Migration for ParachainStakingMigrateAtStakeAuto
 	#[cfg(feature = "try-runtime")]
 	fn post_upgrade(&self) -> Result<(), &'static str> {
 		MigrateAtStakeAutoCompound::<T>::post_upgrade()
-	}
-}
-
-/// Migrate `AtStake` storage item to remove entries for paid-out rounds
-pub struct ParachainStakingRemovePaidRoundsFromAtStake<T>(PhantomData<T>);
-impl<T: ParachainStakingConfig> Migration for ParachainStakingRemovePaidRoundsFromAtStake<T> {
-	fn friendly_name(&self) -> &str {
-		"MM_Parachain_Staking_Remove_Paid_Rounds_From_At_Stake"
-	}
-
-	fn migrate(&self, _available_weight: Weight) -> Weight {
-		RemovePaidRoundsFromAtStake::<T>::on_runtime_upgrade()
-	}
-
-	/// Run a standard pre-runtime test. This works the same way as in a normal runtime upgrade.
-	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade(&self) -> Result<(), &'static str> {
-		RemovePaidRoundsFromAtStake::<T>::pre_upgrade()
-	}
-
-	/// Run a standard post-runtime test. This works the same way as in a normal runtime upgrade.
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(&self) -> Result<(), &'static str> {
-		RemovePaidRoundsFromAtStake::<T>::post_upgrade()
 	}
 }
 
@@ -759,8 +735,6 @@ where
 		// let xcm_supported_assets = XcmPaymentSupportedAssets::<Runtime>(Default::default());
 
 		let migration_elasticity = MigrateBaseFeeElasticity::<Runtime>(Default::default());
-		let staking_remove_at_stake_paid_rounds =
-			ParachainStakingRemovePaidRoundsFromAtStake::<Runtime>(Default::default());
 		let staking_at_stake_auto_compound =
 			ParachainStakingMigrateAtStakeAutoCompound::<Runtime>(Default::default());
 		vec![
@@ -801,7 +775,6 @@ where
 			// completed in runtime 1600
 			// Box::new(xcm_transactor_transact_signed),
 			Box::new(migration_elasticity),
-			Box::new(staking_remove_at_stake_paid_rounds),
 			Box::new(staking_at_stake_auto_compound),
 		]
 	}


### PR DESCRIPTION
### What does it do?
* Removes `RemovePaidRoundsFromAtStake` migration, which would be performed manually due to the high PoV size.
* Runs `MigrateAtStakeAutoCompound` only for last `N` unpaid rounds defined by `RewardPaymentDelay`.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
