### PR TITLE
[MOON-1989] Randomness precompile unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7107,7 +7107,6 @@ dependencies = [
  "parity-scale-codec",
  "precompile-utils",
  "scale-info",
- "serde",
  "session-keys-primitives",
  "sp-core",
  "sp-io",

--- a/pallets/randomness/src/lib.rs
+++ b/pallets/randomness/src/lib.rs
@@ -222,7 +222,7 @@ pub mod pallet {
 	/// Removed once $value.request_count == 0
 	#[pallet::storage]
 	#[pallet::getter(fn randomness_results)]
-	pub(crate) type RandomnessResults<T: Config> =
+	pub type RandomnessResults<T: Config> =
 		StorageMap<_, Twox64Concat, RequestType<T>, RandomnessResult<T::Hash>>;
 
 	#[pallet::call]

--- a/precompiles/randomness/Cargo.toml
+++ b/precompiles/randomness/Cargo.toml
@@ -32,7 +32,6 @@ nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moo
 [dev-dependencies]
 derive_more = "0.99"
 hex-literal = "0.3.4"
-serde = "1.0.100"
 
 # Moonbeam
 pallet-author-mapping = { path = "../../pallets/author-mapping" }

--- a/precompiles/randomness/src/lib.rs
+++ b/precompiles/randomness/src/lib.rs
@@ -32,8 +32,8 @@ use precompile_utils::{costs::call_cost, prelude::*};
 use sp_core::{H160, H256, U256};
 use sp_std::{marker::PhantomData, vec, vec::Vec};
 
-// #[cfg(test)]
-// mod mock;
+#[cfg(test)]
+mod mock;
 mod solidity_types;
 #[cfg(test)]
 mod tests;

--- a/precompiles/randomness/src/mock.rs
+++ b/precompiles/randomness/src/mock.rs
@@ -25,7 +25,7 @@ use nimbus_primitives::NimbusId;
 use pallet_evm::{EnsureAddressNever, EnsureAddressRoot};
 use precompile_utils::{precompile_set::*, testing::MockAccount};
 use session_keys_primitives::VrfId;
-use sp_core::{H160, H256};
+use sp_core::H256;
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
 	Perbill,
@@ -102,11 +102,6 @@ impl pallet_balances::Config for Runtime {
 	type ExistentialDeposit = ExistentialDeposit;
 	type AccountStore = System;
 	type WeightInfo = ();
-}
-
-/// The randomness precompile is available at address one in the mock runtime.
-pub fn precompile_address() -> H160 {
-	H160::from_low_u64_be(1)
 }
 
 pub type TestPrecompiles<R> = PrecompileSetBuilder<
@@ -246,4 +241,11 @@ impl ExtBuilder {
 		ext.execute_with(|| System::set_block_number(1));
 		ext
 	}
+}
+
+pub(crate) fn events() -> Vec<RuntimeEvent> {
+	System::events()
+		.into_iter()
+		.map(|r| r.event)
+		.collect::<Vec<_>>()
 }

--- a/precompiles/randomness/src/tests.rs
+++ b/precompiles/randomness/src/tests.rs
@@ -16,7 +16,57 @@
 
 //! Randomness precompile unit tests
 use crate::mock::*;
-use precompile_utils::testing::solidity;
+use pallet_randomness::{Event as RandomnessEvent, RandomnessResults, RequestType};
+use precompile_utils::{assert_event_emitted, testing::*, EvmDataWriter};
+use sp_core::{H160, H256, U256};
+
+#[test]
+fn test_selector_less_than_four_bytes_reverts() {
+	ExtBuilder::default().build().execute_with(|| {
+		PrecompilesValue::get()
+			.prepare_test(Alice, Precompile1, vec![1u8, 2, 3])
+			.execute_reverts(|output| output == b"Tried to read selector out of bounds");
+	});
+}
+
+#[test]
+fn test_unimplemented_selector_reverts() {
+	ExtBuilder::default().build().execute_with(|| {
+		PrecompilesValue::get()
+			.prepare_test(Alice, Precompile1, vec![1u8, 2, 3, 4])
+			.execute_reverts(|output| output == b"Unknown selector");
+	});
+}
+
+#[test]
+fn selectors() {
+	assert!(PCall::relay_epoch_index_selectors().contains(&0x81797566));
+	assert!(PCall::required_deposit_selectors().contains(&0xfb7cfdd7));
+	assert!(PCall::get_request_status_selectors().contains(&0xd8a4676f));
+	assert!(PCall::get_request_selectors().contains(&0xc58343ef));
+	assert!(PCall::request_local_randomness_selectors().contains(&0x9478430c));
+	assert!(PCall::request_babe_randomness_selectors().contains(&0x33c14a63));
+	assert!(PCall::fulfill_request_selectors().contains(&0x9a91eb0d));
+	assert!(PCall::increase_request_fee_selectors().contains(&0xd0408a7f));
+	assert!(PCall::purge_expired_request_selectors().contains(&0x1d26cbab));
+}
+
+#[test]
+fn modifiers() {
+	ExtBuilder::default().build().execute_with(|| {
+		let mut tester =
+			PrecompilesModifierTester::new(PrecompilesValue::get(), Alice, Precompile1);
+
+		tester.test_view_modifier(PCall::relay_epoch_index_selectors());
+		tester.test_view_modifier(PCall::required_deposit_selectors());
+		tester.test_view_modifier(PCall::get_request_status_selectors());
+		tester.test_view_modifier(PCall::get_request_selectors());
+		tester.test_default_modifier(PCall::request_local_randomness_selectors());
+		tester.test_default_modifier(PCall::request_babe_randomness_selectors());
+		tester.test_default_modifier(PCall::fulfill_request_selectors());
+		tester.test_default_modifier(PCall::purge_expired_request_selectors());
+	});
+}
 
 #[test]
 fn test_solidity_interface_has_all_function_selectors_documented_and_implemented() {
@@ -41,4 +91,432 @@ fn test_solidity_interface_has_all_function_selectors_documented_and_implemented
 			}
 		}
 	}
+}
+
+#[test]
+fn relay_epoch_index_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+
+		PrecompilesValue::get()
+			.prepare_test(Alice, Precompile1, PCall::relay_epoch_index {})
+			.execute_returns_encoded(1u64);
+	})
+}
+
+#[test]
+fn required_deposit_works() {
+	ExtBuilder::default().build().execute_with(|| {
+		pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+
+		PrecompilesValue::get()
+			.prepare_test(Alice, Precompile1, PCall::required_deposit {})
+			.execute_returns_encoded(U256::from(10));
+	})
+}
+
+#[test]
+fn get_dne_request_status() {
+	ExtBuilder::default().build().execute_with(|| {
+		pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+
+		PrecompilesValue::get()
+			.prepare_test(
+				Alice,
+				Precompile1,
+				PCall::get_request_status {
+					request_id: 1.into(),
+				},
+			)
+			.execute_returns_encoded(0u8);
+	})
+}
+
+#[test]
+fn get_pending_request_status() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::request_babe_randomness {
+						refund_address: precompile_utils::data::Address(H160::from(Bob)),
+						fee: U256::one(),
+						gas_limit: 100u64,
+						salt: H256::default(),
+						num_words: 1u8,
+					},
+				)
+				.execute_returns([0u8; 32].into());
+
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::get_request_status {
+						request_id: 0.into(),
+					},
+				)
+				.execute_returns_encoded(1u8);
+		})
+}
+
+#[test]
+fn get_ready_request_status() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::request_local_randomness {
+						refund_address: precompile_utils::data::Address(H160::from(Bob)),
+						fee: U256::one(),
+						gas_limit: crate::fulfillment_overhead_gas_cost::<Runtime>(10u8) + 10u64,
+						salt: H256::default(),
+						num_words: 1u8,
+						delay: 2.into(),
+					},
+				)
+				.execute_returns([0u8; 32].into());
+			// run to ready block
+			System::set_block_number(3);
+			// ready status
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::get_request_status {
+						request_id: 0.into(),
+					},
+				)
+				.execute_returns_encoded(2u8);
+		})
+}
+
+#[test]
+fn get_expired_request_status() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::request_local_randomness {
+						refund_address: precompile_utils::data::Address(H160::from(Bob)),
+						fee: U256::one(),
+						gas_limit: crate::fulfillment_overhead_gas_cost::<Runtime>(10u8) + 10u64,
+						salt: H256::default(),
+						num_words: 1u8,
+						delay: 2.into(),
+					},
+				)
+				.execute_returns([0u8; 32].into());
+			// run to expired block
+			System::set_block_number(21);
+			// ready status
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::get_request_status {
+						request_id: 0.into(),
+					},
+				)
+				.execute_returns_encoded(3u8);
+		})
+}
+
+#[test]
+fn get_request_works() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::request_local_randomness {
+						refund_address: precompile_utils::data::Address(H160::from(Bob)),
+						fee: U256::one(),
+						gas_limit: 100u64,
+						salt: H256::default(),
+						num_words: 1u8,
+						delay: 2.into(),
+					},
+				)
+				.execute_returns([0u8; 32].into());
+			// run to expired block
+			System::set_block_number(21);
+			// ready status
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::get_request {
+						request_id: 0.into(),
+					},
+				)
+				.execute_returns(
+					EvmDataWriter::new()
+						.write(U256::zero())
+						.write(precompile_utils::data::Address(H160::from(Bob)))
+						.write(precompile_utils::data::Address(H160::from(Alice)))
+						.write(U256::one())
+						.write(U256::from(100))
+						.write(H256::default())
+						.write(1u8)
+						.write(0u8)
+						.write(3u32)
+						.write(0u64)
+						.write(21u32)
+						.write(0u64)
+						.write(3u8)
+						.build(),
+				);
+		})
+}
+
+#[test]
+fn request_babe_randomness_works() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::request_babe_randomness {
+						refund_address: precompile_utils::data::Address(H160::from(Bob)),
+						fee: U256::one(),
+						gas_limit: 100u64,
+						salt: H256::default(),
+						num_words: 1u8,
+					},
+				)
+				.execute_returns([0u8; 32].into());
+			assert_event_emitted!(RuntimeEvent::Randomness(
+				RandomnessEvent::RandomnessRequestedBabeEpoch {
+					id: 0,
+					refund_address: H160::from(Bob),
+					contract_address: H160::from(Alice),
+					fee: 1,
+					gas_limit: 100u64,
+					num_words: 1u8,
+					salt: H256::default(),
+					earliest_epoch: 3,
+				}
+			));
+		})
+}
+
+#[test]
+fn request_local_randomness_works() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::request_local_randomness {
+						refund_address: precompile_utils::data::Address(H160::from(Bob)),
+						fee: U256::one(),
+						gas_limit: 100u64,
+						salt: H256::default(),
+						num_words: 1u8,
+						delay: 2.into(),
+					},
+				)
+				.execute_returns([0u8; 32].into());
+			assert_event_emitted!(RuntimeEvent::Randomness(
+				RandomnessEvent::RandomnessRequestedLocal {
+					id: 0,
+					refund_address: H160::from(Bob),
+					contract_address: H160::from(Alice),
+					fee: 1,
+					gas_limit: 100u64,
+					num_words: 1u8,
+					salt: H256::default(),
+					earliest_block: 3,
+				}
+			));
+		});
+}
+
+#[test]
+fn fulfill_request_fails_when_gas_limit_below_call_overhead_cost() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::request_local_randomness {
+						refund_address: precompile_utils::data::Address(H160::from(Bob)),
+						fee: U256::one(),
+						gas_limit: 100u64,
+						salt: H256::default(),
+						num_words: 1u8,
+						delay: 2.into(),
+					},
+				)
+				.execute_returns([0u8; 32].into());
+			// run to ready block
+			System::set_block_number(3);
+			// fill randomness results
+			let mut filled_results =
+				RandomnessResults::<Runtime>::get(RequestType::Local(3)).unwrap();
+			filled_results.randomness = Some(H256::default());
+			RandomnessResults::<Runtime>::insert(RequestType::Local(3), filled_results);
+			// fulfill request
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::fulfill_request {
+						request_id: 0.into(),
+					},
+				)
+				.expect_log(crate::log_fulfillment_failed(Alice));
+		})
+}
+
+#[test]
+fn fulfill_request_works() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::request_local_randomness {
+						refund_address: precompile_utils::data::Address(H160::from(Bob)),
+						fee: U256::one(),
+						gas_limit: crate::fulfillment_overhead_gas_cost::<Runtime>(10u8) + 10u64,
+						salt: H256::default(),
+						num_words: 1u8,
+						delay: 2.into(),
+					},
+				)
+				.execute_returns([0u8; 32].into());
+			// run to ready block
+			System::set_block_number(3);
+			// fill randomness results
+			let mut filled_results =
+				RandomnessResults::<Runtime>::get(RequestType::Local(3)).unwrap();
+			filled_results.randomness = Some(H256::default());
+			RandomnessResults::<Runtime>::insert(RequestType::Local(3), filled_results);
+			// fulfill request
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::fulfill_request {
+						request_id: 0.into(),
+					},
+				)
+				.expect_log(crate::log_fulfillment_succeeded(Alice));
+		})
+}
+
+#[test]
+fn increase_request_fee_works() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::request_local_randomness {
+						refund_address: precompile_utils::data::Address(H160::from(Bob)),
+						fee: U256::one(),
+						gas_limit: 100u64,
+						salt: H256::default(),
+						num_words: 1u8,
+						delay: 2.into(),
+					},
+				)
+				.execute_returns([0u8; 32].into());
+			// increase request fee
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::increase_request_fee {
+						request_id: 0.into(),
+						fee_increase: 10.into(),
+					},
+				)
+				.execute_returns(vec![]);
+			assert_event_emitted!(RuntimeEvent::Randomness(
+				RandomnessEvent::RequestFeeIncreased { id: 0, new_fee: 11 }
+			));
+		})
+}
+
+#[test]
+fn purge_expired_request_works() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::request_local_randomness {
+						refund_address: precompile_utils::data::Address(H160::from(Bob)),
+						fee: U256::one(),
+						gas_limit: 100u64,
+						salt: H256::default(),
+						num_words: 1u8,
+						delay: 2.into(),
+					},
+				)
+				.execute_returns([0u8; 32].into());
+			System::set_block_number(21);
+			// purge expired request
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::purge_expired_request {
+						request_id: 0.into(),
+					},
+				)
+				.execute_returns(vec![]);
+			assert_event_emitted!(RuntimeEvent::Randomness(
+				RandomnessEvent::RequestExpirationExecuted { id: 0 }
+			));
+		})
 }

--- a/precompiles/randomness/src/tests.rs
+++ b/precompiles/randomness/src/tests.rs
@@ -15,59 +15,30 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Randomness precompile unit tests
+use crate::mock::*;
+use precompile_utils::testing::solidity;
 
-// use std::collections::HashSet;
+#[test]
+fn test_solidity_interface_has_all_function_selectors_documented_and_implemented() {
+	for file in ["Randomness.sol"] {
+		for solidity_fn in solidity::get_selectors(file) {
+			assert_eq!(
+				solidity_fn.compute_selector_hex(),
+				solidity_fn.docs_selector,
+				"documented selector for '{}' did not match for file '{}'",
+				solidity_fn.signature(),
+				file,
+			);
 
-// use precompile_utils::solidity;
-// use crate::mock::*;
-
-// #[test]
-// fn test_all_actions_are_implemented_in_solidity_interface() {
-// 	let selectors = solidity::get_selectors("Randomness.sol")
-// 		.into_iter()
-// 		.map(|sf| sf.compute_selector())
-// 		.collect::<HashSet<_>>();
-
-// 	assert_eq!(Action::RelayEpochIndex as u32, 0x81797566);
-// 	assert!(selectors.contains(&(Action::RelayEpochIndex as u32)));
-
-// 	assert_eq!(Action::RequestBabeRandomness as u32, 0xbbc9e95f);
-// 	assert!(selectors.contains(&(Action::RequestBabeRandomness as u32)));
-
-// 	assert_eq!(Action::RequestLocalRandomness as u32, 0xb4a11763);
-// 	assert!(selectors.contains(&(Action::RequestLocalRandomness as u32)));
-
-// 	assert_eq!(Action::FulfillRequest as u32, 0xb9904a86);
-// 	assert!(selectors.contains(&(Action::FulfillRequest as u32)));
-
-// 	assert_eq!(Action::IncreaseRequestFee as u32, 0x6a5b3380);
-// 	assert!(selectors.contains(&(Action::IncreaseRequestFee as u32)));
-
-// 	assert_eq!(Action::ExecuteRequestExpiration as u32, 0x8fcdcc49);
-// 	assert!(selectors.contains(&(Action::ExecuteRequestExpiration as u32)));
-// }
-
-// #[test]
-// fn test_solidity_interface_has_all_function_selectors_documented_and_implemented() {
-// 	for file in ["Randomness.sol"] {
-// 		for solidity_fn in solidity::get_selectors(file) {
-// 			assert_eq!(
-// 				solidity_fn.compute_selector_hex(),
-// 				solidity_fn.docs_selector,
-// 				"documented selector for '{}' did not match for file '{}'",
-// 				solidity_fn.signature(),
-// 				file,
-// 			);
-
-// 			let selector = solidity_fn.compute_selector();
-// 			if !PCall::supports_selector(selector) {
-// 				panic!(
-// 					"failed decoding selector 0x{:x} => '{}' as Action for file '{}'",
-// 					selector,
-// 					solidity_fn.signature(),
-// 					file,
-// 				)
-// 			}
-// 		}
-// 	}
-// }
+			let selector = solidity_fn.compute_selector();
+			if !PCall::supports_selector(selector) {
+				panic!(
+					"failed decoding selector 0x{:x} => '{}' as Action for file '{}'",
+					selector,
+					solidity_fn.signature(),
+					file,
+				)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Unit tests for the precompile were not added in the original PR because TS coverage was sufficient.

This PR adds unit tests to the precompile to match pallet unit test coverage. **These only test up to event emission because event emission => storage changes is tested in the pallet and TS.**