### PR TITLE
Staking precompile: candidateAutoCompoundingDelegationCount

### DIFF
--- a/precompiles/parachain-staking/StakingInterface.sol
+++ b/precompiles/parachain-staking/StakingInterface.sol
@@ -85,7 +85,17 @@ interface ParachainStaking {
     function candidateDelegationCount(address candidate)
         external
         view
-        returns (uint256);
+        returns (uint32);
+
+    /// @dev Get the CandidateAutoCompoundingDelegationCount weight hint
+    /// @custom:selector 905f0806
+    /// @param candidate The address for which we are querying the auto compounding
+    ///     delegation count
+    /// @return The number of auto compounding delegations
+    function candidateAutoCompoundingDelegationCount(address candidate)
+        external
+        view
+        returns (uint32);
 
     /// @dev Get the DelegatorDelegationCount weight hint
     /// @custom:selector 067ec822

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -160,7 +160,7 @@ where
 			<pallet_parachain_staking::Pallet<Runtime>>::auto_compounding_delegations(&candidate)
 				.len() as u32;
 
-		Ok(count.into())
+		Ok(count)
 	}
 
 	#[precompile::public("delegatorDelegationCount(address)")]

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -146,6 +146,23 @@ where
 		Ok(result)
 	}
 
+	#[precompile::public("candidateAutoCompoundingDelegationCount(address)")]
+	#[precompile::view]
+	fn candidate_auto_compounding_delegation_count(
+		handle: &mut impl PrecompileHandle,
+		candidate: Address,
+	) -> EvmResult<u32> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
+
+		let candidate = Runtime::AddressMapping::into_account_id(candidate.0);
+
+		let count =
+			<pallet_parachain_staking::Pallet<Runtime>>::auto_compounding_delegations(&candidate)
+				.len() as u32;
+
+		Ok(count.into())
+	}
+
 	#[precompile::public("delegatorDelegationCount(address)")]
 	#[precompile::public("delegator_delegation_count(address)")]
 	#[precompile::view]

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -371,7 +371,7 @@ fn candidate_delegation_count_works() {
 }
 
 #[test]
-fn candidate_auto_compounding_elegation_count_works() {
+fn candidate_auto_compounding_delegation_count_works() {
 	ExtBuilder::default()
 		.with_balances(vec![
 			(Alice.into(), 1_000),

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -56,6 +56,7 @@ fn selectors() {
 	assert!(PCall::candidate_count_selectors().contains(&0xa9a981a3));
 	assert!(PCall::round_selectors().contains(&0x146ca531));
 	assert!(PCall::candidate_delegation_count_selectors().contains(&0x2ec087eb));
+	assert!(PCall::candidate_auto_compounding_delegation_count_selectors().contains(&0x905f0806));
 	assert!(PCall::delegator_delegation_count_selectors().contains(&0x067ec822));
 	assert!(PCall::selected_candidates_selectors().contains(&0xbcf868a6));
 	assert!(PCall::delegation_request_is_pending_selectors().contains(&0x3b16def8));
@@ -366,6 +367,76 @@ fn candidate_delegation_count_works() {
 				.expect_cost(0) // TODO: Test db read/write costs
 				.expect_no_logs()
 				.execute_returns_encoded(3u32);
+		});
+}
+
+#[test]
+fn candidate_auto_compounding_elegation_count_works() {
+	ExtBuilder::default()
+		.with_balances(vec![
+			(Alice.into(), 1_000),
+			(Bob.into(), 50),
+			(Charlie.into(), 50),
+			(David.into(), 50),
+		])
+		.with_candidates(vec![(Alice.into(), 1_000)])
+		.with_delegations(vec![
+			(Bob.into(), Alice.into(), 50),
+			(Charlie.into(), Alice.into(), 50),
+			(David.into(), Alice.into(), 50),
+		])
+		.with_auto_compounding_delegations(vec![(
+			Charlie.into(),
+			Alice.into(),
+			50,
+			Percent::from_percent(50),
+		)])
+		.build()
+		.execute_with(|| {
+			// Assert that there 1 auto compounding delegations to Alice
+			precompiles()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::candidate_auto_compounding_delegation_count {
+						candidate: Address(Alice.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(1u32);
+		});
+}
+
+#[test]
+fn candidate_auto_compounding_elegation_count_works_with_zero() {
+	ExtBuilder::default()
+		.with_balances(vec![
+			(Alice.into(), 1_000),
+			(Bob.into(), 50),
+			(Charlie.into(), 50),
+			(David.into(), 50),
+		])
+		.with_candidates(vec![(Alice.into(), 1_000)])
+		.with_delegations(vec![
+			(Bob.into(), Alice.into(), 50),
+			(Charlie.into(), Alice.into(), 50),
+			(David.into(), Alice.into(), 50),
+		])
+		.build()
+		.execute_with(|| {
+			// Assert that there 0 auto compounding delegations to Alice
+			precompiles()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::candidate_auto_compounding_delegation_count {
+						candidate: Address(Alice.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns_encoded(0u32);
 		});
 }
 


### PR DESCRIPTION
### What does it do?

Add new getter for the number of auto compounding delegations of a candidate.

Smart contracts must have access to that value to properly call `delegateWithAutoCompound` (size hint for proper fees)

Also update the Solidity interface for function `candidateDelegationCount`, which in Rust returns a u32 while Solidity interface returns U256. Should not cause any issues, just improves consistency between Rust and Solidity files.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
