### PR TITLE
only check auto-compound if delegator is to be rewarded

### DIFF
--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -321,7 +321,10 @@ totalBondReward               ${totalBondReward} \
     if (specVersion >= 1900) {
       const expectedAutoCompoundedDelegators = new Set(
         Object.entries(stakedValue[rewarded.collator].delegators)
-          .filter(([_, { autoCompound }]) => !autoCompound.value().isZero())
+          .filter(
+            ([key, { autoCompound }]) =>
+              !autoCompound.value().isZero() && expectedRewardedDelegators.has(key)
+          )
           .map(([key, _]) => key)
       );
       const notAutoCompounded = new Set(


### PR DESCRIPTION
### What does it do?
fixes smoke test to only check auto-compound if delegator is to be rewarded

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
