### PR TITLE
Remove RT-check from staking rewards smoke test

### DIFF
--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -25,9 +25,6 @@ describeSmokeSuite(`When verifying ParachainStaking rewards...`, function (conte
   let predecessorApiAt: ApiDecoration<"promise">;
 
   before("Common Setup", async function () {
-    if (context.polkadotApi.consts.system.version.specVersion.toNumber() < 2000) {
-      this.skip();
-    }
     if (process.env.SKIP_BLOCK_CONSISTENCY_TESTS) {
       debug("Skip Block Consistency flag set, skipping staking rewards tests.");
       this.skip();


### PR DESCRIPTION
### What does it do?
* removes RT-check from staking rewards smoke test
* minor fixes to https://github.com/PureStake/moonbeam/pull/1990

### What important points reviewers should know?
This enables this smoke test to run on Moonbeam (RT<1901)

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
