### PR TITLE
staking smoke test - fix computing outstanding revokes

### DIFF
--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -543,31 +543,6 @@ async function assertRewardsAt(api: ApiPromise, nowBlockNumber: number) {
       for round ${originalRoundNumber.toString()}`
   ).to.be.true;
 
-  const outstandingRevokes: { [key: string]: Set<string> } = (
-    await apiAtRewarded.query.parachainStaking.delegationScheduledRequests.entries()
-  ).reduce(
-    (
-      acc,
-      [
-        {
-          args: [candidateId],
-        },
-        scheduledRequests,
-      ]
-    ) => {
-      if (!(candidateId.toHex() in acc)) {
-        acc[candidateId.toHex()] = new Set();
-      }
-      scheduledRequests
-        .filter((req) => req.action.isRevoke)
-        .forEach((req) => {
-          acc[candidateId.toHex()].add(req.delegator.toHex());
-        });
-      return acc;
-    },
-    {} as { [key: string]: Set<string> }
-  );
-
   debug(`totalRoundIssuance            ${totalRoundIssuance.toString()}
 reservedForParachainBond      ${reservedForParachainBond} \
 (${parachainBondPercent} * totalRoundIssuance)
@@ -607,6 +582,34 @@ totalBondReward               ${totalBondReward} \
   // iterate over the next blocks to verify rewards
   for await (const i of new Array(maxRoundChecks).keys()) {
     const blockNumber = nowRoundFirstBlock.addn(i);
+    const blockHash = await api.rpc.chain.getBlockHash(blockNumber);
+    const apiAtBlock = await api.at(blockHash);
+
+    const outstandingRevokesAtBlock: { [key: string]: Set<string> } = (
+      await apiAtBlock.query.parachainStaking.delegationScheduledRequests.entries()
+    ).reduce(
+      (
+        acc,
+        [
+          {
+            args: [candidateId],
+          },
+          scheduledRequests,
+        ]
+      ) => {
+        if (!(candidateId.toHex() in acc)) {
+          acc[candidateId.toHex()] = new Set();
+        }
+        scheduledRequests
+          .filter((req) => req.action.isRevoke)
+          .forEach((req) => {
+            acc[candidateId.toHex()].add(req.delegator.toHex());
+          });
+        return acc;
+      },
+      {} as { [key: string]: Set<string> }
+    );
+
     const { rewarded, autoCompounded } = await assertRewardedEventsAtBlock(
       api,
       specVersion,
@@ -617,7 +620,7 @@ totalBondReward               ${totalBondReward} \
       totalPoints,
       totalStakingReward,
       stakedValue,
-      outstandingRevokes
+      outstandingRevokesAtBlock
     );
     totalCollatorShare = totalCollatorShare.add(rewarded.collatorSharePerbill);
     totalCollatorCommissionRewarded = totalCollatorCommissionRewarded.add(
@@ -670,7 +673,7 @@ totalBondReward               ${totalBondReward} \
             ([key, { autoCompound }]) =>
               !autoCompound.value().isZero() &&
               expectedRewardedDelegators.has(key) &&
-              !outstandingRevokes[rewarded.collator].has(key)
+              !outstandingRevokesAtBlock[rewarded.collator].has(key)
           )
           .map(([key, _]) => key)
       );


### PR DESCRIPTION
### What does it do?
staking smoke test - fixes computing outstanding revokes to be computed for each rewarded block and not just the first.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
