### PR TITLE
[MOON-2006] change log level for failing to auto-compound to debug

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1841,8 +1841,8 @@ pub mod pallet {
 					candidate.clone(),
 					compound_amount.clone(),
 				) {
-					log::error!(
-								"Error compounding staking reward towards candidate '{:?}' for delegator '{:?}': {:?}",
+					log::debug!(
+								"skipped compounding staking reward towards candidate '{:?}' for delegator '{:?}': {:?}",
 								candidate,
 								delegator,
 								err


### PR DESCRIPTION
### What does it do?
Changes log level for failing to auto-compound to debug

### What important points reviewers should know?
Failure to auto-compound is the normal behavior if a pending revoke exists, and hence shouldn't be treated as an error.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
