### PR TITLE
fix: distribute_rewards not forward balance anymore but create instead

### DIFF
--- a/pallets/moonbeam-orbiters/src/benchmarks.rs
+++ b/pallets/moonbeam-orbiters/src/benchmarks.rs
@@ -230,10 +230,6 @@ benchmarks! {
 		assert_eq!(
 			T::Currency::total_balance(&orbiter), 11_000u32.into()
 		);
-		assert_eq!(
-			T::Currency::total_balance(&collator), 9_000u32.into()
-		);
-
 	}
 
 	on_new_round {

--- a/pallets/moonbeam-orbiters/src/benchmarks.rs
+++ b/pallets/moonbeam-orbiters/src/benchmarks.rs
@@ -230,6 +230,10 @@ benchmarks! {
 		assert_eq!(
 			T::Currency::total_balance(&orbiter), 11_000u32.into()
 		);
+		assert_eq!(
+			T::Currency::total_balance(&collator), 10_000u32.into()
+		);
+
 	}
 
 	on_new_round {


### PR DESCRIPTION
### What does it do?

Initially, `distribute_rewards` took the rewards from the collator and paid them to its orbit, but since #1934 the staking rewards are paid directly to the orbiter without going through the parent collator, so `distribute_rewards` no longer "takes" the collator.


### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
