### PR TITLE
Fix para para-tests (bump gas price)

### DIFF
--- a/tests/para-tests/moonbase/test-migration-txpool.ts
+++ b/tests/para-tests/moonbase/test-migration-txpool.ts
@@ -38,7 +38,7 @@ describeParachain(
                   from: baltathar.address,
                   to: alith.address,
                   value: Web3.utils.toWei("1", "ether"),
-                  gasPrice: Web3.utils.toWei("1", "Gwei"),
+                  gasPrice: Web3.utils.toWei("10", "Gwei"),
                   gas: "0x100000",
                   nonce: baltatharNonce++,
                 },


### PR DESCRIPTION
### What does it do?

Fixes para tests by bumping gas price to reflect changes introduced from #1765.