### PR TITLE
Improve gas checks in Randomness precompile

### DIFF
--- a/precompiles/randomness/src/lib.rs
+++ b/precompiles/randomness/src/lib.rs
@@ -58,9 +58,9 @@ pub fn subcall_overhead_gas_costs<T: pallet_evm::Config>() -> EvmResult<u64> {
 		.compute_cost()
 		.map_err(|_| revert("failed to compute log cost"))?;
 	let call_cost = call_cost(U256::zero(), <T as pallet_evm::Config>::config());
-	Ok(log_cost
+	log_cost
 		.checked_add(call_cost)
-		.ok_or(revert("overflow when computing overhead gas"))?)
+		.ok_or(revert("overflow when computing overhead gas"))
 }
 
 pub const LOG_FULFILLMENT_SUCCEEDED: [u8; 32] = keccak256!("FulFillmentSucceeded()");

--- a/precompiles/randomness/src/lib.rs
+++ b/precompiles/randomness/src/lib.rs
@@ -45,11 +45,22 @@ pub const INCREASE_REQUEST_FEE_ESTIMATED_COST: u64 = 16995;
 pub const EXECUTE_EXPIRATION_ESTIMATED_COST: u64 = 22201;
 
 /// Fulfillment overhead cost, which takes input weight hint -> weight -> return gas
-pub fn fulfillment_overhead_gas_cost<T: pallet_evm::Config>(num_words: u8) -> u64 {
+pub fn prepare_and_finish_fulfillment_gas_cost<T: pallet_evm::Config>(num_words: u8) -> u64 {
 	<T as pallet_evm::Config>::GasWeightMapping::weight_to_gas(
 		SubstrateWeight::<T>::prepare_fulfillment(num_words.into())
 			.saturating_add(SubstrateWeight::<T>::finish_fulfillment()),
 	)
+}
+
+pub fn subcall_overhead_gas_costs<T: pallet_evm::Config>() -> EvmResult<u64> {
+	// cost of log don't depend on specific address.
+	let log_cost = log_fulfillment_failed(H160::zero())
+		.compute_cost()
+		.map_err(|_| revert("failed to compute log cost"))?;
+	let call_cost = call_cost(U256::zero(), <T as pallet_evm::Config>::config());
+	Ok(log_cost
+		.checked_add(call_cost)
+		.ok_or(revert("overflow when computing overhead gas"))?)
 }
 
 pub const LOG_FULFILLMENT_SUCCEEDED: [u8; 32] = keccak256!("FulFillmentSucceeded()");
@@ -65,37 +76,42 @@ pub fn log_fulfillment_failed(address: impl Into<H160>) -> Log {
 
 /// Reverts if fees and gas_limit are not sufficient to make subcall and cleanup
 fn ensure_can_provide_randomness<Runtime>(
-	code_address: H160,
-	gas_limit: u64,
+	remaining_gas: u64,
+	request_gas_limit: u64,
 	request_fee: BalanceOf<Runtime>,
-	clean_up_cost: u64,
+	subcall_overhead_gas_costs: u64,
+	prepare_and_finish_fulfillment_gas_cost: u64,
 ) -> EvmResult<()>
 where
 	Runtime: pallet_randomness::Config + pallet_evm::Config,
 	BalanceOf<Runtime>: Into<U256>,
 {
-	// assert fee > gasLimit * base_fee
-	let gas_limit_as_u256: U256 = gas_limit.into();
+	let request_gas_limit_with_overhead = request_gas_limit
+		.checked_add(subcall_overhead_gas_costs)
+		.ok_or(revert(
+			"overflow when computing request gas limit + overhead",
+		))?;
+
+	// Ensure precompile have enough gas to perform subcall with the overhead.
+	if remaining_gas < request_gas_limit_with_overhead {
+		return Err(revert("not enough gas to perform the call"));
+	}
+
+	// Ensure request fee can pay for this.
+	let total_refunded_gas = prepare_and_finish_fulfillment_gas_cost
+		.checked_add(request_gas_limit_with_overhead)
+		.ok_or(revert("overflow when computed max amount of refunded gas"))?;
+
+	let total_refunded_gas: U256 = total_refunded_gas.into();
 	let (base_fee, _) = <Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price();
-	if let Some(gas_limit_times_base_fee) = gas_limit_as_u256.checked_mul(base_fee) {
-		if gas_limit_times_base_fee >= request_fee.into() {
-			return Err(revert(
-				"Gas limit at current price must be less than fees allotted",
-			));
-		}
-	} else {
+	let execution_max_fee = total_refunded_gas.checked_mul(base_fee).ok_or(revert(
+		"gas limit (with overhead) * base fee overflowed U256",
+	))?;
+
+	if execution_max_fee > request_fee.into() {
 		return Err(revert("Gas limit times base fee overflowed U256"));
 	}
-	let log_cost = log_fulfillment_failed(code_address)
-		.compute_cost()
-		.map_err(|_| revert("failed to compute log cost"))?;
-	// Cost of the call itself that the batch precompile must pay.
-	let call_cost = call_cost(U256::zero(), <Runtime as pallet_evm::Config>::config());
-	// assert gasLimit > overhead cost
-	let overhead = call_cost + log_cost + clean_up_cost;
-	if gas_limit <= overhead {
-		return Err(revert("Gas limit must exceed overhead call cost"));
-	}
+
 	Ok(())
 }
 
@@ -384,6 +400,20 @@ where
 	) -> EvmResult {
 		let request_id = request_id.converted();
 
+		// Since we cannot compute `prepare_and_finish_fulfillment_cost` now (we don't
+		// know the number of words), we compute the cost for the maximum allowed number of
+		// words.
+		let max_prepare_and_finish_fulfillment_cost =
+			prepare_and_finish_fulfillment_gas_cost::<Runtime>(
+				<Runtime as pallet_randomness::Config>::MaxRandomWords::get(),
+			);
+
+		if handle.remaining_gas() < max_prepare_and_finish_fulfillment_cost {
+			return Err(revert(alloc::format!(
+				"provided gas must be at least {max_prepare_and_finish_fulfillment_cost}"
+			)));
+		}
+
 		let pallet_randomness::FulfillArgs {
 			request,
 			deposit,
@@ -391,16 +421,25 @@ where
 		} = Pallet::<Runtime>::prepare_fulfillment(request_id)
 			.map_err(|e| revert(alloc::format!("{:?}", e)))?;
 
+		let prepare_and_finish_fulfillment_cost =
+			prepare_and_finish_fulfillment_gas_cost::<Runtime>(request.num_words);
+		handle.record_cost(prepare_and_finish_fulfillment_cost)?;
+
+		let subcall_overhead_gas_costs = subcall_overhead_gas_costs::<Runtime>()?;
+
 		// check that randomness can be provided
 		ensure_can_provide_randomness::<Runtime>(
-			handle.code_address(),
+			handle.remaining_gas(),
 			request.gas_limit,
 			request.fee,
-			fulfillment_overhead_gas_cost::<Runtime>(request.num_words),
+			subcall_overhead_gas_costs,
+			prepare_and_finish_fulfillment_cost,
 		)?;
 
-		// get gas before subcall
-		let before_remaining_gas = handle.remaining_gas();
+		// We meter this section to know how much gas was actually used.
+		// It contains the gas used by the subcall and the overhead actually
+		// performing a call. It doesn't contain `prepare_and_finish_fulfillment_cost`.
+		let remaining_gas_before = handle.remaining_gas();
 		provide_randomness(
 			handle,
 			request_id,
@@ -408,14 +447,16 @@ where
 			request.contract_address.clone().into(),
 			randomness.into_iter().map(|x| H256(x)).collect(),
 		)?;
+		let remaining_gas_after = handle.remaining_gas();
 
-		// get gas after subcall
-		let after_remaining_gas = handle.remaining_gas();
-		let gas_used: U256 = before_remaining_gas
-			.checked_sub(after_remaining_gas)
+		// We compute the actual gas used to refund the caller.
+		// It is the metered gas + `prepare_and_finish_fulfillment_cost`.
+		let gas_used: U256 = remaining_gas_before
+			.checked_sub(remaining_gas_after)
 			.ok_or(revert("Before remaining gas < After remaining gas"))?
+			.checked_add(prepare_and_finish_fulfillment_cost)
+			.ok_or(revert("overflow when adding real call cost + overhead"))?
 			.into();
-		// cost of execution is before_remaining_gas less after_remaining_gas
 		let (base_fee, _) = <Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price();
 		let cost_of_execution: BalanceOf<Runtime> = gas_used
 			.checked_mul(base_fee)

--- a/precompiles/randomness/src/tests.rs
+++ b/precompiles/randomness/src/tests.rs
@@ -390,10 +390,11 @@ fn fulfill_request_reverts_if_not_enough_gas() {
 					},
 				)
 				.execute_returns([0u8; 32].into());
+
 			// run to ready block
 			System::set_block_number(3);
 
-			// // fill randomness results
+			// fill randomness results
 			let mut filled_results =
 				RandomnessResults::<Runtime>::get(RequestType::Local(3)).unwrap();
 			filled_results.randomness = Some(H256::default());
@@ -437,8 +438,6 @@ fn fulfill_request_works() {
 					+ prepare_and_finish_fulfillment_gas_cost::<Runtime>(1),
 			)
 				* <Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price().0;
-
-			// let gas_limit = crate::prepare_and_finish_fulfillment_gas_cost::<Runtime>(10u8) + 10u64;
 
 			PrecompilesValue::get()
 				.prepare_test(
@@ -544,8 +543,6 @@ fn fulfill_request_works_with_higher_gas() {
 			)
 				* <Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price().0;
 
-			// let gas_limit = crate::prepare_and_finish_fulfillment_gas_cost::<Runtime>(10u8) + 10u64;
-
 			PrecompilesValue::get()
 				.prepare_test(
 					Alice,
@@ -560,8 +557,10 @@ fn fulfill_request_works_with_higher_gas() {
 					},
 				)
 				.execute_returns([0u8; 32].into());
+
 			// run to ready block
 			System::set_block_number(3);
+
 			// fill randomness results
 			let mut filled_results =
 				RandomnessResults::<Runtime>::get(RequestType::Local(3)).unwrap();
@@ -664,8 +663,10 @@ fn fulfill_request_works_with_subcall_revert() {
 					},
 				)
 				.execute_returns([0u8; 32].into());
+
 			// run to ready block
 			System::set_block_number(3);
+
 			// fill randomness results
 			let mut filled_results =
 				RandomnessResults::<Runtime>::get(RequestType::Local(3)).unwrap();

--- a/precompiles/randomness/src/tests.rs
+++ b/precompiles/randomness/src/tests.rs
@@ -15,7 +15,8 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Randomness precompile unit tests
-use crate::mock::*;
+use crate::{mock::*, prepare_and_finish_fulfillment_gas_cost, subcall_overhead_gas_costs};
+use fp_evm::{ExitReason, ExitRevert, ExitSucceed, FeeCalculator};
 use pallet_randomness::{Event as RandomnessEvent, RandomnessResults, RequestType};
 use precompile_utils::{assert_event_emitted, testing::*, EvmDataWriter};
 use sp_core::{H160, H256, U256};
@@ -180,7 +181,7 @@ fn get_ready_request_status() {
 					PCall::request_local_randomness {
 						refund_address: precompile_utils::data::Address(H160::from(Bob)),
 						fee: U256::one(),
-						gas_limit: crate::fulfillment_overhead_gas_cost::<Runtime>(10u8) + 10u64,
+						gas_limit: 10u64,
 						salt: H256::default(),
 						num_words: 1u8,
 						delay: 2.into(),
@@ -216,7 +217,7 @@ fn get_expired_request_status() {
 					PCall::request_local_randomness {
 						refund_address: precompile_utils::data::Address(H160::from(Bob)),
 						fee: U256::one(),
-						gas_limit: crate::fulfillment_overhead_gas_cost::<Runtime>(10u8) + 10u64,
+						gas_limit: 10u64,
 						salt: H256::default(),
 						num_words: 1u8,
 						delay: 2.into(),
@@ -364,12 +365,17 @@ fn request_local_randomness_works() {
 }
 
 #[test]
-fn fulfill_request_fails_when_gas_limit_below_call_overhead_cost() {
+fn fulfill_request_reverts_if_not_enough_gas() {
 	ExtBuilder::default()
 		.with_balances(vec![(Alice.into(), 1000)])
 		.build()
 		.execute_with(|| {
 			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+			let request_gas_limit = 100u64;
+			let total_cost = request_gas_limit
+				+ subcall_overhead_gas_costs::<Runtime>().unwrap()
+				+ prepare_and_finish_fulfillment_gas_cost::<Runtime>(1);
+
 			PrecompilesValue::get()
 				.prepare_test(
 					Alice,
@@ -377,7 +383,7 @@ fn fulfill_request_fails_when_gas_limit_below_call_overhead_cost() {
 					PCall::request_local_randomness {
 						refund_address: precompile_utils::data::Address(H160::from(Bob)),
 						fee: U256::one(),
-						gas_limit: 100u64,
+						gas_limit: request_gas_limit,
 						salt: H256::default(),
 						num_words: 1u8,
 						delay: 2.into(),
@@ -386,21 +392,29 @@ fn fulfill_request_fails_when_gas_limit_below_call_overhead_cost() {
 				.execute_returns([0u8; 32].into());
 			// run to ready block
 			System::set_block_number(3);
-			// fill randomness results
+
+			// // fill randomness results
 			let mut filled_results =
 				RandomnessResults::<Runtime>::get(RequestType::Local(3)).unwrap();
 			filled_results.randomness = Some(H256::default());
 			RandomnessResults::<Runtime>::insert(RequestType::Local(3), filled_results);
+
 			// fulfill request
 			PrecompilesValue::get()
 				.prepare_test(
-					Alice,
+					Charlie,
 					Precompile1,
 					PCall::fulfill_request {
 						request_id: 0.into(),
 					},
 				)
-				.expect_log(crate::log_fulfillment_failed(Alice));
+				.with_target_gas(Some(total_cost - 1))
+				.with_subcall_handle(|_| panic!("should not perform subcall"))
+				.expect_no_logs()
+				.execute_reverts(|revert| revert == b"not enough gas to perform the call");
+
+			// no refund
+			assert_eq!(Balances::free_balance(&AccountId::from(Charlie)), 0);
 		})
 }
 
@@ -411,6 +425,21 @@ fn fulfill_request_works() {
 		.build()
 		.execute_with(|| {
 			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+
+			let request_gas_limit = 100u64;
+			let subcall_used_gas = 50u64;
+			let total_cost = request_gas_limit
+				+ subcall_overhead_gas_costs::<Runtime>().unwrap()
+				+ prepare_and_finish_fulfillment_gas_cost::<Runtime>(1);
+			let refunded_amount = U256::from(
+				subcall_used_gas
+					+ subcall_overhead_gas_costs::<Runtime>().unwrap()
+					+ prepare_and_finish_fulfillment_gas_cost::<Runtime>(1),
+			)
+				* <Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price().0;
+
+			// let gas_limit = crate::prepare_and_finish_fulfillment_gas_cost::<Runtime>(10u8) + 10u64;
+
 			PrecompilesValue::get()
 				.prepare_test(
 					Alice,
@@ -418,7 +447,7 @@ fn fulfill_request_works() {
 					PCall::request_local_randomness {
 						refund_address: precompile_utils::data::Address(H160::from(Bob)),
 						fee: U256::one(),
-						gas_limit: crate::fulfillment_overhead_gas_cost::<Runtime>(10u8) + 10u64,
+						gas_limit: request_gas_limit,
 						salt: H256::default(),
 						num_words: 1u8,
 						delay: 2.into(),
@@ -432,16 +461,276 @@ fn fulfill_request_works() {
 				RandomnessResults::<Runtime>::get(RequestType::Local(3)).unwrap();
 			filled_results.randomness = Some(H256::default());
 			RandomnessResults::<Runtime>::insert(RequestType::Local(3), filled_results);
+
+			let pallet_randomness::FulfillArgs {
+				randomness: random_words,
+				..
+			} = pallet_randomness::Pallet::<Runtime>::prepare_fulfillment(0)
+				.expect("can prepare values");
+
+			let random_words: Vec<H256> = random_words.into_iter().map(|x| x.into()).collect();
+
 			// fulfill request
 			PrecompilesValue::get()
 				.prepare_test(
-					Alice,
+					Charlie,
 					Precompile1,
 					PCall::fulfill_request {
 						request_id: 0.into(),
 					},
 				)
-				.expect_log(crate::log_fulfillment_succeeded(Alice));
+				.with_subcall_handle(move |subcall| {
+					let Subcall {
+						address,
+						transfer,
+						input,
+						target_gas,
+						is_static,
+						context,
+					} = subcall;
+
+					assert_eq!(context.caller, Precompile1.into());
+					assert_eq!(address, Alice.into());
+					assert_eq!(is_static, false);
+					assert_eq!(target_gas, Some(request_gas_limit));
+					assert!(transfer.is_none());
+					assert_eq!(context.address, Alice.into());
+					assert_eq!(context.apparent_value, 0u8.into());
+					// callback function selector: keccak256("rawFulfillRandomWords(uint256,uint256[])")
+					assert_eq!(
+						&input,
+						&EvmDataWriter::new_with_selector(0x1fe543e3_u32)
+							.write(0u64) // request id
+							.write(random_words.clone())
+							.build()
+					);
+
+					SubcallOutput {
+						reason: ExitReason::Succeed(ExitSucceed::Returned),
+						output: b"TEST".to_vec(),
+						cost: subcall_used_gas,
+						logs: vec![],
+					}
+				})
+				.with_target_gas(Some(total_cost))
+				.expect_log(crate::log_fulfillment_succeeded(Precompile1))
+				.execute_returns_encoded(());
+
+			// correctly refunded
+			assert_eq!(
+				U256::from(Balances::free_balance(&AccountId::from(Charlie))),
+				refunded_amount
+			);
+		})
+}
+
+#[test]
+fn fulfill_request_works_with_higher_gas() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+
+			let request_gas_limit = 100u64;
+			let subcall_used_gas = 50u64;
+			let total_cost = request_gas_limit
+				+ subcall_overhead_gas_costs::<Runtime>().unwrap()
+				+ prepare_and_finish_fulfillment_gas_cost::<Runtime>(1);
+			let refunded_amount = U256::from(
+				subcall_used_gas
+					+ subcall_overhead_gas_costs::<Runtime>().unwrap()
+					+ prepare_and_finish_fulfillment_gas_cost::<Runtime>(1),
+			)
+				* <Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price().0;
+
+			// let gas_limit = crate::prepare_and_finish_fulfillment_gas_cost::<Runtime>(10u8) + 10u64;
+
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::request_local_randomness {
+						refund_address: precompile_utils::data::Address(H160::from(Bob)),
+						fee: U256::one(),
+						gas_limit: request_gas_limit,
+						salt: H256::default(),
+						num_words: 1u8,
+						delay: 2.into(),
+					},
+				)
+				.execute_returns([0u8; 32].into());
+			// run to ready block
+			System::set_block_number(3);
+			// fill randomness results
+			let mut filled_results =
+				RandomnessResults::<Runtime>::get(RequestType::Local(3)).unwrap();
+			filled_results.randomness = Some(H256::default());
+			RandomnessResults::<Runtime>::insert(RequestType::Local(3), filled_results);
+
+			let pallet_randomness::FulfillArgs {
+				randomness: random_words,
+				..
+			} = pallet_randomness::Pallet::<Runtime>::prepare_fulfillment(0)
+				.expect("can prepare values");
+
+			let random_words: Vec<H256> = random_words.into_iter().map(|x| x.into()).collect();
+
+			// fulfill request
+			PrecompilesValue::get()
+				.prepare_test(
+					Charlie,
+					Precompile1,
+					PCall::fulfill_request {
+						request_id: 0.into(),
+					},
+				)
+				.with_subcall_handle(move |subcall| {
+					let Subcall {
+						address,
+						transfer,
+						input,
+						target_gas,
+						is_static,
+						context,
+					} = subcall;
+
+					assert_eq!(context.caller, Precompile1.into());
+					assert_eq!(address, Alice.into());
+					assert_eq!(is_static, false);
+					assert_eq!(target_gas, Some(request_gas_limit));
+					assert!(transfer.is_none());
+					assert_eq!(context.address, Alice.into());
+					assert_eq!(context.apparent_value, 0u8.into());
+					// callback function selector: keccak256("rawFulfillRandomWords(uint256,uint256[])")
+					assert_eq!(
+						&input,
+						&EvmDataWriter::new_with_selector(0x1fe543e3_u32)
+							.write(0u64) // request id
+							.write(random_words.clone())
+							.build()
+					);
+
+					SubcallOutput {
+						reason: ExitReason::Succeed(ExitSucceed::Returned),
+						output: b"TEST".to_vec(),
+						cost: subcall_used_gas,
+						logs: vec![],
+					}
+				})
+				.with_target_gas(Some(total_cost + 10_000))
+				.expect_log(crate::log_fulfillment_succeeded(Precompile1))
+				.execute_returns_encoded(());
+
+			// correctly refunded
+			assert_eq!(
+				U256::from(Balances::free_balance(&AccountId::from(Charlie))),
+				refunded_amount
+			);
+		})
+}
+
+#[test]
+fn fulfill_request_works_with_subcall_revert() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 1000)])
+		.build()
+		.execute_with(|| {
+			pallet_evm::AccountCodes::<Runtime>::insert(H160::from(Alice), vec![10u8]);
+
+			let request_gas_limit = 100u64;
+			let subcall_used_gas = 50u64;
+			let total_cost = request_gas_limit
+				+ subcall_overhead_gas_costs::<Runtime>().unwrap()
+				+ prepare_and_finish_fulfillment_gas_cost::<Runtime>(1);
+			let refunded_amount = U256::from(
+				subcall_used_gas
+					+ subcall_overhead_gas_costs::<Runtime>().unwrap()
+					+ prepare_and_finish_fulfillment_gas_cost::<Runtime>(1),
+			)
+				* <Runtime as pallet_evm::Config>::FeeCalculator::min_gas_price().0;
+
+			PrecompilesValue::get()
+				.prepare_test(
+					Alice,
+					Precompile1,
+					PCall::request_local_randomness {
+						refund_address: precompile_utils::data::Address(H160::from(Bob)),
+						fee: U256::one(),
+						gas_limit: request_gas_limit,
+						salt: H256::default(),
+						num_words: 1u8,
+						delay: 2.into(),
+					},
+				)
+				.execute_returns([0u8; 32].into());
+			// run to ready block
+			System::set_block_number(3);
+			// fill randomness results
+			let mut filled_results =
+				RandomnessResults::<Runtime>::get(RequestType::Local(3)).unwrap();
+			filled_results.randomness = Some(H256::default());
+			RandomnessResults::<Runtime>::insert(RequestType::Local(3), filled_results);
+
+			let pallet_randomness::FulfillArgs {
+				randomness: random_words,
+				..
+			} = pallet_randomness::Pallet::<Runtime>::prepare_fulfillment(0)
+				.expect("can prepare values");
+
+			let random_words: Vec<H256> = random_words.into_iter().map(|x| x.into()).collect();
+
+			// fulfill request
+			PrecompilesValue::get()
+				.prepare_test(
+					Charlie,
+					Precompile1,
+					PCall::fulfill_request {
+						request_id: 0.into(),
+					},
+				)
+				.with_subcall_handle(move |subcall| {
+					let Subcall {
+						address,
+						transfer,
+						input,
+						target_gas,
+						is_static,
+						context,
+					} = subcall;
+
+					assert_eq!(context.caller, Precompile1.into());
+					assert_eq!(address, Alice.into());
+					assert_eq!(is_static, false);
+					assert_eq!(target_gas, Some(request_gas_limit));
+					assert!(transfer.is_none());
+					assert_eq!(context.address, Alice.into());
+					assert_eq!(context.apparent_value, 0u8.into());
+					// callback function selector: keccak256("rawFulfillRandomWords(uint256,uint256[])")
+					assert_eq!(
+						&input,
+						&EvmDataWriter::new_with_selector(0x1fe543e3_u32)
+							.write(0u64) // request id
+							.write(random_words.clone())
+							.build()
+					);
+
+					SubcallOutput {
+						reason: ExitReason::Revert(ExitRevert::Reverted),
+						output: vec![],
+						cost: subcall_used_gas,
+						logs: vec![],
+					}
+				})
+				.with_target_gas(Some(total_cost))
+				.expect_log(crate::log_fulfillment_failed(Precompile1))
+				.execute_returns_encoded(());
+
+			// correctly refunded
+			assert_eq!(
+				U256::from(Balances::free_balance(&AccountId::from(Charlie))),
+				refunded_amount
+			);
 		})
 }
 

--- a/precompiles/utils/src/testing/execution.rs
+++ b/precompiles/utils/src/testing/execution.rs
@@ -27,6 +27,7 @@ use {
 	sp_std::boxed::Box,
 };
 
+#[must_use]
 pub struct PrecompilesTester<'p, P> {
 	precompiles: &'p P,
 	handle: MockHandle,


### PR DESCRIPTION
### What does it do?

Improve gas checks in the precompile.

### What important points reviewers should know?

Now the request gas_limit is how much gas will be available inside the the target `rawFulfillRandomWords` function, without any overhead costs. This simplifies the computations, and is backward compatible with current design (since it will be less that what it is required now).

The fulfiller however must now call the precompile with enough gas for the request gas_limit **plus the overhead**.  They will be refunded the actually used amount, overhead included. They are also refunded the cost of the transaction itself.

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
