### PR TITLE
[MOON-2032] remove Default* config constants from parachain-staking unit tests

### DIFF
--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -101,9 +101,11 @@ impl pallet_balances::Config for Test {
 	type WeightInfo = ();
 }
 impl block_author::Config for Test {}
+const GENESIS_BLOCKS_PER_ROUND: u32 = 5;
+const GENESIS_COLLATOR_COMMISSION: Perbill = Perbill::from_percent(20);
+const GENESIS_PARACHAIN_BOND_RESERVE_PERCENT: Percent = Percent::from_percent(30);
 parameter_types! {
 	pub const MinBlocksPerRound: u32 = 3;
-	pub const DefaultBlocksPerRound: u32 = 5;
 	pub const LeaveCandidatesDelay: u32 = 2;
 	pub const CandidateBondLessDelay: u32 = 2;
 	pub const LeaveDelegatorsDelay: u32 = 2;
@@ -114,8 +116,6 @@ parameter_types! {
 	pub const MaxTopDelegationsPerCandidate: u32 = 4;
 	pub const MaxBottomDelegationsPerCandidate: u32 = 4;
 	pub const MaxDelegationsPerDelegator: u32 = 4;
-	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
-	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
 	pub const MinCollatorStk: u128 = 10;
 	pub const MinDelegatorStk: u128 = 5;
 	pub const MinDelegation: u128 = 3;
@@ -236,9 +236,9 @@ impl ExtBuilder {
 			candidates: self.collators,
 			delegations: self.delegations,
 			inflation_config: self.inflation,
-			collator_commission: DefaultCollatorCommission::get(),
-			parachain_bond_reserve_percent: DefaultParachainBondReservePercent::get(),
-			blocks_per_round: DefaultBlocksPerRound::get(),
+			collator_commission: GENESIS_COLLATOR_COMMISSION,
+			parachain_bond_reserve_percent: GENESIS_PARACHAIN_BOND_RESERVE_PERCENT,
+			blocks_per_round: GENESIS_BLOCKS_PER_ROUND,
 		}
 		.assimilate_storage(&mut t)
 		.expect("Parachain Staking's storage can be assimilated");
@@ -285,14 +285,14 @@ pub(crate) fn roll_blocks(num_blocks: u32) -> BlockNumber {
 /// This will complete the block in which the round change occurs.
 /// Returns the number of blocks played.
 pub(crate) fn roll_to_round_begin(round: BlockNumber) -> BlockNumber {
-	let block = (round - 1) * DefaultBlocksPerRound::get();
+	let block = (round - 1) * GENESIS_BLOCKS_PER_ROUND;
 	roll_to(block)
 }
 
 /// Rolls block-by-block to the end of the specified round.
 /// The block following will be the one in which the specified round change occurs.
 pub(crate) fn roll_to_round_end(round: BlockNumber) -> BlockNumber {
-	let block = round * DefaultBlocksPerRound::get() - 1;
+	let block = round * GENESIS_BLOCKS_PER_ROUND - 1;
 	roll_to(block)
 }
 
@@ -652,7 +652,7 @@ pub mod block_author {
 #[test]
 fn roll_to_round_begin_works() {
 	ExtBuilder::default().build().execute_with(|| {
-		// these tests assume blocks-per-round of 5, as established by DefaultBlocksPerRound
+		// these tests assume blocks-per-round of 5, as established by GENESIS_BLOCKS_PER_ROUND
 		assert_eq!(System::block_number(), 1); // we start on block 1
 
 		let num_blocks = roll_to_round_begin(1);
@@ -672,7 +672,7 @@ fn roll_to_round_begin_works() {
 #[test]
 fn roll_to_round_end_works() {
 	ExtBuilder::default().build().execute_with(|| {
-		// these tests assume blocks-per-round of 5, as established by DefaultBlocksPerRound
+		// these tests assume blocks-per-round of 5, as established by GENESIS_BLOCKS_PER_ROUND
 		assert_eq!(System::block_number(), 1); // we start on block 1
 
 		let num_blocks = roll_to_round_end(1);

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -143,10 +143,11 @@ impl pallet_timestamp::Config for Runtime {
 	type MinimumPeriod = MinimumPeriod;
 	type WeightInfo = ();
 }
-
+const GENESIS_BLOCKS_PER_ROUND: u32 = 5;
+const GENESIS_COLLATOR_COMMISSION: Perbill = Perbill::from_percent(20);
+const GENESIS_PARACHAIN_BOND_RESERVE_PERCENT: Percent = Percent::from_percent(30);
 parameter_types! {
 	pub const MinBlocksPerRound: u32 = 3;
-	pub const DefaultBlocksPerRound: u32 = 5;
 	pub const LeaveCandidatesDelay: u32 = 2;
 	pub const CandidateBondLessDelay: u32 = 2;
 	pub const LeaveDelegatorsDelay: u32 = 2;
@@ -157,8 +158,6 @@ parameter_types! {
 	pub const MaxTopDelegationsPerCandidate: u32 = 4;
 	pub const MaxBottomDelegationsPerCandidate: u32 = 4;
 	pub const MaxDelegationsPerDelegator: u32 = 4;
-	pub const DefaultCollatorCommission: Perbill = Perbill::from_percent(20);
-	pub const DefaultParachainBondReservePercent: Percent = Percent::from_percent(30);
 	pub const MinCollatorStk: u128 = 10;
 	pub const MinDelegatorStk: u128 = 5;
 	pub const MinDelegation: u128 = 3;
@@ -283,9 +282,9 @@ impl ExtBuilder {
 			candidates: self.collators,
 			delegations: self.delegations,
 			inflation_config: self.inflation,
-			collator_commission: DefaultCollatorCommission::get(),
-			parachain_bond_reserve_percent: DefaultParachainBondReservePercent::get(),
-			blocks_per_round: DefaultBlocksPerRound::get(),
+			collator_commission: GENESIS_COLLATOR_COMMISSION,
+			parachain_bond_reserve_percent: GENESIS_PARACHAIN_BOND_RESERVE_PERCENT,
+			blocks_per_round: GENESIS_BLOCKS_PER_ROUND,
 		}
 		.assimilate_storage(&mut t)
 		.expect("Parachain Staking's storage can be assimilated");
@@ -317,7 +316,7 @@ pub(crate) fn roll_to(n: BlockNumber) {
 /// Rolls block-by-block to the beginning of the specified round.
 /// This will complete the block in which the round change occurs.
 pub(crate) fn roll_to_round_begin(round: BlockNumber) {
-	let block = (round - 1) * DefaultBlocksPerRound::get();
+	let block = (round - 1) * GENESIS_BLOCKS_PER_ROUND;
 	roll_to(block)
 }
 


### PR DESCRIPTION
#1798 moved some config associated constants to genesis but did not update the unit test mocks

this PR updates the unit test mocks to close out MOON-2032
