### PR TITLE
CENTS in Kusama are now 1e12/3000

### DIFF
--- a/tests/smoke-tests/test-relay-xcm-fees.ts
+++ b/tests/smoke-tests/test-relay-xcm-fees.ts
@@ -71,7 +71,7 @@ describeSmokeSuite(`Verify XCM weight fees for relay`, (context) => {
       relayRuntime.startsWith("westend")
         ? units / 100n
         : relayRuntime.startsWith("kusama")
-        ? units / 30_000n
+        ? units / 3_000n
         : units / 100n;
     const coef = cent / 10n;
 


### PR DESCRIPTION
### What does it do?
Changes the smoke test to reflect the fact that Kusama treats CENTS as 1e12/3000
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
