### PR TITLE
update weights, remove all entries from AtStake on round change

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1532,7 +1532,7 @@ pub mod pallet {
 					// the given round. The weight is added based on the number of backend
 					// items removed.
 					let remove_result =
-						<AtStake<T>>::clear_prefix(paid_for_round, u32::max_value(), None);
+						<AtStake<T>>::clear_prefix(paid_for_round, 20, None);
 					result
 						.1
 						.saturating_add(T::DbWeight::get().writes(remove_result.backend as u64))

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1531,8 +1531,7 @@ pub mod pallet {
 					// remove all candidates that did not produce any blocks for
 					// the given round. The weight is added based on the number of backend
 					// items removed.
-					let remove_result =
-						<AtStake<T>>::clear_prefix(paid_for_round, 20, None);
+					let remove_result = <AtStake<T>>::clear_prefix(paid_for_round, 20, None);
 					result
 						.1
 						.saturating_add(T::DbWeight::get().writes(remove_result.backend as u64))

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1528,11 +1528,17 @@ pub mod pallet {
 					<DelayedPayouts<T>>::remove(paid_for_round);
 					<Points<T>>::remove(paid_for_round);
 
-					// remove up to 1000 candidates that did not produce any blocks for
-					// the given round
-					let _ = <AtStake<T>>::clear_prefix(paid_for_round, 1000, None);
+					// remove all candidates that did not produce any blocks for
+					// the given round. The weight is added based on the number of backend
+					// items removed.
+					let remove_result =
+						<AtStake<T>>::clear_prefix(paid_for_round, u32::max_value(), None);
+					result
+						.1
+						.saturating_add(T::DbWeight::get().writes(remove_result.backend as u64))
+				} else {
+					result.1 // weight consumed by pay_one_collator_reward
 				}
-				result.1 // weight consumed by pay_one_collator_reward
 			} else {
 				Weight::from_ref_time(0u64)
 			}

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -419,7 +419,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking DelegationScheduledRequests (r:9 w:0)
 	// Storage: ParachainStaking TopDelegations (r:9 w:0)
 	// Storage: ParachainStaking AutoCompoundingDelegations (r:9 w:0)
-	// Storage: ParachainStaking MigratedAtStake (r:1 w:1)
 	// Storage: ParachainStaking Total (r:1 w:0)
 	// Storage: ParachainStaking AwardedPts (r:2 w:1)
 	// Storage: ParachainStaking AtStake (r:1 w:10)
@@ -431,18 +430,17 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn round_transition_on_initialize(x: u32, y: u32, ) -> Weight {
 		Weight::from_ref_time(363_268_000 as u64)
 			// Standard Error: 1_140_000
-			.saturating_add(Weight::from_ref_time(47_699_000 as u64).saturating_mul(x as u64))
+			.saturating_add(Weight::from_ref_time(43_560_000 as u64).saturating_mul(x as u64))
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(142_000 as u64).saturating_mul(y as u64))
-			.saturating_add(T::DbWeight::get().reads(181 as u64))
+			.saturating_add(Weight::from_ref_time(139_000 as u64).saturating_mul(y as u64))
+			.saturating_add(T::DbWeight::get().reads(180 as u64))
 			.saturating_add(T::DbWeight::get().reads((4 as u64).saturating_mul(x as u64)))
-			.saturating_add(T::DbWeight::get().writes(172 as u64))
+			.saturating_add(T::DbWeight::get().writes(171 as u64))
 			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(x as u64)))
 	}
 	// Storage: ParachainStaking DelayedPayouts (r:1 w:0)
 	// Storage: ParachainStaking Points (r:1 w:0)
 	// Storage: ParachainStaking AwardedPts (r:2 w:1)
-	// Storage: ParachainStaking MigratedAtStake (r:1 w:0)
 	// Storage: ParachainStaking AtStake (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: MoonbeamOrbiters OrbiterPerRound (r:1 w:0)
@@ -451,7 +449,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_ref_time(61_374_000 as u64)
 			// Standard Error: 5_000
 			.saturating_add(Weight::from_ref_time(15_651_000 as u64).saturating_mul(y as u64))
-			.saturating_add(T::DbWeight::get().reads(8 as u64))
+			.saturating_add(T::DbWeight::get().reads(7 as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(y as u64)))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(y as u64)))
@@ -792,7 +790,6 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking DelegationScheduledRequests (r:9 w:0)
 	// Storage: ParachainStaking TopDelegations (r:9 w:0)
 	// Storage: ParachainStaking AutoCompoundingDelegations (r:9 w:0)
-	// Storage: ParachainStaking MigratedAtStake (r:1 w:1)
 	// Storage: ParachainStaking Total (r:1 w:0)
 	// Storage: ParachainStaking AwardedPts (r:2 w:1)
 	// Storage: ParachainStaking AtStake (r:1 w:10)
@@ -804,18 +801,17 @@ impl WeightInfo for () {
 	fn round_transition_on_initialize(x: u32, y: u32, ) -> Weight {
 		Weight::from_ref_time(363_268_000 as u64)
 			// Standard Error: 1_140_000
-			.saturating_add(Weight::from_ref_time(47_699_000 as u64).saturating_mul(x as u64))
+			.saturating_add(Weight::from_ref_time(43_560_000 as u64).saturating_mul(x as u64))
 			// Standard Error: 3_000
-			.saturating_add(Weight::from_ref_time(142_000 as u64).saturating_mul(y as u64))
-			.saturating_add(RocksDbWeight::get().reads(181 as u64))
+			.saturating_add(Weight::from_ref_time(139_000 as u64).saturating_mul(y as u64))
+			.saturating_add(RocksDbWeight::get().reads(180 as u64))
 			.saturating_add(RocksDbWeight::get().reads((4 as u64).saturating_mul(x as u64)))
-			.saturating_add(RocksDbWeight::get().writes(172 as u64))
+			.saturating_add(RocksDbWeight::get().writes(171 as u64))
 			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(x as u64)))
 	}
 	// Storage: ParachainStaking DelayedPayouts (r:1 w:0)
 	// Storage: ParachainStaking Points (r:1 w:0)
 	// Storage: ParachainStaking AwardedPts (r:2 w:1)
-	// Storage: ParachainStaking MigratedAtStake (r:1 w:0)
 	// Storage: ParachainStaking AtStake (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: MoonbeamOrbiters OrbiterPerRound (r:1 w:0)
@@ -824,7 +820,7 @@ impl WeightInfo for () {
 		Weight::from_ref_time(61_374_000 as u64)
 			// Standard Error: 5_000
 			.saturating_add(Weight::from_ref_time(15_651_000 as u64).saturating_mul(y as u64))
-			.saturating_add(RocksDbWeight::get().reads(8 as u64))
+			.saturating_add(RocksDbWeight::get().reads(7 as u64))
 			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(y as u64)))
 			.saturating_add(RocksDbWeight::get().writes(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(y as u64)))

--- a/tests/tests/test-staking/test-rewards-auto-compound.ts
+++ b/tests/tests/test-staking/test-rewards-auto-compound.ts
@@ -380,17 +380,31 @@ describeDevMoonbeam("Staking - Rewards Auto-Compound - bottom delegation kick", 
         ),
       ])
     );
+
+    // fill all delegations, we split this into two blocks as it will not fit into one
     await expectOk(
       context.createBlock([
-        // delegate a lower amount from Ethan, so they are kicked when new delegation comes
         context.polkadotApi.tx.parachainStaking
           .delegate(baltathar.address, MIN_GLMR_DELEGATOR, 0, 1)
           .signAsync(ethan),
-        ...otherDelegators.map((d) =>
-          context.polkadotApi.tx.parachainStaking
-            .delegate(alith.address, MIN_GLMR_DELEGATOR + 10n * GLMR, delegationCount++, 1)
-            .signAsync(d)
-        ),
+        ...otherDelegators
+          .slice(0, 150)
+          .map((d) =>
+            context.polkadotApi.tx.parachainStaking
+              .delegate(alith.address, MIN_GLMR_DELEGATOR + 10n * GLMR, delegationCount++, 1)
+              .signAsync(d)
+          ),
+      ])
+    );
+    await expectOk(
+      context.createBlock([
+        ...otherDelegators
+          .slice(150)
+          .map((d) =>
+            context.polkadotApi.tx.parachainStaking
+              .delegate(alith.address, MIN_GLMR_DELEGATOR + 10n * GLMR, delegationCount++, 1)
+              .signAsync(d)
+          ),
       ])
     );
 
@@ -435,6 +449,7 @@ describeDevMoonbeam("Staking - Rewards Auto-Compound - bottom delegation kick", 
       await context.polkadotApi.query.parachainStaking.autoCompoundingDelegations(
         baltathar.address
       );
+
     expect(autoCompoundDelegationsAlithAfter.toJSON()).to.be.empty;
     expect(autoCompoundDelegationsBaltatharAfter.toJSON()).to.not.be.empty;
   });


### PR DESCRIPTION
### What does it do?
* Update weights
* Remove all entries from AtStake on round change (formerly only 1000 were removed)

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
