### PR TITLE
calculate maxRoundChecks from first block of round

### DIFF
--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -253,7 +253,10 @@ totalBondReward               ${totalBondReward} \
   const awardedCollatorCount = awardedCollators.length;
 
   // compute max rounds respecting the current block number and the number of awarded collators
-  const maxRoundChecks = Math.min(latestBlockNumber - nowBlockNumber + 1, awardedCollatorCount);
+  const maxRoundChecks = Math.min(
+    latestBlockNumber - nowRoundFirstBlock.toNumber() + 1,
+    awardedCollatorCount
+  );
   debug(`verifying ${maxRoundChecks} blocks for rewards (awarded ${awardedCollatorCount})`);
   const expectedRewardedCollators = new Set(awardedCollators);
   const rewardedCollators = new Set<HexString>();


### PR DESCRIPTION
### What does it do?
fixes smoke test scenario where `maxRoundChecks` would be incorrectly calculated from the input block number for the reward round, instead of, from the first block of round. This would test to not check all blocks, and then the test would fail:

```
latest  1208 (2170231 / 0x862d879bead4682e9f951a91fcb5b71dbe39fea759543f7bb94cd3ac7e3dbe31)
now     1207 (2170199 / 0x3862fd0ef926b8e1636d4e70279660ae620bc331c03835cb11a57b66b3de4482)
round   1205 (prior round last block   2164799 / 0x2189c5d92c7df59808af01979bddf0271c951de09c3e384e6801e900d6588060)
paid in 1207 (first block   2168400 / 0x5d08d44932e556103160f20d2b09e5028a1263765026861533ecf0d771cee407 / prior   0x5e0f14a944dcaaf7fdbd5f59286feca08ef61faa7c8596c4872e252f252385dc)

verifying 33 blocks for rewards (awarded 68)
```

The above calculation should've been from first block of round `1207` - `2168400` and not the input block number `2170199`

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
