### PR TITLE
Utility.asDerivativeV2 test skipped for moonriver/beam

### DIFF
--- a/tests/smoke-tests/test-relay-indices.ts
+++ b/tests/smoke-tests/test-relay-indices.ts
@@ -199,6 +199,13 @@ describeSmokeSuite(
           debug(`Runtime version is ${rtVersion}, which is less than 2100. Skipping test. `);
           this.skip();
         }
+
+        const chainType = context.polkadotApi.consts.system.version.specName.toString();
+        if (chainType !== "moonbase") {
+          debug(`Chain type ${chainType} does not support V2, skipping.`);
+          this.skip();
+        }
+
         const inputCall = context.relayApi.tx.balances.transfer(ALITH_SESSION_ADDRESS, 1000);
         const callHex = context.relayApi.tx.utility.asDerivative(0, inputCall).method.toHex();
         const resp = await xcmTransactorV2.encodeUtilityAsDerivative(


### PR DESCRIPTION
### What does it do?
Skips out `Utility.asDerivativeV2` precompile smoke test for moonriver and moonbeam chains, as not currently deployed yet. Runs as normal for moonbase chains.
