### PR TITLE
Remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,20 +416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "futures-core",
- "getrandom 0.2.8",
- "instant",
- "pin-project-lite 0.2.9",
- "rand 0.8.5",
- "tokio",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,29 +1417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cumulus-client-consensus-relay-chain"
-version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
-dependencies = [
- "async-trait",
- "cumulus-client-consensus-common",
- "cumulus-primitives-core",
- "cumulus-relay-chain-interface",
- "futures 0.3.25",
- "parking_lot 0.12.1",
- "sc-consensus",
- "sp-api",
- "sp-block-builder",
- "sp-blockchain",
- "sp-consensus",
- "sp-core",
- "sp-inherents",
- "sp-runtime",
- "substrate-prometheus-endpoint",
- "tracing",
-]
-
-[[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
 source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
@@ -1721,34 +1684,6 @@ dependencies = [
  "sp-blockchain",
  "sp-state-machine",
  "thiserror",
-]
-
-[[package]]
-name = "cumulus-relay-chain-rpc-interface"
-version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
-dependencies = [
- "async-trait",
- "backoff",
- "cumulus-primitives-core",
- "cumulus-relay-chain-interface",
- "futures 0.3.25",
- "futures-timer",
- "jsonrpsee",
- "parity-scale-codec",
- "polkadot-service",
- "sc-client-api",
- "sc-rpc-api",
- "sp-api",
- "sp-authority-discovery",
- "sp-consensus-babe",
- "sp-core",
- "sp-runtime",
- "sp-state-machine",
- "sp-storage",
- "tokio",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -2349,7 +2284,6 @@ name = "evm-tracing-events"
 version = "0.1.0"
 dependencies = [
  "environmental",
- "ethereum",
  "ethereum-types",
  "evm",
  "evm-gasometer",
@@ -2403,12 +2337,6 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "faster-hex"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e2ce894d53b295cf97b05685aa077950ff3e8541af83217fc720a6437169f8"
 
 [[package]]
 name = "fastrand"
@@ -4637,11 +4565,9 @@ version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core",
  "flume",
- "futures 0.3.25",
  "hex-literal",
  "jsonrpsee",
  "parity-scale-codec",
- "tokio",
  "xcm",
 ]
 
@@ -4845,7 +4771,6 @@ dependencies = [
  "frame-try-runtime",
  "hex",
  "hex-literal",
- "log",
  "moonbeam-core-primitives",
  "moonbeam-evm-tracer",
  "moonbeam-relay-encoder",
@@ -4863,7 +4788,6 @@ dependencies = [
  "pallet-author-mapping",
  "pallet-author-slot-filter",
  "pallet-balances",
- "pallet-base-fee",
  "pallet-collective",
  "pallet-conviction-voting",
  "pallet-crowdloan-rewards",
@@ -4881,7 +4805,6 @@ dependencies = [
  "pallet-evm-precompile-collective",
  "pallet-evm-precompile-crowdloan-rewards",
  "pallet-evm-precompile-democracy",
- "pallet-evm-precompile-dispatch",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-parachain-staking",
  "pallet-evm-precompile-proxy",
@@ -4905,7 +4828,6 @@ dependencies = [
  "pallet-randomness-collective-flip",
  "pallet-referenda",
  "pallet-scheduler",
- "pallet-society",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -4953,16 +4875,13 @@ name = "moonbeam"
 version = "0.12.3"
 dependencies = [
  "assert_cmd",
- "futures 0.3.25",
  "hex",
  "moonbeam-cli",
  "moonbeam-service",
  "nix 0.23.1",
  "pallet-xcm",
- "serde",
  "serde_json",
  "tempfile",
- "tracing-core",
  "xcm-builder",
 ]
 
@@ -4972,7 +4891,6 @@ version = "0.28.0"
 dependencies = [
  "clap",
  "cumulus-client-cli",
- "cumulus-client-service",
  "cumulus-primitives-core",
  "frame-benchmarking-cli",
  "log",
@@ -4981,19 +4899,15 @@ dependencies = [
  "nimbus-primitives",
  "parity-scale-codec",
  "polkadot-cli",
- "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-service",
  "sc-cli",
- "sc-finality-grandpa",
  "sc-service",
  "sc-sysinfo",
- "sc-telemetry",
  "sc-tracing",
  "sp-core",
  "sp-runtime",
  "substrate-build-script-utils",
- "substrate-prometheus-endpoint",
  "try-runtime-cli",
 ]
 
@@ -5006,7 +4920,6 @@ dependencies = [
  "clap",
  "libsecp256k1",
  "primitive-types",
- "sha3",
  "sp-runtime",
  "tiny-bip39",
  "url",
@@ -5019,10 +4932,8 @@ dependencies = [
  "ethereum-types",
  "evm-tracing-events",
  "hex",
- "moonbeam-rpc-primitives-debug",
  "parity-scale-codec",
  "serde",
- "serde_json",
  "sp-std",
 ]
 
@@ -5031,7 +4942,6 @@ name = "moonbeam-core-primitives"
 version = "0.1.1"
 dependencies = [
  "account",
- "fp-self-contained",
  "sp-core",
  "sp-runtime",
 ]
@@ -5040,18 +4950,13 @@ dependencies = [
 name = "moonbeam-evm-tracer"
 version = "0.1.0"
 dependencies = [
- "ethereum-types",
  "evm",
  "evm-gasometer",
  "evm-runtime",
  "evm-tracing-events",
- "fp-evm",
  "moonbeam-primitives-ext",
  "pallet-evm",
  "parity-scale-codec",
- "sp-core",
- "sp-io",
- "sp-runtime",
  "sp-std",
 ]
 
@@ -5061,24 +4966,19 @@ version = "0.1.0"
 dependencies = [
  "fc-db",
  "fc-rpc",
- "futures 0.3.25",
  "jsonrpsee",
- "parity-scale-codec",
  "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
- "tokio",
 ]
 
 [[package]]
 name = "moonbeam-primitives-ext"
 version = "0.1.0"
 dependencies = [
- "ethereum-types",
  "evm-tracing-events",
  "parity-scale-codec",
- "sp-externalities",
  "sp-runtime-interface",
  "sp-std",
 ]
@@ -5092,12 +4992,10 @@ dependencies = [
  "frame-system",
  "kusama-runtime",
  "pallet-evm-precompile-relay-encoder",
- "pallet-proxy",
  "pallet-staking",
  "pallet-utility",
  "parity-scale-codec",
  "polkadot-runtime",
- "rococo-runtime",
  "sp-runtime",
  "sp-std",
  "westend-runtime",
@@ -5109,13 +5007,10 @@ name = "moonbeam-rpc-core-debug"
 version = "0.1.0"
 dependencies = [
  "ethereum-types",
- "futures 0.3.25",
  "jsonrpsee",
  "moonbeam-client-evm-tracing",
  "moonbeam-rpc-core-types",
  "serde",
- "serde_json",
- "sp-core",
 ]
 
 [[package]]
@@ -5123,12 +5018,10 @@ name = "moonbeam-rpc-core-trace"
 version = "0.6.0"
 dependencies = [
  "ethereum-types",
- "futures 0.3.25",
  "jsonrpsee",
  "moonbeam-client-evm-tracing",
  "moonbeam-rpc-core-types",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -5140,7 +5033,6 @@ dependencies = [
  "fc-rpc-core",
  "jsonrpsee",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -5149,7 +5041,6 @@ version = "0.1.0"
 dependencies = [
  "ethereum-types",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -5158,7 +5049,6 @@ version = "0.1.0"
 dependencies = [
  "ethereum",
  "ethereum-types",
- "fc-consensus",
  "fc-db",
  "fc-rpc",
  "fp-rpc",
@@ -5174,7 +5064,6 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-core",
  "sp-io",
  "sp-runtime",
  "tokio",
@@ -5184,16 +5073,10 @@ dependencies = [
 name = "moonbeam-rpc-primitives-debug"
 version = "0.1.0"
 dependencies = [
- "environmental",
  "ethereum",
  "ethereum-types",
- "hex",
  "parity-scale-codec",
- "serde",
- "serde_json",
  "sp-api",
- "sp-core",
- "sp-io",
  "sp-runtime",
  "sp-std",
 ]
@@ -5205,7 +5088,6 @@ dependencies = [
  "ethereum",
  "parity-scale-codec",
  "sp-api",
- "sp-io",
  "sp-runtime",
  "sp-std",
 ]
@@ -5214,11 +5096,8 @@ dependencies = [
 name = "moonbeam-rpc-trace"
 version = "0.6.0"
 dependencies = [
- "ethereum",
  "ethereum-types",
- "fc-consensus",
  "fc-rpc",
- "fc-rpc-core",
  "fp-rpc",
  "futures 0.3.25",
  "jsonrpsee",
@@ -5227,17 +5106,11 @@ dependencies = [
  "moonbeam-rpc-core-types",
  "moonbeam-rpc-primitives-debug",
  "sc-client-api",
- "sc-network",
  "sc-utils",
- "serde",
- "sha3",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
- "sp-io",
  "sp-runtime",
- "sp-std",
- "sp-transaction-pool",
  "tokio",
  "tracing",
 ]
@@ -5248,20 +5121,16 @@ version = "0.6.0"
 dependencies = [
  "ethereum-types",
  "fc-rpc",
- "frame-system",
  "jsonrpsee",
  "moonbeam-rpc-core-txpool",
  "moonbeam-rpc-primitives-txpool",
- "rlp",
  "sc-transaction-pool",
  "sc-transaction-pool-api",
  "serde",
  "sha3",
  "sp-api",
  "sp-blockchain",
- "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -5310,7 +5179,6 @@ dependencies = [
  "pallet-author-mapping",
  "pallet-author-slot-filter",
  "pallet-balances",
- "pallet-base-fee",
  "pallet-collective",
  "pallet-crowdloan-rewards",
  "pallet-democracy",
@@ -5326,10 +5194,8 @@ dependencies = [
  "pallet-evm-precompile-collective",
  "pallet-evm-precompile-crowdloan-rewards",
  "pallet-evm-precompile-democracy",
- "pallet-evm-precompile-dispatch",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-parachain-staking",
- "pallet-evm-precompile-proxy",
  "pallet-evm-precompile-randomness",
  "pallet-evm-precompile-relay-encoder",
  "pallet-evm-precompile-sha3fips",
@@ -5349,7 +5215,6 @@ dependencies = [
  "pallet-randomness",
  "pallet-randomness-collective-flip",
  "pallet-scheduler",
- "pallet-society",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -5395,15 +5260,12 @@ version = "0.8.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
- "impl-trait-for-tuples",
  "log",
  "moonbeam-xcm-benchmarks",
  "pallet-asset-manager",
  "pallet-author-inherent",
  "pallet-author-mapping",
  "pallet-author-slot-filter",
- "pallet-base-fee",
- "pallet-collective",
  "pallet-democracy",
  "pallet-evm",
  "pallet-migrations",
@@ -5422,37 +5284,24 @@ dependencies = [
 name = "moonbeam-service"
 version = "0.28.0"
 dependencies = [
- "ansi_term",
- "assert_cmd",
  "async-io",
- "async-trait",
  "bip32",
- "cumulus-client-cli",
- "cumulus-client-collator",
  "cumulus-client-consensus-common",
- "cumulus-client-consensus-relay-chain",
  "cumulus-client-network",
  "cumulus-client-service",
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-inprocess-interface",
  "cumulus-relay-chain-interface",
- "cumulus-relay-chain-rpc-interface",
- "cumulus-test-relay-sproof-builder",
- "derive_more",
- "exit-future",
  "fc-consensus",
  "fc-db",
  "fc-mapping-sync",
  "fc-rpc",
  "fc-rpc-core",
  "flume",
- "fp-consensus",
  "fp-rpc",
  "fp-storage",
  "frame-benchmarking",
- "frame-benchmarking-cli",
- "frame-system-rpc-runtime-api",
  "futures 0.3.25",
  "hex-literal",
  "jsonrpsee",
@@ -5475,33 +5324,21 @@ dependencies = [
  "moonriver-runtime",
  "nimbus-consensus",
  "nimbus-primitives",
- "nix 0.23.1",
- "pallet-author-inherent",
  "pallet-ethereum",
  "pallet-parachain-staking",
- "pallet-sudo",
  "pallet-transaction-payment-rpc",
  "pallet-transaction-payment-rpc-runtime-api",
- "parity-scale-codec",
- "parking_lot 0.12.1",
  "polkadot-cli",
- "polkadot-parachain",
  "polkadot-primitives",
- "polkadot-runtime-common",
  "polkadot-service",
  "prometheus",
- "rand 0.7.3",
  "sc-basic-authorship",
  "sc-block-builder",
  "sc-chain-spec",
- "sc-cli",
  "sc-client-api",
- "sc-client-db",
  "sc-consensus",
  "sc-consensus-manual-seal",
  "sc-executor",
- "sc-finality-grandpa",
- "sc-informant",
  "sc-network",
  "sc-network-common",
  "sc-rpc",
@@ -5521,7 +5358,6 @@ dependencies = [
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
- "sp-inherents",
  "sp-io",
  "sp-keystore",
  "sp-offchain",
@@ -5531,16 +5367,12 @@ dependencies = [
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
- "substrate-build-script-utils",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
- "substrate-test-client",
  "substrate-test-runtime",
  "substrate-test-runtime-client",
  "tiny-bip39",
  "tokio",
- "trie-root 0.15.2",
- "xcm",
 ]
 
 [[package]]
@@ -5548,8 +5380,6 @@ name = "moonbeam-vrf"
 version = "0.1.0"
 dependencies = [
  "nimbus-primitives",
- "parity-scale-codec",
- "polkadot-primitives",
  "session-keys-primitives",
  "sp-api",
  "sp-application-crypto",
@@ -5566,12 +5396,10 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
  "pallet-balances",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
  "scale-info",
- "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -5579,7 +5407,6 @@ dependencies = [
  "xcm",
  "xcm-builder",
  "xcm-executor",
- "xcm-primitives",
 ]
 
 [[package]]
@@ -5636,7 +5463,6 @@ dependencies = [
  "pallet-author-mapping",
  "pallet-author-slot-filter",
  "pallet-balances",
- "pallet-base-fee",
  "pallet-collective",
  "pallet-crowdloan-rewards",
  "pallet-democracy",
@@ -5652,10 +5478,8 @@ dependencies = [
  "pallet-evm-precompile-collective",
  "pallet-evm-precompile-crowdloan-rewards",
  "pallet-evm-precompile-democracy",
- "pallet-evm-precompile-dispatch",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-parachain-staking",
- "pallet-evm-precompile-proxy",
  "pallet-evm-precompile-randomness",
  "pallet-evm-precompile-relay-encoder",
  "pallet-evm-precompile-sha3fips",
@@ -5675,7 +5499,6 @@ dependencies = [
  "pallet-randomness",
  "pallet-randomness-collective-flip",
  "pallet-scheduler",
- "pallet-society",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6312,7 +6135,6 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -6481,21 +6303,6 @@ dependencies = [
  "scale-info",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "pallet-base-fee"
-version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#3568a86d0fe222db0c65218fc481907de602a35c"
-dependencies = [
- "fp-evm",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-runtime",
 ]
 
 [[package]]
@@ -6738,7 +6545,6 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "serde",
 ]
 
 [[package]]
@@ -6763,7 +6569,6 @@ dependencies = [
  "parity-scale-codec",
  "rlp",
  "scale-info",
- "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -6800,14 +6605,11 @@ dependencies = [
 name = "pallet-evm-precompile-author-mapping"
 version = "0.2.0"
 dependencies = [
- "derive_more",
  "fp-evm",
  "frame-support",
  "frame-system",
- "hex-literal",
  "log",
  "nimbus-primitives",
- "num_enum",
  "pallet-author-mapping",
  "pallet-balances",
  "pallet-evm",
@@ -6816,7 +6618,6 @@ dependencies = [
  "parity-scale-codec",
  "precompile-utils",
  "scale-info",
- "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -6827,14 +6628,11 @@ dependencies = [
 name = "pallet-evm-precompile-balances-erc20"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "fp-evm",
  "frame-support",
  "frame-system",
  "hex-literal",
  "libsecp256k1",
- "log",
- "num_enum",
  "pallet-balances",
  "pallet-evm",
  "pallet-timestamp",
@@ -6842,9 +6640,7 @@ dependencies = [
  "paste",
  "precompile-utils",
  "scale-info",
- "serde",
  "sha3",
- "slices",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -6855,24 +6651,17 @@ dependencies = [
 name = "pallet-evm-precompile-batch"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "evm",
  "fp-evm",
  "frame-support",
  "frame-system",
  "hex-literal",
- "log",
- "num_enum",
  "pallet-balances",
  "pallet-evm",
  "pallet-timestamp",
  "parity-scale-codec",
- "paste",
  "precompile-utils",
  "scale-info",
- "serde",
- "sha3",
- "slices",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -6901,25 +6690,18 @@ dependencies = [
 name = "pallet-evm-precompile-call-permit"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "evm",
  "fp-evm",
  "frame-support",
  "frame-system",
  "hex-literal",
  "libsecp256k1",
- "log",
- "num_enum",
  "pallet-balances",
  "pallet-evm",
  "pallet-timestamp",
  "parity-scale-codec",
- "paste",
  "precompile-utils",
  "scale-info",
- "serde",
- "sha3",
- "slices",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -6930,27 +6712,19 @@ dependencies = [
 name = "pallet-evm-precompile-collective"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "evm",
  "fp-evm",
  "frame-support",
  "frame-system",
- "hex-literal",
- "log",
- "num_enum",
  "pallet-balances",
  "pallet-collective",
  "pallet-evm",
  "pallet-timestamp",
  "pallet-treasury",
  "parity-scale-codec",
- "paste",
  "precompile-utils",
  "scale-info",
- "serde",
- "sha3",
  "similar-asserts",
- "slices",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -6965,22 +6739,17 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-test-relay-sproof-builder",
- "derive_more",
  "fp-evm",
  "frame-support",
  "frame-system",
  "log",
- "num_enum",
  "pallet-balances",
  "pallet-crowdloan-rewards",
  "pallet-evm",
- "pallet-scheduler",
  "pallet-timestamp",
  "parity-scale-codec",
  "precompile-utils",
- "rustc-hex",
  "scale-info",
- "serde",
  "sha3",
  "sp-core",
  "sp-io",
@@ -6992,13 +6761,11 @@ dependencies = [
 name = "pallet-evm-precompile-democracy"
 version = "0.2.0"
 dependencies = [
- "derive_more",
  "fp-evm",
  "frame-support",
  "frame-system",
  "hex-literal",
  "log",
- "num_enum",
  "pallet-balances",
  "pallet-democracy",
  "pallet-evm",
@@ -7008,21 +6775,10 @@ dependencies = [
  "parity-scale-codec",
  "precompile-utils",
  "scale-info",
- "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "pallet-evm-precompile-dispatch"
-version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#3568a86d0fe222db0c65218fc481907de602a35c"
-dependencies = [
- "fp-evm",
- "frame-support",
- "pallet-evm",
 ]
 
 [[package]]
@@ -7038,22 +6794,17 @@ dependencies = [
 name = "pallet-evm-precompile-parachain-staking"
 version = "1.0.0"
 dependencies = [
- "derive_more",
  "fp-evm",
  "frame-support",
  "frame-system",
  "log",
- "num_enum",
  "pallet-balances",
  "pallet-evm",
  "pallet-parachain-staking",
  "pallet-timestamp",
  "parity-scale-codec",
  "precompile-utils",
- "rustc-hex",
  "scale-info",
- "serde",
- "sha3",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -7064,23 +6815,16 @@ dependencies = [
 name = "pallet-evm-precompile-proxy"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "fp-evm",
  "frame-support",
  "frame-system",
- "hex-literal",
- "log",
- "num_enum",
  "pallet-balances",
  "pallet-evm",
  "pallet-proxy",
  "pallet-timestamp",
  "parity-scale-codec",
  "precompile-utils",
- "rustc-hex",
  "scale-info",
- "serde",
- "sha3",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -7091,20 +6835,14 @@ dependencies = [
 name = "pallet-evm-precompile-randomness"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "fp-evm",
  "frame-support",
  "frame-system",
- "hex-literal",
- "log",
  "nimbus-primitives",
- "num_enum",
  "pallet-author-mapping",
  "pallet-balances",
- "pallet-base-fee",
  "pallet-evm",
  "pallet-randomness",
- "pallet-scheduler",
  "pallet-timestamp",
  "parity-scale-codec",
  "precompile-utils",
@@ -7122,23 +6860,16 @@ version = "0.1.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
- "derive_more",
  "fp-evm",
  "frame-support",
  "frame-system",
- "hex-literal",
- "log",
- "num_enum",
  "pallet-balances",
  "pallet-evm",
  "pallet-staking",
  "pallet-timestamp",
  "parity-scale-codec",
  "precompile-utils",
- "rustc-hex",
  "scale-info",
- "serde",
- "sha3",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -7169,25 +6900,17 @@ name = "pallet-evm-precompile-xcm-transactor"
 version = "0.2.0"
 dependencies = [
  "cumulus-primitives-core",
- "derive_more",
- "evm",
  "fp-evm",
  "frame-support",
  "frame-system",
- "log",
- "num_enum",
  "orml-traits",
  "pallet-balances",
  "pallet-evm",
  "pallet-timestamp",
- "pallet-xcm",
  "pallet-xcm-transactor",
  "parity-scale-codec",
  "precompile-utils",
- "rustc-hex",
  "scale-info",
- "serde",
- "sha3",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -7203,21 +6926,15 @@ name = "pallet-evm-precompile-xcm-utils"
 version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core",
- "derive_more",
  "fp-evm",
  "frame-support",
  "frame-system",
- "num_enum",
- "orml-traits",
  "pallet-balances",
  "pallet-evm",
  "pallet-timestamp",
  "parity-scale-codec",
- "polkadot-parachain",
  "precompile-utils",
  "scale-info",
- "serde",
- "sha3",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -7233,12 +6950,9 @@ name = "pallet-evm-precompile-xtokens"
 version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core",
- "derive_more",
  "fp-evm",
  "frame-support",
  "frame-system",
- "log",
- "num_enum",
  "orml-traits",
  "orml-xtokens",
  "pallet-balances",
@@ -7247,10 +6961,7 @@ dependencies = [
  "pallet-xcm",
  "parity-scale-codec",
  "precompile-utils",
- "rustc-hex",
  "scale-info",
- "serde",
- "sha3",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -7265,14 +6976,11 @@ dependencies = [
 name = "pallet-evm-precompileset-assets-erc20"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "fp-evm",
  "frame-support",
  "frame-system",
  "hex-literal",
  "libsecp256k1",
- "log",
- "num_enum",
  "pallet-assets",
  "pallet-balances",
  "pallet-evm",
@@ -7281,9 +6989,7 @@ dependencies = [
  "paste",
  "precompile-utils",
  "scale-info",
- "serde",
  "sha3",
- "slices",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -7409,7 +7115,6 @@ dependencies = [
  "cumulus-primitives-core",
  "frame-support",
  "frame-system",
- "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -7497,7 +7202,6 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
  "nimbus-primitives",
  "pallet-balances",
  "parity-scale-codec",
@@ -7684,7 +7388,6 @@ dependencies = [
 name = "pallet-randomness"
 version = "0.1.0"
 dependencies = [
- "derive_more",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -7696,7 +7399,6 @@ dependencies = [
  "pallet-evm",
  "parity-scale-codec",
  "scale-info",
- "serde",
  "session-keys-primitives",
  "sp-consensus-vrf",
  "sp-core",
@@ -8085,16 +7787,13 @@ dependencies = [
  "orml-traits",
  "pallet-balances",
  "pallet-timestamp",
- "pallet-xcm",
  "parity-scale-codec",
  "scale-info",
- "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
  "xcm",
- "xcm-builder",
  "xcm-executor",
  "xcm-primitives",
 ]
@@ -9629,14 +9328,12 @@ dependencies = [
  "fp-evm",
  "frame-support",
  "frame-system",
- "hex",
  "hex-literal",
  "impl-trait-for-tuples",
  "log",
  "num_enum",
  "pallet-evm",
  "parity-scale-codec",
- "paste",
  "precompile-utils-macro",
  "scale-info",
  "serde",
@@ -9658,7 +9355,6 @@ dependencies = [
  "macrotest",
  "num_enum",
  "precompile-utils",
- "prettyplease",
  "proc-macro2",
  "quote",
  "sha3",
@@ -11838,7 +11534,6 @@ name = "session-keys-primitives"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "frame-support",
  "nimbus-primitives",
  "parity-scale-codec",
  "scale-info",
@@ -11846,11 +11541,9 @@ dependencies = [
  "sp-application-crypto",
  "sp-consensus-babe",
  "sp-consensus-vrf",
- "sp-core",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -12013,18 +11706,6 @@ name = "slice-group-by"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
-
-[[package]]
-name = "slices"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2086e458a369cdca838e9f6ed04b4cc2e3ce636d99abb80c9e2eada107749cf"
-dependencies = [
- "faster-hex",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "slot-range-helper"
@@ -12670,7 +12351,7 @@ dependencies = [
  "sp-trie",
  "thiserror",
  "tracing",
- "trie-root 0.17.0",
+ "trie-root",
 ]
 
 [[package]]
@@ -12777,7 +12458,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "trie-db",
- "trie-root 0.17.0",
+ "trie-root",
 ]
 
 [[package]]
@@ -13628,15 +13309,6 @@ dependencies = [
  "log",
  "rustc-hex",
  "smallvec",
-]
-
-[[package]]
-name = "trie-root"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b779f7c1c8fe9276365d9d5be5c4b5adeacf545117bb3f64c974305789c5c0b"
-dependencies = [
- "hash-db",
 ]
 
 [[package]]
@@ -14710,13 +14382,10 @@ dependencies = [
  "ethereum-types",
  "frame-support",
  "frame-system",
- "hex",
  "log",
  "orml-traits",
  "parity-scale-codec",
  "scale-info",
- "serde",
- "sha3",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-exclude = [ "bin/utils/moonkey" ]
+exclude = [ "bin/utils/moonkey", "tests/node_modules" ]
 members = [
 	"bin/utils/moonkey",
 	"client/rpc/finality",
@@ -30,6 +30,15 @@ members = [
 	"runtime/moonbase",
 	"runtime/moonbeam",
 	"runtime/moonriver",
+]
+
+[workspace.metadata.cargo-machete]
+# Substrate macros require those dependencies in Cargo.toml, which are
+	# not used outside the macros.
+ignored = [
+	"codec",
+	"parity_scale_codec",
+	"scale_info",
 ]
 
 [patch.crates-io]

--- a/client/evm-tracing/Cargo.toml
+++ b/client/evm-tracing/Cargo.toml
@@ -11,11 +11,9 @@ version = "0.1.0"
 ethereum-types = { version = "0.14" }
 hex = { version = "0.4", features = [ "serde" ] }
 serde = { version = "1.0", features = [ "derive" ] }
-serde_json = { version = "1.0" }
 
 # Moonbeam
 evm-tracing-events = { path = "../../primitives/rpc/evm-tracing-events" }
-moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug" }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }

--- a/client/rpc-core/debug/Cargo.toml
+++ b/client/rpc-core/debug/Cargo.toml
@@ -9,11 +9,7 @@ version = "0.1.0"
 
 [dependencies]
 ethereum-types = "0.14"
-futures = { version = "0.3", features = [ "compat" ] }
 jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
 moonbeam-client-evm-tracing = { path = "../../evm-tracing" }
 moonbeam-rpc-core-types = { path = "../types" }
 serde = { version = "1.0", features = [ "derive" ] }
-serde_json = "1.0"
-
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }

--- a/client/rpc-core/trace/Cargo.toml
+++ b/client/rpc-core/trace/Cargo.toml
@@ -9,9 +9,7 @@ version = "0.6.0"
 
 [dependencies]
 ethereum-types = "0.14"
-futures = { version = "0.3.1", features = [ "compat" ] }
 jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
 moonbeam-client-evm-tracing = { path = "../../evm-tracing" }
 moonbeam-rpc-core-types = { path = "../types" }
 serde = { version = "1.0", features = [ "derive" ] }
-serde_json = "1.0"

--- a/client/rpc-core/txpool/Cargo.toml
+++ b/client/rpc-core/txpool/Cargo.toml
@@ -12,6 +12,5 @@ ethereum = { version = "0.14.0", default-features = false, features = [ "with-co
 ethereum-types = "0.14"
 jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
 serde = { version = "1.0", features = [ "derive" ] }
-serde_json = "1.0"
 
 fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }

--- a/client/rpc-core/types/Cargo.toml
+++ b/client/rpc-core/types/Cargo.toml
@@ -10,4 +10,3 @@ version = "0.1.0"
 [dependencies]
 ethereum-types = "0.14"
 serde = { version = "1.0", features = [ "derive" ] }
-serde_json = "1.0"

--- a/client/rpc/debug/Cargo.toml
+++ b/client/rpc/debug/Cargo.toml
@@ -25,14 +25,12 @@ sc-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-
 sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 
 # Frontier
 ethereum = { version = "0.14.0", default-features = false, features = [ "with-codec" ] }
 ethereum-types = "0.14"
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
 fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
 fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", features = [ "rpc_binary_search_estimate" ] }
 fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }

--- a/client/rpc/finality/Cargo.toml
+++ b/client/rpc/finality/Cargo.toml
@@ -9,10 +9,7 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-futures = { version = "0.3", features = [ "compat" ] }
 jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
-parity-scale-codec = "3.0.0"
-tokio = { version = "1.12.0", features = [ "sync", "time" ] }
 
 fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
 fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }

--- a/client/rpc/manual-xcm/Cargo.toml
+++ b/client/rpc/manual-xcm/Cargo.toml
@@ -9,11 +9,9 @@ version = "0.1.0"
 
 [dependencies]
 flume = "0.10.9"
-futures = { version = "0.3", features = [ "compat" ] }
 hex-literal = "0.3.3"
 jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
 parity-scale-codec = "3.0.0"
-tokio = { version = "1.12.0", features = [ "sync", "time" ] }
 xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }

--- a/client/rpc/trace/Cargo.toml
+++ b/client/rpc/trace/Cargo.toml
@@ -8,12 +8,9 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.6.0"
 
 [dependencies]
-ethereum = { version = "0.14.0", features = [ "with-codec" ] }
 ethereum-types = "0.14"
 futures = { version = "0.3" }
 jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
-serde = { version = "1.0", features = [ "derive" ] }
-sha3 = "0.10"
 tokio = { version = "1.10", features = [ "sync", "time" ] }
 tracing = "0.1.34"
 
@@ -25,18 +22,12 @@ moonbeam-rpc-primitives-debug = { path = "../../../primitives/rpc/debug" }
 
 # Substrate
 sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-network = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 
 # Frontier
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
 fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", features = [ "rpc_binary_search_estimate" ] }
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
 fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }

--- a/client/rpc/txpool/Cargo.toml
+++ b/client/rpc/txpool/Cargo.toml
@@ -9,7 +9,6 @@ version = "0.6.0"
 
 [dependencies]
 jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
-rlp = "0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 sha3 = "0.10"
 
@@ -18,14 +17,11 @@ moonbeam-rpc-core-txpool = { path = "../../rpc-core/txpool" }
 moonbeam-rpc-primitives-txpool = { path = "../../../primitives/rpc/txpool" }
 
 # Substrate
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-transaction-pool-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 
 # Frontier
 ethereum-types = "0.14"

--- a/client/vrf/Cargo.toml
+++ b/client/vrf/Cargo.toml
@@ -9,7 +9,6 @@ version = "0.1.0"
 
 [dependencies]
 # Substrate
-codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ] }
 sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-application-crypto = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-consensus-vrf = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -22,6 +21,3 @@ session-keys-primitives = { path = "../../primitives/session-keys" }
 
 # Nimbus
 nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32" }
-
-# Polkadot
-polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }

--- a/core-primitives/Cargo.toml
+++ b/core-primitives/Cargo.toml
@@ -10,7 +10,6 @@ version = "0.1.1"
 [dependencies]
 account = { path = "../primitives/account", default-features = false }
 
-fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
@@ -18,7 +17,6 @@ sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbea
 default = [ "std" ]
 std = [
 	"account/std",
-	"fp-self-contained/std",
 	"sp-core/std",
 	"sp-runtime/std",
 ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -7,13 +7,20 @@ homepage = "https://moonbeam.network"
 license = "GPL-3.0-only"
 version = "0.12.3"
 
+[package.metadata.cargo-machete]
+ignored = [
+	# https://github.com/bnjbvr/cargo-machete/issues/58
+	# cargo-machete currently don't detect dependencies used only in features
+	"moonbeam_service",
+	"pallet_xcm",
+	"xcm_builder",
+]
+
 [[bin]]
 name = 'moonbeam'
 path = 'src/main.rs'
 
 [dependencies]
-futures = { version = "0.3.1", features = [ "compat" ] }
-
 moonbeam-cli = { path = "cli", default-features = false }
 moonbeam-service = { path = "service", default-features = false }
 
@@ -21,10 +28,8 @@ moonbeam-service = { path = "service", default-features = false }
 assert_cmd = "0.12"
 hex = "0.4.3"
 nix = "0.23"
-serde = { version = "1.0.101", features = [ "derive" ] }
 serde_json = "1.0"
 tempfile = "3.2.0"
-tracing-core = "0.1.29"
 
 # Benchmarking
 pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }

--- a/node/cli-opt/Cargo.toml
+++ b/node/cli-opt/Cargo.toml
@@ -11,7 +11,6 @@ bip32 = { git = "https://github.com/purestake/crates", branch = "bip32-v0.4.0-fi
 clap = { version = "4.0.9", features = [ "derive" ] }
 libsecp256k1 = "0.7"
 primitive-types = "0.12.0"
-sha3 = "0.10"
 tiny-bip39 = "0.8"
 url = "2.2.2"
 

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -3,6 +3,10 @@ name = "moonbeam-cli"
 authors = [ "PureStake" ]
 edition = "2021"
 version = "0.28.0"
+
+[package.metadata.cargo-machete]
+ignored = [ "substrate_build_script_utils" ]
+
 [dependencies]
 clap = { version = "4.0.9", features = [ "derive" ] }
 log = "0.4.8"
@@ -15,25 +19,20 @@ service = { package = "moonbeam-service", path = "../service", default-features 
 # Substrate
 frame-benchmarking-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-finality-grandpa = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-service = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-sysinfo = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-telemetry = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-substrate-prometheus-endpoint = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 try-runtime-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true }
 
 # Cumulus / Nimbus
 cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
 nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32" }
 
 # Polkadot
 polkadot-cli = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 polkadot-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -6,13 +6,16 @@ homepage = "https://moonbeam.network"
 license = "GPL-3.0-only"
 version = "0.28.0"
 
+[package.metadata.cargo-machete]
+ignored = [
+	# https://github.com/bnjbvr/cargo-machete/issues/58
+	# cargo-machete currently don't detect dependencies used only in features
+	"polkadot_cli",
+]
+
 [dependencies]
-ansi_term = "0.12.1"
 async-io = "1.3"
-async-trait = "0.1.42"
 bip32 = { git = "https://github.com/purestake/crates", branch = "bip32-v0.4.0-fix", default-features = false, features = [ "bip39" ] }
-derive_more = "0.99"
-exit-future = "0.2"
 flume = "0.10.9"
 futures = { version = "0.3.1", features = [ "compat" ] }
 hex-literal = "0.3.4"
@@ -20,13 +23,11 @@ jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros
 libsecp256k1 = { version = "0.7", features = [ "hmac" ] }
 log = "0.4"
 maplit = "1.0.2"
-parking_lot = "0.12.0"
 serde = { version = "1.0.101", features = [ "derive" ] }
 serde_json = "1.0"
 sha3 = { version = "0.10", default-features = false }
 tiny-bip39 = { version = "0.8", default-features = false }
 tokio = { version = "1.13.0", features = [ "macros", "sync" ] }
-trie-root = "0.15.2"
 
 # Moonbeam
 cli-opt = { package = "moonbeam-cli-opt", path = "../cli-opt" }
@@ -49,20 +50,14 @@ moonbeam-runtime = { path = "../../runtime/moonbeam", optional = true }
 moonriver-runtime = { path = "../../runtime/moonriver", optional = true }
 
 # Substrate
-frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 pallet-transaction-payment-rpc = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-parity-scale-codec = "3.0.0"
 sc-basic-authorship = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-chain-spec = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", features = [ "wasmtime" ] }
 sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-client-db = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-consensus-manual-seal = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-executor = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", features = [ "wasmtime" ] }
-sc-finality-grandpa = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-informant = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-network = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-network-common = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sc-rpc = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
@@ -78,7 +73,6 @@ sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "m
 sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 sp-offchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
@@ -97,58 +91,37 @@ fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polk
 fc-mapping-sync = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
 fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", features = [ "rpc_binary_search_estimate" ] }
 fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-fp-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
 fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
 fp-storage = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
 pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", features = [ "forbid-evm-reentrancy" ] }
 
 # Cumulus / Nimbus
-cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-client-collator = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
 cumulus-client-consensus-common = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-client-consensus-relay-chain = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
 cumulus-client-network = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
 cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
 cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
 cumulus-relay-chain-inprocess-interface = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
 cumulus-relay-chain-interface = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
 nimbus-consensus = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32" }
 # TODO we should be able to depend only on the primitives crate once we move the inherent data provider there.
 nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32" }
 
 # Polkadot
 polkadot-cli = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 polkadot-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 # Benchmarking
 frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-frame-benchmarking-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 
 [dev-dependencies]
-assert_cmd = "0.12"
-nix = "0.23"
 prometheus = { version = "0.13.0", default-features = false }
-rand = "0.7.3"
 sc-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 
-# Polkadot dev-dependencies
-polkadot-runtime-common = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-
 # Substrate dev-dependencies
-pallet-sudo = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-substrate-test-client = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 substrate-test-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 substrate-test-runtime-client = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-
-[build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 
 [features]
 default = [

--- a/pallets/asset-manager/Cargo.toml
+++ b/pallets/asset-manager/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.1.0"
 
 [dependencies]
 log = { version = "0.4", default-features = false }
-serde = { version = "1.0.124", optional = true }
 
 # Moonbeam
 xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
@@ -37,7 +36,6 @@ std = [
 	"frame-system/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
-	"serde",
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/pallets/ethereum-chain-id/Cargo.toml
+++ b/pallets/ethereum-chain-id/Cargo.toml
@@ -5,8 +5,6 @@ edition = "2021"
 version = "1.0.0"
 
 [dependencies]
-serde = { version = "1.0.101", optional = true, features = [ "derive" ] }
-
 # Substrate
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -20,6 +18,5 @@ std = [
 	"frame-system/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
-	"serde",
 ]
 try-runtime = [ "frame-support/try-runtime" ]

--- a/pallets/ethereum-xcm/Cargo.toml
+++ b/pallets/ethereum-xcm/Cargo.toml
@@ -12,7 +12,6 @@ targets = [ "x86_64-unknown-linux-gnu" ]
 
 [dependencies]
 ethereum = { version = "0.14.0", default-features = false, features = [ "with-codec" ] }
-serde = { version = "1.0.137", optional = true }
 
 # Parity
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
@@ -68,7 +67,6 @@ std = [
 	"pallet-timestamp/std",
 	"rlp/std",
 	"scale-info/std",
-	"serde",
 	# Substrate
 	"sp-io/std",
 	"sp-runtime/std",

--- a/pallets/maintenance-mode/Cargo.toml
+++ b/pallets/maintenance-mode/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-log = "0.4"
-
 # Substrate
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }

--- a/pallets/moonbeam-orbiters/Cargo.toml
+++ b/pallets/moonbeam-orbiters/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-log = "0.4"
-
 # Substrate
 frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }

--- a/pallets/moonbeam-xcm-benchmarks/Cargo.toml
+++ b/pallets/moonbeam-xcm-benchmarks/Cargo.toml
@@ -5,11 +5,6 @@ edition = "2021"
 version = "0.2.0"
 
 [dependencies]
-log = { version = "0.4", default-features = false }
-serde = { version = "1.0.124", optional = true }
-
-# Moonbeam
-xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
 
 # Substrate
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -40,12 +35,18 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"parity-scale-codec/std",
-	"serde",
 	"sp-std/std",
-	"xcm-primitives/std",
 	"xcm/std",
 ]
 
 try-runtime = [ "frame-support/try-runtime" ]
 
-runtime-benchmarks = [ "frame-benchmarking", "frame-system/runtime-benchmarks", "pallet-xcm-benchmarks/runtime-benchmarks", "parity-scale-codec", "scale-info", "xcm-executor/runtime-benchmarks", "xcm/runtime-benchmarks" ]
+runtime-benchmarks = [
+	"frame-benchmarking",
+	"frame-system/runtime-benchmarks",
+	"pallet-xcm-benchmarks/runtime-benchmarks",
+	"parity-scale-codec",
+	"scale-info",
+	"xcm-executor/runtime-benchmarks",
+	"xcm/runtime-benchmarks",
+]

--- a/pallets/randomness/Cargo.toml
+++ b/pallets/randomness/Cargo.toml
@@ -14,7 +14,6 @@ log = "0.4"
 nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-serde = { version = "1.0.101", optional = true }
 session-keys-primitives = { path = "../../primitives/session-keys", default-features = false }
 sp-consensus-vrf = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -26,7 +25,6 @@ sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-po
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
-derive_more = "0.99"
 pallet-author-mapping = { path = "../author-mapping" }
 pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 
@@ -41,7 +39,6 @@ std = [
 	"pallet-evm/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
-	"serde",
 	"session-keys-primitives/std",
 	"sp-consensus-vrf/std",
 	"sp-core/std",

--- a/pallets/xcm-transactor/Cargo.toml
+++ b/pallets/xcm-transactor/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.2.0"
 
 [dependencies]
 log = { version = "0.4", default-features = false }
-serde = { version = "1.0.124", optional = true }
 
 # Moonbeam
 xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
@@ -26,7 +25,6 @@ cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch
 # Polkadot / XCM
 orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 # Benchmarks
@@ -35,7 +33,6 @@ frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = 
 [dev-dependencies]
 pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 parity-scale-codec = { version = "3.0.0" }
 sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 
@@ -48,7 +45,6 @@ std = [
 	"frame-system/std",
 	"orml-traits/std",
 	"parity-scale-codec/std",
-	"serde",
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/precompiles/assets-erc20/Cargo.toml
+++ b/precompiles/assets-erc20/Cargo.toml
@@ -6,10 +6,7 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
 paste = "1.0.6"
-slices = "0.2.0"
 
 # Moonbeam
 precompile-utils = { path = "../utils", default-features = false }
@@ -32,10 +29,8 @@ fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-pol
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
-derive_more = { version = "0.99" }
 hex-literal = "0.3.4"
 libsecp256k1 = "0.7"
-serde = { version = "1.0.100" }
 sha3 = "0.10"
 
 # Moonbeam

--- a/precompiles/author-mapping/Cargo.toml
+++ b/precompiles/author-mapping/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.2.0"
 
 [dependencies]
 log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
 
 # Moonbeam
 pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
@@ -29,10 +28,6 @@ pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam
 nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 [dev-dependencies]
-derive_more = "0.99"
-hex-literal = "0.3.4"
-serde = "1.0.100"
-
 # Moonbeam
 pallet-author-mapping = { path = "../../pallets/author-mapping" }
 precompile-utils = { path = "../utils", features = [ "testing" ] }

--- a/precompiles/balances-erc20/Cargo.toml
+++ b/precompiles/balances-erc20/Cargo.toml
@@ -6,10 +6,7 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
 paste = "1.0.6"
-slices = "0.2.0"
 
 # Moonbeam
 precompile-utils = { path = "../utils", default-features = false }
@@ -29,10 +26,8 @@ fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-pol
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
-derive_more = { version = "0.99" }
 hex-literal = "0.3.4"
 libsecp256k1 = "0.7"
-serde = { version = "1.0.100" }
 sha3 = "0.10"
 
 # Moonbeam

--- a/precompiles/batch/Cargo.toml
+++ b/precompiles/batch/Cargo.toml
@@ -6,11 +6,6 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
-paste = "1.0.6"
-slices = "0.2.0"
-
 # Moonbeam
 precompile-utils = { path = "../utils", default-features = false }
 
@@ -28,12 +23,8 @@ fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-pol
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
-derive_more = { version = "0.99" }
 hex-literal = "0.3.4"
-serde = { version = "1.0.100" }
-sha3 = "0.10"
 
-codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
 pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 precompile-utils = { path = "../utils", features = [ "testing" ] }

--- a/precompiles/call-permit/Cargo.toml
+++ b/precompiles/call-permit/Cargo.toml
@@ -6,10 +6,6 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
-paste = "1.0.6"
-slices = "0.2.0"
 
 # Moonbeam
 precompile-utils = { path = "../utils", default-features = false }
@@ -29,11 +25,8 @@ fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-pol
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
-derive_more = { version = "0.99" }
 hex-literal = "0.3.4"
 libsecp256k1 = "0.7"
-serde = { version = "1.0.100" }
-sha3 = "0.10"
 
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
 pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }

--- a/precompiles/collective/Cargo.toml
+++ b/precompiles/collective/Cargo.toml
@@ -5,11 +5,10 @@ description = "A Precompile wrapping the collective pallet."
 edition = "2021"
 version = "0.1.0"
 
+[package.metadata.cargo-machete]
+ignored = [ "evm" ]
+
 [dependencies]
-log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
-paste = "1.0.6"
-slices = "0.2.0"
 
 # Moonbeam
 precompile-utils = { path = "../utils", default-features = false }
@@ -29,10 +28,6 @@ fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-pol
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
-derive_more = { version = "0.99" }
-hex-literal = "0.3.4"
-serde = { version = "1.0.100" }
-sha3 = "0.10"
 similar-asserts = "1.1.0"
 
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }

--- a/precompiles/crowdloan-rewards/Cargo.toml
+++ b/precompiles/crowdloan-rewards/Cargo.toml
@@ -7,8 +7,6 @@ version = "0.6.0"
 
 [dependencies]
 log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
-rustc-hex = { version = "2.0.1", default-features = false }
 
 # Moonbeam
 pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -25,8 +23,6 @@ fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-pol
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
-derive_more = "0.99"
-serde = "1.0.100"
 sha3 = "0.10"
 
 # Moonbeam
@@ -35,7 +31,6 @@ precompile-utils = { path = "../utils", features = [ "testing" ] }
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
 pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
 sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }

--- a/precompiles/pallet-democracy/Cargo.toml
+++ b/precompiles/pallet-democracy/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.2.0"
 
 [dependencies]
 log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
 
 # Moonbeam
 precompile-utils = { path = "../utils", default-features = false }
@@ -28,9 +27,7 @@ sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-po
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
-derive_more = "0.99"
 hex-literal = "0.3.4"
-serde = "1.0.100"
 
 # Moonbeam
 precompile-utils = { path = "../utils", features = [ "testing" ] }

--- a/precompiles/parachain-staking/Cargo.toml
+++ b/precompiles/parachain-staking/Cargo.toml
@@ -7,8 +7,6 @@ version = "1.0.0"
 
 [dependencies]
 log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
-rustc-hex = { version = "2.0.1", default-features = false }
 
 # Moonbeam
 pallet-parachain-staking = { path = "../../pallets/parachain-staking", default-features = false }
@@ -28,10 +26,6 @@ fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-pol
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
-derive_more = "0.99"
-serde = "1.0.100"
-sha3 = "0.10"
-
 # Moonbeam
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 

--- a/precompiles/proxy/Cargo.toml
+++ b/precompiles/proxy/Cargo.toml
@@ -5,11 +5,10 @@ description = "A Precompile to make proxy calls encoding accessible to pallet-ev
 edition = "2021"
 version = "0.1.0"
 
-[dependencies]
-log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
-rustc-hex = { version = "2.0.1", default-features = false }
+[package.metadata.cargo-machete]
+ignored = [ "parity_scale_codec" ]
 
+[dependencies]
 # Moonbeam
 precompile-utils = { path = "../utils", default-features = false }
 
@@ -17,7 +16,6 @@ precompile-utils = { path = "../utils", default-features = false }
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -27,17 +25,13 @@ fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-pol
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
-derive_more = "0.99"
-hex-literal = "0.3.3"
-serde = "1.0.100"
-sha3 = "0.10"
-
 # Moonbeam
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 # Substrate
 pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
 sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
@@ -49,8 +43,6 @@ std = [
 	"frame-system/std",
 	"pallet-evm/std",
 	"pallet-proxy/std",
-	"parity-scale-codec/std",
-	"parity-scale-codec/std",
 	"precompile-utils/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/precompiles/randomness/Cargo.toml
+++ b/precompiles/randomness/Cargo.toml
@@ -6,9 +6,6 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
-
 # Moonbeam
 pallet-randomness = { path = "../../pallets/randomness", default-features = false }
 precompile-utils = { path = "../utils", default-features = false }
@@ -23,15 +20,12 @@ sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-pol
 sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 # Frontier
-pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 # Nimbus
 nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 [dev-dependencies]
-derive_more = "0.99"
-hex-literal = "0.3.4"
 
 # Moonbeam
 pallet-author-mapping = { path = "../../pallets/author-mapping" }
@@ -40,7 +34,6 @@ session-keys-primitives = { path = "../../primitives/session-keys" }
 
 # Substrate
 pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
 sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
@@ -53,7 +46,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"nimbus-primitives/std",
-	"pallet-base-fee/std",
 	"pallet-evm/std",
 	"pallet-randomness/std",
 	"precompile-utils/std",

--- a/precompiles/relay-encoder/Cargo.toml
+++ b/precompiles/relay-encoder/Cargo.toml
@@ -6,10 +6,6 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
-rustc-hex = { version = "2.0.1", default-features = false }
-
 # Moonbeam
 precompile-utils = { path = "../utils", default-features = false }
 
@@ -31,10 +27,6 @@ pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 [dev-dependencies]
-derive_more = "0.99"
-hex-literal = "0.3.3"
-serde = "1.0.100"
-sha3 = "0.10"
 
 # Moonbeam
 precompile-utils = { path = "../utils", features = [ "testing" ] }

--- a/precompiles/utils/Cargo.toml
+++ b/precompiles/utils/Cargo.toml
@@ -8,17 +8,15 @@ version = "0.1.0"
 [dependencies]
 affix = "0.1.2"
 derive_more = { version = "0.99", optional = true }
-hex = { version = "0.4.3", default-features = false }
+
 hex-literal = { version = "0.3.1", optional = true }
 impl-trait-for-tuples = "0.2.2"
 log = "0.4"
 num_enum = { version = "0.5.3", default-features = false }
-paste = "1.0.8"
 scale-info = { version = "2.0", optional = true, default-features = false, features = [ "derive" ] }
 serde = { version = "1.0.100", optional = true }
 sha3 = { version = "0.10", default-features = false }
 similar-asserts = { version = "1.1.0", optional = true }
-
 
 # Moonbeam
 precompile-utils-macro = { path = "macro" }

--- a/precompiles/utils/macro/Cargo.toml
+++ b/precompiles/utils/macro/Cargo.toml
@@ -19,7 +19,6 @@ path = "tests/precompile.rs"
 [dependencies]
 case = "1.0"
 num_enum = { version = "0.5.3", default-features = false }
-prettyplease = "0.1.18"
 proc-macro2 = "1.0"
 quote = "1.0"
 sha3 = "0.10"

--- a/precompiles/xcm-transactor/Cargo.toml
+++ b/precompiles/xcm-transactor/Cargo.toml
@@ -6,10 +6,6 @@ edition = "2021"
 version = "0.2.0"
 
 [dependencies]
-log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
-rustc-hex = { version = "2.0.1", default-features = false }
-
 # Moonbeam
 pallet-xcm-transactor = { path = "../../pallets/xcm-transactor", default-features = false }
 precompile-utils = { path = "../utils", default-features = false }
@@ -23,7 +19,6 @@ sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbea
 sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 # Frontier
-evm = { version = "0.37.0", default-features = false, features = [ "with-codec" ] }
 fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
@@ -31,10 +26,6 @@ pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam
 xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 [dev-dependencies]
-derive_more = "0.99"
-serde = "1.0.100"
-sha3 = "0.10"
-
 # Moonbeam
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 xcm-primitives = { path = "../../primitives/xcm/" }
@@ -50,7 +41,6 @@ sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-pol
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
 
 # Polkadot
-pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 
@@ -62,7 +52,6 @@ default = [ "std" ]
 std = [
 	"frame-support/std",
 	"frame-system/std",
-	"pallet-evm/std",
 	"pallet-xcm-transactor/std",
 	"precompile-utils/std",
 	"sp-core/std",

--- a/precompiles/xcm-utils/Cargo.toml
+++ b/precompiles/xcm-utils/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-num_enum = { version = "0.5.3", default-features = false }
-
 # Moonbeam
 precompile-utils = { path = "../utils", default-features = false }
 xcm-primitives = { path = "../../primitives/xcm", default-features = false }
@@ -28,9 +26,6 @@ xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkad
 xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 [dev-dependencies]
-derive_more = "0.99"
-serde = "1.0.100"
-sha3 = "0.10"
 
 # Moonbeam
 precompile-utils = { path = "../utils", features = [ "testing" ] }
@@ -47,11 +42,7 @@ sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbea
 cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
 
 # Polkadot
-polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-
-# ORML
-orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32" }
 
 [features]
 default = [ "std" ]
@@ -59,11 +50,9 @@ std = [
 	"codec/std",
 	"frame-support/std",
 	"frame-system/std",
-	"orml-traits/std",
 	"pallet-balances/std",
 	"pallet-evm/std",
 	"pallet-timestamp/std",
-	"polkadot-parachain/std",
 	"precompile-utils/std",
 	"sp-core/std",
 	"sp-io/std",

--- a/precompiles/xtokens/Cargo.toml
+++ b/precompiles/xtokens/Cargo.toml
@@ -6,10 +6,6 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-log = "0.4"
-num_enum = { version = "0.5.3", default-features = false }
-rustc-hex = { version = "2.0.1", default-features = false }
-
 # Moonbeam
 precompile-utils = { path = "../utils", default-features = false }
 xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
@@ -30,10 +26,6 @@ orml-xtokens = { git = "https://github.com/purestake/open-runtime-module-library
 xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 [dev-dependencies]
-derive_more = "0.99"
-serde = "1.0.100"
-sha3 = "0.10"
-
 # Moonbeam
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -7,6 +7,14 @@ license = "GPL-3.0-only"
 repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.1"
 
+[package.metadata.cargo-machete]
+ignored = [
+	# used in features only
+	"blake2_rfc",
+	"sp_runtime_interface",
+	"sp_std",
+]
+
 [package.metadata.docs.rs]
 targets = [ "x86_64-unknown-linux-gnu" ]
 

--- a/primitives/ext/Cargo.toml
+++ b/primitives/ext/Cargo.toml
@@ -8,14 +8,11 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-ethereum-types = { version = "0.14", default-features = false }
-
 # Moonbeam
 evm-tracing-events = { path = "../rpc/evm-tracing-events", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-externalities = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-runtime-interface = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
@@ -23,9 +20,7 @@ sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-po
 default = [ "std" ]
 std = [
 	"codec/std",
-	"ethereum-types/std",
 	"evm-tracing-events/std",
-	"sp-externalities/std",
 	"sp-runtime-interface/std",
 	"sp-std/std",
 ]

--- a/primitives/rpc/debug/Cargo.toml
+++ b/primitives/rpc/debug/Cargo.toml
@@ -8,18 +8,12 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
 [dependencies]
-environmental = { version = "1.1.2", default-features = false }
 ethereum = { version = "0.14.0", default-features = false, features = [ "with-codec" ] }
 ethereum-types = { version = "0.14", default-features = false }
-hex = { version = "0.4", optional = true, features = [ "serde" ] }
-serde = { version = "1.0", optional = true, features = [ "derive" ] }
-serde_json = { version = "1.0", optional = true }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
@@ -27,15 +21,9 @@ sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-po
 default = [ "std" ]
 std = [
 	"codec/std",
-	"environmental/std",
 	"ethereum-types/std",
 	"ethereum/std",
-	"hex",
-	"serde",
-	"serde_json",
 	"sp-api/std",
-	"sp-core/std",
-	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
 ]

--- a/primitives/rpc/evm-tracing-events/Cargo.toml
+++ b/primitives/rpc/evm-tracing-events/Cargo.toml
@@ -15,7 +15,6 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 sp-runtime-interface = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 # Ethereum
-ethereum = { version = "0.14.0", default-features = false, features = [ "with-codec" ] }
 ethereum-types = { version = "0.14", default-features = false }
 evm = { version = "0.37.0", default-features = false, features = [ "with-codec" ] }
 evm-gasometer = { version = "0.37.0", default-features = false }
@@ -27,7 +26,6 @@ std = [
 	"codec/std",
 	"environmental/std",
 	"ethereum-types/std",
-	"ethereum/std",
 	"evm-gasometer/std",
 	"evm-runtime/std",
 	"evm/std",

--- a/primitives/rpc/txpool/Cargo.toml
+++ b/primitives/rpc/txpool/Cargo.toml
@@ -13,7 +13,6 @@ ethereum = { version = "0.14.0", default-features = false, features = [ "with-co
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
 sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
@@ -22,7 +21,6 @@ default = [ "std" ]
 std = [
 	"ethereum/std",
 	"sp-api/std",
-	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",
 ]

--- a/primitives/session-keys/Cargo.toml
+++ b/primitives/session-keys/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
@@ -15,17 +14,14 @@ sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-po
 sp-application-crypto = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-consensus-babe = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-consensus-vrf = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
 sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 [features]
 default = [ "std" ]
 std = [
 	"async-trait",
-	"frame-support/std",
 	"nimbus-primitives/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
@@ -33,10 +29,8 @@ std = [
 	"sp-application-crypto/std",
 	"sp-consensus-babe/std",
 	"sp-consensus-vrf/std",
-	"sp-core/std",
 	"sp-inherents/std",
 	"sp-keystore",
 	"sp-runtime/std",
-	"sp-std/std",
 ]
 runtime-benchmarks = []

--- a/primitives/xcm/Cargo.toml
+++ b/primitives/xcm/Cargo.toml
@@ -13,10 +13,7 @@ targets = [ "x86_64-unknown-linux-gnu" ]
 [dependencies]
 ethereum = { version = "0.14.0", default-features = false, features = [ "with-codec" ] }
 ethereum-types = { version = "0.14", default-features = false }
-hex = { version = "0.4", default-features = false }
 log = "0.4"
-serde = { version = "1.0.101", optional = true, default-features = false, features = [ "derive" ] }
-sha3 = { version = "0.10", default-features = false }
 
 # Substrate
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -36,10 +33,7 @@ xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbe
 [features]
 default = [ "std" ]
 std = [
-	"hex/std",
 	"parity-scale-codec/std",
-	"serde/std",
-	"sha3/std",
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -8,7 +8,6 @@ license = "GPL-3.0-only"
 version = "0.8.0-dev"
 
 [dependencies]
-impl-trait-for-tuples = "0.2.1"
 log = "0.4"
 
 # Moonbeam
@@ -23,7 +22,6 @@ pallet-xcm-transactor = { path = "../../pallets/xcm-transactor", default-feature
 # Substrate
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-collective = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -32,7 +30,6 @@ sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbea
 sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 # Frontier
-pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 # Nimbus
@@ -48,7 +45,6 @@ std = [
 	"pallet-asset-manager/std",
 	"pallet-author-inherent/std",
 	"pallet-author-mapping/std",
-	"pallet-base-fee/std",
 	"pallet-evm/std",
 	"pallet-migrations/std",
 	"pallet-parachain-staking/std",

--- a/runtime/evm_tracer/Cargo.toml
+++ b/runtime/evm_tracer/Cargo.toml
@@ -7,6 +7,13 @@ license = "GPL-3.0-only"
 repository = "https://github.com/PureStake/moonbeam/"
 version = "0.1.0"
 
+[package.metadata.cargo-machete]
+# used in features or required by macros
+# `cargo machete` gives false positives in those cases
+ignored = [
+	"pallet_evm",
+]
+
 [dependencies]
 
 # Moonbeam
@@ -15,33 +22,24 @@ moonbeam-primitives-ext = { path = "../../primitives/ext", default-features = fa
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 
 # Frontier
-ethereum-types = { version = "0.14", default-features = false }
 evm = { version = "0.37.0", default-features = false, features = [ "with-codec" ] }
 evm-gasometer = { version = "0.37.0", default-features = false }
 evm-runtime = { version = "0.37.0", default-features = false }
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [features]
 default = [ "std" ]
 std = [
 	"codec/std",
-	"ethereum-types/std",
 	"evm-gasometer/std",
 	"evm-runtime/std",
 	"evm-tracing-events/std",
 	"evm/std",
 	"evm/with-serde",
-	"fp-evm/std",
 	"moonbeam-primitives-ext/std",
 	"pallet-evm/std",
-	"sp-core/std",
-	"sp-runtime/std",
 	"sp-std/std",
 ]

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -8,9 +8,29 @@ homepage = "https://moonbeam.network"
 license = "GPL-3.0-only"
 version = "0.8.4"
 
+[package.metadata.cargo-machete]
+# used in features or required by macros
+# `cargo machete` gives false positives in those cases
+ignored = [
+	"evm_tracing_events",
+	"frame_benchmarking",
+	"frame_system_benchmarking",
+	"frame_system_rpc_runtime_api",
+	"frame_try_runtime",
+	"hex_literal",
+	"moonbeam_evm_tracer",
+	"pallet_transaction_payment_rpc_runtime_api",
+	"pallet_xcm_benchmarks",
+	"rlp",
+	"sp_block_builder",
+	"sp_debug_derive",
+	"sp_offchain",
+	"sp_session",
+	"substrate_wasm_builder",
+]
+
 [dependencies]
 hex-literal = { version = "0.3.4", optional = true }
-log = "0.4"
 rlp = { version = "0.5", optional = true, default-features = false }
 serde = { version = "1.0.101", optional = true, default-features = false, features = [ "derive" ] }
 sha3 = { version = "0.10", optional = true, default-features = false }
@@ -79,7 +99,6 @@ pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonb
 pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-referenda = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-society = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-sudo = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -106,12 +125,10 @@ sp-version = { git = "https://github.com/purestake/substrate", branch = "moonbea
 fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 pallet-evm-precompile-blake2 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -194,7 +211,6 @@ std = [
 	"pallet-author-mapping/std",
 	"pallet-author-slot-filter/std",
 	"pallet-balances/std",
-	"pallet-base-fee/std",
 	"pallet-collective/std",
 	"pallet-conviction-voting/std",
 	"pallet-crowdloan-rewards/std",
@@ -227,7 +243,6 @@ std = [
 	"pallet-randomness/std",
 	"pallet-referenda/std",
 	"pallet-scheduler/std",
-	"pallet-society/std",
 	"pallet-sudo/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
@@ -298,7 +313,6 @@ runtime-benchmarks = [
 	"pallet-preimage/runtime-benchmarks",
 	"pallet-randomness/runtime-benchmarks",
 	"pallet-referenda/runtime-benchmarks",
-	"pallet-society/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-xcm-benchmarks",
 	"pallet-xcm-transactor/runtime-benchmarks",
@@ -327,7 +341,6 @@ try-runtime = [
 	"pallet-preimage/try-runtime",
 	"pallet-referenda/try-runtime",
 	"pallet-scheduler/try-runtime",
-	"pallet-society/try-runtime",
 	"pallet-timestamp/try-runtime",
 ]
 

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -8,6 +8,27 @@ homepage = "https://moonbeam.network"
 license = "GPL-3.0-only"
 version = "0.8.4"
 
+[package.metadata.cargo-machete]
+# used in features or required by macros
+# `cargo machete` gives false positives in those cases
+ignored = [
+	"evm_tracing_events",
+	"frame_benchmarking",
+	"frame_system_benchmarking",
+	"frame_system_rpc_runtime_api",
+	"frame_try_runtime",
+	"hex_literal",
+	"moonbeam_evm_tracer",
+	"moonbeam_xcm_benchmarks",
+	"pallet_transaction_payment_rpc_runtime_api",
+	"pallet_xcm_benchmarks",
+	"rlp",
+	"sp_block_builder",
+	"sp_offchain",
+	"sp_session",
+	"substrate_wasm_builder",
+]
+
 [dependencies]
 hex-literal = { version = "0.3.4", optional = true }
 log = "0.4"
@@ -48,7 +69,6 @@ pallet-evm-precompile-collective = { path = "../../precompiles/collective", defa
 pallet-evm-precompile-crowdloan-rewards = { path = "../../precompiles/crowdloan-rewards", default-features = false }
 pallet-evm-precompile-democracy = { path = "../../precompiles/pallet-democracy", default-features = false }
 pallet-evm-precompile-parachain-staking = { path = "../../precompiles/parachain-staking", default-features = false }
-pallet-evm-precompile-proxy = { path = "../../precompiles/proxy", default-features = false }
 pallet-evm-precompile-randomness = { path = "../../precompiles/randomness", default-features = false }
 pallet-evm-precompile-relay-encoder = { path = "../../precompiles/relay-encoder", default-features = false }
 pallet-evm-precompile-xcm-transactor = { path = "../../precompiles/xcm-transactor", default-features = false }
@@ -76,7 +96,6 @@ pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "mo
 pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-society = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -100,12 +119,10 @@ sp-version = { git = "https://github.com/purestake/substrate", branch = "moonbea
 fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 pallet-evm-precompile-blake2 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -189,7 +206,6 @@ std = [
 	"pallet-author-mapping/std",
 	"pallet-author-slot-filter/std",
 	"pallet-balances/std",
-	"pallet-base-fee/std",
 	"pallet-collective/std",
 	"pallet-crowdloan-rewards/std",
 	"pallet-democracy/std",
@@ -219,7 +235,6 @@ std = [
 	"pallet-randomness-collective-flip/std",
 	"pallet-randomness/std",
 	"pallet-scheduler/std",
-	"pallet-society/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
@@ -280,7 +295,6 @@ runtime-benchmarks = [
 	"pallet-parachain-staking/runtime-benchmarks",
 	"pallet-preimage/runtime-benchmarks",
 	"pallet-randomness/runtime-benchmarks",
-	"pallet-society/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-xcm-benchmarks",
 	"pallet-xcm-transactor/runtime-benchmarks",
@@ -307,6 +321,5 @@ try-runtime = [
 	"pallet-parachain-staking/try-runtime",
 	"pallet-preimage/try-runtime",
 	"pallet-scheduler/try-runtime",
-	"pallet-society/try-runtime",
 	"pallet-timestamp/try-runtime",
 ]

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -8,6 +8,28 @@ homepage = "https://moonbeam.network"
 license = "GPL-3.0-only"
 version = "0.8.4"
 
+[package.metadata.cargo-machete]
+# used in features or required by macros
+# `cargo machete` gives false positives in those cases
+ignored = [
+	"evm_tracing_events",
+	"frame_benchmarking",
+	"frame_system_benchmarking",
+	"frame_system_rpc_runtime_api",
+	"frame_try_runtime",
+	"hex_literal",
+	"moonbeam_evm_tracer",
+	"moonbeam_xcm_benchmarks",
+	"pallet_transaction_payment_rpc_runtime_api",
+	"pallet_xcm_benchmarks",
+	"rlp",
+	"sp_block_builder",
+	"sp_debug_derive",
+	"sp_offchain",
+	"sp_session",
+	"substrate_wasm_builder",
+]
+
 [dependencies]
 hex-literal = { version = "0.3.4", optional = true }
 log = "0.4"
@@ -48,7 +70,6 @@ pallet-evm-precompile-collective = { path = "../../precompiles/collective", defa
 pallet-evm-precompile-crowdloan-rewards = { path = "../../precompiles/crowdloan-rewards", default-features = false }
 pallet-evm-precompile-democracy = { path = "../../precompiles/pallet-democracy", default-features = false }
 pallet-evm-precompile-parachain-staking = { path = "../../precompiles/parachain-staking", default-features = false }
-pallet-evm-precompile-proxy = { path = "../../precompiles/proxy", default-features = false }
 pallet-evm-precompile-randomness = { path = "../../precompiles/randomness", default-features = false }
 pallet-evm-precompile-relay-encoder = { path = "../../precompiles/relay-encoder", default-features = false }
 pallet-evm-precompile-xcm-transactor = { path = "../../precompiles/xcm-transactor", default-features = false }
@@ -76,7 +97,6 @@ pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "mo
 pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-society = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -101,12 +121,10 @@ sp-version = { git = "https://github.com/purestake/substrate", branch = "moonbea
 fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 pallet-evm-precompile-blake2 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
 pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
@@ -189,7 +207,6 @@ std = [
 	"pallet-author-mapping/std",
 	"pallet-author-slot-filter/std",
 	"pallet-balances/std",
-	"pallet-base-fee/std",
 	"pallet-collective/std",
 	"pallet-crowdloan-rewards/std",
 	"pallet-democracy/std",
@@ -218,7 +235,6 @@ std = [
 	"pallet-randomness-collective-flip/std",
 	"pallet-randomness/std",
 	"pallet-scheduler/std",
-	"pallet-society/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
@@ -284,7 +300,6 @@ runtime-benchmarks = [
 	"pallet-parachain-staking/runtime-benchmarks",
 	"pallet-preimage/runtime-benchmarks",
 	"pallet-randomness/runtime-benchmarks",
-	"pallet-society/runtime-benchmarks",
 	"pallet-timestamp/runtime-benchmarks",
 	"pallet-xcm-benchmarks",
 	"pallet-xcm-transactor/runtime-benchmarks",
@@ -310,6 +325,5 @@ try-runtime = [
 	"pallet-parachain-staking/try-runtime",
 	"pallet-preimage/try-runtime",
 	"pallet-scheduler/try-runtime",
-	"pallet-society/try-runtime",
 	"pallet-timestamp/try-runtime",
 ]

--- a/runtime/relay-encoder/Cargo.toml
+++ b/runtime/relay-encoder/Cargo.toml
@@ -25,12 +25,10 @@ cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch
 
 [dev-dependencies]
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 pallet-utility = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
 
 kusama-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 polkadot-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-rococo-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 westend-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
 
 [features]
@@ -40,7 +38,6 @@ std = [
 	"frame-system/std",
 	"pallet-evm-precompile-relay-encoder/std",
 	"pallet-staking/std",
-	"parity-scale-codec/std",
 	"parity-scale-codec/std",
 	"sp-runtime/std",
 	"sp-std/std",


### PR DESCRIPTION
### What does it do?

Used `cargo machete --with-metadata`. I contributed to the crate to allow listing false positives to ignore in the workspace `Cargo.toml`, since common false positives are crates required by Substrate macros. This contribution is not yet published on crates.io, and require installing from this git repo: https://github.com/bnjbvr/cargo-machete

There is still the issue of the tool finding a cargo crate inside `tests/node_modules`, which should be fixed by this PR:
https://github.com/bnjbvr/cargo-machete/pull/48

Once this is fixed, we could probably add a CI check to unsure we don't forget to remove useless dependencies.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
