### PR TITLE
Clean up min multiplier

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -394,7 +394,7 @@ parameter_types! {
 	/// Minimum amount of the multiplier. This value cannot be too low. A test case should ensure
 	/// that combined with `AdjustmentVariable`, we can recover from the minimum.
 	/// See `multiplier_can_grow_from_zero` in integration_tests.rs.
-	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000);
+	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 10);
 	/// Maximum multiplier. We pick a value that is expensive but not impossibly so; it should act
 	/// as a safety net.
 	pub MaximumMultiplier: Multiplier = Multiplier::from(100_000u128);

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -3331,7 +3331,7 @@ mod fee_tests {
 			// 1 "real" day (at 12-second blocks)
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(0), 7200),
-				U256::from(1_250_000), // lower bound enforced
+				U256::from(125_000_000), // lower bound enforced
 			);
 			assert_eq!(
 				sim(1_000_000_000, Perbill::from_percent(25), 7200),

--- a/tests/tests/test-fees/test-fee-multiplier.ts
+++ b/tests/tests/test-fees/test-fee-multiplier.ts
@@ -29,14 +29,13 @@ describeDevMoonbeam("Max Fee Multiplier", (context) => {
       .toString();
 
     const U128_MAX = new BN("340282366920938463463374607431768211455");
-    const newMultiplierValue = context.polkadotApi.createType("u128", U128_MAX);
 
     // set transaction-payment's multiplier to something above max in storage. on the next round,
     // it should enforce its upper bound and reset it.
     await context.polkadotApi.tx.sudo
       .sudo(
         context.polkadotApi.tx.system.setStorage([
-          [MULTIPLIER_STORAGE_KEY, bnToHex(newMultiplierValue)],
+          [MULTIPLIER_STORAGE_KEY, bnToHex(U128_MAX, { isLe: true, bitLength: 128 })],
         ])
       )
       .signAndSend(alith);
@@ -146,6 +145,38 @@ describeDevMoonbeam("Max Fee Multiplier", (context) => {
     let amount = (withdrawEvent.event.data as any).amount.toBigInt();
     expect(amount).to.equal(20_828_626_522_358_406_588n);
   });
+});
+
+describeDevMoonbeam("Min Fee Multiplier", (context) => {
+  beforeEach("set to min multiplier", async () => {
+    const MULTIPLIER_STORAGE_KEY = context.polkadotApi.query.transactionPayment.nextFeeMultiplier
+      .key(0)
+      .toString();
+
+    // set transaction-payment's multiplier to something above max in storage. on the next round,
+    // it should enforce its upper bound and reset it.
+    await context.polkadotApi.tx.sudo
+      .sudo(
+        context.polkadotApi.tx.system.setStorage([
+          [MULTIPLIER_STORAGE_KEY, bnToHex(1n, { isLe: true, bitLength: 128 })],
+        ])
+      )
+      .signAndSend(alith);
+    await context.createBlock();
+  });
+
+  it("should enforce lower bound", async () => {
+    const MULTIPLIER_STORAGE_KEY = context.polkadotApi.query.transactionPayment.nextFeeMultiplier
+      .key(0)
+      .toString();
+
+    // we set it to u128_max, but the max should have been enforced in on_finalize()
+    const multiplier = (
+      await context.polkadotApi.query.transactionPayment.nextFeeMultiplier()
+    ).toBigInt();
+    expect(multiplier).to.equal(100_000_000_000_000_000n);
+  });
+
 });
 
 describeDevMoonbeam("Max Fee Multiplier - initial value", (context) => {

--- a/tests/tests/test-fees/test-fee-multiplier.ts
+++ b/tests/tests/test-fees/test-fee-multiplier.ts
@@ -48,6 +48,10 @@ describeDevMoonbeam("Max Fee Multiplier", (context) => {
       await context.polkadotApi.query.transactionPayment.nextFeeMultiplier()
     ).toBigInt();
     expect(multiplier).to.equal(100_000_000_000_000_000_000_000n);
+
+    const result = await context.ethers.send("eth_gasPrice", []);
+    const gasPrice = BigInt(result);
+    expect(gasPrice).to.eq(125_000_000_000_000n);
   });
 
   it("should have spendable runtime upgrade", async () => {
@@ -175,6 +179,10 @@ describeDevMoonbeam("Min Fee Multiplier", (context) => {
       await context.polkadotApi.query.transactionPayment.nextFeeMultiplier()
     ).toBigInt();
     expect(multiplier).to.equal(100_000_000_000_000_000n);
+
+    const result = await context.ethers.send("eth_gasPrice", []);
+    const gasPrice = BigInt(result);
+    expect(gasPrice).to.eq(125_000_000n);
   });
 
 });
@@ -185,6 +193,10 @@ describeDevMoonbeam("Max Fee Multiplier - initial value", (context) => {
       await context.polkadotApi.query.transactionPayment.nextFeeMultiplier()
     ).toBigInt();
     expect(initialValue).to.equal(8_000_000_000_000_000_000n);
+
+    const result = await context.ethers.send("eth_gasPrice", []);
+    const gasPrice = BigInt(result);
+    expect(gasPrice).to.eq(10_000_000_000n);
   });
 });
 

--- a/tests/tests/test-fees/test-fee-multiplier.ts
+++ b/tests/tests/test-fees/test-fee-multiplier.ts
@@ -184,7 +184,6 @@ describeDevMoonbeam("Min Fee Multiplier", (context) => {
     const gasPrice = BigInt(result);
     expect(gasPrice).to.eq(125_000_000n);
   });
-
 });
 
 describeDevMoonbeam("Max Fee Multiplier - initial value", (context) => {


### PR DESCRIPTION
### What does it do?

Cleans up the `MinimumMultiplier` used for our `pallet-parachain-staking` config.

Specifically:

* Adjusts the value to represent the `0.1` that was specified in #1765
* Adds tests to show that it's enforced properly

Additionally, TODO:
 - [X] Add tests to show what this does in terms of `base_fee`