### PR TITLE
Adds support for typescript-api generated types in tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -357,7 +357,7 @@ jobs:
           cd ../tests
           npm ci
           #### Prepares and copies the typescript generated API to include in the tests
-          npm setup-typescript-api 
+          npm run setup-typescript-api 
 
           #### Compile typescript tests into javascript (more stable for Mocha)
           #### This also better display typescript issues

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,6 +354,11 @@ jobs:
           cd moonbeam-types-bundle
           npm ci
           npm run build
+
+          ####  Preparing the typescript api
+          cd ../typescript-api
+          npm ci
+
           cd ../tests
           npm ci
           #### Prepares and copies the typescript generated API to include in the tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -356,6 +356,8 @@ jobs:
           npm run build
           cd ../tests
           npm ci
+          #### Prepares and copies the typescript generated API to include in the tests
+          npm setup-typescript-api 
 
           #### Compile typescript tests into javascript (more stable for Mocha)
           #### This also better display typescript issues

--- a/tests/package.json
+++ b/tests/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "test-with-logs": "mocha --printlogs -r ts-node/register 'tests/**/test-*.ts'",
+    "setup-typescript-api": "cd ../typescript-api && npm run build && cp -r build ../tests/node_modules/@moonbeam-network/api-augment",
     "pre-build-contracts": "ts-node tools/pre-build-contracts.ts && npx prettier -w ./contracts/compiled/*.json",
     "test": "mocha --parallel -r ts-node/register 'tests/**/test-*.ts' -- -j 4",
     "test-seq": "mocha -r ts-node/register 'tests/**/test-*.ts'",


### PR DESCRIPTION
The tests should be run against actual typescript-api instead of picking them from NPM.

However, npm link or symlink don't work due to an issue with tsc, so they need to be copied.
