### PR TITLE
Add owner admin frezer issuer accessors to assets precompile

### DIFF
--- a/precompiles/assets-erc20/ERC20.sol
+++ b/precompiles/assets-erc20/ERC20.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity >=0.8.3;
 
+/// @author The Moonbeam Team
 /// @title ERC20 interface
 /// @dev see https://github.com/ethereum/EIPs/issues/20
 /// @dev copied from https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/precompiles/assets-erc20/ERC20.sol
+++ b/precompiles/assets-erc20/ERC20.sol
@@ -37,41 +37,6 @@ interface IERC20 {
         view
         returns (uint256);
 
-    /// @dev Function to check the owner of the asset
-    /// @custom:selector 8da5cb5b
-    /// @return the address of the owner.
-    function owner()
-        external
-        view
-        returns (address);
-
-    /// @dev Function to check the freezer of the asset
-    /// @dev Freezer: the account that can freeze an asset
-    /// @custom:selector 92716054
-    /// @return the address of the freezer.
-    function freezer()
-        external
-        view
-        returns (address);
-
-    /// @dev Function to check the issuer of the asset
-    /// @dev Issuer: the account that can issue tokens for an asset
-    /// @custom:selector 1d143848
-    /// @return the address of the issuer.
-    function issuer()
-        external
-        view
-        returns (address);
-
-    /// @dev Function to check the admin of the asset
-    /// @dev Admin: the account that can unfreeze and force transfer
-    /// @custom:selector f851a440
-    /// @return the address of the admin.
-    function admin()
-        external
-        view
-        returns (address);
-
     /// @dev Transfer token for a specified address
     /// @custom:selector a9059cbb
     /// @param to The address to transfer to.

--- a/precompiles/assets-erc20/ERC20.sol
+++ b/precompiles/assets-erc20/ERC20.sol
@@ -37,6 +37,41 @@ interface IERC20 {
         view
         returns (uint256);
 
+    /// @dev Function to check the owner of the asset
+    /// @custom:selector 8da5cb5b
+    /// @return the address of the owner.
+    function owner()
+        external
+        view
+        returns (address);
+
+    /// @dev Function to check the freezer of the asset
+    /// @dev Freezer: the account that can freeze an asset
+    /// @custom:selector 92716054
+    /// @return the address of the freezer.
+    function freezer()
+        external
+        view
+        returns (address);
+
+    /// @dev Function to check the issuer of the asset
+    /// @dev Issuer: the account that can issue tokens for an asset
+    /// @custom:selector 1d143848
+    /// @return the address of the issuer.
+    function issuer()
+        external
+        view
+        returns (address);
+
+    /// @dev Function to check the admin of the asset
+    /// @dev Admin: the account that can unfreeze and force transfer
+    /// @custom:selector f851a440
+    /// @return the address of the admin.
+    function admin()
+        external
+        view
+        returns (address);
+
     /// @dev Transfer token for a specified address
     /// @custom:selector a9059cbb
     /// @param to The address to transfer to.

--- a/precompiles/assets-erc20/Permit.sol
+++ b/precompiles/assets-erc20/Permit.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity >=0.8.3;
 
+/// @author The Moonbeam Team
 /// @title Extension of the ERC20 interface that allows users to
 /// sign permit messages to interact with contracts without needing to
 /// make a first approve transaction.

--- a/precompiles/assets-erc20/Roles.sol
+++ b/precompiles/assets-erc20/Roles.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity >=0.8.3;
+
+/// @title Extension of the ERC20 interface that allows users to
+/// get the account capable of fullfiling different asset roles
+interface Roles {
+    /// @dev Function to check the owner of the asset
+    /// @custom:selector 8da5cb5b
+    /// @return the address of the owner.
+    function owner()
+        external
+        view
+        returns (address);
+
+    /// @dev Function to check the freezer of the asset
+    /// @dev Freezer: the account that can freeze an asset
+    /// @custom:selector 92716054
+    /// @return the address of the freezer.
+    function freezer()
+        external
+        view
+        returns (address);
+
+    /// @dev Function to check the issuer of the asset
+    /// @dev Issuer: the account that can issue tokens for an asset
+    /// @custom:selector 1d143848
+    /// @return the address of the issuer.
+    function issuer()
+        external
+        view
+        returns (address);
+
+    /// @dev Function to check the admin of the asset
+    /// @dev Admin: the account that can unfreeze and force transfer
+    /// @custom:selector f851a440
+    /// @return the address of the admin.
+    function admin()
+        external
+        view
+        returns (address);
+}

--- a/precompiles/assets-erc20/Roles.sol
+++ b/precompiles/assets-erc20/Roles.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity >=0.8.3;
 
-/// @title Extension of the ERC20 interface that allows users to
-/// get the account capable of fullfiling different asset roles
+/// @author The Moonbeam Team
+/// @title ERC20 interface Asset Roles
+/// @dev Extension of the ERC20 interface that allows users to get the account capable of fulfilling different asset roles
+/// @custom:address 0xFFFFFFFE + hex(assetId)
 interface Roles {
     /// @dev Function to check the owner of the asset
     /// @custom:selector 8da5cb5b

--- a/precompiles/assets-erc20/src/eip2612.rs
+++ b/precompiles/assets-erc20/src/eip2612.rs
@@ -128,6 +128,7 @@ where
 	IsLocal: Get<bool>,
 	<Runtime as pallet_timestamp::Config>::Moment: Into<U256>,
 	AssetIdOf<Runtime, Instance>: Display,
+	Runtime::AccountId: Into<H160>,
 {
 	fn compute_domain_separator(address: H160, asset_id: AssetIdOf<Runtime, Instance>) -> [u8; 32] {
 		let asset_name = pallet_assets::Pallet::<Runtime, Instance>::name(asset_id);

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -19,9 +19,11 @@
 
 use core::fmt::Display;
 use fp_evm::PrecompileHandle;
-use frame_support::traits::fungibles::approvals::Inspect as ApprovalInspect;
-use frame_support::traits::fungibles::metadata::Inspect as MetadataInspect;
 use frame_support::traits::fungibles::Inspect;
+use frame_support::traits::fungibles::{
+	approvals::Inspect as ApprovalInspect, metadata::Inspect as MetadataInspect,
+	roles::Inspect as RolesInspect,
+};
 use frame_support::traits::{ConstBool, Get, OriginTrait};
 use frame_support::{
 	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
@@ -130,6 +132,7 @@ where
 	IsLocal: Get<bool>,
 	<Runtime as pallet_timestamp::Config>::Moment: Into<U256>,
 	AssetIdOf<Runtime, Instance>: Display,
+	Runtime::AccountId: Into<H160>,
 {
 	/// PrecompileSet discrimiant. Allows to knows if the address maps to an asset id,
 	/// and if this is the case which one.
@@ -417,6 +420,66 @@ where
 		Ok(pallet_assets::Pallet::<Runtime, Instance>::decimals(
 			asset_id,
 		))
+	}
+
+	#[precompile::public("owner()")]
+	#[precompile::view]
+	fn owner(
+		asset_id: AssetIdOf<Runtime, Instance>,
+		handle: &mut impl PrecompileHandle,
+	) -> EvmResult<Address> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		let owner: H160 = pallet_assets::Pallet::<Runtime, Instance>::owner(asset_id)
+			.ok_or(revert("No owner set"))?
+			.into();
+
+		Ok(Address(owner))
+	}
+
+	#[precompile::public("issuer()")]
+	#[precompile::view]
+	fn issuer(
+		asset_id: AssetIdOf<Runtime, Instance>,
+		handle: &mut impl PrecompileHandle,
+	) -> EvmResult<Address> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		let issuer: H160 = pallet_assets::Pallet::<Runtime, Instance>::issuer(asset_id)
+			.ok_or(revert("No issuer set"))?
+			.into();
+
+		Ok(Address(issuer))
+	}
+
+	#[precompile::public("admin()")]
+	#[precompile::view]
+	fn admin(
+		asset_id: AssetIdOf<Runtime, Instance>,
+		handle: &mut impl PrecompileHandle,
+	) -> EvmResult<Address> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		let admin: H160 = pallet_assets::Pallet::<Runtime, Instance>::admin(asset_id)
+			.ok_or(revert("No admin set"))?
+			.into();
+
+		Ok(Address(admin))
+	}
+
+	#[precompile::public("freezer()")]
+	#[precompile::view]
+	fn freezer(
+		asset_id: AssetIdOf<Runtime, Instance>,
+		handle: &mut impl PrecompileHandle,
+	) -> EvmResult<Address> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		let freezer: H160 = pallet_assets::Pallet::<Runtime, Instance>::freezer(asset_id)
+			.ok_or(revert("No freezer set"))?
+			.into();
+
+		Ok(Address(freezer))
 	}
 
 	// From here: only for locals, we need to check whether we are in local assets otherwise fail

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -67,6 +67,10 @@ fn selectors() {
 	assert!(ForeignPCall::total_supply_selectors().contains(&0x18160ddd));
 	assert!(ForeignPCall::approve_selectors().contains(&0x095ea7b3));
 	assert!(ForeignPCall::allowance_selectors().contains(&0xdd62ed3e));
+	assert!(ForeignPCall::freezer_selectors().contains(&0x92716054));
+	assert!(ForeignPCall::owner_selectors().contains(&0x8da5cb5b));
+	assert!(ForeignPCall::issuer_selectors().contains(&0x1d143848));
+	assert!(ForeignPCall::admin_selectors().contains(&0xf851a440));
 	assert!(ForeignPCall::transfer_selectors().contains(&0xa9059cbb));
 	assert!(ForeignPCall::transfer_from_selectors().contains(&0x23b872dd));
 	assert!(ForeignPCall::name_selectors().contains(&0x06fdde03));
@@ -2420,6 +2424,94 @@ fn burn_overflow() {
 				.expect_cost(1756u64) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_reverts(|e| e == b"value: Value is too large for balance type");
+		});
+}
+
+#[test]
+fn get_owner() {
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(ForeignAssets::force_create(
+				RuntimeOrigin::root(),
+				0u128,
+				CryptoAlith.into(),
+				true,
+				1
+			));
+
+			precompiles()
+				.prepare_test(CryptoAlith, ForeignAssetId(0u128), ForeignPCall::owner {})
+				.expect_cost(0)
+				.expect_no_logs()
+				.execute_returns_encoded(Address(CryptoAlith.into()));
+		});
+}
+
+#[test]
+fn get_issuer() {
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(ForeignAssets::force_create(
+				RuntimeOrigin::root(),
+				0u128,
+				CryptoAlith.into(),
+				true,
+				1
+			));
+
+			precompiles()
+				.prepare_test(CryptoAlith, ForeignAssetId(0u128), ForeignPCall::issuer {})
+				.expect_cost(0)
+				.expect_no_logs()
+				.execute_returns_encoded(Address(CryptoAlith.into()));
+		});
+}
+
+#[test]
+fn get_admin() {
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(ForeignAssets::force_create(
+				RuntimeOrigin::root(),
+				0u128,
+				CryptoAlith.into(),
+				true,
+				1
+			));
+
+			precompiles()
+				.prepare_test(CryptoAlith, ForeignAssetId(0u128), ForeignPCall::admin {})
+				.expect_cost(0)
+				.expect_no_logs()
+				.execute_returns_encoded(Address(CryptoAlith.into()));
+		});
+}
+
+#[test]
+fn get_freezer() {
+	ExtBuilder::default()
+		.with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
+		.build()
+		.execute_with(|| {
+			assert_ok!(ForeignAssets::force_create(
+				RuntimeOrigin::root(),
+				0u128,
+				CryptoAlith.into(),
+				true,
+				1
+			));
+
+			precompiles()
+				.prepare_test(CryptoAlith, ForeignAssetId(0u128), ForeignPCall::freezer {})
+				.expect_cost(0)
+				.expect_no_logs()
+				.execute_returns_encoded(Address(CryptoAlith.into()));
 		});
 }
 

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -2433,7 +2433,7 @@ fn get_owner() {
 		.with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
 		.build()
 		.execute_with(|| {
-			assert_ok!(ForeignAssets::force_create(
+			assert_ok!(LocalAssets::force_create(
 				RuntimeOrigin::root(),
 				0u128,
 				CryptoAlith.into(),
@@ -2441,11 +2441,18 @@ fn get_owner() {
 				1
 			));
 
+			assert_ok!(LocalAssets::transfer_ownership(
+				RuntimeOrigin::signed(CryptoAlith.into()),
+				0u128,
+				// owner
+				Bob.into(),
+			));
+
 			precompiles()
-				.prepare_test(CryptoAlith, ForeignAssetId(0u128), ForeignPCall::owner {})
+				.prepare_test(CryptoAlith, LocalAssetId(0u128), ForeignPCall::owner {})
 				.expect_cost(0)
 				.expect_no_logs()
-				.execute_returns_encoded(Address(CryptoAlith.into()));
+				.execute_returns_encoded(Address(Bob.into()));
 		});
 }
 
@@ -2455,7 +2462,7 @@ fn get_issuer() {
 		.with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
 		.build()
 		.execute_with(|| {
-			assert_ok!(ForeignAssets::force_create(
+			assert_ok!(LocalAssets::force_create(
 				RuntimeOrigin::root(),
 				0u128,
 				CryptoAlith.into(),
@@ -2463,11 +2470,22 @@ fn get_issuer() {
 				1
 			));
 
+			assert_ok!(LocalAssets::set_team(
+				RuntimeOrigin::signed(CryptoAlith.into()),
+				0u128,
+				// Issuer
+				Bob.into(),
+				// admin
+				CryptoAlith.into(),
+				// freezer
+				CryptoAlith.into(),
+			));
+
 			precompiles()
-				.prepare_test(CryptoAlith, ForeignAssetId(0u128), ForeignPCall::issuer {})
+				.prepare_test(CryptoAlith, LocalAssetId(0u128), ForeignPCall::issuer {})
 				.expect_cost(0)
 				.expect_no_logs()
-				.execute_returns_encoded(Address(CryptoAlith.into()));
+				.execute_returns_encoded(Address(Bob.into()));
 		});
 }
 
@@ -2477,7 +2495,7 @@ fn get_admin() {
 		.with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
 		.build()
 		.execute_with(|| {
-			assert_ok!(ForeignAssets::force_create(
+			assert_ok!(LocalAssets::force_create(
 				RuntimeOrigin::root(),
 				0u128,
 				CryptoAlith.into(),
@@ -2485,11 +2503,22 @@ fn get_admin() {
 				1
 			));
 
+			assert_ok!(LocalAssets::set_team(
+				RuntimeOrigin::signed(CryptoAlith.into()),
+				0u128,
+				// Issuer
+				CryptoAlith.into(),
+				// admin
+				Bob.into(),
+				// freezer
+				CryptoAlith.into(),
+			));
+
 			precompiles()
-				.prepare_test(CryptoAlith, ForeignAssetId(0u128), ForeignPCall::admin {})
+				.prepare_test(CryptoAlith, LocalAssetId(0u128), ForeignPCall::admin {})
 				.expect_cost(0)
 				.expect_no_logs()
-				.execute_returns_encoded(Address(CryptoAlith.into()));
+				.execute_returns_encoded(Address(Bob.into()));
 		});
 }
 
@@ -2499,7 +2528,7 @@ fn get_freezer() {
 		.with_balances(vec![(CryptoAlith.into(), 1000), (Bob.into(), 2500)])
 		.build()
 		.execute_with(|| {
-			assert_ok!(ForeignAssets::force_create(
+			assert_ok!(LocalAssets::force_create(
 				RuntimeOrigin::root(),
 				0u128,
 				CryptoAlith.into(),
@@ -2507,11 +2536,22 @@ fn get_freezer() {
 				1
 			));
 
+			assert_ok!(LocalAssets::set_team(
+				RuntimeOrigin::signed(CryptoAlith.into()),
+				0u128,
+				// Issuer
+				CryptoAlith.into(),
+				// admin
+				CryptoAlith.into(),
+				// freezer
+				Bob.into(),
+			));
+
 			precompiles()
-				.prepare_test(CryptoAlith, ForeignAssetId(0u128), ForeignPCall::freezer {})
+				.prepare_test(CryptoAlith, LocalAssetId(0u128), ForeignPCall::freezer {})
 				.expect_cost(0)
 				.expect_no_logs()
-				.execute_returns_encoded(Address(CryptoAlith.into()));
+				.execute_returns_encoded(Address(Bob.into()));
 		});
 }
 

--- a/tests/contracts/compiled/Roles.json
+++ b/tests/contracts/compiled/Roles.json
@@ -1,0 +1,103 @@
+{
+  "byteCode": "0x",
+  "contract": {
+    "abi": [
+      {
+        "inputs": [],
+        "name": "admin",
+        "outputs": [
+          { "internalType": "address", "name": "", "type": "address" }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "freezer",
+        "outputs": [
+          { "internalType": "address", "name": "", "type": "address" }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "issuer",
+        "outputs": [
+          { "internalType": "address", "name": "", "type": "address" }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      },
+      {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+          { "internalType": "address", "name": "", "type": "address" }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+      }
+    ],
+    "devdoc": {
+      "kind": "dev",
+      "methods": {
+        "admin()": {
+          "custom:selector": "f851a440",
+          "details": "Function to check the admin of the assetAdmin: the account that can unfreeze and force transfer",
+          "returns": { "_0": "the address of the admin." }
+        },
+        "freezer()": {
+          "custom:selector": "92716054",
+          "details": "Function to check the freezer of the assetFreezer: the account that can freeze an asset",
+          "returns": { "_0": "the address of the freezer." }
+        },
+        "issuer()": {
+          "custom:selector": "1d143848",
+          "details": "Function to check the issuer of the assetIssuer: the account that can issue tokens for an asset",
+          "returns": { "_0": "the address of the issuer." }
+        },
+        "owner()": {
+          "custom:selector": "8da5cb5b",
+          "details": "Function to check the owner of the asset",
+          "returns": { "_0": "the address of the owner." }
+        }
+      },
+      "title": "Extension of the ERC20 interface that allows users to get the account capable of fullfiling different asset roles",
+      "version": 1
+    },
+    "evm": {
+      "assembly": "",
+      "bytecode": {
+        "functionDebugData": {},
+        "generatedSources": [],
+        "linkReferences": {},
+        "object": "",
+        "opcodes": "",
+        "sourceMap": ""
+      },
+      "deployedBytecode": {
+        "functionDebugData": {},
+        "generatedSources": [],
+        "immutableReferences": {},
+        "linkReferences": {},
+        "object": "",
+        "opcodes": "",
+        "sourceMap": ""
+      },
+      "gasEstimates": null,
+      "legacyAssembly": null,
+      "methodIdentifiers": {
+        "admin()": "f851a440",
+        "freezer()": "92716054",
+        "issuer()": "1d143848",
+        "owner()": "8da5cb5b"
+      }
+    },
+    "ewasm": { "wasm": "" },
+    "metadata": "{\"compiler\":{\"version\":\"0.8.17+commit.8df45f5f\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"name\":\"admin\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"freezer\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"issuer\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{\"admin()\":{\"custom:selector\":\"f851a440\",\"details\":\"Function to check the admin of the assetAdmin: the account that can unfreeze and force transfer\",\"returns\":{\"_0\":\"the address of the admin.\"}},\"freezer()\":{\"custom:selector\":\"92716054\",\"details\":\"Function to check the freezer of the assetFreezer: the account that can freeze an asset\",\"returns\":{\"_0\":\"the address of the freezer.\"}},\"issuer()\":{\"custom:selector\":\"1d143848\",\"details\":\"Function to check the issuer of the assetIssuer: the account that can issue tokens for an asset\",\"returns\":{\"_0\":\"the address of the issuer.\"}},\"owner()\":{\"custom:selector\":\"8da5cb5b\",\"details\":\"Function to check the owner of the asset\",\"returns\":{\"_0\":\"the address of the owner.\"}}},\"title\":\"Extension of the ERC20 interface that allows users to get the account capable of fullfiling different asset roles\",\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"main.sol\":\"Roles\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"main.sol\":{\"keccak256\":\"0x2c3d6a75a1aed6de9485b9b5ff28b7bd72d2b4e69e131241f4db841da6e2b898\",\"license\":\"GPL-3.0-only\",\"urls\":[\"bzz-raw://d6e18dfdbfd088171266f15fbe23d16244d9f9d124c841c54f00ad741c908b50\",\"dweb:/ipfs/QmYAjPNs5WKTv8FgKF5pJC6Uzs5pvm46FgaXf46FwhCws5\"]}},\"version\":1}",
+    "storageLayout": { "storage": [], "types": null },
+    "userdoc": { "kind": "user", "methods": {}, "version": 1 }
+  },
+  "sourceCode": "// SPDX-License-Identifier: GPL-3.0-only\npragma solidity >=0.8.3;\n\n/// @title Extension of the ERC20 interface that allows users to\n/// get the account capable of fullfiling different asset roles\ninterface Roles {\n    /// @dev Function to check the owner of the asset\n    /// @custom:selector 8da5cb5b\n    /// @return the address of the owner.\n    function owner()\n        external\n        view\n        returns (address);\n\n    /// @dev Function to check the freezer of the asset\n    /// @dev Freezer: the account that can freeze an asset\n    /// @custom:selector 92716054\n    /// @return the address of the freezer.\n    function freezer()\n        external\n        view\n        returns (address);\n\n    /// @dev Function to check the issuer of the asset\n    /// @dev Issuer: the account that can issue tokens for an asset\n    /// @custom:selector 1d143848\n    /// @return the address of the issuer.\n    function issuer()\n        external\n        view\n        returns (address);\n\n    /// @dev Function to check the admin of the asset\n    /// @dev Admin: the account that can unfreeze and force transfer\n    /// @custom:selector f851a440\n    /// @return the address of the admin.\n    function admin()\n        external\n        view\n        returns (address);\n}\n"
+}

--- a/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
+++ b/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
@@ -42,9 +42,7 @@ const LOCAL_ASSET_EXTENDED_ERC20_INTERFACE = new ethers.utils.Interface(
   LOCAL_ASSET_EXTENDED_ERC20_CONTRACT.contract.abi
 );
 
-const ROLES_INTERFACE = new ethers.utils.Interface(
-  ROLES_CONTRACT.contract.abi
-);
+const ROLES_INTERFACE = new ethers.utils.Interface(ROLES_CONTRACT.contract.abi);
 
 describeDevMoonbeamAllEthTxTypes(
   "Precompiles - Assets-ERC20 Wasm",

--- a/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
+++ b/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
@@ -180,7 +180,7 @@ describeDevMoonbeamAllEthTxTypes(
     });
 
     it("allows to call owner", async function () {
-      let data = ROLES_INTERFACE.encodeFunctionData(
+      const data = ROLES_INTERFACE.encodeFunctionData(
         // action
         "owner",
         []
@@ -196,12 +196,12 @@ describeDevMoonbeamAllEthTxTypes(
         },
       ]);
 
-      let account = "0x" + baltathar.address.slice(2).padStart(64, "0");
+      const account = "0x" + baltathar.address.slice(2).padStart(64, "0");
       expect(tx_call.result).equals(account.toLocaleLowerCase());
     });
 
     it("allows to call freezer", async function () {
-      let data = ROLES_INTERFACE.encodeFunctionData(
+      const data = ROLES_INTERFACE.encodeFunctionData(
         // action
         "freezer",
         []
@@ -217,12 +217,12 @@ describeDevMoonbeamAllEthTxTypes(
         },
       ]);
 
-      let account = "0x" + baltathar.address.slice(2).padStart(64, "0");
+      const account = "0x" + baltathar.address.slice(2).padStart(64, "0");
       expect(tx_call.result).equals(account.toLocaleLowerCase());
     });
 
     it("allows to call admin", async function () {
-      let data = ROLES_INTERFACE.encodeFunctionData(
+      const data = ROLES_INTERFACE.encodeFunctionData(
         // action
         "admin",
         []
@@ -238,12 +238,12 @@ describeDevMoonbeamAllEthTxTypes(
         },
       ]);
 
-      let account = "0x" + baltathar.address.slice(2).padStart(64, "0");
+      const account = "0x" + baltathar.address.slice(2).padStart(64, "0");
       expect(tx_call.result).equals(account.toLocaleLowerCase());
     });
 
     it("allows to call issuer", async function () {
-      let data = ROLES_INTERFACE.encodeFunctionData(
+      const data = ROLES_INTERFACE.encodeFunctionData(
         // action
         "issuer",
         []
@@ -259,7 +259,7 @@ describeDevMoonbeamAllEthTxTypes(
         },
       ]);
 
-      let account = "0x" + baltathar.address.slice(2).padStart(64, "0");
+      const account = "0x" + baltathar.address.slice(2).padStart(64, "0");
       expect(tx_call.result).equals(account.toLocaleLowerCase());
     });
   },

--- a/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
+++ b/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
@@ -36,9 +36,14 @@ const SELECTORS = {
 };
 const GAS_PRICE = "0x" + (1_000_000_000).toString(16);
 const LOCAL_ASSET_EXTENDED_ERC20_CONTRACT = getCompiled("LocalAssetExtendedErc20Instance");
+const ROLES_CONTRACT = getCompiled("Roles");
 
 const LOCAL_ASSET_EXTENDED_ERC20_INTERFACE = new ethers.utils.Interface(
   LOCAL_ASSET_EXTENDED_ERC20_CONTRACT.contract.abi
+);
+
+const ROLES_INTERFACE = new ethers.utils.Interface(
+  ROLES_CONTRACT.contract.abi
 );
 
 describeDevMoonbeamAllEthTxTypes(
@@ -174,6 +179,90 @@ describeDevMoonbeamAllEthTxTypes(
 
       let amount_hex = "0x" + bnToHex(amount).slice(2).padStart(64, "0");
       expect(tx_call.result).equals(amount_hex);
+    });
+
+    it("allows to call owner", async function () {
+      let data = ROLES_INTERFACE.encodeFunctionData(
+        // action
+        "owner",
+        []
+      );
+      const tx_call = await customWeb3Request(context.web3, "eth_call", [
+        {
+          from: alith.address,
+          value: "0x0",
+          gas: "0x10000",
+          gasPrice: GAS_PRICE,
+          to: assetAddress,
+          data: data,
+        },
+      ]);
+
+      let account = "0x" + baltathar.address.slice(2).padStart(64, "0");
+      expect(tx_call.result).equals(account.toLocaleLowerCase());
+    });
+
+    it("allows to call freezer", async function () {
+      let data = ROLES_INTERFACE.encodeFunctionData(
+        // action
+        "freezer",
+        []
+      );
+      const tx_call = await customWeb3Request(context.web3, "eth_call", [
+        {
+          from: alith.address,
+          value: "0x0",
+          gas: "0x10000",
+          gasPrice: GAS_PRICE,
+          to: assetAddress,
+          data: data,
+        },
+      ]);
+
+      let account = "0x" + baltathar.address.slice(2).padStart(64, "0");
+      expect(tx_call.result).equals(account.toLocaleLowerCase());
+    });
+
+    it("allows to call admin", async function () {
+      let data = ROLES_INTERFACE.encodeFunctionData(
+        // action
+        "admin",
+        []
+      );
+      const tx_call = await customWeb3Request(context.web3, "eth_call", [
+        {
+          from: alith.address,
+          value: "0x0",
+          gas: "0x10000",
+          gasPrice: GAS_PRICE,
+          to: assetAddress,
+          data: data,
+        },
+      ]);
+
+      let account = "0x" + baltathar.address.slice(2).padStart(64, "0");
+      expect(tx_call.result).equals(account.toLocaleLowerCase());
+    });
+
+    it("allows to call issuer", async function () {
+      let data = ROLES_INTERFACE.encodeFunctionData(
+        // action
+        "issuer",
+        []
+      );
+      const tx_call = await customWeb3Request(context.web3, "eth_call", [
+        {
+          from: alith.address,
+          value: "0x0",
+          gas: "0x10000",
+          gasPrice: GAS_PRICE,
+          to: assetAddress,
+          data: data,
+        },
+      ]);
+
+      let account = "0x" + baltathar.address.slice(2).padStart(64, "0");
+      expect(tx_call.result).equals(account.toLocaleLowerCase());
     });
   },
   true


### PR DESCRIPTION
### What does it do?
Adds `owner`, `issuer`, `freezer` and `admin` accessors for assets. I added them to the ERC20.sol precompile, although I can also add them only for local assets if requested.

**Owner**: owner of the asset, can change any other role.
**Issuer**: account capable of minting tokens for such asset.
**Freezer**: account capable of freezing an asset.
**Admin**: account capable of unfreeze and force transfer tokens for an asset.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
