### PR TITLE
Missing 'view' modifiers in XC20 precompile

### DIFF
--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -149,6 +149,7 @@ where
 	}
 
 	#[precompile::public("totalSupply()")]
+	#[precompile::view]
 	fn total_supply(
 		asset_id: AssetIdOf<Runtime, Instance>,
 		handle: &mut impl PrecompileHandle,
@@ -159,6 +160,7 @@ where
 	}
 
 	#[precompile::public("balanceOf(address)")]
+	#[precompile::view]
 	fn balance_of(
 		asset_id: AssetIdOf<Runtime, Instance>,
 		handle: &mut impl PrecompileHandle,
@@ -179,6 +181,7 @@ where
 	}
 
 	#[precompile::public("allowance(address,address)")]
+	#[precompile::view]
 	fn allowance(
 		asset_id: AssetIdOf<Runtime, Instance>,
 		handle: &mut impl PrecompileHandle,
@@ -374,6 +377,7 @@ where
 	}
 
 	#[precompile::public("name()")]
+	#[precompile::view]
 	fn name(
 		asset_id: AssetIdOf<Runtime, Instance>,
 		handle: &mut impl PrecompileHandle,
@@ -388,6 +392,7 @@ where
 	}
 
 	#[precompile::public("symbol()")]
+	#[precompile::view]
 	fn symbol(
 		asset_id: AssetIdOf<Runtime, Instance>,
 		handle: &mut impl PrecompileHandle,
@@ -402,6 +407,7 @@ where
 	}
 
 	#[precompile::public("decimals()")]
+	#[precompile::view]
 	fn decimals(
 		asset_id: AssetIdOf<Runtime, Instance>,
 		handle: &mut impl PrecompileHandle,

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -84,6 +84,17 @@ fn selectors() {
 	assert!(ForeignPCall::eip2612_permit_selectors().contains(&0xd505accf));
 	assert!(ForeignPCall::eip2612_domain_separator_selectors().contains(&0x3644e515));
 
+	assert!(ForeignPCall::mint_selectors().contains(&0x40c10f19));
+	assert!(ForeignPCall::burn_selectors().contains(&0x9dc29fac));
+	assert!(ForeignPCall::freeze_selectors().contains(&0x8d1fdf2f));
+	assert!(ForeignPCall::thaw_selectors().contains(&0x5ea20216));
+	assert!(ForeignPCall::freeze_asset_selectors().contains(&0xd4937f51));
+	assert!(ForeignPCall::thaw_asset_selectors().contains(&0x51ec2ad7));
+	assert!(ForeignPCall::transfer_ownership_selectors().contains(&0xf2fde38b));
+	assert!(ForeignPCall::set_team_selectors().contains(&0xc7d93c59));
+	assert!(ForeignPCall::set_metadata_selectors().contains(&0x37d2c2f4));
+	assert!(ForeignPCall::clear_metadata_selectors().contains(&0xefb6d432));
+
 	assert_eq!(
 		crate::SELECTOR_LOG_TRANSFER,
 		&Keccak256::digest(b"Transfer(address,address,uint256)")[..]
@@ -93,6 +104,51 @@ fn selectors() {
 		crate::SELECTOR_LOG_APPROVAL,
 		&Keccak256::digest(b"Approval(address,address,uint256)")[..]
 	);
+}
+
+#[test]
+fn modifiers() {
+	ExtBuilder::default()
+		.with_balances(vec![(Account::Alice, 1000)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(ForeignAssets::force_create(
+				Origin::root(),
+				0u128,
+				Account::Alice.into(),
+				true,
+				1
+			));
+			let mut tester = PrecompilesModifierTester::new(
+				precompiles(),
+				Account::Alice,
+				Account::ForeignAssetId(0u128),
+			);
+
+			tester.test_view_modifier(ForeignPCall::balance_of_selectors());
+			tester.test_view_modifier(ForeignPCall::total_supply_selectors());
+			tester.test_default_modifier(ForeignPCall::approve_selectors());
+			tester.test_view_modifier(ForeignPCall::allowance_selectors());
+			tester.test_default_modifier(ForeignPCall::transfer_selectors());
+			tester.test_default_modifier(ForeignPCall::transfer_from_selectors());
+			tester.test_view_modifier(ForeignPCall::name_selectors());
+			tester.test_view_modifier(ForeignPCall::symbol_selectors());
+			tester.test_view_modifier(ForeignPCall::decimals_selectors());
+			tester.test_view_modifier(ForeignPCall::eip2612_nonces_selectors());
+			tester.test_default_modifier(ForeignPCall::eip2612_permit_selectors());
+			tester.test_view_modifier(ForeignPCall::eip2612_domain_separator_selectors());
+
+			tester.test_default_modifier(ForeignPCall::mint_selectors());
+			tester.test_default_modifier(ForeignPCall::burn_selectors());
+			tester.test_default_modifier(ForeignPCall::freeze_selectors());
+			tester.test_default_modifier(ForeignPCall::thaw_selectors());
+			tester.test_default_modifier(ForeignPCall::freeze_asset_selectors());
+			tester.test_default_modifier(ForeignPCall::thaw_asset_selectors());
+			tester.test_default_modifier(ForeignPCall::transfer_ownership_selectors());
+			tester.test_default_modifier(ForeignPCall::set_team_selectors());
+			tester.test_default_modifier(ForeignPCall::set_metadata_selectors());
+			tester.test_default_modifier(ForeignPCall::clear_metadata_selectors());
+		});
 }
 
 #[test]

--- a/precompiles/author-mapping/src/tests.rs
+++ b/precompiles/author-mapping/src/tests.rs
@@ -75,6 +75,19 @@ fn selectors() {
 }
 
 #[test]
+fn modifiers() {
+	ExtBuilder::default().build().execute_with(|| {
+		let mut tester = PrecompilesModifierTester::new(precompiles(), Alice, Precompile);
+
+		tester.test_default_modifier(PCall::add_association_selectors());
+		tester.test_default_modifier(PCall::update_association_selectors());
+		tester.test_default_modifier(PCall::clear_association_selectors());
+		tester.test_default_modifier(PCall::remove_keys_selectors());
+		tester.test_default_modifier(PCall::set_keys_selectors());
+	});
+}
+
+#[test]
 fn add_association_works() {
 	ExtBuilder::default()
 		.with_balances(vec![(Alice, 1000)])

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -70,6 +70,32 @@ fn selectors() {
 }
 
 #[test]
+fn modifiers() {
+	ExtBuilder::default()
+		.with_balances(vec![(Account::Alice, 1000)])
+		.build()
+		.execute_with(|| {
+			let mut tester =
+				PrecompilesModifierTester::new(precompiles(), Account::Alice, Account::Precompile);
+
+			tester.test_view_modifier(PCall::balance_of_selectors());
+			tester.test_view_modifier(PCall::total_supply_selectors());
+			tester.test_default_modifier(PCall::approve_selectors());
+			tester.test_view_modifier(PCall::allowance_selectors());
+			tester.test_default_modifier(PCall::transfer_selectors());
+			tester.test_default_modifier(PCall::transfer_from_selectors());
+			tester.test_view_modifier(PCall::name_selectors());
+			tester.test_view_modifier(PCall::symbol_selectors());
+			tester.test_view_modifier(PCall::decimals_selectors());
+			tester.test_payable_modifier(PCall::deposit_selectors());
+			tester.test_default_modifier(PCall::withdraw_selectors());
+			tester.test_view_modifier(PCall::eip2612_nonces_selectors());
+			tester.test_default_modifier(PCall::eip2612_permit_selectors());
+			tester.test_view_modifier(PCall::eip2612_domain_separator_selectors());
+		});
+}
+
+#[test]
 fn get_total_supply() {
 	ExtBuilder::default()
 		.with_balances(vec![(Account::Alice, 1000), (Account::Bob, 2500)])

--- a/precompiles/batch/src/tests.rs
+++ b/precompiles/batch/src/tests.rs
@@ -72,6 +72,20 @@ fn selectors() {
 }
 
 #[test]
+fn modifiers() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice, 1000)])
+		.build()
+		.execute_with(|| {
+			let mut tester = PrecompilesModifierTester::new(precompiles(), Alice, Precompile);
+
+			tester.test_default_modifier(PCall::batch_some_selectors());
+			tester.test_default_modifier(PCall::batch_some_until_failure_selectors());
+			tester.test_default_modifier(PCall::batch_all_selectors());
+		});
+}
+
+#[test]
 fn batch_some_empty() {
 	ExtBuilder::default().build().execute_with(|| {
 		precompiles()

--- a/precompiles/call-permit/src/tests.rs
+++ b/precompiles/call-permit/src/tests.rs
@@ -43,6 +43,20 @@ fn selectors() {
 }
 
 #[test]
+fn modifiers() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice, 1000)])
+		.build()
+		.execute_with(|| {
+			let mut tester = PrecompilesModifierTester::new(precompiles(), Alice, Precompile);
+
+			tester.test_default_modifier(PCall::dispatch_selectors());
+			tester.test_view_modifier(PCall::nonces_selectors());
+			tester.test_view_modifier(PCall::domain_separator_selectors());
+		});
+}
+
+#[test]
 fn valid_permit_returns() {
 	ExtBuilder::default()
 		.with_balances(vec![(Alice, 1000)])

--- a/precompiles/collective/src/tests.rs
+++ b/precompiles/collective/src/tests.rs
@@ -81,6 +81,30 @@ fn selectors() {
 	assert!(PCall::vote_selectors().contains(&0x73e37688));
 	assert!(PCall::close_selectors().contains(&0x638d9d47));
 	assert!(PCall::proposal_hash_selectors().contains(&0xfc379417));
+	assert!(PCall::proposals_selectors().contains(&0x55ef20e6));
+	assert!(PCall::members_selectors().contains(&0xbdd4d18d));
+	assert!(PCall::is_member_selectors().contains(&0xa230c524));
+	assert!(PCall::prime_selectors().contains(&0xc7ee005e));
+}
+
+#[test]
+fn modifiers() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice, 1000)])
+		.build()
+		.execute_with(|| {
+			let mut tester = PrecompilesModifierTester::new(precompiles(), Alice, Precompile);
+
+			tester.test_default_modifier(PCall::execute_selectors());
+			tester.test_default_modifier(PCall::propose_selectors());
+			tester.test_default_modifier(PCall::vote_selectors());
+			tester.test_default_modifier(PCall::close_selectors());
+			tester.test_view_modifier(PCall::proposal_hash_selectors());
+			tester.test_view_modifier(PCall::proposals_selectors());
+			tester.test_view_modifier(PCall::members_selectors());
+			tester.test_view_modifier(PCall::is_member_selectors());
+			tester.test_view_modifier(PCall::prime_selectors());
+		});
 }
 
 #[test]

--- a/precompiles/crowdloan-rewards/Cargo.toml
+++ b/precompiles/crowdloan-rewards/Cargo.toml
@@ -50,6 +50,11 @@ cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulu
 [features]
 default = [ "std" ]
 std = [
+	"codec/std",
+	"cumulus-pallet-parachain-system/std",
+	"cumulus-primitives-core/std",
+	"cumulus-primitives-parachain-inherent/std",
+	"cumulus-test-relay-sproof-builder/std",
 	"fp-evm/std",
 	"frame-support/std",
 	"frame-system/std",

--- a/precompiles/crowdloan-rewards/src/tests.rs
+++ b/precompiles/crowdloan-rewards/src/tests.rs
@@ -53,6 +53,18 @@ fn selectors() {
 }
 
 #[test]
+fn modifiers() {
+	ExtBuilder::default().build().execute_with(|| {
+		let mut tester = PrecompilesModifierTester::new(precompiles(), Alice, Precompile);
+
+		tester.test_view_modifier(PCall::is_contributor_selectors());
+		tester.test_view_modifier(PCall::reward_info_selectors());
+		tester.test_default_modifier(PCall::claim_selectors());
+		tester.test_default_modifier(PCall::update_reward_address_selectors());
+	});
+}
+
+#[test]
 fn selector_less_than_four_bytes() {
 	ExtBuilder::default().build().execute_with(|| {
 		// This selector is only three bytes long when four are required.

--- a/precompiles/pallet-democracy/src/tests.rs
+++ b/precompiles/pallet-democracy/src/tests.rs
@@ -86,6 +86,26 @@ fn selectors() {
 }
 
 #[test]
+fn modifiers() {
+	ExtBuilder::default().build().execute_with(|| {
+		let mut tester = PrecompilesModifierTester::new(precompiles(), Alice, Precompile);
+
+		tester.test_default_modifier(PCall::delegate_selectors());
+		tester.test_view_modifier(PCall::deposit_of_selectors());
+		tester.test_view_modifier(PCall::finished_referendum_info_selectors());
+		tester.test_view_modifier(PCall::lowest_unbaked_selectors());
+		tester.test_view_modifier(PCall::ongoing_referendum_info_selectors());
+		tester.test_default_modifier(PCall::propose_selectors());
+		tester.test_view_modifier(PCall::public_prop_count_selectors());
+		tester.test_default_modifier(PCall::remove_vote_selectors());
+		tester.test_default_modifier(PCall::second_selectors());
+		tester.test_default_modifier(PCall::standard_vote_selectors());
+		tester.test_default_modifier(PCall::un_delegate_selectors());
+		tester.test_default_modifier(PCall::unlock_selectors());
+	});
+}
+
+#[test]
 fn prop_count_zero() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Assert that no props have been opened.

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -82,6 +82,46 @@ fn selectors() {
 }
 
 #[test]
+fn modifiers() {
+	ExtBuilder::default().build().execute_with(|| {
+		let mut tester = PrecompilesModifierTester::new(precompiles(), Alice, Precompile);
+
+		tester.test_view_modifier(PCall::is_delegator_selectors());
+		tester.test_view_modifier(PCall::is_candidate_selectors());
+		tester.test_view_modifier(PCall::is_selected_candidate_selectors());
+		tester.test_view_modifier(PCall::points_selectors());
+		tester.test_view_modifier(PCall::min_delegation_selectors());
+		tester.test_view_modifier(PCall::candidate_count_selectors());
+		tester.test_view_modifier(PCall::round_selectors());
+		tester.test_view_modifier(PCall::candidate_delegation_count_selectors());
+		tester.test_view_modifier(PCall::delegator_delegation_count_selectors());
+		tester.test_view_modifier(PCall::selected_candidates_selectors());
+		tester.test_view_modifier(PCall::delegation_request_is_pending_selectors());
+		tester.test_view_modifier(PCall::candidate_exit_is_pending_selectors());
+		tester.test_view_modifier(PCall::candidate_request_is_pending_selectors());
+		tester.test_default_modifier(PCall::join_candidates_selectors());
+		tester.test_default_modifier(PCall::schedule_leave_candidates_selectors());
+		tester.test_default_modifier(PCall::execute_leave_candidates_selectors());
+		tester.test_default_modifier(PCall::cancel_leave_candidates_selectors());
+		tester.test_default_modifier(PCall::go_offline_selectors());
+		tester.test_default_modifier(PCall::go_online_selectors());
+		tester.test_default_modifier(PCall::candidate_bond_more_selectors());
+		tester.test_default_modifier(PCall::schedule_candidate_bond_less_selectors());
+		tester.test_default_modifier(PCall::execute_candidate_bond_less_selectors());
+		tester.test_default_modifier(PCall::cancel_candidate_bond_less_selectors());
+		tester.test_default_modifier(PCall::delegate_selectors());
+		tester.test_default_modifier(PCall::schedule_leave_delegators_selectors());
+		tester.test_default_modifier(PCall::execute_leave_delegators_selectors());
+		tester.test_default_modifier(PCall::cancel_leave_delegators_selectors());
+		tester.test_default_modifier(PCall::schedule_revoke_delegation_selectors());
+		tester.test_default_modifier(PCall::delegator_bond_more_selectors());
+		tester.test_default_modifier(PCall::schedule_delegator_bond_less_selectors());
+		tester.test_default_modifier(PCall::execute_delegation_request_selectors());
+		tester.test_default_modifier(PCall::cancel_delegation_request_selectors());
+	});
+}
+
+#[test]
 fn selector_less_than_four_bytes() {
 	ExtBuilder::default().build().execute_with(|| {
 		precompiles()

--- a/precompiles/proxy/src/tests.rs
+++ b/precompiles/proxy/src/tests.rs
@@ -52,6 +52,19 @@ fn selectors() {
 	assert!(PCall::add_proxy_selectors().contains(&0x74a34dd3));
 	assert!(PCall::remove_proxy_selectors().contains(&0xfef3f708));
 	assert!(PCall::remove_proxies_selectors().contains(&0x14a5b5fa));
+	assert!(PCall::is_proxy_selectors().contains(&0xe26d38ed));
+}
+
+#[test]
+fn modifiers() {
+	ExtBuilder::default().build().execute_with(|| {
+		let mut tester = PrecompilesModifierTester::new(PrecompilesValue::get(), Alice, Precompile);
+
+		tester.test_default_modifier(PCall::add_proxy_selectors());
+		tester.test_default_modifier(PCall::remove_proxy_selectors());
+		tester.test_default_modifier(PCall::remove_proxies_selectors());
+		tester.test_view_modifier(PCall::is_proxy_selectors());
+	});
 }
 
 #[test]

--- a/precompiles/relay-encoder/src/tests.rs
+++ b/precompiles/relay-encoder/src/tests.rs
@@ -46,6 +46,24 @@ fn selectors() {
 }
 
 #[test]
+fn modifiers() {
+	ExtBuilder::default().build().execute_with(|| {
+		let mut tester = PrecompilesModifierTester::new(PrecompilesValue::get(), Alice, Precompile);
+
+		tester.test_view_modifier(PCall::encode_bond_selectors());
+		tester.test_view_modifier(PCall::encode_bond_extra_selectors());
+		tester.test_view_modifier(PCall::encode_unbond_selectors());
+		tester.test_view_modifier(PCall::encode_withdraw_unbonded_selectors());
+		tester.test_view_modifier(PCall::encode_validate_selectors());
+		tester.test_view_modifier(PCall::encode_nominate_selectors());
+		tester.test_view_modifier(PCall::encode_chill_selectors());
+		tester.test_view_modifier(PCall::encode_set_payee_selectors());
+		tester.test_view_modifier(PCall::encode_set_controller_selectors());
+		tester.test_view_modifier(PCall::encode_rebond_selectors());
+	});
+}
+
+#[test]
 fn selector_less_than_four_bytes() {
 	ExtBuilder::default().build().execute_with(|| {
 		precompiles()

--- a/precompiles/utils/src/testing.rs
+++ b/precompiles/utils/src/testing.rs
@@ -40,6 +40,18 @@ pub struct SubcallOutput {
 	pub logs: Vec<Log>,
 }
 
+pub fn decode_revert_message(encoded: &[u8]) -> &[u8] {
+	let encoded_len = encoded.len();
+	// selector 4 + offset 32 + string length 32
+	if encoded_len > 68 {
+		let message_len = encoded[36..68].iter().sum::<u8>();
+		if encoded_len >= 68 + message_len as usize {
+			return &encoded[68..68 + message_len as usize];
+		}
+	}
+	b"decode_revert_message: error"
+}
+
 pub trait SubcallTrait: FnMut(Subcall) -> SubcallOutput + 'static {}
 
 impl<T: FnMut(Subcall) -> SubcallOutput + 'static> SubcallTrait for T {}
@@ -284,18 +296,6 @@ impl<'p, P: PrecompileSet> PrecompilesTester<'p, P> {
 		res
 	}
 
-	fn decode_revert_message(encoded: &[u8]) -> &[u8] {
-		let encoded_len = encoded.len();
-		// selector 4 + offset 32 + string length 32
-		if encoded_len > 68 {
-			let message_len = encoded[36..68].iter().sum::<u8>();
-			if encoded_len >= 68 + message_len as usize {
-				return &encoded[68..68 + message_len as usize];
-			}
-		}
-		b"decode_revert_message: error"
-	}
-
 	/// Execute the precompile set and expect some precompile to have been executed, regardless of the
 	/// result.
 	pub fn execute_some(mut self) {
@@ -317,7 +317,7 @@ impl<'p, P: PrecompileSet> PrecompilesTester<'p, P> {
 
 		match res {
 			Some(Err(PrecompileFailure::Revert { output, .. })) => {
-				let decoded = Self::decode_revert_message(&output);
+				let decoded = decode_revert_message(&output);
 				eprintln!(
 					"Revert message (bytes): {:?}",
 					sp_core::hexdisplay::HexDisplay::from(&decoded)
@@ -362,7 +362,7 @@ impl<'p, P: PrecompileSet> PrecompilesTester<'p, P> {
 
 		match res {
 			Some(Err(PrecompileFailure::Revert { output, .. })) => {
-				let decoded = Self::decode_revert_message(&output);
+				let decoded = decode_revert_message(&output);
 				if !check(decoded) {
 					eprintln!(
 						"Revert message (bytes): {:?}",
@@ -433,6 +433,111 @@ impl core::fmt::Debug for PrettyLog {
 			.field("data", &bytes)
 			.field("data_utf8", &message)
 			.finish()
+	}
+}
+
+pub struct PrecompilesModifierTester<P> {
+	precompiles: P,
+	handle: MockHandle,
+}
+
+impl<P: PrecompileSet> PrecompilesModifierTester<P> {
+	pub fn new(precompiles: P, from: impl Into<H160>, to: impl Into<H160>) -> Self {
+		let to = to.into();
+		let mut handle = MockHandle::new(
+			to.clone(),
+			Context {
+				address: to,
+				caller: from.into(),
+				apparent_value: U256::zero(),
+			},
+		);
+
+		handle.gas_limit = u64::MAX;
+
+		Self {
+			precompiles,
+			handle,
+		}
+	}
+
+	fn is_view(&mut self, selector: u32) -> bool {
+		// View: calling with static should not revert with static-related message.
+		let handle = &mut self.handle;
+		handle.is_static = true;
+		handle.context.apparent_value = U256::zero();
+		handle.input = EvmDataWriter::new_with_selector(selector).build();
+
+		let res = self.precompiles.execute(handle);
+
+		match res {
+			Some(Err(PrecompileFailure::Revert { output, .. })) => {
+				let decoded = decode_revert_message(&output);
+
+				dbg!(decoded) != b"Can't call non-static function in static context"
+			}
+			Some(_) => true,
+			None => panic!("tried to check view modifier on unknown precompile"),
+		}
+	}
+
+	fn is_payable(&mut self, selector: u32) -> bool {
+		// Payable: calling with value should not revert with payable-related message.
+		let handle = &mut self.handle;
+		handle.is_static = false;
+		handle.context.apparent_value = U256::one();
+		handle.input = EvmDataWriter::new_with_selector(selector).build();
+
+		let res = self.precompiles.execute(handle);
+
+		match res {
+			Some(Err(PrecompileFailure::Revert { output, .. })) => {
+				let decoded = decode_revert_message(&output);
+
+				decoded != b"Function is not payable"
+			}
+			Some(_) => true,
+			None => panic!("tried to check payable modifier on unknown precompile"),
+		}
+	}
+
+	pub fn test_view_modifier(&mut self, selectors: &[u32]) {
+		for &s in selectors {
+			assert!(
+				self.is_view(s),
+				"Function doesn't behave like a view function."
+			);
+			assert!(
+				!self.is_payable(s),
+				"Function doesn't behave like a non-payable function."
+			)
+		}
+	}
+
+	pub fn test_payable_modifier(&mut self, selectors: &[u32]) {
+		for &s in selectors {
+			assert!(
+				!self.is_view(s),
+				"Function doesn't behave like a non-view function."
+			);
+			assert!(
+				self.is_payable(s),
+				"Function doesn't behave like a payable function."
+			);
+		}
+	}
+
+	pub fn test_default_modifier(&mut self, selectors: &[u32]) {
+		for &s in selectors {
+			assert!(
+				!self.is_view(s),
+				"Function doesn't behave like a non-view function."
+			);
+			assert!(
+				!self.is_payable(s),
+				"Function doesn't behave like a non-payable function."
+			);
+		}
 	}
 }
 

--- a/precompiles/xcm-transactor/src/tests.rs
+++ b/precompiles/xcm-transactor/src/tests.rs
@@ -32,8 +32,50 @@ fn precompiles() -> TestPrecompiles<Runtime> {
 fn selectors() {
 	assert!(PCallV1::index_to_account_selectors().contains(&0x3fdc4f36));
 	assert!(PCallV1::transact_info_selectors().contains(&0xd07d87c3));
+	assert!(PCallV1::transact_info_with_signed_selectors().contains(&0xb689e20c));
+	assert!(PCallV1::fee_per_second_selectors().contains(&0x906c9990));
 	assert!(PCallV1::transact_through_derivative_multilocation_selectors().contains(&0x94a63c54));
 	assert!(PCallV1::transact_through_derivative_selectors().contains(&0x02ae072d));
+	assert!(PCallV1::transact_through_signed_multilocation_selectors().contains(&0x71d31587));
+	assert!(PCallV1::transact_through_signed_selectors().contains(&0x42ca339d));
+
+	assert!(PCallV2::index_to_account_selectors().contains(&0x3fdc4f36));
+	assert!(PCallV2::transact_info_with_signed_selectors().contains(&0xb689e20c));
+	assert!(PCallV2::fee_per_second_selectors().contains(&0x906c9990));
+	assert!(PCallV2::transact_through_derivative_multilocation_selectors().contains(&0xfe430475));
+	assert!(PCallV2::transact_through_derivative_selectors().contains(&0x185de2ae));
+	assert!(PCallV2::transact_through_signed_multilocation_selectors().contains(&0xd7ab340c));
+	assert!(PCallV2::transact_through_signed_selectors().contains(&0xb648f3fe));
+}
+
+#[test]
+fn modifiers() {
+	ExtBuilder::default().build().execute_with(|| {
+		let mut tester =
+			PrecompilesModifierTester::new(precompiles(), Alice, precompile_address_v1());
+
+		tester.test_view_modifier(PCallV1::index_to_account_selectors());
+		tester.test_view_modifier(PCallV1::transact_info_selectors());
+		tester.test_view_modifier(PCallV1::transact_info_with_signed_selectors());
+		tester.test_view_modifier(PCallV1::fee_per_second_selectors());
+		tester
+			.test_default_modifier(PCallV1::transact_through_derivative_multilocation_selectors());
+		tester.test_default_modifier(PCallV1::transact_through_derivative_selectors());
+		tester.test_default_modifier(PCallV1::transact_through_signed_multilocation_selectors());
+		tester.test_default_modifier(PCallV1::transact_through_signed_selectors());
+
+		let mut tester =
+			PrecompilesModifierTester::new(precompiles(), Alice, precompile_address_v2());
+
+		tester.test_view_modifier(PCallV2::index_to_account_selectors());
+		tester.test_view_modifier(PCallV2::transact_info_with_signed_selectors());
+		tester.test_view_modifier(PCallV2::fee_per_second_selectors());
+		tester
+			.test_default_modifier(PCallV2::transact_through_derivative_multilocation_selectors());
+		tester.test_default_modifier(PCallV2::transact_through_derivative_selectors());
+		tester.test_default_modifier(PCallV2::transact_through_signed_multilocation_selectors());
+		tester.test_default_modifier(PCallV2::transact_through_signed_selectors());
+	});
 }
 
 #[test]

--- a/precompiles/xcm-utils/Cargo.toml
+++ b/precompiles/xcm-utils/Cargo.toml
@@ -56,12 +56,19 @@ orml-traits = { git = "https://github.com/purestake/open-runtime-module-library"
 [features]
 default = [ "std" ]
 std = [
+	"codec/std",
 	"frame-support/std",
 	"frame-system/std",
+	"orml-traits/std",
+	"pallet-balances/std",
 	"pallet-evm/std",
+	"pallet-timestamp/std",
+	"polkadot-parachain/std",
 	"precompile-utils/std",
 	"sp-core/std",
+	"sp-io/std",
 	"sp-std/std",
+	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm-primitives/std",
 ]

--- a/precompiles/xcm-utils/src/tests.rs
+++ b/precompiles/xcm-utils/src/tests.rs
@@ -31,6 +31,19 @@ fn precompiles() -> TestPrecompiles<Runtime> {
 #[test]
 fn test_selector_enum() {
 	assert!(PCall::multilocation_to_address_selectors().contains(&0x343b3e00));
+	assert!(PCall::weight_message_selectors().contains(&0x25d54154));
+	assert!(PCall::get_units_per_second_selectors().contains(&0x3f0f65db));
+}
+
+#[test]
+fn modifiers() {
+	ExtBuilder::default().build().execute_with(|| {
+		let mut tester = PrecompilesModifierTester::new(precompiles(), Alice, Precompile);
+
+		tester.test_view_modifier(PCall::multilocation_to_address_selectors());
+		tester.test_view_modifier(PCall::weight_message_selectors());
+		tester.test_view_modifier(PCall::get_units_per_second_selectors());
+	});
 }
 
 #[test]

--- a/precompiles/xtokens/src/tests.rs
+++ b/precompiles/xtokens/src/tests.rs
@@ -41,6 +41,19 @@ fn test_selector_enum() {
 }
 
 #[test]
+fn modifiers() {
+	ExtBuilder::default().build().execute_with(|| {
+		let mut tester = PrecompilesModifierTester::new(precompiles(), Alice, Precompile);
+
+		tester.test_default_modifier(PCall::transfer_selectors());
+		tester.test_default_modifier(PCall::transfer_multiasset_selectors());
+		tester.test_default_modifier(PCall::transfer_multi_currencies_selectors());
+		tester.test_default_modifier(PCall::transfer_with_fee_selectors());
+		tester.test_default_modifier(PCall::transfer_multiasset_with_fee_selectors());
+	});
+}
+
+#[test]
 fn selector_less_than_four_bytes() {
 	ExtBuilder::default().build().execute_with(|| {
 		precompiles()


### PR DESCRIPTION
### What does it do?

Add missing `view` modifiers on XC20 precompile functions, which are currently not callable from other contracts view functions.

Did not see other missing `view` modifers.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

- Extract modifiers from Solidity files and check they match Rust code.

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
