### PR TITLE
[MOON-1943] add PayoutCollatorReward trait to override payout behavior for orbiters

### DIFF
--- a/pallets/moonbeam-orbiters/src/lib.rs
+++ b/pallets/moonbeam-orbiters/src/lib.rs
@@ -554,6 +554,11 @@ pub mod pallet {
 				T::DbWeight::get().writes(1)
 			}
 		}
+
+		/// Check if an account is an orbiter account for a given round
+		pub fn is_orbiter(for_round: T::RoundIndex, collator: T::AccountId) -> bool {
+			OrbiterPerRound::<T>::contains_key(for_round, &collator)
+		}
 	}
 }
 

--- a/pallets/moonbeam-orbiters/src/lib.rs
+++ b/pallets/moonbeam-orbiters/src/lib.rs
@@ -50,7 +50,7 @@ use nimbus_primitives::{AccountLookup, NimbusId};
 pub mod pallet {
 	use super::*;
 	use frame_support::pallet_prelude::*;
-	use frame_support::traits::{Currency, Imbalance, NamedReservableCurrency};
+	use frame_support::traits::{Currency, NamedReservableCurrency};
 	use frame_system::pallet_prelude::*;
 	use sp_runtime::traits::{CheckedSub, One, Saturating, StaticLookup, Zero};
 
@@ -534,19 +534,11 @@ pub mod pallet {
 			amount: BalanceOf<T>,
 		) -> Weight {
 			if let Some(orbiter) = OrbiterPerRound::<T>::take(pay_for_round, &collator) {
-				if let Ok(amount_to_transfer) = T::Currency::withdraw(
-					&collator,
-					amount,
-					frame_support::traits::WithdrawReasons::TRANSFER,
-					frame_support::traits::ExistenceRequirement::KeepAlive,
-				) {
-					let real_reward = amount_to_transfer.peek();
-					if T::Currency::resolve_into_existing(&orbiter, amount_to_transfer).is_ok() {
-						Self::deposit_event(Event::OrbiterRewarded {
-							account: orbiter,
-							rewards: real_reward,
-						});
-					}
+				if T::Currency::deposit_into_existing(&orbiter, amount).is_ok() {
+					Self::deposit_event(Event::OrbiterRewarded {
+						account: orbiter,
+						rewards: amount,
+					});
 				}
 				T::WeightInfo::distribute_rewards()
 			} else {

--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -1289,6 +1289,23 @@ benchmarks! {
 			"delegation must have an auto-compound entry",
 		);
 	}
+
+	mint_collator_reward {
+		let mut seed = Seed::new();
+		let collator = create_funded_collator::<T>(
+			"collator",
+			seed.take(),
+			0u32.into(),
+			true,
+			1,
+		)?;
+		let original_free_balance = T::Currency::free_balance(&collator);
+	}: {
+		Pallet::<T>::mint_collator_reward(1u32.into(), collator.clone(), 50u32.into())
+	}
+	verify {
+		assert_eq!(T::Currency::free_balance(&collator), original_free_balance + 50u32.into());
+	}
 }
 
 #[cfg(test)]

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -170,7 +170,7 @@ pub mod pallet {
 		type OnCollatorPayout: OnCollatorPayout<Self::AccountId, BalanceOf<Self>>;
 		/// Handler to distribute a collator's reward.
 		/// If you don't need it, you can specify the type `MintCollatorReward`.
-		type PayoutCollatorReward: PayoutCollatorReward<Self::AccountId, BalanceOf<Self>>;
+		type PayoutCollatorReward: PayoutCollatorReward<Self>;
 		/// Handler to notify the runtime when a new round begin.
 		/// If you don't need it, you can specify the type `()`.
 		type OnNewRound: OnNewRound;
@@ -1911,19 +1911,6 @@ pub mod pallet {
 	impl<T: Config> Get<Vec<T::AccountId>> for Pallet<T> {
 		fn get() -> Vec<T::AccountId> {
 			Self::selected_candidates()
-		}
-	}
-
-	/// Defines the default behavior for paying out the collator's reward. The amount is directly
-	/// deposited into the collator's account
-	pub struct MintCollatorReward<T>(core::marker::PhantomData<T>);
-	impl<T: Config> PayoutCollatorReward<T::AccountId, BalanceOf<T>> for MintCollatorReward<T> {
-		fn payout_collator_reward(
-			for_round: RoundIndex,
-			collator_id: T::AccountId,
-			amount: BalanceOf<T>,
-		) -> Weight {
-			Pallet::<T>::mint_collator_reward(for_round, collator_id, amount)
 		}
 	}
 }

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -166,10 +166,10 @@ pub mod pallet {
 		/// Get the current block author
 		type BlockAuthor: Get<Self::AccountId>;
 		/// Handler to notify the runtime when a collator is paid.
-		/// If you don't need it, you can specify the `MintCollatorReward`.
+		/// If you don't need it, you can specify the type `()`.
 		type OnCollatorPayout: OnCollatorPayout<Self::AccountId, BalanceOf<Self>>;
 		/// Handler to distribute a collator's reward.
-		/// If you don't need it, you can specify the type `()`.
+		/// If you don't need it, you can specify the type `MintCollatorReward`.
 		type PayoutCollatorReward: PayoutCollatorReward<Self::AccountId, BalanceOf<Self>>;
 		/// Handler to notify the runtime when a new round begin.
 		/// If you don't need it, you can specify the type `()`.

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -166,7 +166,7 @@ pub mod pallet {
 		/// Get the current block author
 		type BlockAuthor: Get<Self::AccountId>;
 		/// Handler to notify the runtime when a collator is paid.
-		/// If you don't need it, you can specify the type `()`.
+		/// If you don't need it, you can specify the `MintCollatorReward`.
 		type OnCollatorPayout: OnCollatorPayout<Self::AccountId, BalanceOf<Self>>;
 		/// Handler to distribute a collator's reward.
 		/// If you don't need it, you can specify the type `()`.
@@ -1911,6 +1911,22 @@ pub mod pallet {
 	impl<T: Config> Get<Vec<T::AccountId>> for Pallet<T> {
 		fn get() -> Vec<T::AccountId> {
 			Self::selected_candidates()
+		}
+	}
+
+	/// Defines the default behavior for paying out the collator's reward. The amount is directly
+	/// deposited into the collator's account
+	pub struct MintCollatorReward<T>(core::marker::PhantomData<T>);
+	impl<T> crate::PayoutCollatorReward<T::AccountId, BalanceOf<T>> for MintCollatorReward<T>
+	where
+		T: Config,
+	{
+		fn payout_collator_reward(
+			for_round: RoundIndex,
+			collator_id: T::AccountId,
+			amount: BalanceOf<T>,
+		) -> Weight {
+			Pallet::<T>::mint_collator_reward(for_round, collator_id, amount)
 		}
 	}
 }

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1584,7 +1584,6 @@ pub mod pallet {
 				let num_delegators = state.delegations.len();
 				if state.delegations.is_empty() {
 					// solo collator with no delegators
-					// Self::mint(amt_due, collator.clone());
 					extra_weight = extra_weight
 						.saturating_add(T::PayoutCollatorReward::payout_collator_reward(
 							paid_for_round,
@@ -1602,7 +1601,6 @@ pub mod pallet {
 					let commission = pct_due * collator_issuance;
 					amt_due = amt_due.saturating_sub(commission);
 					let collator_reward = (collator_pct * amt_due).saturating_add(commission);
-					// Self::mint(collator_reward, collator.clone());
 					extra_weight = extra_weight
 						.saturating_add(T::PayoutCollatorReward::payout_collator_reward(
 							paid_for_round,
@@ -1851,7 +1849,7 @@ pub mod pallet {
 			candidate: T::AccountId,
 			delegator: T::AccountId,
 		) -> Weight {
-			let mut weight = T::DbWeight::get().reads(0);
+			let mut weight = T::DbWeight::get().reads(0); // TODO create benchmark for this function
 
 			if let Ok(amount_transferred) =
 				T::Currency::deposit_into_existing(&delegator, amt.clone())

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1917,7 +1917,7 @@ pub mod pallet {
 	/// Defines the default behavior for paying out the collator's reward. The amount is directly
 	/// deposited into the collator's account
 	pub struct MintCollatorReward<T>(core::marker::PhantomData<T>);
-	impl<T> crate::PayoutCollatorReward<T::AccountId, BalanceOf<T>> for MintCollatorReward<T>
+	impl<T> PayoutCollatorReward<T::AccountId, BalanceOf<T>> for MintCollatorReward<T>
 	where
 		T: Config,
 	{

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1917,10 +1917,7 @@ pub mod pallet {
 	/// Defines the default behavior for paying out the collator's reward. The amount is directly
 	/// deposited into the collator's account
 	pub struct MintCollatorReward<T>(core::marker::PhantomData<T>);
-	impl<T> PayoutCollatorReward<T::AccountId, BalanceOf<T>> for MintCollatorReward<T>
-	where
-		T: Config,
-	{
+	impl<T: Config> PayoutCollatorReward<T::AccountId, BalanceOf<T>> for MintCollatorReward<T> {
 		fn payout_collator_reward(
 			for_round: RoundIndex,
 			collator_id: T::AccountId,

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1619,12 +1619,12 @@ pub mod pallet {
 						let percent = Perbill::from_rational(amount, state.total);
 						let due = percent * amt_due;
 						if !due.is_zero() {
-							Self::mint_and_compound(
+							extra_weight = extra_weight.saturating_add(Self::mint_and_compound(
 								due,
 								auto_compound.clone(),
 								collator.clone(),
 								owner.clone(),
-							);
+							));
 						}
 					}
 				}
@@ -1849,8 +1849,7 @@ pub mod pallet {
 			candidate: T::AccountId,
 			delegator: T::AccountId,
 		) -> Weight {
-			let mut weight = T::DbWeight::get().reads(0); // TODO create benchmark for this function
-
+			let mut weight = T::WeightInfo::mint_collator_reward();
 			if let Ok(amount_transferred) =
 				T::Currency::deposit_into_existing(&delegator, amt.clone())
 			{

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -169,7 +169,7 @@ pub mod pallet {
 		/// If you don't need it, you can specify the type `()`.
 		type OnCollatorPayout: OnCollatorPayout<Self::AccountId, BalanceOf<Self>>;
 		/// Handler to distribute a collator's reward.
-		/// If you don't need it, you can specify the type `MintCollatorReward`.
+		/// To use the default implementation of minting rewards, specify the type `()`.
 		type PayoutCollatorReward: PayoutCollatorReward<Self>;
 		/// Handler to notify the runtime when a new round begin.
 		/// If you don't need it, you can specify the type `()`.

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -141,7 +141,7 @@ impl Config for Test {
 	type MinDelegation = MinDelegation;
 	type BlockAuthor = BlockAuthor;
 	type OnCollatorPayout = ();
-	type PayoutCollatorReward = crate::MintCollatorReward<Test>;
+	type PayoutCollatorReward = ();
 	type OnNewRound = ();
 	type WeightInfo = ();
 }

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -120,16 +120,6 @@ parameter_types! {
 	pub const MinDelegatorStk: u128 = 5;
 	pub const MinDelegation: u128 = 3;
 }
-pub struct MintCollatorReward;
-impl crate::PayoutCollatorReward<AccountId, Balance> for MintCollatorReward {
-	fn payout_collator_reward(
-		for_round: pallet_parachain_staking::RoundIndex,
-		collator_id: AccountId,
-		amount: Balance,
-	) -> Weight {
-		ParachainStaking::mint_collator_reward(for_round, collator_id, amount)
-	}
-}
 impl Config for Test {
 	type Event = Event;
 	type Currency = Balances;
@@ -151,7 +141,7 @@ impl Config for Test {
 	type MinDelegation = MinDelegation;
 	type BlockAuthor = BlockAuthor;
 	type OnCollatorPayout = ();
-	type PayoutCollatorReward = MintCollatorReward;
+	type PayoutCollatorReward = crate::MintCollatorReward<Test>;
 	type OnNewRound = ();
 	type WeightInfo = ();
 }

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -120,6 +120,16 @@ parameter_types! {
 	pub const MinDelegatorStk: u128 = 5;
 	pub const MinDelegation: u128 = 3;
 }
+pub struct MintCollatorReward;
+impl crate::PayoutCollatorReward<AccountId, Balance> for MintCollatorReward {
+	fn payout_collator_reward(
+		for_round: pallet_parachain_staking::RoundIndex,
+		collator_id: AccountId,
+		amount: Balance,
+	) -> Weight {
+		ParachainStaking::mint_collator_reward(for_round, collator_id, amount)
+	}
+}
 impl Config for Test {
 	type Event = Event;
 	type Currency = Balances;
@@ -141,6 +151,7 @@ impl Config for Test {
 	type MinDelegation = MinDelegation;
 	type BlockAuthor = BlockAuthor;
 	type OnCollatorPayout = ();
+	type PayoutCollatorReward = MintCollatorReward;
 	type OnNewRound = ();
 	type WeightInfo = ();
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -9061,7 +9061,7 @@ fn test_on_initialize_weights() {
 			//
 			// following this assertion, we add individual weights together to show that we can
 			// derive this number independently.
-			let expected_on_init = 3_169_932_000;
+			let expected_on_init = 3_180_112_000;
 			assert_eq!(Weight::from_ref_time(expected_on_init), weight);
 
 			// assemble weight manually to ensure it is well understood
@@ -9084,7 +9084,7 @@ fn test_on_initialize_weights() {
 
 			// add weight for invoking handle_delayed_payouts
 			// (goes away when we skip paying the first collator during round change)
-			let handle_delayed_payouts_weight = 688_435_000;
+			let handle_delayed_payouts_weight = 698_615_000;
 			expected_weight += handle_delayed_payouts_weight;
 
 			assert_eq!(Weight::from_ref_time(expected_weight), weight);

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -9061,7 +9061,7 @@ fn test_on_initialize_weights() {
 			//
 			// following this assertion, we add individual weights together to show that we can
 			// derive this number independently.
-			let expected_on_init = 3_017_871_000;
+			let expected_on_init = 3_169_932_000;
 			assert_eq!(Weight::from_ref_time(expected_on_init), weight);
 
 			// assemble weight manually to ensure it is well understood
@@ -9084,7 +9084,7 @@ fn test_on_initialize_weights() {
 
 			// add weight for invoking handle_delayed_payouts
 			// (goes away when we skip paying the first collator during round change)
-			let handle_delayed_payouts_weight = 536_374_000;
+			let handle_delayed_payouts_weight = 688_435_000;
 			expected_weight += handle_delayed_payouts_weight;
 
 			assert_eq!(Weight::from_ref_time(expected_weight), weight);

--- a/pallets/parachain-staking/src/traits.rs
+++ b/pallets/parachain-staking/src/traits.rs
@@ -45,10 +45,22 @@ impl OnNewRound for () {
 }
 
 /// Defines the behavior to payout the collator's reward.
-pub trait PayoutCollatorReward<AccountId, Balance> {
+pub trait PayoutCollatorReward<Runtime: crate::Config> {
 	fn payout_collator_reward(
 		round_index: crate::RoundIndex,
-		collator_id: AccountId,
-		amount: Balance,
+		collator_id: Runtime::AccountId,
+		amount: crate::BalanceOf<Runtime>,
 	) -> Weight;
+}
+
+/// Defines the default behavior for paying out the collator's reward. The amount is directly
+/// deposited into the collator's account.
+impl<Runtime: crate::Config> PayoutCollatorReward<Runtime> for () {
+	fn payout_collator_reward(
+		for_round: crate::RoundIndex,
+		collator_id: Runtime::AccountId,
+		amount: crate::BalanceOf<Runtime>,
+	) -> Weight {
+		crate::Pallet::<Runtime>::mint_collator_reward(for_round, collator_id, amount)
+	}
 }

--- a/pallets/parachain-staking/src/traits.rs
+++ b/pallets/parachain-staking/src/traits.rs
@@ -52,12 +52,3 @@ pub trait PayoutCollatorReward<AccountId, Balance> {
 		amount: Balance,
 	) -> Weight;
 }
-impl<AccountId, Balance> PayoutCollatorReward<AccountId, Balance> for () {
-	fn payout_collator_reward(
-		_round_index: crate::RoundIndex,
-		_collator_id: AccountId,
-		_amount: Balance,
-	) -> Weight {
-		Weight::zero()
-	}
-}

--- a/pallets/parachain-staking/src/traits.rs
+++ b/pallets/parachain-staking/src/traits.rs
@@ -16,28 +16,48 @@
 
 //! traits for parachain-staking
 
+use frame_support::pallet_prelude::Weight;
+
 pub trait OnCollatorPayout<AccountId, Balance> {
 	fn on_collator_payout(
 		for_round: crate::RoundIndex,
 		collator_id: AccountId,
 		amount: Balance,
-	) -> frame_support::pallet_prelude::Weight;
+	) -> Weight;
 }
 impl<AccountId, Balance> OnCollatorPayout<AccountId, Balance> for () {
 	fn on_collator_payout(
 		_for_round: crate::RoundIndex,
 		_collator_id: AccountId,
 		_amount: Balance,
-	) -> frame_support::pallet_prelude::Weight {
-		frame_support::pallet_prelude::Weight::zero()
+	) -> Weight {
+		Weight::zero()
 	}
 }
 
 pub trait OnNewRound {
-	fn on_new_round(round_index: crate::RoundIndex) -> frame_support::pallet_prelude::Weight;
+	fn on_new_round(round_index: crate::RoundIndex) -> Weight;
 }
 impl OnNewRound for () {
-	fn on_new_round(_round_index: crate::RoundIndex) -> frame_support::pallet_prelude::Weight {
-		frame_support::pallet_prelude::Weight::zero()
+	fn on_new_round(_round_index: crate::RoundIndex) -> Weight {
+		Weight::zero()
+	}
+}
+
+/// Defines the behavior to payout the collator's reward.
+pub trait PayoutCollatorReward<AccountId, Balance> {
+	fn payout_collator_reward(
+		round_index: crate::RoundIndex,
+		collator_id: AccountId,
+		amount: Balance,
+	) -> Weight;
+}
+impl<AccountId, Balance> PayoutCollatorReward<AccountId, Balance> for () {
+	fn payout_collator_reward(
+		_round_index: crate::RoundIndex,
+		_collator_id: AccountId,
+		_amount: Balance,
+	) -> Weight {
+		Weight::zero()
 	}
 }

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -542,7 +542,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: System Account (r:1 w:1)
 	#[rustfmt::skip]
 	fn mint_collator_reward() -> Weight {
-		Weight::from_ref_time(27_061_000 as u64)
+		Weight::from_ref_time(37_241_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -962,7 +962,7 @@ impl WeightInfo for () {
 	// Storage: System Account (r:1 w:1)
 	#[rustfmt::skip]
 	fn mint_collator_reward() -> Weight {
-		Weight::from_ref_time(27_061_000 as u64)
+		Weight::from_ref_time(37_241_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -117,6 +117,8 @@ pub trait WeightInfo {
 	fn set_auto_compound(x: u32, y: u32, ) -> Weight;
 	#[rustfmt::skip]
 	fn delegate_with_auto_compound(x: u32, y: u32, z: u32, ) -> Weight;
+	#[rustfmt::skip]
+	fn mint_collator_reward() -> Weight;
 }
 
 /// Weights for parachain_staking using the Substrate node and recommended hardware.
@@ -489,6 +491,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(8 as u64))
 			.saturating_add(T::DbWeight::get().writes(8 as u64))
 	}
+	// Storage: System Account (r:1 w:1)
+	#[rustfmt::skip]
+	fn mint_collator_reward() -> Weight {
+		Weight::from_ref_time(27_061_000 as u64)
+			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().writes(1 as u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -859,5 +868,12 @@ impl WeightInfo for () {
 			.saturating_add(Weight::from_ref_time(71_000 as u64).saturating_mul(y as u64))
 			.saturating_add(RocksDbWeight::get().reads(8 as u64))
 			.saturating_add(RocksDbWeight::get().writes(8 as u64))
+	}
+	// Storage: System Account (r:1 w:1)
+	#[rustfmt::skip]
+	fn mint_collator_reward() -> Weight {
+		Weight::from_ref_time(27_061_000 as u64)
+			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 }

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -266,6 +266,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MinDelegatorStk = MinDelegatorStk;
 	type MinDelegation = MinDelegation;
 	type BlockAuthor = BlockAuthor;
+	type PayoutCollatorReward = ();
 	type OnCollatorPayout = ();
 	type OnNewRound = ();
 	type WeightInfo = ();

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -266,7 +266,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MinDelegatorStk = MinDelegatorStk;
 	type MinDelegation = MinDelegation;
 	type BlockAuthor = BlockAuthor;
-	type PayoutCollatorReward = ();
+	type PayoutCollatorReward = pallet_parachain_staking::MintCollatorReward<Runtime>;
 	type OnCollatorPayout = ();
 	type OnNewRound = ();
 	type WeightInfo = ();

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -266,7 +266,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MinDelegatorStk = MinDelegatorStk;
 	type MinDelegation = MinDelegation;
 	type BlockAuthor = BlockAuthor;
-	type PayoutCollatorReward = pallet_parachain_staking::MintCollatorReward<Runtime>;
+	type PayoutCollatorReward = ();
 	type OnCollatorPayout = ();
 	type OnNewRound = ();
 	type WeightInfo = ();

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -634,20 +634,30 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 
 impl parachain_info::Config for Runtime {}
 
-pub struct OnCollatorPayout;
-impl pallet_parachain_staking::OnCollatorPayout<AccountId, Balance> for OnCollatorPayout {
-	fn on_collator_payout(
-		for_round: pallet_parachain_staking::RoundIndex,
-		collator_id: AccountId,
-		amount: Balance,
-	) -> Weight {
-		MoonbeamOrbiters::distribute_rewards(for_round, collator_id, amount)
-	}
-}
 pub struct OnNewRound;
 impl pallet_parachain_staking::OnNewRound for OnNewRound {
 	fn on_new_round(round_index: pallet_parachain_staking::RoundIndex) -> Weight {
 		MoonbeamOrbiters::on_new_round(round_index)
+	}
+}
+pub struct PayoutCollatorOrOrbiterReward;
+impl pallet_parachain_staking::PayoutCollatorReward<AccountId, Balance>
+	for PayoutCollatorOrOrbiterReward
+{
+	fn payout_collator_reward(
+		for_round: pallet_parachain_staking::RoundIndex,
+		collator_id: AccountId,
+		amount: Balance,
+	) -> Weight {
+		let extra_weight = if MoonbeamOrbiters::is_orbiter(for_round, collator_id) {
+			MoonbeamOrbiters::distribute_rewards(for_round, collator_id, amount)
+		} else {
+			ParachainStaking::mint_collator_reward(for_round, collator_id, amount)
+		};
+
+		<Runtime as frame_system::Config>::DbWeight::get()
+			.reads(1)
+			.saturating_add(extra_weight)
 	}
 }
 
@@ -686,7 +696,8 @@ impl pallet_parachain_staking::Config for Runtime {
 	/// Minimum stake required to be reserved to be a delegator
 	type MinDelegatorStk = ConstU128<{ 1 * currency::UNIT * currency::SUPPLY_FACTOR }>;
 	type BlockAuthor = AuthorInherent;
-	type OnCollatorPayout = OnCollatorPayout;
+	type OnCollatorPayout = ();
+	type PayoutCollatorReward = PayoutCollatorOrOrbiterReward;
 	type OnNewRound = OnNewRound;
 	type WeightInfo = pallet_parachain_staking::weights::SubstrateWeight<Runtime>;
 }

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -641,9 +641,7 @@ impl pallet_parachain_staking::OnNewRound for OnNewRound {
 	}
 }
 pub struct PayoutCollatorOrOrbiterReward;
-impl pallet_parachain_staking::PayoutCollatorReward<AccountId, Balance>
-	for PayoutCollatorOrOrbiterReward
-{
+impl pallet_parachain_staking::PayoutCollatorReward<Runtime> for PayoutCollatorOrOrbiterReward {
 	fn payout_collator_reward(
 		for_round: pallet_parachain_staking::RoundIndex,
 		collator_id: AccountId,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -699,9 +699,7 @@ impl pallet_parachain_staking::OnNewRound for OnNewRound {
 	}
 }
 pub struct PayoutCollatorOrOrbiterReward;
-impl pallet_parachain_staking::PayoutCollatorReward<AccountId, Balance>
-	for PayoutCollatorOrOrbiterReward
-{
+impl pallet_parachain_staking::PayoutCollatorReward<Runtime> for PayoutCollatorOrOrbiterReward {
 	fn payout_collator_reward(
 		for_round: pallet_parachain_staking::RoundIndex,
 		collator_id: AccountId,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -692,20 +692,30 @@ parameter_types! {
 
 impl parachain_info::Config for Runtime {}
 
-pub struct OnCollatorPayout;
-impl pallet_parachain_staking::OnCollatorPayout<AccountId, Balance> for OnCollatorPayout {
-	fn on_collator_payout(
-		for_round: pallet_parachain_staking::RoundIndex,
-		collator_id: AccountId,
-		amount: Balance,
-	) -> Weight {
-		MoonbeamOrbiters::distribute_rewards(for_round, collator_id, amount)
-	}
-}
 pub struct OnNewRound;
 impl pallet_parachain_staking::OnNewRound for OnNewRound {
 	fn on_new_round(round_index: pallet_parachain_staking::RoundIndex) -> Weight {
 		MoonbeamOrbiters::on_new_round(round_index)
+	}
+}
+pub struct PayoutCollatorOrOrbiterReward;
+impl pallet_parachain_staking::PayoutCollatorReward<AccountId, Balance>
+	for PayoutCollatorOrOrbiterReward
+{
+	fn payout_collator_reward(
+		for_round: pallet_parachain_staking::RoundIndex,
+		collator_id: AccountId,
+		amount: Balance,
+	) -> Weight {
+		let extra_weight = if MoonbeamOrbiters::is_orbiter(for_round, collator_id) {
+			MoonbeamOrbiters::distribute_rewards(for_round, collator_id, amount)
+		} else {
+			ParachainStaking::mint_collator_reward(for_round, collator_id, amount)
+		};
+
+		<Runtime as frame_system::Config>::DbWeight::get()
+			.reads(1)
+			.saturating_add(extra_weight)
 	}
 }
 
@@ -744,7 +754,8 @@ impl pallet_parachain_staking::Config for Runtime {
 	/// Minimum stake required to be reserved to be a delegator
 	type MinDelegatorStk = ConstU128<{ 500 * currency::MILLIGLMR * currency::SUPPLY_FACTOR }>;
 	type BlockAuthor = AuthorInherent;
-	type OnCollatorPayout = OnCollatorPayout;
+	type OnCollatorPayout = ();
+	type PayoutCollatorReward = PayoutCollatorOrOrbiterReward;
 	type OnNewRound = OnNewRound;
 	type WeightInfo = pallet_parachain_staking::weights::SubstrateWeight<Runtime>;
 }

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -699,9 +699,7 @@ impl pallet_parachain_staking::OnNewRound for OnNewRound {
 	}
 }
 pub struct PayoutCollatorOrOrbiterReward;
-impl pallet_parachain_staking::PayoutCollatorReward<AccountId, Balance>
-	for PayoutCollatorOrOrbiterReward
-{
+impl pallet_parachain_staking::PayoutCollatorReward<Runtime> for PayoutCollatorOrOrbiterReward {
 	fn payout_collator_reward(
 		for_round: pallet_parachain_staking::RoundIndex,
 		collator_id: AccountId,


### PR DESCRIPTION
### What does it do?
adds PayoutCollatorReward trait to override payout behavior for orbiters

### :warning:  Breaking Change :warning: 
* `Rewarded` event is no longer emitted together with the `OrbiterRewarded` event if the account is an orbiter. Either `Rewarded` or `OrbiterRewarded` event will be emitted based on the type of collator (candidate / orbiter)

#### Before
```
// events
Rewarded { account: 0xabcd..., rewards: 100 }
OrbiterRewarded { account: 0xabcd..., rewards: 100 }
```

#### Now
```
// events
OrbiterRewarded { account: 0xabcd..., rewards: 100 }
```


### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
