### PR TITLE
fix rust docs generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install tooling
+        run: |
+          sudo apt-get install -y protobuf-compiler
+          protoc --version
       - name: Checkout repository
         uses: actions/checkout@v1
 


### PR DESCRIPTION
### What does it do?

Rust docs generation fails since the last dependencies upgrade because libp2p now needs protobuf-compiler, even to build the rust doc.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
