### PR TITLE
Fix proxy precompile error message for smart contracts

### DIFF
--- a/precompiles/proxy/src/lib.rs
+++ b/precompiles/proxy/src/lib.rs
@@ -55,7 +55,7 @@ where
 		// Check that caller is not a smart contract s.t. no code is inserted into
 		// pallet_evm::AccountCodes except if the caller is another precompile i.e. CallPermit
 		if !(caller_code.is_empty() || &caller_code == &[0x60, 0x00, 0x60, 0x00, 0xfd]) {
-			Err(revert("Batch not callable by smart contracts"))
+			Err(revert("Proxy not callable by smart contracts"))
 		} else {
 			Ok(())
 		}

--- a/precompiles/proxy/src/tests.rs
+++ b/precompiles/proxy/src/tests.rs
@@ -518,7 +518,7 @@ fn fails_if_called_by_smart_contract() {
 						delay: 1,
 					},
 				)
-				.execute_reverts(|output| output == b"Batch not callable by smart contracts");
+				.execute_reverts(|output| output == b"Proxy not callable by smart contracts");
 		})
 }
 


### PR DESCRIPTION
Changes error message for proxy precompile if called by smart contract from `Batch not callable by smart contracts` to `Proxy not callable by smart contracts`
