### PR TITLE
Update proxies for new pallets

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -912,6 +912,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 						| RuntimeCall::ParachainStaking(..)
 						| RuntimeCall::Democracy(..)
 						| RuntimeCall::Referenda(..)
+						| RuntimeCall::Preimage(..)
 						| RuntimeCall::ConvictionVoting(..)
 						| RuntimeCall::CouncilCollective(..)
 						| RuntimeCall::TreasuryCouncilCollective(..)
@@ -929,6 +930,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				c,
 				RuntimeCall::Democracy(..)
 					| RuntimeCall::Referenda(..)
+					| RuntimeCall::Preimage(..)
 					| RuntimeCall::ConvictionVoting(..)
 					| RuntimeCall::CouncilCollective(..)
 					| RuntimeCall::TreasuryCouncilCollective(..)

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -851,7 +851,7 @@ impl pallet_evm_precompile_proxy::EvmProxyCallFilter for ProxyType {
 				}
 			}
 			ProxyType::NonTransfer => {
-				call.value == U256::default()
+				call.value == U256::zero()
 					&& match PrecompileName::from_address(call.to.0) {
 						Some(
 							PrecompileName::AuthorMappingPrecompile
@@ -862,14 +862,14 @@ impl pallet_evm_precompile_proxy::EvmProxyCallFilter for ProxyType {
 					}
 			}
 			ProxyType::Governance => {
-				call.value == U256::default()
+				call.value == U256::zero()
 					&& matches!(
 						PrecompileName::from_address(call.to.0),
 						Some(ref precompile) if is_governance_precompile(precompile)
 					)
 			}
 			ProxyType::Staking => {
-				call.value == U256::default()
+				call.value == U256::zero()
 					&& matches!(
 						PrecompileName::from_address(call.to.0),
 						Some(
@@ -887,7 +887,7 @@ impl pallet_evm_precompile_proxy::EvmProxyCallFilter for ProxyType {
 				!recipient_has_code && !PrecompilesValue::get().is_precompile(call.to.0)
 			}
 			ProxyType::AuthorMapping => {
-				call.value == U256::default()
+				call.value == U256::zero()
 					&& matches!(
 						PrecompileName::from_address(call.to.0),
 						Some(PrecompileName::AuthorMappingPrecompile)
@@ -910,10 +910,14 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 					RuntimeCall::System(..)
 						| RuntimeCall::Timestamp(..)
 						| RuntimeCall::ParachainStaking(..)
-						| RuntimeCall::CouncilCollective(..)
 						| RuntimeCall::Democracy(..)
-						| RuntimeCall::Identity(..)
+						| RuntimeCall::Referenda(..)
+						| RuntimeCall::ConvictionVoting(..)
+						| RuntimeCall::CouncilCollective(..)
+						| RuntimeCall::TreasuryCouncilCollective(..)
 						| RuntimeCall::TechCommitteeCollective(..)
+						| RuntimeCall::OpenTechCommitteeCollective(..)
+						| RuntimeCall::Identity(..)
 						| RuntimeCall::Utility(..)
 						| RuntimeCall::Proxy(..) | RuntimeCall::AuthorMapping(..)
 						| RuntimeCall::CrowdloanRewards(
@@ -924,8 +928,12 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			ProxyType::Governance => matches!(
 				c,
 				RuntimeCall::Democracy(..)
+					| RuntimeCall::Referenda(..)
+					| RuntimeCall::ConvictionVoting(..)
 					| RuntimeCall::CouncilCollective(..)
+					| RuntimeCall::TreasuryCouncilCollective(..)
 					| RuntimeCall::TechCommitteeCollective(..)
+					| RuntimeCall::OpenTechCommitteeCollective(..)
 					| RuntimeCall::Utility(..)
 			),
 			ProxyType::Staking => matches!(

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -851,6 +851,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 						| RuntimeCall::Timestamp(..)
 						| RuntimeCall::ParachainStaking(..)
 						| RuntimeCall::Democracy(..)
+						| RuntimeCall::Preimage(..)
 						| RuntimeCall::CouncilCollective(..)
 						| RuntimeCall::TreasuryCouncilCollective(..)
 						| RuntimeCall::TechCommitteeCollective(..)
@@ -865,6 +866,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			ProxyType::Governance => matches!(
 				c,
 				RuntimeCall::Democracy(..)
+					| RuntimeCall::Preimage(..)
 					| RuntimeCall::CouncilCollective(..)
 					| RuntimeCall::TreasuryCouncilCollective(..)
 					| RuntimeCall::TechCommitteeCollective(..)

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -852,8 +852,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 						| RuntimeCall::ParachainStaking(..)
 						| RuntimeCall::Democracy(..)
 						| RuntimeCall::CouncilCollective(..)
-						| RuntimeCall::Identity(..)
+						| RuntimeCall::TreasuryCouncilCollective(..)
 						| RuntimeCall::TechCommitteeCollective(..)
+						| RuntimeCall::Identity(..)
 						| RuntimeCall::Utility(..)
 						| RuntimeCall::Proxy(..) | RuntimeCall::AuthorMapping(..)
 						| RuntimeCall::CrowdloanRewards(
@@ -865,6 +866,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				c,
 				RuntimeCall::Democracy(..)
 					| RuntimeCall::CouncilCollective(..)
+					| RuntimeCall::TreasuryCouncilCollective(..)
 					| RuntimeCall::TechCommitteeCollective(..)
 					| RuntimeCall::Utility(..)
 			),

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -761,6 +761,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 						| RuntimeCall::ParachainStaking(..)
 						| RuntimeCall::Democracy(..)
 						| RuntimeCall::Referenda(..)
+						| RuntimeCall::Preimage(..)
 						| RuntimeCall::ConvictionVoting(..)
 						| RuntimeCall::CouncilCollective(..)
 						| RuntimeCall::TreasuryCouncilCollective(..)
@@ -778,6 +779,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 				c,
 				RuntimeCall::Democracy(..)
 					| RuntimeCall::Referenda(..)
+					| RuntimeCall::Preimage(..)
 					| RuntimeCall::ConvictionVoting(..)
 					| RuntimeCall::CouncilCollective(..)
 					| RuntimeCall::TreasuryCouncilCollective(..)

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -760,9 +760,13 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 						| RuntimeCall::Timestamp(..)
 						| RuntimeCall::ParachainStaking(..)
 						| RuntimeCall::Democracy(..)
+						| RuntimeCall::Referenda(..)
+						| RuntimeCall::ConvictionVoting(..)
 						| RuntimeCall::CouncilCollective(..)
-						| RuntimeCall::Identity(..)
+						| RuntimeCall::TreasuryCouncilCollective(..)
 						| RuntimeCall::TechCommitteeCollective(..)
+						| RuntimeCall::OpenTechCommitteeCollective(..)
+						| RuntimeCall::Identity(..)
 						| RuntimeCall::Utility(..)
 						| RuntimeCall::Proxy(..) | RuntimeCall::AuthorMapping(..)
 						| RuntimeCall::CrowdloanRewards(
@@ -773,8 +777,12 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			ProxyType::Governance => matches!(
 				c,
 				RuntimeCall::Democracy(..)
+					| RuntimeCall::Referenda(..)
+					| RuntimeCall::ConvictionVoting(..)
 					| RuntimeCall::CouncilCollective(..)
+					| RuntimeCall::TreasuryCouncilCollective(..)
 					| RuntimeCall::TechCommitteeCollective(..)
+					| RuntimeCall::OpenTechCommitteeCollective(..)
 					| RuntimeCall::Utility(..)
 			),
 			ProxyType::Staking => matches!(


### PR DESCRIPTION
Updates the rules of the Proxy types based on the new pallets (referenda and the missing TreasuryCouncil)