### PR TITLE
Skipping AtStake smoketests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,8 +354,15 @@ jobs:
           cd moonbeam-types-bundle
           npm ci
           npm run build
+
+          ####  Preparing the typescript api
+          cd ../typescript-api
+          npm ci
+
           cd ../tests
           npm ci
+          #### Prepares and copies the typescript generated API to include in the tests
+          npm run setup-typescript-api 
 
           #### Compile typescript tests into javascript (more stable for Mocha)
           #### This also better display typescript issues

--- a/tests/package.json
+++ b/tests/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "test-with-logs": "mocha --printlogs -r ts-node/register 'tests/**/test-*.ts'",
+    "setup-typescript-api": "cd ../typescript-api && npm run build && cp -r build ../tests/node_modules/@moonbeam-network/api-augment",
     "pre-build-contracts": "ts-node tools/pre-build-contracts.ts && npx prettier -w ./contracts/compiled/*.json",
     "test": "mocha --parallel -r ts-node/register 'tests/**/test-*.ts' -- -j 4",
     "test-seq": "mocha -r ts-node/register 'tests/**/test-*.ts'",

--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -13,6 +13,9 @@ if (!process.env.SKIP_BLOCK_CONSISTENCY_TESTS) {
   describeSmokeSuite(`Verify staking rewards`, function (context) {
     it("rewards are given as expected", async function () {
       this.timeout(500000);
+      if (context.polkadotApi.consts.system.version.specVersion.toNumber() < 2000){
+        this.skip()
+      }
       const atBlockNumber = process.env.BLOCK_NUMBER
         ? parseInt(process.env.BLOCK_NUMBER)
         : (await context.polkadotApi.rpc.chain.getHeader()).number.toNumber();

--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -13,8 +13,8 @@ if (!process.env.SKIP_BLOCK_CONSISTENCY_TESTS) {
   describeSmokeSuite(`Verify staking rewards`, function (context) {
     it("rewards are given as expected", async function () {
       this.timeout(500000);
-      if (context.polkadotApi.consts.system.version.specVersion.toNumber() < 2000){
-        this.skip()
+      if (context.polkadotApi.consts.system.version.specVersion.toNumber() < 2000) {
+        this.skip();
       }
       const atBlockNumber = process.env.BLOCK_NUMBER
         ? parseInt(process.env.BLOCK_NUMBER)

--- a/tests/smoke-tests/test-staking-round-cleanup.ts
+++ b/tests/smoke-tests/test-staking-round-cleanup.ts
@@ -49,7 +49,7 @@ if (!process.env.SKIP_BLOCK_CONSISTENCY_TESTS) {
       this.timeout(500000);
 
       const specVersion = context.polkadotApi.consts.system.version.specVersion.toNumber();
-      if (specVersion < 1900) {
+      if (specVersion < 2000) {
         debug(`ChainSpec ${specVersion} does not include the storage cleanup, skipping test`);
         this.skip();
       }


### PR DESCRIPTION
### What does it do?
Skips the AtStake smoke tests given the incompatibility with prod runtime data.
