### PR TITLE
introduce breaking and not-breaking label check

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -21,7 +21,8 @@ jobs:
           REQUIRED_LABELS_ALL: ""
           BANNED_LABELS: ""
   enforce-breaking-changes-label:
-    if: contains(github.event.label.*.name, 'B5-clientnoteworthy') || contains(github.event.label.*.name, 'B7-runtimenoteworthy')
+    # if: contains(github.event.label.*.name, 'B5-clientnoteworthy') || contains(github.event.label.*.name, 'B7-runtimenoteworthy')
+    if: contains(github.event.label.*.name, 'B5-clientnoteworthy')
     runs-on: ubuntu-latest
     steps:
       - uses: yogevbd/enforce-label-action@2.2.2

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -13,7 +13,7 @@ jobs:
           REQUIRED_LABELS_ALL: ""
           BANNED_LABELS: ""
       - name: Verify breaking changes label
-        if: contains(github.event.pull_request.labels.*.name.*.name, 'B5-clientnoteworthy') || contains(github.event.pull_request.labels.*.name.*.name, 'B7-runtimenoteworthy')
+        if: contains(github.event.pull_request.labels.*.name, 'B5-clientnoteworthy') || contains(github.event.pull_request.labels.*.name, 'B7-runtimenoteworthy')
         uses: yogevbd/enforce-label-action@2.2.2
         with:
           REQUIRED_LABELS_ANY: "breaking,not-breaking"

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -13,7 +13,7 @@ jobs:
           REQUIRED_LABELS_ALL: ""
           BANNED_LABELS: ""
       - name: Verify breaking changes label
-        if: contains(github.event.label.*.name, 'B5-clientnoteworthy')
+        if: contains(github.event.pull_request.labels.*.name.*.name, 'B5-clientnoteworthy') || contains(github.event.pull_request.labels.*.name.*.name, 'B7-runtimenoteworthy')
         uses: yogevbd/enforce-label-action@2.2.2
         with:
           REQUIRED_LABELS_ANY: "breaking,not-breaking"
@@ -27,8 +27,3 @@ jobs:
           REQUIRED_LABELS_ANY: "D1-audited👍,D5-nicetohaveaudit⚠️,D9-needsaudit👮,D2-notlive,D3-trivial"
           REQUIRED_LABELS_ALL: ""
           BANNED_LABELS: ""
-  # enforce-breaking-changes-label:
-  #   # if: contains(github.event.label.*.name, 'B5-clientnoteworthy') || contains(github.event.label.*.name, 'B7-runtimenoteworthy')
-  #   if: contains(github.event.label.*.name, 'B5-clientnoteworthy')
-  #   runs-on: ubuntu-latest
-  #   steps:

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -20,3 +20,12 @@ jobs:
           REQUIRED_LABELS_ANY: "D1-audited👍,D5-nicetohaveaudit⚠️,D9-needsaudit👮,D2-notlive,D3-trivial"
           REQUIRED_LABELS_ALL: ""
           BANNED_LABELS: ""
+  enforce-breaking-changes-label:
+    if: contains(github.event.label.*.name, 'B5-clientnoteworthy') || contains(github.event.label.*.name, 'B5-runtimenoteworthy')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: yogevbd/enforce-label-action@2.2.2
+        with:
+          REQUIRED_LABELS_ANY: "breaking,not-breaking"
+          REQUIRED_LABELS_ALL: ""
+          BANNED_LABELS: ""

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -12,6 +12,13 @@ jobs:
           REQUIRED_LABELS_ANY: "B0-silent,B5-clientnoteworthy,B7-runtimenoteworthy"
           REQUIRED_LABELS_ALL: ""
           BANNED_LABELS: ""
+      - name: Verify breaking changes label
+        if: contains(github.event.label.*.name, 'B5-clientnoteworthy')
+        uses: yogevbd/enforce-label-action@2.2.2
+        with:
+          REQUIRED_LABELS_ANY: "breaking,not-breaking"
+          REQUIRED_LABELS_ALL: ""
+          BANNED_LABELS: ""
   enforce-auditability-label:
     runs-on: ubuntu-latest
     steps:
@@ -20,13 +27,8 @@ jobs:
           REQUIRED_LABELS_ANY: "D1-audited👍,D5-nicetohaveaudit⚠️,D9-needsaudit👮,D2-notlive,D3-trivial"
           REQUIRED_LABELS_ALL: ""
           BANNED_LABELS: ""
-  enforce-breaking-changes-label:
-    # if: contains(github.event.label.*.name, 'B5-clientnoteworthy') || contains(github.event.label.*.name, 'B7-runtimenoteworthy')
-    if: contains(github.event.label.*.name, 'B5-clientnoteworthy')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
-        with:
-          REQUIRED_LABELS_ANY: "breaking,not-breaking"
-          REQUIRED_LABELS_ALL: ""
-          BANNED_LABELS: ""
+  # enforce-breaking-changes-label:
+  #   # if: contains(github.event.label.*.name, 'B5-clientnoteworthy') || contains(github.event.label.*.name, 'B7-runtimenoteworthy')
+  #   if: contains(github.event.label.*.name, 'B5-clientnoteworthy')
+  #   runs-on: ubuntu-latest
+  #   steps:

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -21,7 +21,7 @@ jobs:
           REQUIRED_LABELS_ALL: ""
           BANNED_LABELS: ""
   enforce-breaking-changes-label:
-    if: contains(github.event.label.*.name, 'B5-clientnoteworthy') || contains(github.event.label.*.name, 'B5-runtimenoteworthy')
+    if: contains(github.event.label.*.name, 'B5-clientnoteworthy') || contains(github.event.label.*.name, 'B7-runtimenoteworthy')
     runs-on: ubuntu-latest
     steps:
       - uses: yogevbd/enforce-label-action@2.2.2


### PR DESCRIPTION
### What does it do?
Enforces PRs having `B5-clientnoteworthy` or `B7-runtimenoteworthy` label to also have either `breaking` or `not-breaking` labels. A PR having `breaking` label must be present in the breaking changes section of a release.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
