### PR TITLE
[Moon-1953] Refactor staking tests, reset events between blocks

### DIFF
--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -459,40 +459,6 @@ macro_rules! assert_tail_eq {
 	};
 }
 
-/// Panics if an event is not found in the system log of events
-#[macro_export]
-macro_rules! assert_event_emitted {
-	($event:expr) => {
-		match &$event {
-			e => {
-				assert!(
-					crate::mock::events().iter().find(|x| *x == e).is_some(),
-					"Event {:?} was not found in events: \n {:?}",
-					e,
-					crate::mock::events()
-				);
-			}
-		}
-	};
-}
-
-/// Panics if an event is found in the system log of events
-#[macro_export]
-macro_rules! assert_event_not_emitted {
-	($event:expr) => {
-		match &$event {
-			e => {
-				assert!(
-					crate::mock::events().iter().find(|x| *x == e).is_none(),
-					"Event {:?} was found in events: \n {:?}",
-					e,
-					crate::mock::events()
-				);
-			}
-		}
-	};
-}
-
 // Same storage changes as ParachainStaking::on_finalize
 pub(crate) fn set_author(round: BlockNumber, acc: u64, pts: u32) {
 	<Points<Test>>::mutate(round, |p| *p += pts);

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -266,7 +266,6 @@ pub(crate) fn roll_to(n: BlockNumber) -> BlockNumber {
 	let mut block = System::block_number();
 	while block < n {
 		block = roll_one_block();
-		println!("{} {:#?}", block, events());
 		num_blocks += 1;
 	}
 	num_blocks
@@ -302,6 +301,12 @@ pub(crate) fn events() -> Vec<pallet::Event<Test>> {
 }
 
 /// Asserts that some events were never emitted.
+///
+/// # Example
+///
+/// ```
+/// assert_no_events!();
+/// ```
 #[macro_export]
 macro_rules! assert_no_events {
 	() => {
@@ -310,6 +315,16 @@ macro_rules! assert_no_events {
 }
 
 /// Asserts that emitted events match exactly the given input.
+///
+/// # Example
+///
+/// ```
+/// assert_events_eq!(
+///		Foo { x: 1, y: 2 },
+///		Bar { value: "test" },
+///		Baz { a: 10, b: 20 },
+/// );
+/// ```
 #[macro_export]
 macro_rules! assert_events_eq {
 	($event:expr) => {
@@ -321,6 +336,15 @@ macro_rules! assert_events_eq {
 }
 
 /// Asserts that some emitted events match the given input.
+///
+/// # Example
+///
+/// ```
+/// assert_events_emitted!(
+///		Foo { x: 1, y: 2 },
+///		Baz { a: 10, b: 20 },
+/// );
+/// ```
 #[macro_export]
 macro_rules! assert_events_emitted {
 	($event:expr) => {
@@ -342,6 +366,15 @@ macro_rules! assert_events_emitted {
 }
 
 /// Asserts that some events were never emitted.
+///
+/// # Example
+///
+/// ```
+/// assert_events_not_emitted!(
+///		Foo { x: 1, y: 2 },
+///		Bar { value: "test" },
+/// );
+/// ```
 #[macro_export]
 macro_rules! assert_events_not_emitted {
 	($event:expr) => {
@@ -363,6 +396,16 @@ macro_rules! assert_events_not_emitted {
 }
 
 /// Asserts that the emitted events are exactly equal to the input patterns.
+///
+/// # Example
+///
+/// ```
+/// assert_events_eq_match!(
+///		Foo { x: 1, .. },
+///		Bar { .. },
+///		Baz { a: 10, b: 20 },
+/// );
+/// ```
 #[macro_export]
 macro_rules! assert_events_eq_match {
 	($index:expr;) => {
@@ -396,6 +439,15 @@ macro_rules! assert_events_eq_match {
 }
 
 /// Asserts that some emitted events match the input patterns.
+///
+/// # Example
+///
+/// ```
+/// assert_events_emitted_match!(
+///		Foo { x: 1, .. },
+///		Baz { a: 10, b: 20 },
+/// );
+/// ```
 #[macro_export]
 macro_rules! assert_events_emitted_match {
 	($event:pat_param) => {
@@ -415,6 +467,15 @@ macro_rules! assert_events_emitted_match {
 }
 
 /// Asserts that the input patterns match none of the emitted events.
+///
+/// # Example
+///
+/// ```
+/// assert_events_not_emitted_match!(
+///		Foo { x: 1, .. },
+///		Baz { a: 10, b: 20 },
+/// );
+/// ```
 #[macro_export]
 macro_rules! assert_events_not_emitted_match {
 	($event:pat_param) => {
@@ -430,36 +491,6 @@ macro_rules! assert_events_not_emitted_match {
 		$(
 			assert_events_not_emitted_match!($events);
 		)+
-	};
-}
-
-/// Assert that one array is equal to the tail of the other. A more generic and testable version of
-/// assert_eq_last_events.
-#[macro_export]
-macro_rules! assert_tail_eq {
-	($tail:expr, $arr:expr $(,)?) => {
-		if $tail.len() != 0 {
-			// 0-length always passes
-
-			if $tail.len() > $arr.len() {
-				similar_asserts::assert_eq!($tail, $arr); // will fail
-			}
-
-			let len_diff = $arr.len() - $tail.len();
-			similar_asserts::assert_eq!($tail, $arr[len_diff..]);
-		}
-	};
-	($tail:expr, $arr:expr, $($arg:tt)*) => {
-		if $tail.len() != 0 {
-			// 0-length always passes
-
-			if $tail.len() > $arr.len() {
-				similar_asserts::assert_eq!($tail, $arr, $($arg)*); // will fail
-			}
-
-			let len_diff = $arr.len() - $tail.len();
-			similar_asserts::assert_eq!($tail, $arr[len_diff..], $($arg)*);
-		}
 	};
 }
 
@@ -646,44 +677,6 @@ fn roll_to_round_end_works() {
 		assert_eq!(System::block_number(), 14);
 		assert_eq!(num_blocks, 5);
 	});
-}
-
-#[test]
-fn assert_tail_eq_works() {
-	assert_tail_eq!(vec![1, 2], vec![0, 1, 2]);
-
-	assert_tail_eq!(vec![1], vec![1]);
-
-	assert_tail_eq!(
-		vec![0u32; 0], // 0 length array
-		vec![0u32; 1]  // 1-length array
-	);
-
-	assert_tail_eq!(vec![0u32, 0], vec![0u32, 0]);
-}
-
-#[test]
-#[should_panic]
-fn assert_tail_eq_panics_on_non_equal_tail() {
-	assert_tail_eq!(vec![2, 2], vec![0, 1, 2]);
-}
-
-#[test]
-#[should_panic]
-fn assert_tail_eq_panics_on_empty_arr() {
-	assert_tail_eq!(vec![2, 2], vec![0u32; 0]);
-}
-
-#[test]
-#[should_panic]
-fn assert_tail_eq_panics_on_longer_tail() {
-	assert_tail_eq!(vec![1, 2, 3], vec![1, 2]);
-}
-
-#[test]
-#[should_panic]
-fn assert_tail_eq_panics_on_unequal_elements_same_length_array() {
-	assert_tail_eq!(vec![1, 2, 3], vec![0, 1, 2]);
 }
 
 #[test]

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -703,6 +703,36 @@ fn test_assert_events_eq_fails_if_event_missing() {
 
 #[test]
 #[should_panic]
+fn test_assert_events_eq_fails_if_event_extra() {
+	ExtBuilder::default().build().execute_with(|| {
+		inject_test_events();
+
+		assert_events_eq!(
+			ParachainStakingEvent::CollatorChosen {
+				round: 2,
+				collator_account: 1,
+				total_exposed_amount: 10,
+			},
+			ParachainStakingEvent::NewRound {
+				starting_block: 10,
+				round: 2,
+				selected_collators_number: 1,
+				total_balance: 10,
+			},
+			ParachainStakingEvent::Rewarded {
+				account: 1,
+				rewards: 100,
+			},
+			ParachainStakingEvent::Rewarded {
+				account: 1,
+				rewards: 200,
+			},
+		);
+	});
+}
+
+#[test]
+#[should_panic]
 fn test_assert_events_eq_fails_if_event_wrong_order() {
 	ExtBuilder::default().build().execute_with(|| {
 		inject_test_events();
@@ -863,6 +893,21 @@ fn test_assert_events_eq_match_fails_if_event_missing() {
 		assert_events_eq_match!(
 			ParachainStakingEvent::CollatorChosen { .. },
 			ParachainStakingEvent::NewRound { .. },
+		);
+	});
+}
+
+#[test]
+#[should_panic]
+fn test_assert_events_eq_match_fails_if_event_extra() {
+	ExtBuilder::default().build().execute_with(|| {
+		inject_test_events();
+
+		assert_events_eq_match!(
+			ParachainStakingEvent::CollatorChosen { .. },
+			ParachainStakingEvent::NewRound { .. },
+			ParachainStakingEvent::Rewarded { .. },
+			ParachainStakingEvent::Rewarded { .. },
 		);
 	});
 }


### PR DESCRIPTION
### What does it do?
* refactors staking tests by resetting events between blocks. 
* simplifies assert macros

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
