### PR TITLE
Fix trackInfo accessor

### DIFF
--- a/precompiles/referenda/src/lib.rs
+++ b/precompiles/referenda/src/lib.rs
@@ -157,7 +157,7 @@ where
 		let track_info = &tracks[index].1;
 
 		Ok((
-			track_info.name.as_bytes().into(),
+			track_info.name.into(),
 			track_info.max_deciding.into(),
 			track_info.decision_deposit.into(),
 			track_info.prepare_period.into(),


### PR DESCRIPTION
When querying the trackInfo, we get `error: data out-of-bounds` which, based on [this answer](https://stackoverflow.com/a/74883563), means the ABI does not match the return value.

When I look at the other examples of returning `string memory` in our precompiles, they use `$string.as_slice().into()` but we are using `$string.as_bytes().into()` so I think the ABI is expecting `string memory` but we are returning `bytes memory` for this parameter. When I try to change it to `$string.as_slice().into()`, it returns the following compiler error: 
```
error[E0599]: no method named `as_slice` found for reference `&'static str` in the current scope
   --> precompiles/referenda/src/lib.rs:160:20
    |
160 |             track_info.name.as_slice().into(),
    |                             ^^^^^^^^ method not found in `&'static str`
```
But when I just do `$string.into()` it compiles. Not sure if `&'static str.into()` matches `string memory` but I am pretty sure that converting into bytes returns `bytes memory` instead of `string memory`.

@nanocryk is there an easy way to verify that the ABI matches the precompile return values? 
