### PR TITLE
Use a github token associated to a user to be able to trigger CI for automated PRs

### DIFF
--- a/.github/workflows/upgrade-typescript-api.yml
+++ b/.github/workflows/upgrade-typescript-api.yml
@@ -44,9 +44,8 @@ jobs:
           ./scripts/runtime-upgrade.sh ${{ github.event.inputs.spec_version }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.TYPESCRIPT_GITHUB_SECRET }}
         with:
+          token: ${{ secrets.TYPESCRIPT_GITHUB_SECRET }}
           base: master
           branch: "typescript-api-${{ github.event.inputs.spec_version }}"
           commit-message: typescript API v0.${{ github.event.inputs.spec_version }}.0"

--- a/.github/workflows/upgrade-typescript-api.yml
+++ b/.github/workflows/upgrade-typescript-api.yml
@@ -44,6 +44,8 @@ jobs:
           ./scripts/runtime-upgrade.sh ${{ github.event.inputs.spec_version }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.TYPESCRIPT_GITHUB_SECRET }}
         with:
           base: master
           branch: "typescript-api-${{ github.event.inputs.spec_version }}"


### PR DESCRIPTION
### What does it do?

Use a github token associated to a user to be able to trigger CI for automated PRs.

This is the workaround proposed here: https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-536204092

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
