### PR TITLE
[MOON-1978] cleanup atStake at each block

### DIFF
--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -259,7 +259,7 @@ pub(crate) fn roll_one_block() -> BlockNumber {
 }
 
 /// Rolls to the desired block. Returns the number of blocks played.
-pub(crate) fn roll_to(n: BlockNumber) -> BlockNumber {
+pub(crate) fn roll_to(n: BlockNumber) -> u32 {
 	let mut num_blocks = 0;
 	let mut block = System::block_number();
 	while block < n {


### PR DESCRIPTION
### What does it do?
Achieves the same result as #1896 but in a simpler way - Continues to clean up `AtStake` entries at each block of a round for collators that did not produce a block.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
