### PR TITLE
Use chainType for running in Dev mode

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -222,7 +222,7 @@ impl IdentifyVariant for Box<dyn ChainSpec> {
 	}
 
 	fn is_dev(&self) -> bool {
-		self.id().ends_with("dev")
+		self.chain_type() == sc_chain_spec::ChainType::Development
 	}
 }
 


### PR DESCRIPTION
### What does it do?

Before this PR, we used the chain spec identifier to know if we had to launch the node in dev mode, it is more logical to use the chain type, because this field is made for that.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
