### PR TITLE
Take into account orbiter event

### DIFF
--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -806,6 +806,19 @@ async function assertRewardedEventsAtBlock(
         amount: event.data[1] as u128,
       };
     }
+    // Now orbiters have their own event. To replicate previous behavior,
+    // we take the collator associated and mark rewards as if they were
+    // to the collator
+    else if (apiAtBlock.events.moonbeamOrbiters.OrbiterRewarded.is(event)) {
+      rewardCount++;
+      let collator = await apiAtBlock.query.moonbeamOrbiters.accountLookupOverride(
+        event.data[0].toHex()
+      );
+      rewards[collator.unwrap().toHex()] = {
+        account: collator.unwrap().toHex(),
+        amount: event.data[1] as u128,
+      };
+    }
 
     if (specVersion >= 1900) {
       if (apiAtBlock.events.parachainStaking.Compounded.is(event)) {

--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -806,18 +806,21 @@ async function assertRewardedEventsAtBlock(
         amount: event.data[1] as u128,
       };
     }
-    // Now orbiters have their own event. To replicate previous behavior,
-    // we take the collator associated and mark rewards as if they were
-    // to the collator
-    else if (apiAtBlock.events.moonbeamOrbiters.OrbiterRewarded.is(event)) {
-      rewardCount++;
-      let collator = await apiAtBlock.query.moonbeamOrbiters.accountLookupOverride(
-        event.data[0].toHex()
-      );
-      rewards[collator.unwrap().toHex()] = {
-        account: collator.unwrap().toHex(),
-        amount: event.data[1] as u128,
-      };
+
+    if (specVersion >= 2000) {
+      // Now orbiters have their own event. To replicate previous behavior,
+      // we take the collator associated and mark rewards as if they were
+      // to the collator
+      if (apiAtBlock.events.moonbeamOrbiters.OrbiterRewarded.is(event)) {
+        rewardCount++;
+        let collator = await apiAtBlock.query.moonbeamOrbiters.accountLookupOverride(
+          event.data[0].toHex()
+        );
+        rewards[collator.unwrap().toHex()] = {
+          account: collator.unwrap().toHex(),
+          amount: event.data[1] as u128,
+        };
+      }
     }
 
     if (specVersion >= 1900) {


### PR DESCRIPTION
### What does it do?
Fixes staking smoke-tests to take into account moonbeam reward orbiter event in runtimes > 2000.
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
