### PR TITLE
upgrade to v0.9.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5280,6 +5280,7 @@ dependencies = [
  "pallet-randomness",
  "pallet-randomness-collective-flip",
  "pallet-referenda",
+ "pallet-root-testing",
  "pallet-scheduler",
  "pallet-society",
  "pallet-sudo",
@@ -5726,6 +5727,7 @@ dependencies = [
  "pallet-proxy-genesis-companion",
  "pallet-randomness",
  "pallet-randomness-collective-flip",
+ "pallet-root-testing",
  "pallet-scheduler",
  "pallet-society",
  "pallet-timestamp",
@@ -6059,6 +6061,7 @@ dependencies = [
  "pallet-randomness",
  "pallet-randomness-collective-flip",
  "pallet-referenda",
+ "pallet-root-testing",
  "pallet-scheduler",
  "pallet-society",
  "pallet-timestamp",
@@ -8248,6 +8251,21 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-arithmetic",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-root-testing"
+version = "1.0.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "async-trait",
  "fc-db",
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "fp-storage",
  "kvdb-rocksdb",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "fc-db",
  "fp-consensus",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2737,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2893,7 +2893,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2907,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "evm",
  "frame-support",
@@ -2920,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2936,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2948,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6900,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7118,7 +7118,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -7186,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "environmental",
  "evm",
@@ -7292,7 +7292,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "fp-evm",
 ]
@@ -7300,7 +7300,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7465,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "fp-evm",
  "num",
@@ -7644,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -7653,7 +7653,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
 dependencies = [
  "fp-evm",
  "ripemd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "async-trait",
  "fc-db",
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "fp-storage",
  "kvdb-rocksdb",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "fc-db",
  "fp-consensus",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2737,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2893,7 +2893,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2907,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "evm",
  "frame-support",
@@ -2920,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2936,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2948,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6900,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7118,7 +7118,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -7186,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "environmental",
  "evm",
@@ -7292,7 +7292,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "fp-evm",
 ]
@@ -7300,7 +7300,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7465,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "fp-evm",
  "num",
@@ -7644,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -7653,7 +7653,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#d2dace2b0a96c60e40559bb978b672808809d62c"
 dependencies = [
  "fp-evm",
  "ripemd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,16 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
- "gimli",
+ "gimli 0.26.2",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli 0.27.1",
 ]
 
 [[package]]
@@ -49,11 +58,32 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aead"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array 0.14.6",
+]
+
+[[package]]
+name = "aead"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
  "generic-array 0.14.6",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "aes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+dependencies = [
+ "aes-soft",
+ "aesni",
+ "cipher 0.2.5",
 ]
 
 [[package]]
@@ -62,10 +92,24 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "cfg-if 1.0.0",
- "cipher",
+ "cfg-if",
+ "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
+dependencies = [
+ "aead 0.3.2",
+ "aes 0.6.0",
+ "cipher 0.2.5",
+ "ctr 0.6.0",
+ "ghash 0.3.1",
+ "subtle",
 ]
 
 [[package]]
@@ -74,12 +118,32 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
+ "aead 0.4.3",
+ "aes 0.7.5",
+ "cipher 0.3.0",
+ "ctr 0.8.0",
+ "ghash 0.4.4",
  "subtle",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
+dependencies = [
+ "cipher 0.2.5",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "aesni"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
+dependencies = [
+ "cipher 0.2.5",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -151,10 +215,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "array-bytes"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a913633b0c922e6b745072795f50d90ebea78ba31a57e2ac8c2fc7b50950949"
+
+[[package]]
+name = "array-bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f72e9d6fac4bc80778ea470b20197b88d28c292bb7d60c3fb099280003cd19"
 
 [[package]]
 name = "arrayref"
@@ -184,6 +260,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "asn1-rs"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ff05a702273012438132f449575dbc804e27b2f3cbe3069aa237d26c98fa33"
+dependencies = [
+ "asn1-rs-derive 0.1.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf6690c370453db30743b373a60ba498fc0d6d83b11f4abfd87a84a075db5dd4"
+dependencies = [
+ "asn1-rs-derive 0.4.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b7511298d5b7784b40b092d9e9dcd3a627a5707e4b5e507931ab0d44eeebf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "asn1_der"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,56 +351,6 @@ name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "once_cell",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
 
 [[package]]
 name = "async-io"
@@ -290,77 +383,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-process"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
-dependencies = [
- "async-io",
- "autocfg",
- "blocking",
- "cfg-if 1.0.0",
- "event-listener",
- "futures-lite",
- "libc",
- "once_cell",
- "signal-hook",
- "winapi",
-]
-
-[[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-attributes",
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite 0.2.9",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-std-resolver"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba50e24d9ee0a8950d3d03fc6d0dd10aa14b5de3b101949b4e160f7fee7c723"
-dependencies = [
- "async-std",
- "async-trait",
- "futures-io",
- "futures-util",
- "pin-utils",
- "socket2",
- "trust-dns-resolver",
-]
-
-[[package]]
-name = "async-task"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
-
-[[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -369,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "asynchronous-codec"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
+checksum = "06a0daa378f5fd10634e44b0a29b2a87b890657658e072a30d6f26e57ddee182"
 dependencies = [
  "bytes",
  "futures-sink",
@@ -392,7 +418,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -416,31 +442,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "futures-core",
- "getrandom 0.2.8",
- "instant",
- "pin-project-lite 0.2.9",
- "rand 0.8.5",
- "tokio",
-]
-
-[[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
- "addr2line",
+ "addr2line 0.19.0",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "miniz_oxide",
- "object",
+ "miniz_oxide 0.6.2",
+ "object 0.30.3",
  "rustc-demangle",
 ]
 
@@ -486,21 +498,17 @@ dependencies = [
 [[package]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.1.0",
  "async-trait",
- "beefy-primitives",
  "fnv",
  "futures 0.3.25",
- "futures-timer",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "sc-chain-spec",
  "sc-client-api",
  "sc-consensus",
- "sc-finality-grandpa",
  "sc-keystore",
  "sc-network",
  "sc-network-common",
@@ -509,6 +517,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-arithmetic",
+ "sp-beefy",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
@@ -523,18 +532,17 @@ dependencies = [
 [[package]]
 name = "beefy-gadget-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "beefy-gadget",
- "beefy-primitives",
  "futures 0.3.25",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-rpc",
- "sc-utils",
  "serde",
+ "sp-beefy",
  "sp-core",
  "sp-runtime",
  "thiserror",
@@ -543,28 +551,11 @@ dependencies = [
 [[package]]
 name = "beefy-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "beefy-primitives",
  "sp-api",
+ "sp-beefy",
  "sp-runtime",
-]
-
-[[package]]
-name = "beefy-primitives"
-version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api",
- "sp-application-crypto",
- "sp-core",
- "sp-io",
- "sp-mmr-primitives",
- "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
@@ -679,7 +670,7 @@ dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "constant_time_eq",
  "digest 0.10.5",
 ]
@@ -716,6 +707,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-modes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a0e8073e8baa88212fb5823574c02ebccb395136ba9a164ab89379ec6072f0"
+dependencies = [
+ "block-padding 0.2.1",
+ "cipher 0.2.5",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,20 +730,6 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-
-[[package]]
-name = "blocking"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
-dependencies = [
- "async-channel",
- "async-task",
- "atomic-waker",
- "fastrand",
- "futures-lite",
- "once_cell",
-]
 
 [[package]]
 name = "bounded-vec"
@@ -808,9 +795,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bzip2-sys"
@@ -876,6 +863,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ccm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aca1a8fbc20b50ac9673ff014abfb2b5f4085ee1a850d408f14a159c5853ac7"
+dependencies = [
+ "aead 0.3.2",
+ "cipher 0.2.5",
+ "subtle",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,12 +893,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -917,8 +909,8 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
- "cfg-if 1.0.0",
- "cipher",
+ "cfg-if",
+ "cipher 0.3.0",
  "cpufeatures",
  "zeroize",
 ]
@@ -929,9 +921,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18446b09be63d457bbec447509e85f662f32952b035ce892290396bc0b0cff5"
 dependencies = [
- "aead",
+ "aead 0.4.3",
  "chacha20",
- "cipher",
+ "cipher 0.3.0",
  "poly1305",
  "zeroize",
 ]
@@ -946,7 +938,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.44",
  "wasm-bindgen",
  "winapi",
 ]
@@ -966,6 +958,15 @@ dependencies = [
 
 [[package]]
 name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array 0.14.6",
+]
+
+[[package]]
+name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
@@ -975,11 +976,11 @@ dependencies = [
 
 [[package]]
 name = "ckb-merkle-mountain-range"
-version = "0.3.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f061f97d64fd1822664bdfb722f7ae5469a97b77567390f7442be5b5dc82a5b"
+checksum = "56ccb671c5921be8a84686e6212ca184cb1d7c51cadcdbfcbd1cc3f042f5dfb8"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
 ]
 
 [[package]]
@@ -995,14 +996,14 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.18"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
@@ -1010,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.18"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1140,7 +1141,17 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
+]
+
+[[package]]
+name = "cpu-time"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1151,6 +1162,12 @@ checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cpuid-bool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "cranelift-bforest"
@@ -1174,7 +1191,7 @@ dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.26.2",
  "log",
  "regalloc2",
  "smallvec",
@@ -1251,12 +1268,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1265,7 +1297,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -1275,7 +1307,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -1287,7 +1319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
@@ -1299,7 +1331,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -1309,7 +1341,7 @@ version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1352,6 +1384,16 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
+dependencies = [
+ "generic-array 0.14.6",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-mac"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
@@ -1361,13 +1403,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor"
-version = "0.1.26"
+name = "ctr"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
 dependencies = [
- "quote",
- "syn",
+ "cipher 0.2.5",
 ]
 
 [[package]]
@@ -1376,13 +1417,13 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
- "cipher",
+ "cipher 0.3.0",
 ]
 
 [[package]]
 name = "cumulus-client-cli"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1397,7 +1438,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1420,12 +1461,15 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "async-trait",
+ "cumulus-client-pov-recovery",
+ "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "dyn-clone",
  "futures 0.3.25",
+ "log",
  "parity-scale-codec",
  "polkadot-primitives",
  "sc-client-api",
@@ -1440,7 +1484,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1463,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1486,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
@@ -1509,19 +1553,24 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
  "cumulus-client-consensus-common",
  "cumulus-client-pov-recovery",
  "cumulus-primitives-core",
+ "cumulus-relay-chain-inprocess-interface",
  "cumulus-relay-chain-interface",
+ "cumulus-relay-chain-minimal-node",
+ "futures 0.3.25",
  "parking_lot 0.12.1",
  "polkadot-primitives",
  "sc-client-api",
  "sc-consensus",
  "sc-service",
+ "sc-sysinfo",
+ "sc-telemetry",
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
@@ -1532,7 +1581,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1549,7 +1598,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -1577,7 +1626,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1588,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1604,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1622,7 +1671,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -1637,7 +1686,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1660,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "cumulus-primitives-core",
  "futures 0.3.25",
@@ -1673,7 +1722,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1689,7 +1738,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1714,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1728,24 +1777,23 @@ dependencies = [
  "sp-blockchain",
  "sp-state-machine",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
- "array-bytes",
+ "array-bytes 6.0.0",
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
  "futures 0.3.25",
- "lru 0.8.1",
- "polkadot-availability-distribution",
+ "lru",
  "polkadot-core-primitives",
  "polkadot-network-bridge",
- "polkadot-node-core-av-store",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
@@ -1757,8 +1805,6 @@ dependencies = [
  "sc-keystore",
  "sc-network",
  "sc-network-common",
- "sc-network-light",
- "sc-network-sync",
  "sc-service",
  "sc-telemetry",
  "sc-tracing",
@@ -1777,24 +1823,25 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "async-trait",
- "backoff",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "futures 0.3.25",
  "futures-timer",
  "jsonrpsee",
+ "lru",
  "parity-scale-codec",
  "polkadot-service",
  "sc-client-api",
  "sc-rpc-api",
+ "serde",
+ "serde_json",
  "sp-api",
  "sp-authority-discovery",
  "sp-consensus-babe",
  "sp-core",
- "sp-runtime",
  "sp-state-machine",
  "sp-storage",
  "tokio",
@@ -1805,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -1899,6 +1946,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,7 +2013,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe398ac75057914d7d07307bf67dc7f3f574a26783b4fc7805a20ffa9f506e82"
+dependencies = [
+ "asn1-rs 0.3.1",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d4bc9b0db0a0df9ae64634ac5bdefb7afcb534e182275ca0beadbe486701c1"
+dependencies = [
+ "asn1-rs 0.5.1",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1942,6 +2053,37 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07adf7be193b71cc36b193d0f5fe60b918a3a9db4dad0449f57bcfd519704a3"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f91d4cfa921f1c05904dc3c57b4a32c38aed3340cce209f3a6fd1478babafc4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -2020,7 +2162,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -2047,13 +2189,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "dns-parser"
-version = "0.8.0"
+name = "displaydoc"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "byteorder",
- "quick-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2103,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
 name = "ecdsa"
@@ -2121,9 +2264,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.0.3"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "signature",
 ]
@@ -2175,6 +2318,9 @@ dependencies = [
  "ff",
  "generic-array 0.14.6",
  "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -2245,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "environmental"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
+checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "errno"
@@ -2317,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81224dc661606574f5a0f28c9947d0ee1d93ff11c5f1c4e7272f52e8c0b5483c"
+checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
  "ethbloom",
  "fixed-hash",
@@ -2494,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "async-trait",
  "fc-db",
@@ -2513,12 +2659,12 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "fp-storage",
  "kvdb-rocksdb",
  "log",
- "parity-db 0.4.2",
+ "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-client-db",
@@ -2532,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "fc-db",
  "fp-consensus",
@@ -2549,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2557,7 +2703,6 @@ dependencies = [
  "fc-db",
  "fc-rpc-core",
  "fp-ethereum",
- "fp-evm",
  "fp-rpc",
  "fp-storage",
  "futures 0.3.25",
@@ -2565,7 +2710,7 @@ dependencies = [
  "jsonrpsee",
  "libsecp256k1",
  "log",
- "lru 0.8.1",
+ "lru",
  "parity-scale-codec",
  "prometheus",
  "rand 0.8.5",
@@ -2592,12 +2737,11 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "ethereum",
  "ethereum-types",
  "jsonrpsee",
- "rlp",
  "rustc-hex",
  "serde",
  "serde_json",
@@ -2638,7 +2782,7 @@ version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "windows-sys 0.42.0",
@@ -2646,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "finality-grandpa"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22349c6a11563a202d95772a68e0fcf56119e74ea8a2a19cf2301460fcd0df5"
+checksum = "e24e6c429951433ccb7c87fd528c60084834dcd14763182c1f83291bcde24c34"
 dependencies = [
  "either",
  "futures 0.3.25",
@@ -2686,7 +2830,7 @@ checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
  "libz-sys",
- "miniz_oxide",
+ "miniz_oxide 0.5.4",
 ]
 
 [[package]]
@@ -2720,7 +2864,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2737,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2749,7 +2893,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2757,14 +2901,13 @@ dependencies = [
  "frame-support",
  "num_enum",
  "parity-scale-codec",
- "sp-core",
  "sp-std",
 ]
 
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "evm",
  "frame-support",
@@ -2777,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2786,7 +2929,6 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-core",
- "sp-io",
  "sp-runtime",
  "sp-std",
 ]
@@ -2794,12 +2936,10 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
- "ethereum",
  "frame-support",
  "parity-scale-codec",
- "parity-util-mem",
  "scale-info",
  "serde",
  "sp-runtime",
@@ -2808,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -2823,7 +2963,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2846,10 +2986,10 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "Inflector",
- "array-bytes",
+ "array-bytes 4.1.0",
  "chrono",
  "clap",
  "comfy-table",
@@ -2858,16 +2998,13 @@ dependencies = [
  "frame-system",
  "gethostname",
  "handlebars",
- "hash-db",
  "itertools",
- "kvdb",
  "lazy_static",
  "linked-hash-map",
  "log",
- "memory-db",
  "parity-scale-codec",
  "rand 0.8.5",
- "rand_pcg 0.3.1",
+ "rand_pcg",
  "sc-block-builder",
  "sc-cli",
  "sc-client-api",
@@ -2877,7 +3014,6 @@ dependencies = [
  "sc-sysinfo",
  "serde",
  "serde_json",
- "serde_nanos",
  "sp-api",
  "sp-blockchain",
  "sp-core",
@@ -2887,9 +3023,9 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-state-machine",
+ "sp-std",
  "sp-storage",
  "sp-trie",
- "tempfile",
  "thiserror",
  "thousands",
 ]
@@ -2897,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2908,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2916,6 +3052,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-arithmetic",
+ "sp-core",
  "sp-npos-elections",
  "sp-runtime",
  "sp-std",
@@ -2924,7 +3061,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2944,16 +3081,32 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df6bb8542ef006ef0de09a5c4420787d79823c0ed7924225822362fd2bf2ff2d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "parity-scale-codec",
  "scale-info",
  "serde",
 ]
 
 [[package]]
+name = "frame-remote-externalities"
+version = "0.10.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
+dependencies = [
+ "futures 0.3.25",
+ "log",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "substrate-rpc-client",
+ "tokio",
+]
+
+[[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2985,7 +3138,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2999,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3011,7 +3164,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3021,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "log",
@@ -3039,7 +3192,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3054,7 +3207,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3063,7 +3216,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3188,8 +3341,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2411eed028cdf8c8034eaf21f9915f956b6c3abec4d4c7949ee67f0721127bd"
 dependencies = [
  "futures-io",
- "rustls",
- "webpki",
+ "rustls 0.20.7",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3273,7 +3426,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
@@ -3286,11 +3439,21 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+dependencies = [
+ "opaque-debug 0.3.0",
+ "polyval 0.4.5",
 ]
 
 [[package]]
@@ -3300,7 +3463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99"
 dependencies = [
  "opaque-debug 0.3.0",
- "polyval",
+ "polyval 0.5.3",
 ]
 
 [[package]]
@@ -3313,6 +3476,12 @@ dependencies = [
  "indexmap",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221996f774192f0f718773def8201c4ae31f02616a54ccfc2d358bb0e5cefdec"
 
 [[package]]
 name = "glob"
@@ -3331,18 +3500,6 @@ dependencies = [
  "fnv",
  "log",
  "regex",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3429,6 +3586,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3444,12 +3610,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac 0.8.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac 0.10.1",
  "digest 0.9.0",
 ]
 
@@ -3517,6 +3702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3567,7 +3758,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls",
+ "rustls 0.20.7",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
@@ -3596,6 +3787,12 @@ dependencies = [
  "cxx",
  "cxx-build",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3630,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "if-watch"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065c008e570a43c00de6aed9714035e5ea6a498c255323db9091722af6ee67dd"
+checksum = "ba7abdbb86e485125dad06c2691e1e393bf3b08c7b743b43aa162a00fd39062e"
 dependencies = [
  "async-io",
  "core-foundation",
@@ -3643,6 +3840,7 @@ dependencies = [
  "log",
  "rtnetlink",
  "system-configuration",
+ "tokio",
  "windows",
 ]
 
@@ -3710,7 +3908,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -3729,10 +3927,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "interceptor"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8a11ae2da61704edada656798b61c94b35ecac2c58eb955156987d5e6be90b"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "log",
+ "rand 0.8.5",
+ "rtcp",
+ "rtp",
+ "thiserror",
+ "tokio",
+ "waitgroup",
+ "webrtc-srtp",
+ "webrtc-util",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "ip_network"
@@ -3757,6 +3984,18 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes 1.0.4",
+ "rustix 0.36.7",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "itertools"
@@ -3793,22 +4032,23 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.15.1"
-source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d291e3a5818a2384645fd9756362e6d89cf0541b0b916fa7702ea4a9833608e"
 dependencies = [
  "jsonrpsee-core",
- "jsonrpsee-http-server",
  "jsonrpsee-proc-macros",
+ "jsonrpsee-server",
  "jsonrpsee-types",
  "jsonrpsee-ws-client",
- "jsonrpsee-ws-server",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.15.1"
-source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965de52763f2004bc91ac5bcec504192440f0b568a5d621c59d9dbd6f886c3fb"
 dependencies = [
  "futures-util",
  "http",
@@ -3827,8 +4067,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.15.1"
-source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e70b4439a751a5de7dd5ed55eacff78ebf4ffe0fc009cb1ebb11417f5b536b"
 dependencies = [
  "anyhow",
  "arrayvec 0.7.2",
@@ -3839,10 +4080,8 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "globset",
- "http",
  "hyper",
  "jsonrpsee-types",
- "lazy_static",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rustc-hash",
@@ -3852,32 +4091,15 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-futures",
- "unicase",
-]
-
-[[package]]
-name = "jsonrpsee-http-server"
-version = "0.15.1"
-source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"
-dependencies = [
- "futures-channel",
- "futures-util",
- "hyper",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-futures",
 ]
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.15.1"
-source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baa6da1e4199c10d7b1d0a6e5e8bd8e55f351163b6f4b3cbb044672a69bd4c1c"
 dependencies = [
+ "heck",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -3885,9 +4107,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-server"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb69dad85df79527c019659a992498d03f8495390496da2f07e6c24c2b356fc"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "http",
+ "hyper",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
+ "serde",
+ "serde_json",
+ "soketto",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "jsonrpsee-types"
-version = "0.15.1"
-source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bd522fe1ce3702fd94812965d7bb7a3364b1c9aba743944c5a00529aae80f8c"
 dependencies = [
  "anyhow",
  "beef",
@@ -3899,8 +4144,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.15.1"
-source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b83daeecfc6517cfe210df24e570fb06213533dfb990318fae781f4c7119dd9"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
@@ -3909,31 +4155,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-ws-server"
-version = "0.15.1"
-source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"
-dependencies = [
- "futures-channel",
- "futures-util",
- "http",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "serde_json",
- "soketto",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
 name = "k256"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "sha2 0.10.6",
@@ -3947,10 +4174,9 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "kusama-runtime"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
- "beefy-primitives",
  "bitvec",
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -3977,13 +4203,13 @@ dependencies = [
  "pallet-election-provider-support-benchmarking",
  "pallet-elections-phragmen",
  "pallet-fast-unstake",
- "pallet-gilt",
  "pallet-grandpa",
  "pallet-identity",
  "pallet-im-online",
  "pallet-indices",
  "pallet-membership",
  "pallet-multisig",
+ "pallet-nis",
  "pallet-nomination-pools",
  "pallet-nomination-pools-benchmarking",
  "pallet-nomination-pools-runtime-api",
@@ -3999,7 +4225,6 @@ dependencies = [
  "pallet-session-benchmarking",
  "pallet-society",
  "pallet-staking",
- "pallet-staking-reward-fn",
  "pallet-timestamp",
  "pallet-tips",
  "pallet-transaction-payment",
@@ -4022,6 +4247,7 @@ dependencies = [
  "sp-api",
  "sp-arithmetic",
  "sp-authority-discovery",
+ "sp-beefy",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-core",
@@ -4045,8 +4271,8 @@ dependencies = [
 
 [[package]]
 name = "kusama-runtime-constants"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -4058,45 +4284,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "kvdb"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585089ceadba0197ffe9af6740ab350b325e3c1f5fccfbc3522e0250c750409b"
+checksum = "e7d770dcb02bf6835887c3a979b5107a04ff4bbde97a5f0928d27404a155add9"
 dependencies = [
- "parity-util-mem",
  "smallvec",
 ]
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d109c87bfb7759edd2a49b2649c1afe25af785d930ad6a38479b4dc70dd873"
+checksum = "bf7a85fe66f9ff9cd74e169fdd2c94c6e1e74c412c99a73b4df3200b5d3760b2"
 dependencies = [
  "kvdb",
- "parity-util-mem",
  "parking_lot 0.12.1",
 ]
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c076cc2cdbac89b9910c853a36c957d3862a779f31c2661174222cefb49ee597"
+checksum = "2182b8219fee6bd83aacaab7344e840179ae079d5216aa4e249b4d704646a844"
 dependencies = [
  "kvdb",
- "log",
  "num_cpus",
- "parity-util-mem",
  "parking_lot 0.12.1",
  "regex",
  "rocksdb",
@@ -4130,7 +4343,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "winapi",
 ]
 
@@ -4142,16 +4355,15 @@ checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "libp2p"
-version = "0.49.0"
+version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec878fda12ebec479186b3914ebc48ff180fa4c51847e11a1a68bf65249e02c1"
+checksum = "2e0a0d2f693675f49ded13c5d510c48b78069e23cbd9108d7ccd59f6dc568819"
 dependencies = [
  "bytes",
  "futures 0.3.25",
  "futures-timer",
  "getrandom 0.2.8",
  "instant",
- "lazy_static",
  "libp2p-core",
  "libp2p-dns",
  "libp2p-identify",
@@ -4161,11 +4373,12 @@ dependencies = [
  "libp2p-mplex",
  "libp2p-noise",
  "libp2p-ping",
+ "libp2p-quic",
  "libp2p-request-response",
  "libp2p-swarm",
- "libp2p-swarm-derive",
  "libp2p-tcp",
  "libp2p-wasm-ext",
+ "libp2p-webrtc",
  "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr",
@@ -4176,9 +4389,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799676bb0807c788065e57551c6527d461ad572162b0519d1958946ff9e0539d"
+checksum = "b6a8fcd392ff67af6cc3f03b1426c41f7f26b6b9aff2dc632c1c56dd649e571f"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -4188,17 +4401,18 @@ dependencies = [
  "futures 0.3.25",
  "futures-timer",
  "instant",
- "lazy_static",
  "log",
  "multiaddr",
  "multihash",
  "multistream-select",
+ "once_cell",
  "parking_lot 0.12.1",
  "pin-project",
  "prost",
  "prost-build",
  "rand 0.8.5",
  "rw-stream-sink",
+ "sec1",
  "sha2 0.10.6",
  "smallvec",
  "thiserror",
@@ -4209,11 +4423,10 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2322c9fb40d99101def6a01612ee30500c89abbbecb6297b3cd252903a4c1720"
+checksum = "8e42a271c1b49f789b92f7fc87749fa79ce5c7bdc88cbdfacb818a4bca47fec5"
 dependencies = [
- "async-std-resolver",
  "futures 0.3.25",
  "libp2p-core",
  "log",
@@ -4224,9 +4437,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.40.0"
+version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf9a121f699e8719bda2e6e9e9b6ddafc6cff4602471d6481c1067930ccb29b"
+checksum = "c052d0026f4817b44869bfb6810f4e1112f43aec8553f2cb38881c524b563abf"
 dependencies = [
  "asynchronous-codec",
  "futures 0.3.25",
@@ -4234,7 +4447,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "lru 0.8.1",
+ "lru",
  "prost",
  "prost-build",
  "prost-codec",
@@ -4245,9 +4458,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.41.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6721c200e2021f6c3fab8b6cf0272ead8912d871610ee194ebd628cecf428f22"
+checksum = "2766dcd2be8c87d5e1f35487deb22d765f49c6ae1251b3633efe3b25698bd3d2"
 dependencies = [
  "arrayvec 0.7.2",
  "asynchronous-codec",
@@ -4273,13 +4486,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761704e727f7d68d58d7bc2231eafae5fc1b9814de24290f126df09d4bd37a15"
+checksum = "04f378264aade9872d6ccd315c0accc18be3a35d15fc1b9c36e5b6f983b62b5b"
 dependencies = [
- "async-io",
  "data-encoding",
- "dns-parser",
  "futures 0.3.25",
  "if-watch",
  "libp2p-core",
@@ -4288,14 +4499,16 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "socket2",
+ "tokio",
+ "trust-dns-proto",
  "void",
 ]
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee31b08e78b7b8bfd1c4204a9dd8a87b4fcdf6dafc57eb51701c1c264a81cb9"
+checksum = "5ad8a64f29da86005c86a4d2728b8a0719e9b192f4092b609fd8790acb9dec55"
 dependencies = [
  "libp2p-core",
  "libp2p-identify",
@@ -4307,9 +4520,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692664acfd98652de739a8acbb0a0d670f1d67190a49be6b4395e22c37337d89"
+checksum = "03805b44107aa013e7cbbfa5627b31c36cbedfdfb00603c0311998882bc4bace"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4325,31 +4538,32 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048155686bd81fe6cb5efdef0c6290f25ad32a0a42e8f4f72625cf6a505a206f"
+checksum = "a978cb57efe82e892ec6f348a536bfbd9fee677adbe5689d7a93ad3a9bffbf2e"
 dependencies = [
  "bytes",
  "curve25519-dalek 3.2.0",
  "futures 0.3.25",
- "lazy_static",
  "libp2p-core",
  "log",
+ "once_cell",
  "prost",
  "prost-build",
  "rand 0.8.5",
  "sha2 0.10.6",
  "snow",
  "static_assertions",
- "x25519-dalek",
+ "thiserror",
+ "x25519-dalek 1.1.1",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-ping"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7228b9318d34689521349a86eb39a3c3a802c9efc99a0568062ffb80913e3f91"
+checksum = "929fcace45a112536e22b3dcfd4db538723ef9c3cb79f672b98be2cc8e25f37f"
 dependencies = [
  "futures 0.3.25",
  "futures-timer",
@@ -4362,10 +4576,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-request-response"
-version = "0.22.1"
+name = "libp2p-quic"
+version = "0.7.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8827af16a017b65311a410bb626205a9ad92ec0473967618425039fa5231adc1"
+checksum = "01e7c867e95c8130667b24409d236d37598270e6da69b3baf54213ba31ffca59"
+dependencies = [
+ "bytes",
+ "futures 0.3.25",
+ "futures-timer",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-tls",
+ "log",
+ "parking_lot 0.12.1",
+ "quinn-proto",
+ "rand 0.8.5",
+ "rustls 0.20.7",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3236168796727bfcf4927f766393415361e2c644b08bedb6a6b13d957c9a4884"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4381,9 +4616,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.40.1"
+version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d13df7c37807965d82930c0e4b04a659efcb6cca237373b206043db5398ecf"
+checksum = "b2a35472fe3276b3855c00f1c032ea8413615e030256429ad5349cdf67c6e1a0"
 dependencies = [
  "either",
  "fnv",
@@ -4391,19 +4626,21 @@ dependencies = [
  "futures-timer",
  "instant",
  "libp2p-core",
+ "libp2p-swarm-derive",
  "log",
  "pin-project",
  "rand 0.8.5",
  "smallvec",
  "thiserror",
+ "tokio",
  "void",
 ]
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.30.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0eddc4497a8b5a506013c40e8189864f9c3a00db2b25671f428ae9007f3ba32"
+checksum = "9d527d5827582abd44a6d80c07ff8b50b4ee238a8979e05998474179e79dc400"
 dependencies = [
  "heck",
  "quote",
@@ -4412,11 +4649,10 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9839d96761491c6d3e238e70554b856956fca0ab60feb9de2cd08eed4473fa92"
+checksum = "b4b257baf6df8f2df39678b86c578961d48cc8b68642a12f0f763f56c8e5858d"
 dependencies = [
- "async-io",
  "futures 0.3.25",
  "futures-timer",
  "if-watch",
@@ -4424,13 +4660,32 @@ dependencies = [
  "libp2p-core",
  "log",
  "socket2",
+ "tokio",
+]
+
+[[package]]
+name = "libp2p-tls"
+version = "0.1.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7905ce0d040576634e8a3229a7587cc8beab83f79db6023800f1792895defa8"
+dependencies = [
+ "futures 0.3.25",
+ "futures-rustls",
+ "libp2p-core",
+ "rcgen 0.10.0",
+ "ring",
+ "rustls 0.20.7",
+ "thiserror",
+ "webpki 0.22.0",
+ "x509-parser 0.14.0",
+ "yasna",
 ]
 
 [[package]]
 name = "libp2p-wasm-ext"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b5b8e7a73e379e47b1b77f8a82c4721e97eca01abcd18e9cd91a23ca6ce97"
+checksum = "1bb1a35299860e0d4b3c02a3e74e3b293ad35ae0cee8a056363b0c862d082069"
 dependencies = [
  "futures 0.3.25",
  "js-sys",
@@ -4441,10 +4696,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-websocket"
-version = "0.39.0"
+name = "libp2p-webrtc"
+version = "0.4.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3758ae6f89b2531a24b6d9f5776bda6a626b60a57600d7185d43dfa75ca5ecc4"
+checksum = "cdb6cd86dd68cba72308ea05de1cebf3ba0ae6e187c40548167955d4e3970f6a"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "futures 0.3.25",
+ "futures-timer",
+ "hex",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-noise",
+ "log",
+ "multihash",
+ "prost",
+ "prost-build",
+ "prost-codec",
+ "rand 0.8.5",
+ "rcgen 0.9.3",
+ "serde",
+ "stun",
+ "thiserror",
+ "tinytemplate",
+ "tokio",
+ "tokio-util",
+ "webrtc",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d705506030d5c0aaf2882437c70dab437605f21c5f9811978f694e6917a3b54"
 dependencies = [
  "either",
  "futures 0.3.25",
@@ -4461,9 +4747,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f079097a21ad017fc8139460630286f02488c8c13b26affb46623aa20d8845"
+checksum = "4f63594a0aa818642d9d4915c791945053877253f08a3626f13416b5cd928a29"
 dependencies = [
  "futures 0.3.25",
  "libp2p-core",
@@ -4588,6 +4874,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4603,17 +4895,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
- "value-bag",
-]
-
-[[package]]
-name = "lru"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
-dependencies = [
- "hashbrown",
+ "cfg-if",
 ]
 
 [[package]]
@@ -4729,6 +5011,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest 0.10.5",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4740,7 +5031,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "480b5a5de855d11ff13195950bdc8b98b5e942ef47afc447f6615cdcc4e15d80"
 dependencies = [
- "rustix",
+ "rustix 0.35.13",
 ]
 
 [[package]]
@@ -4763,22 +5054,12 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac11bb793c28fa095b7554466f53b3a60a2cd002afdac01bcf135cbd73a269"
+checksum = "5e0c7cba9ce19ac7ffd2053ac9f49843bbd3f4318feedfd74e85c19d5fb0ba66"
 dependencies = [
  "hash-db",
  "hashbrown",
- "parity-util-mem",
-]
-
-[[package]]
-name = "memory-lru"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce95ae042940bad7e312857b929ee3d11b8f799a80cb7b9c7ec5125516906395"
-dependencies = [
- "lru 0.8.1",
 ]
 
 [[package]]
@@ -4826,6 +5107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4838,12 +5128,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "mmr-gadget"
+version = "4.0.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
+dependencies = [
+ "futures 0.3.25",
+ "log",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-offchain",
+ "sp-api",
+ "sp-beefy",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-mmr-primitives",
+ "sp-runtime",
+]
+
+[[package]]
+name = "mmr-rpc"
+version = "4.0.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
+dependencies = [
+ "anyhow",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "serde",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-mmr-primitives",
+ "sp-runtime",
+]
+
+[[package]]
 name = "mockall"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "downcast",
  "fragile",
  "lazy_static",
@@ -4858,7 +5183,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "proc-macro2",
  "quote",
  "syn",
@@ -5059,7 +5384,7 @@ dependencies = [
  "primitive-types",
  "sha3 0.10.6",
  "sp-runtime",
- "tiny-bip39",
+ "tiny-bip39 0.8.2",
  "url",
 ]
 
@@ -5592,7 +5917,7 @@ dependencies = [
  "substrate-test-client",
  "substrate-test-runtime",
  "substrate-test-runtime-client",
- "tiny-bip39",
+ "tiny-bip39 0.8.2",
  "tokio",
  "trie-root 0.15.2",
  "xcm",
@@ -5779,14 +6104,14 @@ dependencies = [
 
 [[package]]
 name = "multiaddr"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c580bfdd8803cce319b047d239559a22f809094aaea4ac13902a1fdcfcd4261"
+checksum = "a4aebdb21e90f81d13ed01dc84123320838e53963c2ca94b60b305d3fa64f31e"
 dependencies = [
  "arrayref",
- "bs58",
  "byteorder",
  "data-encoding",
+ "multibase",
  "multihash",
  "percent-encoding",
  "serde",
@@ -5845,9 +6170,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multistream-select"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bc41247ec209813e2fd414d6e16b9d94297dacf3cd613fa6ef09cd4d9755c10"
+checksum = "c8552ab875c1313b97b8d20cb857b9fd63e2d1d6a0a1b53ce9821e575405f27a"
 dependencies = [
  "bytes",
  "futures 0.3.25",
@@ -5867,7 +6192,7 @@ dependencies = [
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
  "rand 0.8.5",
  "rand_distr",
@@ -5963,17 +6288,17 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b654097027250401127914afb37cb1f311df6610a9891ff07a757e94199027"
 dependencies = [
- "async-io",
  "bytes",
  "futures 0.3.25",
  "libc",
  "log",
+ "tokio",
 ]
 
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.32#80b35ba5f656ff9323da3e2810b8134f358a3d03"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.37#9d2cd21e902f583b47e6710c52f8e65c52bcc46b"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -6004,7 +6329,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.32#80b35ba5f656ff9323da3e2810b8134f358a3d03"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.37#9d2cd21e902f583b47e6710c52f8e65c52bcc46b"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -6027,7 +6352,7 @@ checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset",
 ]
@@ -6039,8 +6364,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -6077,22 +6403,11 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.4.1",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
+ "num-rational",
  "num-traits",
 ]
 
@@ -6149,24 +6464,12 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-dependencies = [
- "autocfg",
- "num-bigint 0.2.6",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
- "num-bigint 0.4.3",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -6187,7 +6490,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -6225,6 +6528,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e20717fa0541f39bd146692035c37bedfa532b3e5071b35761082407546b2a"
+dependencies = [
+ "asn1-rs 0.3.1",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+dependencies = [
+ "asn1-rs 0.5.1",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6250,9 +6580,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "orchestra"
-version = "0.0.2"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aab54694ddaa8a9b703724c6ef04272b2d27bc32d2c855aae5cdd1857216b43"
+checksum = "17e7d5b6bb115db09390bed8842c94180893dd83df3dfce7354f2a2aa090a4ee"
 dependencies = [
  "async-trait",
  "dyn-clonable",
@@ -6267,9 +6597,9 @@ dependencies = [
 
 [[package]]
 name = "orchestra-proc-macro"
-version = "0.0.2"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a702b2f6bf592b3eb06c00d80d05afaf7a8eff6b41bb361e397d799acc21b45a"
+checksum = "c2af4dabb2286b0be0e9711d2d24e25f6217048b71210cffd3daddc3b5c84e1f"
 dependencies = [
  "expander 0.0.6",
  "itertools",
@@ -6292,7 +6622,7 @@ dependencies = [
 [[package]]
 name = "orml-traits"
 version = "0.4.1-dev"
-source = "git+https://github.com/purestake/open-runtime-module-library?branch=moonbeam-polkadot-v0.9.32#1b39c1fbeaf1e233e470319f4aa9106909c3879b"
+source = "git+https://github.com/purestake/open-runtime-module-library?branch=moonbeam-polkadot-v0.9.37#536b291262dbd2c28c7464b24dbb7a83678a4906"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -6310,7 +6640,7 @@ dependencies = [
 [[package]]
 name = "orml-utilities"
 version = "0.4.1-dev"
-source = "git+https://github.com/purestake/open-runtime-module-library?branch=moonbeam-polkadot-v0.9.32#1b39c1fbeaf1e233e470319f4aa9106909c3879b"
+source = "git+https://github.com/purestake/open-runtime-module-library?branch=moonbeam-polkadot-v0.9.37#536b291262dbd2c28c7464b24dbb7a83678a4906"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6324,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "orml-xcm-support"
 version = "0.4.1-dev"
-source = "git+https://github.com/purestake/open-runtime-module-library?branch=moonbeam-polkadot-v0.9.32#1b39c1fbeaf1e233e470319f4aa9106909c3879b"
+source = "git+https://github.com/purestake/open-runtime-module-library?branch=moonbeam-polkadot-v0.9.37#536b291262dbd2c28c7464b24dbb7a83678a4906"
 dependencies = [
  "frame-support",
  "orml-traits",
@@ -6338,7 +6668,7 @@ dependencies = [
 [[package]]
 name = "orml-xtokens"
 version = "0.4.1-dev"
-source = "git+https://github.com/purestake/open-runtime-module-library?branch=moonbeam-polkadot-v0.9.32#1b39c1fbeaf1e233e470319f4aa9106909c3879b"
+source = "git+https://github.com/purestake/open-runtime-module-library?branch=moonbeam-polkadot-v0.9.37#536b291262dbd2c28c7464b24dbb7a83678a4906"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -6363,6 +6693,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.6",
+]
+
+[[package]]
+name = "p384"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.6",
+]
+
+[[package]]
 name = "pallet-asset-manager"
 version = "0.1.0"
 dependencies = [
@@ -6385,13 +6737,14 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
+ "sp-core",
  "sp-runtime",
  "sp-std",
 ]
@@ -6399,7 +6752,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.32#80b35ba5f656ff9323da3e2810b8134f358a3d03"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.37#9d2cd21e902f583b47e6710c52f8e65c52bcc46b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6439,7 +6792,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.32#80b35ba5f656ff9323da3e2810b8134f358a3d03"
+source = "git+https://github.com/purestake/nimbus?branch=moonbeam-polkadot-v0.9.37#9d2cd21e902f583b47e6710c52f8e65c52bcc46b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6457,7 +6810,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6473,7 +6826,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6488,7 +6841,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6512,7 +6865,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6532,7 +6885,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6547,14 +6900,13 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "fp-evm",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
- "serde",
  "sp-core",
  "sp-runtime",
 ]
@@ -6562,15 +6914,15 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "beefy-primitives",
  "frame-support",
  "frame-system",
  "pallet-session",
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "sp-beefy",
  "sp-runtime",
  "sp-std",
 ]
@@ -6578,11 +6930,10 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.1.0",
  "beefy-merkle-tree",
- "beefy-primitives",
  "frame-support",
  "frame-system",
  "log",
@@ -6592,6 +6943,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
+ "sp-beefy",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -6601,7 +6953,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6619,7 +6971,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6638,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6655,7 +7007,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6672,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "pallet-crowdloan-rewards"
 version = "0.6.0"
-source = "git+https://github.com/purestake/crowdloan-rewards?branch=moonbeam-polkadot-v0.9.32#a373cae9c35531db3fe37276434c51539b834267"
+source = "git+https://github.com/purestake/crowdloan-rewards?branch=moonbeam-polkadot-v0.9.37#24b1051b9e75c64a03b2472e272a479a1759d58a"
 dependencies = [
  "ed25519-dalek",
  "frame-benchmarking",
@@ -6694,7 +7046,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6712,7 +7064,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6721,7 +7073,7 @@ dependencies = [
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
- "rand 0.7.3",
+ "rand 0.8.5",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
@@ -6729,14 +7081,13 @@ dependencies = [
  "sp-npos-elections",
  "sp-runtime",
  "sp-std",
- "static_assertions",
  "strum",
 ]
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6749,7 +7100,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6767,7 +7118,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -6785,7 +7136,6 @@ dependencies = [
  "parity-scale-codec",
  "rlp",
  "scale-info",
- "serde",
  "sp-io",
  "sp-runtime",
  "sp-std",
@@ -6836,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "environmental",
  "evm",
@@ -6848,10 +7198,8 @@ dependencies = [
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
- "primitive-types",
  "rlp",
  "scale-info",
- "serde",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -6944,7 +7292,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "fp-evm",
 ]
@@ -6952,7 +7300,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7107,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7117,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "fp-evm",
  "num",
@@ -7296,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -7305,7 +7653,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.32#238d0025b3995aed7fb18782203d5478b7899918"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#96bf341dfedd3c867484078ae2ba2ca6a08d8c2e"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -7442,16 +7790,13 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
  "frame-support",
  "frame-system",
  "log",
- "pallet-balances",
- "pallet-staking",
- "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-io",
@@ -7461,24 +7806,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-gilt"
-version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7501,7 +7831,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7517,7 +7847,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7537,7 +7867,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7571,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7611,9 +7941,8 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "ckb-merkle-mountain-range",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -7624,21 +7953,6 @@ dependencies = [
  "sp-mmr-primitives",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "pallet-mmr-rpc"
-version = "3.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
-dependencies = [
- "jsonrpsee",
- "parity-scale-codec",
- "serde",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-mmr-primitives",
- "sp-runtime",
 ]
 
 [[package]]
@@ -7662,7 +7976,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7676,9 +7990,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-nis"
+version = "4.0.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7695,7 +8025,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7715,7 +8045,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7725,7 +8055,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7742,7 +8072,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7786,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7803,7 +8133,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7860,7 +8190,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7874,7 +8204,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7892,7 +8222,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7907,12 +8237,13 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -7925,7 +8256,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7936,12 +8267,13 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "sp-weights",
 ]
 
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7962,14 +8294,14 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "pallet-session",
  "pallet-staking",
- "rand 0.7.3",
+ "rand 0.8.5",
  "sp-runtime",
  "sp-session",
  "sp-std",
@@ -7978,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7992,7 +8324,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8015,7 +8347,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -8026,16 +8358,33 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "log",
  "sp-arithmetic",
 ]
 
 [[package]]
+name = "pallet-state-trie-migration"
+version = "4.0.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8049,7 +8398,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8067,7 +8416,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8086,7 +8435,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8102,7 +8451,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8118,7 +8467,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8130,7 +8479,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8147,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8163,7 +8512,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8178,7 +8527,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8192,8 +8541,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8210,8 +8559,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8254,32 +8603,13 @@ dependencies = [
 [[package]]
 name = "parachain-info"
 version = "0.1.0"
-source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.32#6d9310724ce42b7c8bf5b398ce09e5eda844c668"
+source = "git+https://github.com/purestake/cumulus?branch=moonbeam-polkadot-v0.9.37#5f977c2a76ee969f3cbe4f531b64b75c2e92bf2b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "scale-info",
-]
-
-[[package]]
-name = "parity-db"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8fdb726a43661fa54b43e7114e6b88b2289cae388eb3ad766d9d1754d83fce"
-dependencies = [
- "blake2-rfc",
- "crc32fast",
- "fs2",
- "hex",
- "libc",
- "log",
- "lz4",
- "memmap2",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "snap",
 ]
 
 [[package]]
@@ -8335,44 +8665,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 
 [[package]]
-name = "parity-util-mem"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d32c34f4f5ca7f9196001c0aba5a1f9a5a12382c8944b8b0f90233282d1e8f8"
-dependencies = [
- "cfg-if 1.0.0",
- "ethereum-types",
- "hashbrown",
- "impl-trait-for-tuples",
- "lru 0.8.1",
- "parity-util-mem-derive",
- "parking_lot 0.12.1",
- "primitive-types",
- "smallvec",
- "winapi",
-]
-
-[[package]]
-name = "parity-util-mem-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
-dependencies = [
- "proc-macro2",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "parity-wasm"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ad52817c4d343339b3bc2e26861bd21478eda0b7509acf83505727000512ac"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "parity-wasm"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8411,7 +8703,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall",
@@ -8425,7 +8717,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -8470,6 +8762,24 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -8593,14 +8903,14 @@ checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "futures 0.3.25",
+ "polkadot-node-metrics",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "rand 0.8.5",
  "tracing-gum",
@@ -8608,8 +8918,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "futures 0.3.25",
  "polkadot-node-network-protocol",
@@ -8622,13 +8932,13 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "derive_more",
  "fatality",
  "futures 0.3.25",
- "lru 0.8.1",
+ "lru",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -8645,12 +8955,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "fatality",
  "futures 0.3.25",
- "lru 0.8.1",
+ "lru",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -8666,8 +8976,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -8679,12 +8989,13 @@ dependencies = [
  "polkadot-performance-test",
  "polkadot-service",
  "sc-cli",
+ "sc-executor",
  "sc-service",
  "sc-sysinfo",
  "sc-tracing",
  "sp-core",
+ "sp-io",
  "sp-keyring",
- "sp-trie",
  "substrate-build-script-utils",
  "thiserror",
  "try-runtime-cli",
@@ -8692,14 +9003,15 @@ dependencies = [
 
 [[package]]
 name = "polkadot-client"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
- "beefy-primitives",
+ "async-trait",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "frame-system",
  "frame-system-rpc-runtime-api",
+ "futures 0.3.25",
  "kusama-runtime",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8715,6 +9027,7 @@ dependencies = [
  "sc-service",
  "sp-api",
  "sp-authority-discovery",
+ "sp-beefy",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
@@ -8735,8 +9048,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "always-assert",
  "bitvec",
@@ -8757,11 +9070,10 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "parity-scale-codec",
- "parity-util-mem",
  "scale-info",
  "sp-core",
  "sp-runtime",
@@ -8770,15 +9082,15 @@ dependencies = [
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "derive_more",
  "fatality",
  "futures 0.3.25",
  "futures-timer",
  "indexmap",
- "lru 0.8.1",
+ "lru",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -8795,8 +9107,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -8809,8 +9121,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "futures 0.3.25",
  "futures-timer",
@@ -8829,8 +9141,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -8839,9 +9151,9 @@ dependencies = [
  "futures 0.3.25",
  "parity-scale-codec",
  "parking_lot 0.12.1",
+ "polkadot-node-metrics",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
- "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
  "sc-network",
@@ -8853,8 +9165,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "futures 0.3.25",
  "parity-scale-codec",
@@ -8871,15 +9183,15 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "bitvec",
  "derive_more",
  "futures 0.3.25",
  "futures-timer",
  "kvdb",
- "lru 0.8.1",
+ "lru",
  "merlin",
  "parity-scale-codec",
  "polkadot-node-jaeger",
@@ -8900,8 +9212,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "bitvec",
  "futures 0.3.25",
@@ -8920,8 +9232,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8939,8 +9251,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "futures 0.3.25",
  "polkadot-node-subsystem",
@@ -8954,16 +9266,17 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
+ "futures-timer",
  "parity-scale-codec",
  "polkadot-node-core-pvf",
+ "polkadot-node-metrics",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-node-subsystem-util",
  "polkadot-parachain",
  "polkadot-primitives",
  "sp-maybe-compressed-blob",
@@ -8972,12 +9285,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "futures 0.3.25",
+ "polkadot-node-metrics",
  "polkadot-node-subsystem",
- "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "sc-client-api",
  "sc-consensus-babe",
@@ -8987,8 +9300,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "futures 0.3.25",
  "futures-timer",
@@ -9004,13 +9317,13 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "fatality",
  "futures 0.3.25",
  "kvdb",
- "lru 0.8.1",
+ "lru",
  "parity-scale-codec",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -9023,25 +9336,25 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
  "futures-timer",
  "polkadot-node-subsystem",
+ "polkadot-overseer",
  "polkadot-primitives",
  "sp-blockchain",
  "sp-inherents",
- "sp-runtime",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "bitvec",
  "fatality",
@@ -9058,13 +9371,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "always-assert",
  "assert_matches",
- "async-process",
- "async-std",
+ "cpu-time",
  "futures 0.3.25",
  "futures-timer",
  "parity-scale-codec",
@@ -9085,13 +9397,14 @@ dependencies = [
  "sp-tracing",
  "sp-wasm-interface",
  "tempfile",
+ "tokio",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "futures 0.3.25",
  "polkadot-node-primitives",
@@ -9106,15 +9419,14 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "futures 0.3.25",
- "memory-lru",
- "parity-util-mem",
+ "lru",
+ "polkadot-node-metrics",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
- "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "sp-consensus-babe",
  "tracing-gum",
@@ -9122,10 +9434,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
- "async-std",
  "lazy_static",
  "log",
  "mick-jaeger",
@@ -9136,12 +9447,13 @@ dependencies = [
  "sc-network",
  "sp-core",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "bs58",
  "futures 0.3.25",
@@ -9159,8 +9471,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -9182,8 +9494,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "bounded-vec",
  "futures 0.3.25",
@@ -9204,8 +9516,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -9214,8 +9526,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -9237,19 +9549,19 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "async-trait",
  "derive_more",
  "fatality",
  "futures 0.3.25",
+ "futures-channel",
  "itertools",
  "kvdb",
- "lru 0.8.1",
- "parity-db 0.3.17",
+ "lru",
+ "parity-db",
  "parity-scale-codec",
- "parity-util-mem",
  "parking_lot 0.11.2",
  "pin-project",
  "polkadot-node-jaeger",
@@ -9270,15 +9582,14 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
  "futures-timer",
- "lru 0.8.1",
+ "lru",
  "orchestra",
- "parity-util-mem",
  "parking_lot 0.12.1",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
@@ -9288,18 +9599,18 @@ dependencies = [
  "sc-client-api",
  "sp-api",
  "sp-core",
+ "tikv-jemalloc-ctl",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-parachain"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "derive_more",
  "frame-support",
  "parity-scale-codec",
- "parity-util-mem",
  "polkadot-core-primitives",
  "scale-info",
  "serde",
@@ -9310,8 +9621,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-performance-test"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "env_logger",
  "kusama-runtime",
@@ -9325,14 +9636,12 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "bitvec",
- "frame-system",
  "hex-literal",
  "parity-scale-codec",
- "parity-util-mem",
  "polkadot-core-primitives",
  "polkadot-parachain",
  "scale-info",
@@ -9349,19 +9658,17 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-std",
- "sp-trie",
- "sp-version",
 ]
 
 [[package]]
 name = "polkadot-rpc"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
  "jsonrpsee",
- "pallet-mmr-rpc",
+ "mmr-rpc",
  "pallet-transaction-payment-rpc",
  "polkadot-primitives",
  "sc-chain-spec",
@@ -9387,10 +9694,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
- "beefy-primitives",
  "bitvec",
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9453,6 +9759,7 @@ dependencies = [
  "smallvec",
  "sp-api",
  "sp-authority-discovery",
+ "sp-beefy",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-core",
@@ -9476,10 +9783,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
- "beefy-primitives",
  "bitvec",
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9496,6 +9802,7 @@ dependencies = [
  "pallet-election-provider-multi-phase",
  "pallet-session",
  "pallet-staking",
+ "pallet-staking-reward-fn",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-treasury",
@@ -9509,6 +9816,7 @@ dependencies = [
  "serde_derive",
  "slot-range-helper",
  "sp-api",
+ "sp-beefy",
  "sp-core",
  "sp-inherents",
  "sp-io",
@@ -9523,8 +9831,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-constants"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -9537,8 +9845,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -9549,8 +9857,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -9592,12 +9900,11 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "async-trait",
  "beefy-gadget",
- "beefy-primitives",
  "frame-support",
  "frame-system-rpc-runtime-api",
  "futures 0.3.25",
@@ -9606,12 +9913,13 @@ dependencies = [
  "kusama-runtime-constants",
  "kvdb",
  "kvdb-rocksdb",
- "lru 0.8.1",
+ "lru",
+ "mmr-gadget",
  "pallet-babe",
  "pallet-im-online",
  "pallet-staking",
  "pallet-transaction-payment-rpc-runtime-api",
- "parity-db 0.3.17",
+ "parity-db",
  "polkadot-approval-distribution",
  "polkadot-availability-bitfield-distribution",
  "polkadot-availability-distribution",
@@ -9673,6 +9981,7 @@ dependencies = [
  "serde_json",
  "sp-api",
  "sp-authority-discovery",
+ "sp-beefy",
  "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
@@ -9682,6 +9991,7 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-keystore",
+ "sp-mmr-primitives",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
@@ -9699,8 +10009,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
@@ -9720,8 +10030,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-table"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -9735,7 +10045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "log",
  "wepoll-ffi",
@@ -9755,11 +10065,22 @@ dependencies = [
 
 [[package]]
 name = "polyval"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+dependencies = [
+ "cpuid-bool",
+ "opaque-debug 0.3.0",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "opaque-debug 0.3.0",
  "universal-hash",
@@ -9937,9 +10258,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -9950,7 +10271,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fnv",
  "lazy_static",
  "memchr",
@@ -10013,9 +10334,9 @@ dependencies = [
 
 [[package]]
 name = "prost-codec"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011ae9ff8359df7915f97302d591cdd9e0e27fbd5a4ddc5bd13b71079bb20987"
+checksum = "0dc34979ff898b6e141106178981ce2596c387ea6e62533facfc61a37fc879c0"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -10074,10 +10395,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.21"
+name = "quinn-proto"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "72ef4ced82a24bb281af338b9e8f94429b6eca01b4e66d899f40031f074e74c9"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring",
+ "rustc-hash",
+ "rustls 0.20.7",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -10099,7 +10438,6 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -10172,15 +10510,6 @@ dependencies = [
 
 [[package]]
 name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
@@ -10216,6 +10545,31 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
+dependencies = [
+ "pem",
+ "ring",
+ "time 0.3.17",
+ "x509-parser 0.13.2",
+ "yasna",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+dependencies = [
+ "pem",
+ "ring",
+ "time 0.3.17",
+ "yasna",
 ]
 
 [[package]]
@@ -10310,23 +10664,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
-name = "remote-externalities"
-version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
-dependencies = [
- "env_logger",
- "log",
- "parity-scale-codec",
- "serde",
- "serde_json",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-version",
- "substrate-rpc-client",
-]
-
-[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10414,17 +10751,17 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "beefy-merkle-tree",
- "beefy-primitives",
  "frame-benchmarking",
  "frame-executive",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex-literal",
  "log",
  "pallet-authority-discovery",
@@ -10438,7 +10775,6 @@ dependencies = [
  "pallet-collective",
  "pallet-democracy",
  "pallet-elections-phragmen",
- "pallet-gilt",
  "pallet-grandpa",
  "pallet-identity",
  "pallet-im-online",
@@ -10446,6 +10782,7 @@ dependencies = [
  "pallet-membership",
  "pallet-mmr",
  "pallet-multisig",
+ "pallet-nis",
  "pallet-offences",
  "pallet-preimage",
  "pallet-proxy",
@@ -10454,6 +10791,7 @@ dependencies = [
  "pallet-session",
  "pallet-society",
  "pallet-staking",
+ "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-tips",
@@ -10476,6 +10814,7 @@ dependencies = [
  "smallvec",
  "sp-api",
  "sp-authority-discovery",
+ "sp-beefy",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-core",
@@ -10498,8 +10837,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -10521,18 +10860,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtcp"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1919efd6d4a6a85d13388f9487549bb8e359f17198cc03ffd72f79b553873691"
+dependencies = [
+ "bytes",
+ "thiserror",
+ "webrtc-util",
+]
+
+[[package]]
 name = "rtnetlink"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
 dependencies = [
- "async-global-executor",
  "futures 0.3.25",
  "log",
  "netlink-packet-route",
  "netlink-proto",
  "nix 0.24.2",
  "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "rtp"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a095411ff00eed7b12e4c6a118ba984d113e1079582570d56a5ee723f11f80"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "rand 0.8.5",
+ "serde",
+ "thiserror",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -10572,6 +10936,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.35.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10579,10 +10952,37 @@ checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 0.7.5",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.0.46",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 1.0.4",
+ "libc",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct 0.6.1",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -10593,8 +10993,8 @@ checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -10662,7 +11062,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "log",
  "sp-core",
@@ -10673,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -10684,7 +11084,7 @@ dependencies = [
  "parity-scale-codec",
  "prost",
  "prost-build",
- "rand 0.7.3",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
  "sp-api",
@@ -10700,7 +11100,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "futures 0.3.25",
  "futures-timer",
@@ -10723,7 +11123,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -10739,11 +11139,9 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "impl-trait-for-tuples",
  "memmap2",
- "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-network-common",
  "sc-telemetry",
@@ -10756,7 +11154,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10767,9 +11165,9 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.1.0",
  "chrono",
  "clap",
  "fdlimit",
@@ -10778,7 +11176,7 @@ dependencies = [
  "log",
  "names",
  "parity-scale-codec",
- "rand 0.7.3",
+ "rand 0.8.5",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -10800,18 +11198,17 @@ dependencies = [
  "sp-runtime",
  "sp-version",
  "thiserror",
- "tiny-bip39",
+ "tiny-bip39 1.0.0",
  "tokio",
 ]
 
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "fnv",
  "futures 0.3.25",
- "hash-db",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -10828,14 +11225,13 @@ dependencies = [
  "sp-runtime",
  "sp-state-machine",
  "sp-storage",
- "sp-trie",
  "substrate-prometheus-endpoint",
 ]
 
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10843,7 +11239,7 @@ dependencies = [
  "kvdb-rocksdb",
  "linked-hash-map",
  "log",
- "parity-db 0.3.17",
+ "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-client-api",
@@ -10860,13 +11256,14 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
  "futures-timer",
  "libp2p",
  "log",
+ "mockall",
  "parking_lot 0.12.1",
  "sc-client-api",
  "sc-utils",
@@ -10884,7 +11281,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -10913,19 +11310,18 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "fork-tree",
  "futures 0.3.25",
  "log",
  "merlin",
- "num-bigint 0.2.6",
- "num-rational 0.2.4",
+ "num-bigint",
+ "num-rational",
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "rand 0.7.3",
  "sc-client-api",
  "sc-consensus",
  "sc-consensus-epochs",
@@ -10933,7 +11329,6 @@ dependencies = [
  "sc-keystore",
  "sc-telemetry",
  "schnorrkel",
- "serde",
  "sp-api",
  "sp-application-crypto",
  "sp-block-builder",
@@ -10944,10 +11339,8 @@ dependencies = [
  "sp-consensus-vrf",
  "sp-core",
  "sp-inherents",
- "sp-io",
  "sp-keystore",
  "sp-runtime",
- "sp-version",
  "substrate-prometheus-endpoint",
  "thiserror",
 ]
@@ -10955,7 +11348,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "futures 0.3.25",
  "jsonrpsee",
@@ -10977,7 +11370,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10990,7 +11383,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -11024,7 +11417,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -11042,16 +11435,14 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "thiserror",
 ]
 
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "lazy_static",
- "lru 0.7.8",
+ "lru",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sc-executor-common",
@@ -11059,12 +11450,10 @@ dependencies = [
  "sc-executor-wasmtime",
  "sp-api",
  "sp-core",
- "sp-core-hashing-proc-macro",
  "sp-externalities",
  "sp-io",
  "sp-panic-handler",
  "sp-runtime-interface",
- "sp-tasks",
  "sp-trie",
  "sp-version",
  "sp-wasm-interface",
@@ -11075,13 +11464,10 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "environmental",
- "parity-scale-codec",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-sandbox",
  "sp-wasm-interface",
  "thiserror",
  "wasm-instrument",
@@ -11091,14 +11477,12 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "log",
- "parity-scale-codec",
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface",
- "sp-sandbox",
  "sp-wasm-interface",
  "wasmi",
 ]
@@ -11106,19 +11490,16 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "log",
  "once_cell",
- "parity-scale-codec",
- "parity-wasm 0.45.0",
- "rustix",
+ "rustix 0.35.13",
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface",
- "sp-sandbox",
  "sp-wasm-interface",
  "wasmtime",
 ]
@@ -11126,10 +11507,10 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "ahash",
- "array-bytes",
+ "array-bytes 4.1.0",
  "async-trait",
  "dyn-clone",
  "finality-grandpa",
@@ -11144,7 +11525,6 @@ dependencies = [
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus",
- "sc-keystore",
  "sc-network",
  "sc-network-common",
  "sc-network-gossip",
@@ -11167,7 +11547,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.25",
@@ -11178,7 +11558,6 @@ dependencies = [
  "sc-finality-grandpa",
  "sc-rpc",
  "serde",
- "serde_json",
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
@@ -11188,16 +11567,14 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "ansi_term",
  "futures 0.3.25",
  "futures-timer",
  "log",
- "parity-util-mem",
  "sc-client-api",
  "sc-network-common",
- "sc-transaction-pool-api",
  "sp-blockchain",
  "sp-runtime",
 ]
@@ -11205,9 +11582,9 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.1.0",
  "async-trait",
  "parking_lot 0.12.1",
  "serde_json",
@@ -11220,30 +11597,25 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.1.0",
  "async-trait",
  "asynchronous-codec",
- "bitflags",
+ "backtrace",
  "bytes",
- "cid",
  "either",
  "fnv",
- "fork-tree",
  "futures 0.3.25",
  "futures-timer",
  "ip_network",
  "libp2p",
- "linked-hash-map",
- "linked_hash_set",
  "log",
- "lru 0.7.8",
+ "lru",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "pin-project",
- "prost",
- "rand 0.7.3",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
@@ -11267,7 +11639,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "cid",
  "futures 0.3.25",
@@ -11281,13 +11653,12 @@ dependencies = [
  "sp-runtime",
  "thiserror",
  "unsigned-varint",
- "void",
 ]
 
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -11313,14 +11684,14 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "ahash",
  "futures 0.3.25",
  "futures-timer",
  "libp2p",
  "log",
- "lru 0.7.8",
+ "lru",
  "sc-network-common",
  "sc-peerset",
  "sp-runtime",
@@ -11331,9 +11702,9 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.1.0",
  "futures 0.3.25",
  "libp2p",
  "log",
@@ -11352,14 +11723,15 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.1.0",
+ "async-trait",
  "fork-tree",
  "futures 0.3.25",
  "libp2p",
  "log",
- "lru 0.7.8",
+ "lru",
  "mockall",
  "parity-scale-codec",
  "prost",
@@ -11376,23 +11748,24 @@ dependencies = [
  "sp-core",
  "sp-finality-grandpa",
  "sp-runtime",
+ "substrate-prometheus-endpoint",
  "thiserror",
 ]
 
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.1.0",
  "futures 0.3.25",
- "hex",
  "libp2p",
  "log",
  "parity-scale-codec",
  "pin-project",
  "sc-network-common",
  "sc-peerset",
+ "sc-utils",
  "sp-consensus",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -11401,9 +11774,9 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.1.0",
  "bytes",
  "fnv",
  "futures 0.3.25",
@@ -11415,7 +11788,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network-common",
  "sc-peerset",
@@ -11431,7 +11804,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "futures 0.3.25",
  "libp2p",
@@ -11444,7 +11817,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -11453,10 +11826,9 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "futures 0.3.25",
- "hash-db",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -11483,13 +11855,10 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "futures 0.3.25",
  "jsonrpsee",
- "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
  "sc-chain-spec",
  "sc-transaction-pool-api",
  "scale-info",
@@ -11498,7 +11867,6 @@ dependencies = [
  "sp-core",
  "sp-rpc",
  "sp-runtime",
- "sp-tracing",
  "sp-version",
  "thiserror",
 ]
@@ -11506,53 +11874,60 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "futures 0.3.25",
+ "http",
  "jsonrpsee",
  "log",
  "serde_json",
  "substrate-prometheus-endpoint",
  "tokio",
+ "tower",
+ "tower-http",
 ]
 
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
+ "array-bytes 4.1.0",
  "futures 0.3.25",
+ "futures-util",
  "hex",
  "jsonrpsee",
+ "log",
  "parity-scale-codec",
+ "parking_lot 0.12.1",
  "sc-chain-spec",
+ "sc-client-api",
  "sc-transaction-pool-api",
  "serde",
  "sp-api",
  "sp-blockchain",
  "sp-core",
  "sp-runtime",
+ "sp-version",
  "thiserror",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "directories",
  "exit-future",
  "futures 0.3.25",
  "futures-timer",
- "hash-db",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
- "parity-util-mem",
  "parking_lot 0.12.1",
  "pin-project",
- "rand 0.7.3",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -11580,19 +11955,15 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-api",
- "sp-application-crypto",
- "sp-block-builder",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
  "sp-externalities",
- "sp-inherents",
  "sp-keystore",
  "sp-runtime",
  "sp-session",
  "sp-state-machine",
  "sp-storage",
- "sp-tracing",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
  "sp-trie",
@@ -11609,21 +11980,18 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "log",
  "parity-scale-codec",
- "parity-util-mem",
- "parity-util-mem-derive",
  "parking_lot 0.12.1",
- "sc-client-api",
  "sp-core",
 ]
 
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11642,13 +12010,13 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "futures 0.3.25",
  "libc",
  "log",
- "rand 0.7.3",
- "rand_pcg 0.2.1",
+ "rand 0.8.5",
+ "rand_pcg",
  "regex",
  "sc-telemetry",
  "serde",
@@ -11661,7 +12029,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "chrono",
  "futures 0.3.25",
@@ -11669,7 +12037,8 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "pin-project",
- "rand 0.7.3",
+ "rand 0.8.5",
+ "sc-utils",
  "serde",
  "serde_json",
  "thiserror",
@@ -11679,7 +12048,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "ansi_term",
  "atty",
@@ -11710,7 +12079,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11721,7 +12090,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -11729,7 +12098,6 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "parity-util-mem",
  "parking_lot 0.12.1",
  "sc-client-api",
  "sc-transaction-pool-api",
@@ -11748,7 +12116,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -11762,8 +12130,9 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
+ "backtrace",
  "futures 0.3.25",
  "futures-timer",
  "lazy_static",
@@ -11774,12 +12143,12 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d8a765117b237ef233705cc2cc4c6a27fccd46eea6ef0c8c6dae5f3ef407f8"
+checksum = "001cf62ece89779fd16105b5f515ad0e5cedcd5440d3dd806bb067978e7c3608"
 dependencies = [
  "bitvec",
- "cfg-if 1.0.0",
+ "cfg-if",
  "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
@@ -11788,9 +12157,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcd47b380d8c4541044e341dcd9475f55ba37ddc50c908d945fc036a8642496"
+checksum = "303959cf613a6f6efd19ed4b4ad5bf79966a13352716299ad532cfb115f4205c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11840,12 +12209,34 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "sdp"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d22a5ef407871893fd72b4562ee15e4742269b173959db4b8df6f538c414e13"
+dependencies = [
+ "rand 0.8.5",
+ "substring",
+ "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -11947,18 +12338,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11967,21 +12358,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_nanos"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44969a61f5d316be20a42ff97816efb3b407a924d06824c3d8a49fa8450de0e"
-dependencies = [
  "serde",
 ]
 
@@ -12012,7 +12394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -12024,7 +12406,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.5",
 ]
@@ -12048,7 +12430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -12060,7 +12442,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.5",
 ]
@@ -12101,16 +12483,6 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
-
-[[package]]
-name = "signal-hook"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
 
 [[package]]
 name = "signal-hook-registry"
@@ -12192,8 +12564,8 @@ dependencies = [
 
 [[package]]
 name = "slot-range-helper"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -12229,7 +12601,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "774d05a3edae07ce6d68ea6984f3c05e9bba8927e3dd591e3b479e5b03213d0d"
 dependencies = [
- "aes-gcm",
+ "aes-gcm 0.9.4",
  "blake2",
  "chacha20poly1305",
  "curve25519-dalek 4.0.0-pre.1",
@@ -12260,6 +12632,7 @@ dependencies = [
  "bytes",
  "flate2",
  "futures 0.3.25",
+ "http",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -12269,7 +12642,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "hash-db",
  "log",
@@ -12287,7 +12660,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -12298,8 +12671,8 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "7.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12311,15 +12684,14 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "5.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "6.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "integer-sqrt",
  "num-traits",
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-debug-derive",
  "sp-std",
  "static_assertions",
 ]
@@ -12327,7 +12699,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12340,7 +12712,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12350,9 +12722,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-beefy"
+version = "4.0.0-dev"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-mmr-primitives",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12364,11 +12753,11 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "futures 0.3.25",
  "log",
- "lru 0.7.8",
+ "lru",
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "sp-api",
@@ -12382,11 +12771,10 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
- "futures-timer",
  "log",
  "parity-scale-codec",
  "sp-core",
@@ -12401,7 +12789,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12419,7 +12807,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "merlin",
@@ -12442,13 +12830,11 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic",
- "sp-runtime",
  "sp-std",
  "sp-timestamp",
 ]
@@ -12456,7 +12842,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12468,14 +12854,13 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "7.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.1.0",
  "base58",
  "bitflags",
  "blake2",
- "byteorder",
  "dyn-clonable",
  "ed25519-zebra",
  "futures 0.3.25",
@@ -12486,12 +12871,10 @@ dependencies = [
  "libsecp256k1",
  "log",
  "merlin",
- "num-traits",
  "parity-scale-codec",
- "parity-util-mem",
  "parking_lot 0.12.1",
  "primitive-types",
- "rand 0.7.3",
+ "rand 0.8.5",
  "regex",
  "scale-info",
  "schnorrkel",
@@ -12507,15 +12890,14 @@ dependencies = [
  "ss58-registry",
  "substrate-bip39",
  "thiserror",
- "tiny-bip39",
- "wasmi",
+ "tiny-bip39 1.0.0",
  "zeroize",
 ]
 
 [[package]]
 name = "sp-core-hashing"
-version = "4.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "5.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "blake2",
  "byteorder",
@@ -12529,7 +12911,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12540,7 +12922,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -12548,8 +12930,8 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "4.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "5.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12558,8 +12940,8 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.12.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "0.13.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -12570,7 +12952,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12588,7 +12970,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -12601,17 +12983,16 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "7.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "bytes",
+ "ed25519",
  "ed25519-dalek",
  "futures 0.3.25",
- "hash-db",
  "libsecp256k1",
  "log",
  "parity-scale-codec",
- "parking_lot 0.12.1",
  "secp256k1",
  "sp-core",
  "sp-externalities",
@@ -12621,15 +13002,14 @@ dependencies = [
  "sp-std",
  "sp-tracing",
  "sp-trie",
- "sp-wasm-interface",
  "tracing",
  "tracing-core",
 ]
 
 [[package]]
 name = "sp-keyring"
-version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "7.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -12639,8 +13019,8 @@ dependencies = [
 
 [[package]]
 name = "sp-keystore"
-version = "0.12.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "0.13.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -12657,7 +13037,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "thiserror",
  "zstd",
@@ -12666,8 +13046,9 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
+ "ckb-merkle-mountain-range",
  "log",
  "parity-scale-codec",
  "scale-info",
@@ -12677,12 +13058,13 @@ dependencies = [
  "sp-debug-derive",
  "sp-runtime",
  "sp-std",
+ "thiserror",
 ]
 
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12696,7 +13078,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12705,8 +13087,8 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "4.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "5.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -12716,7 +13098,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -12725,17 +13107,16 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "7.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "parity-util-mem",
  "paste",
- "rand 0.7.3",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "sp-application-crypto",
@@ -12748,8 +13129,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "7.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12766,8 +13147,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "5.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "6.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -12777,23 +13158,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-sandbox"
-version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
-dependencies = [
- "log",
- "parity-scale-codec",
- "sp-core",
- "sp-io",
- "sp-std",
- "sp-wasm-interface",
- "wasmi",
-]
-
-[[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12807,25 +13174,25 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
+ "sp-core",
  "sp-runtime",
  "sp-std",
 ]
 
 [[package]]
 name = "sp-state-machine"
-version = "0.12.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "0.13.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "hash-db",
  "log",
- "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "rand 0.7.3",
+ "rand 0.8.5",
  "smallvec",
  "sp-core",
  "sp-externalities",
@@ -12834,18 +13201,17 @@ dependencies = [
  "sp-trie",
  "thiserror",
  "tracing",
- "trie-root 0.17.0",
 ]
 
 [[package]]
 name = "sp-std"
-version = "4.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "5.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 
 [[package]]
 name = "sp-storage"
-version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "7.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "impl-serde 0.4.0",
  "parity-scale-codec",
@@ -12856,28 +13222,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-tasks"
-version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
-dependencies = [
- "log",
- "sp-core",
- "sp-externalities",
- "sp-io",
- "sp-runtime-interface",
- "sp-std",
-]
-
-[[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "futures-timer",
  "log",
  "parity-scale-codec",
- "sp-api",
  "sp-inherents",
  "sp-runtime",
  "sp-std",
@@ -12886,8 +13238,8 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "5.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "6.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -12899,7 +13251,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12908,7 +13260,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "log",
@@ -12923,14 +13275,14 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "7.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "ahash",
  "hash-db",
  "hashbrown",
  "lazy_static",
- "lru 0.7.8",
+ "lru",
  "memory-db",
  "nohash-hasher",
  "parity-scale-codec",
@@ -12947,11 +13299,11 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "impl-serde 0.4.0",
  "parity-scale-codec",
- "parity-wasm 0.45.0",
+ "parity-wasm",
  "scale-info",
  "serde",
  "sp-core-hashing-proc-macro",
@@ -12964,7 +13316,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -12974,8 +13326,8 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+version = "7.0.0"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -12988,9 +13340,8 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -13028,9 +13379,9 @@ dependencies = [
 
 [[package]]
 name = "ss58-registry"
-version = "1.33.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab7554f8a8b6f8d71cd5a8e6536ef116e2ce0504cf97ebf16311d58065dc8a6"
+checksum = "e40c020d72bc0a9c5660bb71e4a6fdef081493583062c474740a7d59f55f0e7b"
 dependencies = [
  "Inflector",
  "num-format",
@@ -13148,6 +13499,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "stun"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e94b1ec00bad60e6410e058b52f1c66de3dc5fe4d62d09b3e52bb7d3b73e25"
+dependencies = [
+ "base64",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.8.5",
+ "ring",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "url",
+ "webrtc-util",
+]
+
+[[package]]
 name = "substrate-bip39"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13176,7 +13546,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "platforms",
 ]
@@ -13194,17 +13564,15 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.25",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
- "sc-client-api",
  "sc-rpc-api",
  "sc-transaction-pool-api",
- "serde_json",
  "sp-api",
  "sp-block-builder",
  "sp-blockchain",
@@ -13215,9 +13583,8 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "futures-util",
  "hyper",
  "log",
  "prometheus",
@@ -13228,7 +13595,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -13241,7 +13608,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -13251,10 +13618,8 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
- "sp-io",
  "sp-runtime",
  "sp-state-machine",
- "sp-std",
  "sp-trie",
  "trie-db",
 ]
@@ -13262,9 +13627,9 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
- "array-bytes",
+ "array-bytes 4.1.0",
  "async-trait",
  "futures 0.3.25",
  "parity-scale-codec",
@@ -13288,11 +13653,10 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "beefy-merkle-tree",
- "beefy-primitives",
- "cfg-if 1.0.0",
+ "cfg-if",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
@@ -13301,12 +13665,12 @@ dependencies = [
  "pallet-babe",
  "pallet-timestamp",
  "parity-scale-codec",
- "parity-util-mem",
  "sc-service",
  "scale-info",
  "serde",
  "sp-api",
  "sp-application-crypto",
+ "sp-beefy",
  "sp-block-builder",
  "sp-consensus-aura",
  "sp-consensus-babe",
@@ -13332,7 +13696,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "futures 0.3.25",
  "parity-scale-codec",
@@ -13351,7 +13715,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -13362,7 +13726,16 @@ dependencies = [
  "tempfile",
  "toml",
  "walkdir",
- "wasm-gc-api",
+ "wasm-opt",
+]
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -13373,9 +13746,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13433,7 +13806,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "libc",
  "redox_syscall",
@@ -13468,18 +13841,18 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13524,6 +13897,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37706572f4b151dff7a0146e040804e9c26fe3a3118591112f05cf12a4216c1"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "tikv-jemalloc-sys"
 version = "0.5.2+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13546,6 +13930,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tiny-bip39"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13565,12 +13976,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-bip39"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62cc94d358b5a1e84a5cb9109f559aa3c4d634d2b1b4de3d0fa4adc7c78e2861"
+dependencies = [
+ "anyhow",
+ "hmac 0.12.1",
+ "once_cell",
+ "pbkdf2 0.11.0",
+ "rand 0.8.5",
+ "rustc-hash",
+ "sha2 0.10.6",
+ "thiserror",
+ "unicode-normalization",
+ "wasm-bindgen",
+ "zeroize",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -13590,9 +14030,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -13605,7 +14045,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -13625,9 +14065,9 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.7",
  "tokio",
- "webpki",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -13639,6 +14079,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.9",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -13666,6 +14107,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite 0.2.9",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13677,7 +14153,8 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
+ "log",
  "pin-project-lite 0.2.9",
  "tracing-attributes",
  "tracing-core",
@@ -13716,8 +14193,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -13727,8 +14204,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum-proc-macro"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -13829,7 +14306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
  "async-trait",
- "cfg-if 1.0.0",
+ "cfg-if",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -13840,8 +14317,10 @@ dependencies = [
  "lazy_static",
  "rand 0.8.5",
  "smallvec",
+ "socket2",
  "thiserror",
  "tinyvec",
+ "tokio",
  "tracing",
  "url",
 ]
@@ -13852,7 +14331,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "futures-util",
  "ipconfig",
  "lazy_static",
@@ -13861,6 +14340,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
+ "tokio",
  "tracing",
  "trust-dns-proto",
 ]
@@ -13874,22 +14354,25 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.32#385446fe083882c726fe912233fe63741b39359e"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.37#946507ba9ef13e263534176b7b74e26fc56efbd4"
 dependencies = [
  "clap",
- "frame-try-runtime",
+ "frame-remote-externalities",
+ "hex",
  "log",
  "parity-scale-codec",
- "remote-externalities",
- "sc-chain-spec",
  "sc-cli",
  "sc-executor",
  "sc-service",
  "serde",
+ "serde_json",
+ "sp-api",
  "sp-core",
+ "sp-debug-derive",
  "sp-externalities",
  "sp-io",
  "sp-keystore",
+ "sp-rpc",
  "sp-runtime",
  "sp-state-machine",
  "sp-version",
@@ -13920,12 +14403,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e66dcbec4290c69dd03c57e76c2469ea5c7ce109c6dd4351c13055cf71ea055"
 
 [[package]]
+name = "turn"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4712ee30d123ec7ae26d1e1b218395a16c87cdbaf4b3925d170d684af62ea5e8"
+dependencies = [
+ "async-trait",
+ "base64",
+ "futures 0.3.25",
+ "log",
+ "md-5",
+ "rand 0.8.5",
+ "ring",
+ "stun",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "digest 0.10.5",
  "rand 0.8.5",
  "static_assertions",
@@ -13962,15 +14464,6 @@ dependencies = [
  "crunchy",
  "hex",
  "static_assertions",
-]
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -14052,20 +14545,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+dependencies = [
+ "getrandom 0.2.8",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "value-bag"
-version = "1.0.0-alpha.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
-dependencies = [
- "ctor",
- "version_check",
-]
 
 [[package]]
 name = "vcpkg"
@@ -14092,6 +14584,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "waitgroup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
+dependencies = [
+ "atomic-waker",
 ]
 
 [[package]]
@@ -14145,7 +14646,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -14170,7 +14671,7 @@ version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -14206,23 +14707,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
-name = "wasm-gc-api"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c32691b6c7e6c14e7f8fd55361a9088b507aa49620fcd06c09b3a1082186b9"
-dependencies = [
- "log",
- "parity-wasm 0.32.0",
- "rustc-demangle",
-]
-
-[[package]]
 name = "wasm-instrument"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa1dafb3e60065305741e83db35c6c2584bb3725b692b5b66148a38d72ace6cd"
 dependencies = [
- "parity-wasm 0.45.0",
+ "parity-wasm",
+]
+
+[[package]]
+name = "wasm-opt"
+version = "0.110.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68e8037b4daf711393f4be2056246d12d975651b14d581520ad5d1f19219cec"
+dependencies = [
+ "anyhow",
+ "libc",
+ "strum",
+ "strum_macros",
+ "tempfile",
+ "thiserror",
+ "wasm-opt-cxx-sys",
+ "wasm-opt-sys",
+]
+
+[[package]]
+name = "wasm-opt-cxx-sys"
+version = "0.110.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91adbad477e97bba3fbd21dd7bfb594e7ad5ceb9169ab1c93ab9cb0ada636b6f"
+dependencies = [
+ "anyhow",
+ "cxx",
+ "cxx-build",
+ "wasm-opt-sys",
+]
+
+[[package]]
+name = "wasm-opt-sys"
+version = "0.110.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec4fa5a322a4e6ac22fd141f498d56afbdbf9df5debeac32380d2dcaa3e06941"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cxx",
+ "cxx-build",
+ "regex",
 ]
 
 [[package]]
@@ -14246,7 +14777,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06c326c93fbf86419608361a2c925a31754cf109da1b8b55737070b4d6669422"
 dependencies = [
- "parity-wasm 0.45.0",
+ "parity-wasm",
  "wasmi-validation",
  "wasmi_core",
 ]
@@ -14257,7 +14788,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ff416ad1ff0c42e5a926ed5d5fab74c0f098749aa0ad8b2a34b982ce0e867b"
 dependencies = [
- "parity-wasm 0.45.0",
+ "parity-wasm",
 ]
 
 [[package]]
@@ -14269,7 +14800,7 @@ dependencies = [
  "downcast-rs",
  "libm",
  "memory_units",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits",
 ]
 
@@ -14290,11 +14821,11 @@ checksum = "f1f511c4917c83d04da68333921107db75747c4e11a2f654a8e909cc5e0520dc"
 dependencies = [
  "anyhow",
  "bincode",
- "cfg-if 1.0.0",
+ "cfg-if",
  "indexmap",
  "libc",
  "log",
- "object",
+ "object 0.29.0",
  "once_cell",
  "paste",
  "psm",
@@ -14316,7 +14847,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39bf3debfe744bf19dd3732990ce6f8c0ced7439e2370ba4e1d8f5a3660a3178"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -14331,7 +14862,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix",
+ "rustix 0.35.13",
  "serde",
  "sha2 0.9.9",
  "toml",
@@ -14351,9 +14882,9 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "cranelift-wasm",
- "gimli",
+ "gimli 0.26.2",
  "log",
- "object",
+ "object 0.29.0",
  "target-lexicon",
  "thiserror",
  "wasmparser",
@@ -14368,10 +14899,10 @@ checksum = "c7af06848df28b7661471d9a80d30a973e0f401f2e3ed5396ad7e225ed217047"
 dependencies = [
  "anyhow",
  "cranelift-entity",
- "gimli",
+ "gimli 0.26.2",
  "indexmap",
  "log",
- "object",
+ "object 0.29.0",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -14385,16 +14916,16 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9028fb63a54185b3c192b7500ef8039c7bb8d7f62bfc9e7c258483a33a3d13bb"
 dependencies = [
- "addr2line",
+ "addr2line 0.17.0",
  "anyhow",
  "bincode",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpp_demangle",
- "gimli",
+ "gimli 0.26.2",
  "log",
- "object",
+ "object 0.29.0",
  "rustc-demangle",
- "rustix",
+ "rustix 0.35.13",
  "serde",
  "target-lexicon",
  "thiserror",
@@ -14410,9 +14941,9 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25e82d4ef93296785de7efca92f7679dc67fe68a13b625a5ecc8d7503b377a37"
 dependencies = [
- "object",
+ "object 0.29.0",
  "once_cell",
- "rustix",
+ "rustix 0.35.13",
 ]
 
 [[package]]
@@ -14423,7 +14954,7 @@ checksum = "9f0e9bea7d517d114fe66b930b2124ee086516ee93eeebfd97f75f366c5b0553"
 dependencies = [
  "anyhow",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "indexmap",
  "libc",
  "log",
@@ -14432,7 +14963,7 @@ dependencies = [
  "memoffset",
  "paste",
  "rand 0.8.5",
- "rustix",
+ "rustix 0.35.13",
  "thiserror",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -14464,6 +14995,16 @@ dependencies = [
 
 [[package]]
 name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -14478,7 +15019,219 @@ version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
- "webpki",
+ "webpki 0.22.0",
+]
+
+[[package]]
+name = "webrtc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3bc9049bdb2cea52f5fd4f6f728184225bdb867ed0dc2410eab6df5bdd67bb"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "hex",
+ "interceptor",
+ "lazy_static",
+ "log",
+ "rand 0.8.5",
+ "rcgen 0.9.3",
+ "regex",
+ "ring",
+ "rtcp",
+ "rtp",
+ "rustls 0.19.1",
+ "sdp",
+ "serde",
+ "serde_json",
+ "sha2 0.10.6",
+ "stun",
+ "thiserror",
+ "time 0.3.17",
+ "tokio",
+ "turn",
+ "url",
+ "waitgroup",
+ "webrtc-data",
+ "webrtc-dtls",
+ "webrtc-ice",
+ "webrtc-mdns",
+ "webrtc-media",
+ "webrtc-sctp",
+ "webrtc-srtp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-data"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef36a4d12baa6e842582fe9ec16a57184ba35e1a09308307b67d43ec8883100"
+dependencies = [
+ "bytes",
+ "derive_builder",
+ "log",
+ "thiserror",
+ "tokio",
+ "webrtc-sctp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-dtls"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7021987ae0a2ed6c8cd33f68e98e49bb6e74ffe9543310267b48a1bbe3900e5f"
+dependencies = [
+ "aes 0.6.0",
+ "aes-gcm 0.8.0",
+ "async-trait",
+ "bincode",
+ "block-modes",
+ "byteorder",
+ "ccm",
+ "curve25519-dalek 3.2.0",
+ "der-parser 8.1.0",
+ "elliptic-curve",
+ "hkdf",
+ "hmac 0.10.1",
+ "log",
+ "oid-registry 0.6.1",
+ "p256",
+ "p384",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "rcgen 0.9.3",
+ "ring",
+ "rustls 0.19.1",
+ "sec1",
+ "serde",
+ "sha-1",
+ "sha2 0.9.9",
+ "signature",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "webpki 0.21.4",
+ "webrtc-util",
+ "x25519-dalek 2.0.0-pre.1",
+ "x509-parser 0.13.2",
+]
+
+[[package]]
+name = "webrtc-ice"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494483fbb2f5492620871fdc78b084aed8807377f6e3fe88b2e49f0a9c9c41d7"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "crc",
+ "log",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "stun",
+ "thiserror",
+ "tokio",
+ "turn",
+ "url",
+ "uuid",
+ "waitgroup",
+ "webrtc-mdns",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-mdns"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f08dfd7a6e3987e255c4dbe710dde5d94d0f0574f8a21afa95d171376c143106"
+dependencies = [
+ "log",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-media"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2a3c157a040324e5049bcbd644ffc9079e6738fa2cfab2bcff64e5cc4c00d7"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "derive_builder",
+ "displaydoc",
+ "rand 0.8.5",
+ "rtp",
+ "thiserror",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-sctp"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d47adcd9427eb3ede33d5a7f3424038f63c965491beafcc20bc650a2f6679c0"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "crc",
+ "log",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-srtp"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6183edc4c1c6c0175f8812eefdce84dfa0aea9c3ece71c2bf6ddd3c964de3da5"
+dependencies = [
+ "aead 0.4.3",
+ "aes 0.7.5",
+ "aes-gcm 0.9.4",
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "ctr 0.8.0",
+ "hmac 0.11.0",
+ "log",
+ "rtcp",
+ "rtp",
+ "sha-1",
+ "subtle",
+ "thiserror",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f1db1727772c05cf7a2cfece52c3aca8045ca1e176cd517d323489aa3c6d87"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "bytes",
+ "cc",
+ "ipnet",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.24.2",
+ "rand 0.8.5",
+ "thiserror",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]
@@ -14492,10 +15245,9 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
- "beefy-primitives",
  "bitvec",
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -14559,6 +15311,7 @@ dependencies = [
  "smallvec",
  "sp-api",
  "sp-authority-discovery",
+ "sp-beefy",
  "sp-block-builder",
  "sp-consensus-babe",
  "sp-core",
@@ -14582,8 +15335,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -14815,9 +15568,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.0-pre.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5da623d8af10a62342bcbbb230e33e58a63255a58012f8653c578e54bab48df"
+dependencies = [
+ "curve25519-dalek 3.2.0",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9bace5b5589ffead1afb76e43e34cff39cd0f3ce7e170ae0c29e53b88eb1c"
+dependencies = [
+ "asn1-rs 0.3.1",
+ "base64",
+ "data-encoding",
+ "der-parser 7.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.4.0",
+ "ring",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+dependencies = [
+ "asn1-rs 0.5.1",
+ "base64",
+ "data-encoding",
+ "der-parser 8.1.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.6.1",
+ "rusticata-macros",
+ "thiserror",
+ "time 0.3.17",
+]
+
+[[package]]
 name = "xcm"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
@@ -14830,8 +15631,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-builder"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14850,8 +15651,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-executor"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14893,8 +15694,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -14904,8 +15705,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-simulator"
-version = "0.9.32"
-source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.32#2bfbb4adb7eb2fd767abd2d9c84fcb58a258b88f"
+version = "0.9.37"
+source = "git+https://github.com/purestake/polkadot?branch=moonbeam-polkadot-v0.9.37#b4b818d89bf62fa552e7eb0c3aa7aa015ffbb20c"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -14931,6 +15732,15 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "static_assertions",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aed2e7a52e3744ab4d0c05c20aa065258e84c49fd4226f5191b2ed29712710b4"
+dependencies = [
+ "time 0.3.17",
 ]
 
 [[package]]
@@ -14982,3 +15792,18 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[patch.unused]]
+name = "jsonrpsee"
+version = "0.15.1"
+source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"
+
+[[patch.unused]]
+name = "jsonrpsee-core"
+version = "0.15.1"
+source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"
+
+[[patch.unused]]
+name = "jsonrpsee-types"
+version = "0.15.1"
+source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,7 +2640,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "async-trait",
  "fc-db",
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "fp-storage",
  "kvdb-rocksdb",
@@ -2678,7 +2678,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "fc-db",
  "fp-consensus",
@@ -2695,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2737,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2881,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -2893,7 +2893,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2907,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "evm",
  "frame-support",
@@ -2920,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -2936,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2948,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6900,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "pallet-base-fee"
 version = "1.0.0"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7118,7 +7118,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -7186,7 +7186,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "environmental",
  "evm",
@@ -7292,7 +7292,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "fp-evm",
 ]
@@ -7300,7 +7300,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7465,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "fp-evm",
  "num",
@@ -7644,7 +7644,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -7653,7 +7653,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#3011e6881ece08371f167acffa1a622ad0da59be"
+source = "git+https://github.com/purestake/frontier?branch=moonbeam-polkadot-v0.9.37#a825b0dc9cebff30d4a70312c0678c35790e31cf"
 dependencies = [
  "fp-evm",
  "ripemd",

--- a/client/evm-tracing/Cargo.toml
+++ b/client/evm-tracing/Cargo.toml
@@ -19,4 +19,4 @@ moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug" }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }

--- a/client/rpc-core/debug/Cargo.toml
+++ b/client/rpc-core/debug/Cargo.toml
@@ -10,10 +10,10 @@ version = "0.1.0"
 [dependencies]
 ethereum-types = "0.14"
 futures = { version = "0.3", features = [ "compat" ] }
-jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
+jsonrpsee = { version = "0.16.2", default-features = false, features = [ "macros", "server" ] }
 moonbeam-client-evm-tracing = { path = "../../evm-tracing" }
 moonbeam-rpc-core-types = { path = "../types" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }

--- a/client/rpc-core/trace/Cargo.toml
+++ b/client/rpc-core/trace/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.6.0"
 [dependencies]
 ethereum-types = "0.14"
 futures = { version = "0.3.1", features = [ "compat" ] }
-jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
+jsonrpsee = { version = "0.16.2", default-features = false, features = [ "macros", "server" ] }
 moonbeam-client-evm-tracing = { path = "../../evm-tracing" }
 moonbeam-rpc-core-types = { path = "../types" }
 serde = { version = "1.0", features = [ "derive" ] }

--- a/client/rpc-core/txpool/Cargo.toml
+++ b/client/rpc-core/txpool/Cargo.toml
@@ -10,8 +10,8 @@ version = "0.6.0"
 [dependencies]
 ethereum = { version = "0.14.0", default-features = false, features = [ "with-codec" ] }
 ethereum-types = "0.14"
-jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
+jsonrpsee = { version = "0.16.2", default-features = false, features = [ "macros", "server" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
 
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }

--- a/client/rpc/debug/Cargo.toml
+++ b/client/rpc/debug/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 [dependencies]
 futures = { version = "0.3", features = [ "compat" ] }
 hex-literal = "0.3.4"
-jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
+jsonrpsee = { version = "0.16.2", default-features = false, features = [ "macros", "server" ] }
 tokio = { version = "1.10", features = [ "sync", "time" ] }
 
 # Moonbeam
@@ -20,19 +20,19 @@ moonbeam-rpc-core-types = { path = "../../rpc-core/types" }
 moonbeam-rpc-primitives-debug = { path = "../../../primitives/rpc/debug" }
 
 # Substrate
-sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Frontier
 ethereum = { version = "0.14.0", default-features = false, features = [ "with-codec" ] }
 ethereum-types = "0.14"
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", features = [ "rpc_binary_search_estimate" ] }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
+fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", features = [ "rpc-binary-search-estimate" ] }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 use futures::{SinkExt, StreamExt};
-use jsonrpsee::core::RpcResult;
+use jsonrpsee::core::{async_trait, RpcResult};
 pub use moonbeam_rpc_core_debug::{DebugServer, TraceParams};
 
 use tokio::{
@@ -62,7 +62,7 @@ impl Debug {
 	}
 }
 
-#[jsonrpsee::core::async_trait]
+#[async_trait]
 impl DebugServer for Debug {
 	/// Handler for `debug_traceTransaction` request. Communicates with the service-defined task
 	/// using channels.
@@ -150,7 +150,7 @@ where
 		raw_max_memory_usage: usize,
 	) -> (impl Future<Output = ()>, DebugRequester) {
 		let (tx, mut rx): (DebugRequester, _) =
-			sc_utils::mpsc::tracing_unbounded("debug-requester");
+			sc_utils::mpsc::tracing_unbounded("debug-requester", 100_000);
 
 		let fut = async move {
 			loop {
@@ -320,7 +320,10 @@ where
 		// Get Blockchain backend
 		let blockchain = backend.blockchain();
 		// Get the header I want to work with.
-		let header = match client.header(reference_id) {
+		let Ok(hash) = client.expect_block_hash_from_id(&reference_id) else {
+			return Err(internal_err("Block header not found"))
+		};
+		let header = match client.header(hash) {
 			Ok(Some(h)) => h,
 			_ => return Err(internal_err("Block header not found")),
 		};
@@ -357,7 +360,7 @@ where
 
 		// Get block extrinsics.
 		let exts = blockchain
-			.body(reference_id)
+			.body(hash)
 			.map_err(|e| internal_err(format!("Fail to read blockchain db: {:?}", e)))?
 			.unwrap_or_default();
 
@@ -452,7 +455,7 @@ where
 		// Get Blockchain backend
 		let blockchain = backend.blockchain();
 		// Get the header I want to work with.
-		let header = match client.header(reference_id) {
+		let header = match client.header(hash) {
 			Ok(Some(h)) => h,
 			_ => return Err(internal_err("Block header not found")),
 		};
@@ -461,7 +464,7 @@ where
 
 		// Get block extrinsics.
 		let exts = blockchain
-			.body(reference_id)
+			.body(hash)
 			.map_err(|e| internal_err(format!("Fail to read blockchain db: {:?}", e)))?
 			.unwrap_or_default();
 

--- a/client/rpc/debug/src/lib.rs
+++ b/client/rpc/debug/src/lib.rs
@@ -455,7 +455,10 @@ where
 		// Get Blockchain backend
 		let blockchain = backend.blockchain();
 		// Get the header I want to work with.
-		let header = match client.header(hash) {
+		let Ok(reference_hash) = client.expect_block_hash_from_id(&reference_id) else {
+			return Err(internal_err("Block header not found"))
+		};
+		let header = match client.header(reference_hash) {
 			Ok(Some(h)) => h,
 			_ => return Err(internal_err("Block header not found")),
 		};
@@ -464,7 +467,7 @@ where
 
 		// Get block extrinsics.
 		let exts = blockchain
-			.body(hash)
+			.body(reference_hash)
 			.map_err(|e| internal_err(format!("Fail to read blockchain db: {:?}", e)))?
 			.unwrap_or_default();
 

--- a/client/rpc/finality/Cargo.toml
+++ b/client/rpc/finality/Cargo.toml
@@ -10,13 +10,13 @@ version = "0.1.0"
 
 [dependencies]
 futures = { version = "0.3", features = [ "compat" ] }
-jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
+jsonrpsee = { version = "0.16.2", default-features = false, features = [ "macros", "server" ] }
 parity-scale-codec = "3.0.0"
 tokio = { version = "1.12.0", features = [ "sync", "time" ] }
 
-fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }

--- a/client/rpc/manual-xcm/Cargo.toml
+++ b/client/rpc/manual-xcm/Cargo.toml
@@ -11,9 +11,9 @@ version = "0.1.0"
 flume = "0.10.9"
 futures = { version = "0.3", features = [ "compat" ] }
 hex-literal = "0.3.3"
-jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
+jsonrpsee = { version = "0.16.2", default-features = false, features = [ "macros", "server" ] }
 parity-scale-codec = "3.0.0"
 tokio = { version = "1.12.0", features = [ "sync", "time" ] }
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }

--- a/client/rpc/trace/Cargo.toml
+++ b/client/rpc/trace/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.6.0"
 ethereum = { version = "0.14.0", features = [ "with-codec" ] }
 ethereum-types = "0.14"
 futures = { version = "0.3" }
-jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
+jsonrpsee = { version = "0.16.2", default-features = false, features = [ "macros", "server" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 sha3 = "0.10"
 tokio = { version = "1.10", features = [ "sync", "time" ] }
@@ -24,19 +24,19 @@ moonbeam-rpc-core-types = { path = "../../rpc-core/types" }
 moonbeam-rpc-primitives-debug = { path = "../../../primitives/rpc/debug" }
 
 # Substrate
-sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-network = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-network = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Frontier
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", features = [ "rpc_binary_search_estimate" ] }
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
+fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", features = [ "rpc-binary-search-estimate" ] }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }

--- a/client/rpc/trace/src/lib.rs
+++ b/client/rpc/trace/src/lib.rs
@@ -127,10 +127,9 @@ where
 				continue; // no traces for genesis block.
 			}
 
-			let block_id = BlockId::<B>::Number(block_height);
-			let block_header = self
+			let block_hash = self
 				.client
-				.header(block_id)
+				.hash(block_height)
 				.map_err(|e| {
 					format!(
 						"Error when fetching block {} header : {:?}",
@@ -138,8 +137,6 @@ where
 					)
 				})?
 				.ok_or_else(|| format!("Block with height {} don't exist", block_height))?;
-
-			let block_hash = block_header.hash();
 
 			block_hashes.push(block_hash);
 		}
@@ -448,7 +445,7 @@ where
 	) -> (impl Future<Output = ()>, CacheRequester) {
 		// Communication with the outside world :
 		let (requester_tx, mut requester_rx) =
-			sc_utils::mpsc::tracing_unbounded("trace-filter-cache");
+			sc_utils::mpsc::tracing_unbounded("trace-filter-cache", 100_000);
 
 		// Task running in the service.
 		let task = async move {
@@ -782,7 +779,7 @@ where
 		// Get Subtrate block data.
 		let api = client.runtime_api();
 		let block_header = client
-			.header(substrate_block_id)
+			.header(substrate_hash)
 			.map_err(|e| {
 				format!(
 					"Error when fetching substrate block {} header : {:?}",
@@ -825,7 +822,7 @@ where
 		// Get extrinsics (containing Ethereum ones)
 		let extrinsics = backend
 			.blockchain()
-			.body(substrate_block_id)
+			.body(substrate_hash)
 			.map_err(|e| {
 				format!(
 					"Blockchain error when fetching extrinsics of block {} : {:?}",

--- a/client/rpc/txpool/Cargo.toml
+++ b/client/rpc/txpool/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/PureStake/moonbeam/"
 version = "0.6.0"
 
 [dependencies]
-jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
+jsonrpsee = { version = "0.16.2", default-features = false, features = [ "macros", "server" ] }
 rlp = "0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 sha3 = "0.10"
@@ -18,15 +18,15 @@ moonbeam-rpc-core-txpool = { path = "../../rpc-core/txpool" }
 moonbeam-rpc-primitives-txpool = { path = "../../../primitives/rpc/txpool" }
 
 # Substrate
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-transaction-pool-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-transaction-pool-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Frontier
 ethereum-types = "0.14"
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", features = [ "rpc_binary_search_estimate" ] }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", features = [ "rpc-binary-search-estimate" ] }

--- a/client/vrf/Cargo.toml
+++ b/client/vrf/Cargo.toml
@@ -10,18 +10,18 @@ version = "0.1.0"
 [dependencies]
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ] }
-sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-application-crypto = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-consensus-vrf = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-application-crypto = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-consensus-vrf = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Moonbeam
 session-keys-primitives = { path = "../../primitives/session-keys" }
 
 # Nimbus
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32" }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Polkadot
-polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }

--- a/core-primitives/Cargo.toml
+++ b/core-primitives/Cargo.toml
@@ -10,9 +10,9 @@ version = "0.1.1"
 [dependencies]
 account = { path = "../primitives/account", default-features = false }
 
-fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -27,8 +27,8 @@ tempfile = "3.2.0"
 tracing-core = "0.1.29"
 
 # Benchmarking
-pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "moonbase-native", "moonbeam-native", "moonriver-native" ]

--- a/node/cli-opt/Cargo.toml
+++ b/node/cli-opt/Cargo.toml
@@ -19,4 +19,4 @@ url = "2.2.2"
 account = { path = "../../primitives/account" }
 
 # Substrate
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }

--- a/node/cli-opt/src/lib.rs
+++ b/node/cli-opt/src/lib.rs
@@ -78,6 +78,6 @@ pub struct RpcConfig {
 	pub eth_statuses_cache: usize,
 	pub fee_history_limit: u64,
 	pub max_past_logs: u32,
-	pub relay_chain_rpc_url: Option<url::Url>,
+	pub relay_chain_rpc_urls: Vec<url::Url>,
 	pub tracing_raw_max_memory_usage: usize,
 }

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -13,35 +13,35 @@ cli-opt = { package = "moonbeam-cli-opt", path = "../cli-opt", default-features 
 service = { package = "moonbeam-service", path = "../service", default-features = false }
 
 # Substrate
-frame-benchmarking-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-finality-grandpa = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-service = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-sysinfo = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-telemetry = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-substrate-prometheus-endpoint = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-try-runtime-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true }
+frame-benchmarking-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-finality-grandpa = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-service = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-sysinfo = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-telemetry = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+substrate-prometheus-endpoint = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+try-runtime-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true }
 
 # Cumulus / Nimbus
-cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32" }
+cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Polkadot
-polkadot-cli = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-polkadot-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+polkadot-cli = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+polkadot-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+substrate-build-script-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
-default = [ "moonbase-native", "moonbeam-native", "moonriver-native", "wasmtime", "westend-native" ]
+default = [ "moonbase-native", "moonbeam-native", "moonriver-native", "westend-native" ]
 
 westend-native = [ "polkadot-service/westend-native" ]
 
@@ -54,6 +54,5 @@ try-runtime = [
 	"service/try-runtime",
 	"try-runtime-cli",
 ]
-wasmtime = [ "sc-cli/wasmtime" ]
 
 moonbase-runtime-benchmarks = [ "service/moonbase-runtime-benchmarks" ]

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -721,7 +721,7 @@ pub fn run() -> Result<()> {
 					eth_statuses_cache: cli.run.eth_statuses_cache,
 					fee_history_limit: cli.run.fee_history_limit,
 					max_past_logs: cli.run.max_past_logs,
-					relay_chain_rpc_url: cli.run.base.relay_chain_rpc_url,
+					relay_chain_rpc_urls: cli.run.base.relay_chain_rpc_urls,
 					tracing_raw_max_memory_usage: cli.run.tracing_raw_max_memory_usage,
 				};
 
@@ -821,7 +821,7 @@ pub fn run() -> Result<()> {
 					}
 				);
 
-				if rpc_config.relay_chain_rpc_url.is_some() && cli.relaychain_args.len() > 0 {
+				if !rpc_config.relay_chain_rpc_urls.is_empty() && cli.relaychain_args.len() > 0 {
 					warn!(
 						"Detected relay chain node arguments together with \
 					--relay-chain-rpc-url. This command starts a minimal Polkadot node that only \

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -16,7 +16,7 @@ exit-future = "0.2"
 flume = "0.10.9"
 futures = { version = "0.3.1", features = [ "compat" ] }
 hex-literal = "0.3.4"
-jsonrpsee = { version = "0.15.0", default-features = false, features = [ "macros", "server" ] }
+jsonrpsee = { version = "0.16.2", default-features = false, features = [ "macros", "server" ] }
 libsecp256k1 = { version = "0.7", features = [ "hmac" ] }
 log = "0.4"
 maplit = "1.0.2"
@@ -49,108 +49,108 @@ moonbeam-runtime = { path = "../../runtime/moonbeam", optional = true }
 moonriver-runtime = { path = "../../runtime/moonriver", optional = true }
 
 # Substrate
-frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-transaction-payment-rpc = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-transaction-payment-rpc = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 parity-scale-codec = "3.0.0"
-sc-basic-authorship = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-chain-spec = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", features = [ "wasmtime" ] }
-sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-client-db = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-consensus-manual-seal = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-executor = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", features = [ "wasmtime" ] }
-sc-finality-grandpa = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-informant = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-network = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-network-common = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-rpc = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-rpc-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-service = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-sysinfo = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-telemetry = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sc-transaction-pool-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-offchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-session = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-storage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-trie = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-substrate-frame-rpc-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-substrate-prometheus-endpoint = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sc-basic-authorship = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-chain-spec = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-client-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-client-db = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-consensus-manual-seal = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-executor = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-finality-grandpa = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-informant = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-network = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-network-common = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-rpc = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-rpc-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-service = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-sysinfo = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-telemetry = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-tracing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sc-transaction-pool-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-blockchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-consensus = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-offchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-session = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-storage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-trie = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+substrate-frame-rpc-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+substrate-prometheus-endpoint = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Frontier
-fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-fc-mapping-sync = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", features = [ "rpc_binary_search_estimate" ] }
-fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-fp-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-fp-storage = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", features = [ "forbid-evm-reentrancy" ] }
+fc-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+fc-db = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+fc-mapping-sync = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+fc-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", features = [ "rpc-binary-search-estimate" ] }
+fc-rpc-core = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+fp-consensus = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+fp-storage = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", features = [ "forbid-evm-reentrancy" ] }
 
 # Cumulus / Nimbus
-cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-client-collator = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-client-consensus-common = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-client-consensus-relay-chain = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-client-network = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-relay-chain-interface = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-relay-chain-minimal-node = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
-nimbus-consensus = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32" }
+cumulus-client-cli = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-client-collator = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-client-consensus-common = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-client-consensus-relay-chain = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-client-network = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-client-service = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-relay-chain-interface = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-relay-chain-minimal-node = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
+nimbus-consensus = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37" }
 # TODO we should be able to depend only on the primitives crate once we move the inherent data provider there.
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32" }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Polkadot
-polkadot-cli = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-polkadot-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+polkadot-cli = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+polkadot-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+polkadot-service = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Benchmarking
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-frame-benchmarking-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+frame-benchmarking-cli = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [dev-dependencies]
 assert_cmd = "0.12"
 nix = "0.23"
 prometheus = { version = "0.13.0", default-features = false }
 rand = "0.7.3"
-sc-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sc-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Polkadot dev-dependencies
-polkadot-runtime-common = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+polkadot-runtime-common = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Substrate dev-dependencies
-pallet-sudo = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-substrate-test-client = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-substrate-test-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-substrate-test-runtime-client = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-sudo = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+substrate-test-client = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+substrate-test-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+substrate-test-runtime-client = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+substrate-build-script-utils = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [

--- a/node/service/src/client.rs
+++ b/node/service/src/client.rs
@@ -19,7 +19,7 @@ use sp_api::{CallApiAt, NumberFor, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_consensus::BlockStatus;
 use sp_runtime::{
-	generic::{BlockId, SignedBlock},
+	generic::SignedBlock,
 	traits::{BlakeTwo256, Block as BlockT},
 	Justifications,
 };
@@ -225,28 +225,34 @@ impl sc_client_api::UsageProvider<Block> for Client {
 impl sc_client_api::BlockBackend<Block> for Client {
 	fn block_body(
 		&self,
-		id: &BlockId<Block>,
+		hash: <Block as BlockT>::Hash,
 	) -> sp_blockchain::Result<Option<Vec<<Block as BlockT>::Extrinsic>>> {
-		match_client!(self, block_body(id))
+		match_client!(self, block_body(hash))
 	}
 
 	fn block_indexed_body(
 		&self,
-		id: &BlockId<Block>,
+		hash: <Block as BlockT>::Hash,
 	) -> sp_blockchain::Result<Option<Vec<Vec<u8>>>> {
-		match_client!(self, block_indexed_body(id))
+		match_client!(self, block_indexed_body(hash))
 	}
 
-	fn block(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<SignedBlock<Block>>> {
-		match_client!(self, block(id))
+	fn block(
+		&self,
+		hash: <Block as BlockT>::Hash,
+	) -> sp_blockchain::Result<Option<SignedBlock<Block>>> {
+		match_client!(self, block(hash))
 	}
 
-	fn block_status(&self, id: &BlockId<Block>) -> sp_blockchain::Result<BlockStatus> {
-		match_client!(self, block_status(id))
+	fn block_status(&self, hash: <Block as BlockT>::Hash) -> sp_blockchain::Result<BlockStatus> {
+		match_client!(self, block_status(hash))
 	}
 
-	fn justifications(&self, id: &BlockId<Block>) -> sp_blockchain::Result<Option<Justifications>> {
-		match_client!(self, justifications(id))
+	fn justifications(
+		&self,
+		hash: <Block as BlockT>::Hash,
+	) -> sp_blockchain::Result<Option<Justifications>> {
+		match_client!(self, justifications(hash))
 	}
 
 	fn block_hash(
@@ -258,14 +264,14 @@ impl sc_client_api::BlockBackend<Block> for Client {
 
 	fn indexed_transaction(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 	) -> sp_blockchain::Result<Option<Vec<u8>>> {
 		match_client!(self, indexed_transaction(hash))
 	}
 
 	fn has_indexed_transaction(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 	) -> sp_blockchain::Result<bool> {
 		match_client!(self, has_indexed_transaction(hash))
 	}
@@ -278,7 +284,7 @@ impl sc_client_api::BlockBackend<Block> for Client {
 impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 	fn storage(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<StorageData>> {
 		match_client!(self, storage(hash, key))
@@ -286,7 +292,7 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 
 	fn storage_keys(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<StorageKey>> {
 		match_client!(self, storage_keys(hash, key_prefix))
@@ -294,7 +300,7 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 
 	fn storage_hash(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<<Block as BlockT>::Hash>> {
 		match_client!(self, storage_hash(hash, key))
@@ -302,7 +308,7 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 
 	fn storage_pairs(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<(StorageKey, StorageData)>> {
 		match_client!(self, storage_pairs(hash, key_prefix))
@@ -310,7 +316,7 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 
 	fn storage_keys_iter<'a>(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 		prefix: Option<&'a StorageKey>,
 		start_key: Option<&StorageKey>,
 	) -> sp_blockchain::Result<
@@ -321,7 +327,7 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 
 	fn child_storage(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 		child_info: &ChildInfo,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<StorageData>> {
@@ -330,7 +336,7 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 
 	fn child_storage_keys(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 		child_info: &ChildInfo,
 		key_prefix: &StorageKey,
 	) -> sp_blockchain::Result<Vec<StorageKey>> {
@@ -339,7 +345,7 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 
 	fn child_storage_keys_iter<'a>(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 		child_info: ChildInfo,
 		prefix: Option<&'a StorageKey>,
 		start_key: Option<&StorageKey>,
@@ -354,7 +360,7 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 
 	fn child_storage_hash(
 		&self,
-		hash: &<Block as BlockT>::Hash,
+		hash: <Block as BlockT>::Hash,
 		child_info: &ChildInfo,
 		key: &StorageKey,
 	) -> sp_blockchain::Result<Option<<Block as BlockT>::Hash>> {
@@ -363,24 +369,23 @@ impl sc_client_api::StorageProvider<Block, crate::FullBackend> for Client {
 }
 
 impl sp_blockchain::HeaderBackend<Block> for Client {
-	fn header(&self, id: BlockId<Block>) -> sp_blockchain::Result<Option<Header>> {
-		let id = &id;
-		match_client!(self, header(id))
+	fn header(&self, hash: Hash) -> sp_blockchain::Result<Option<Header>> {
+		match_client!(self, header(hash))
 	}
 
 	fn info(&self) -> sp_blockchain::Info<Block> {
 		match_client!(self, info())
 	}
 
-	fn status(&self, id: BlockId<Block>) -> sp_blockchain::Result<sp_blockchain::BlockStatus> {
-		match_client!(self, status(id))
+	fn status(&self, hash: Hash) -> sp_blockchain::Result<sp_blockchain::BlockStatus> {
+		match_client!(self, status(hash))
 	}
 
 	fn number(&self, hash: Hash) -> sp_blockchain::Result<Option<BlockNumber>> {
 		match_client!(self, number(hash))
 	}
 
-	fn hash(&self, number: BlockNumber) -> sp_blockchain::Result<Option<Hash>> {
+	fn hash(&self, number: NumberFor<Block>) -> sp_blockchain::Result<Option<Hash>> {
 		match_client!(self, hash(number))
 	}
 }

--- a/pallets/asset-manager/Cargo.toml
+++ b/pallets/asset-manager/Cargo.toml
@@ -12,23 +12,23 @@ serde = { version = "1.0.124", optional = true }
 xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Polkadot
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Benchmarks
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/pallets/asset-manager/src/lib.rs
+++ b/pallets/asset-manager/src/lib.rs
@@ -54,7 +54,7 @@ pub mod mock;
 pub mod tests;
 pub mod weights;
 
-#[pallet(dev_mode)]
+#[pallet]
 pub mod pallet {
 
 	use crate::weights::WeightInfo;
@@ -316,6 +316,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Register new asset with the asset manager
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::register_foreign_asset())]
 		pub fn register_foreign_asset(
 			origin: OriginFor<T>,
@@ -356,6 +357,7 @@ pub mod pallet {
 
 		/// Change the amount of units we are charging per execution second
 		/// for a given ForeignAssetType
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::set_asset_units_per_second(*num_assets_weight_hint))]
 		pub fn set_asset_units_per_second(
 			origin: OriginFor<T>,
@@ -397,6 +399,7 @@ pub mod pallet {
 		/// Change the xcm type mapping for a given assetId
 		/// We also change this if the previous units per second where pointing at the old
 		/// assetType
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::change_existing_asset_type(*num_assets_weight_hint))]
 		pub fn change_existing_asset_type(
 			origin: OriginFor<T>,
@@ -451,6 +454,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::remove_supported_asset(*num_assets_weight_hint))]
 		pub fn remove_supported_asset(
 			origin: OriginFor<T>,
@@ -483,6 +487,7 @@ pub mod pallet {
 		}
 
 		/// Remove a given assetId -> assetType association
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::remove_existing_asset_type(*num_assets_weight_hint))]
 		pub fn remove_existing_asset_type(
 			origin: OriginFor<T>,
@@ -528,6 +533,7 @@ pub mod pallet {
 		/// The reason is that we dont need to hold a mapping between the multilocation
 		/// and the local asset, as this conversion is deterministic
 		/// Further, we dont allow xcm fee payment in local assets
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::register_local_asset())]
 		pub fn register_local_asset(
 			origin: OriginFor<T>,
@@ -595,6 +601,7 @@ pub mod pallet {
 		/// The weight in this case is the one returned by the trait
 		/// plus the db writes and reads from removing all the associated
 		/// data
+		#[pallet::call_index(6)]
 		#[pallet::weight({
 			let dispatch_info_weight = T::AssetRegistrar::destroy_asset_dispatch_info_weight(
 				*asset_id
@@ -648,6 +655,7 @@ pub mod pallet {
 		/// We do not store anything related to local assets in this pallet other than the counter
 		/// and the counter is not used for destroying the asset, so no additional db reads/writes
 		/// to be counter here
+		#[pallet::call_index(7)]
 		#[pallet::weight({
 			T::AssetRegistrar::destroy_asset_dispatch_info_weight(
 				*asset_id

--- a/pallets/asset-manager/src/mock.rs
+++ b/pallets/asset-manager/src/mock.rs
@@ -171,15 +171,15 @@ impl AssetRegistrar<Test> for MockAssetPalletRegistrar {
 		Ok(())
 	}
 
-	fn destroy_foreign_asset(_asset: u32, _witness: u32) -> Result<(), DispatchError> {
+	fn destroy_foreign_asset(_asset: u32) -> Result<(), DispatchError> {
 		Ok(())
 	}
 
-	fn destroy_local_asset(_asset: u32, _witness: u32) -> Result<(), DispatchError> {
+	fn destroy_local_asset(_asset: u32) -> Result<(), DispatchError> {
 		Ok(())
 	}
 
-	fn destroy_asset_dispatch_info_weight(_asset: u32, _witness: u32) -> Weight {
+	fn destroy_asset_dispatch_info_weight(_asset: u32) -> Weight {
 		Weight::from_ref_time(0)
 	}
 }
@@ -210,7 +210,6 @@ impl Config for Test {
 	type ForeignAssetModifierOrigin = EnsureRoot<u64>;
 	type LocalAssetModifierOrigin = EnsureRoot<u64>;
 	type LocalAssetIdCreator = MockLocalAssetIdCreator;
-	type AssetDestroyWitness = u32;
 	type Currency = Balances;
 	type LocalAssetDeposit = LocalAssetDeposit;
 	type WeightInfo = ();

--- a/pallets/asset-manager/src/tests.rs
+++ b/pallets/asset-manager/src/tests.rs
@@ -814,7 +814,7 @@ fn test_destroy_local_asset_works() {
 		.execute_with(|| {
 			let asset_id = MockLocalAssetIdCreator::create_asset_id_from_metadata(0);
 
-			assert_ok!(AssetManager::set(
+			assert_ok!(AssetManager::register_local_asset(
 				RuntimeOrigin::root(),
 				1u64,
 				1u64,

--- a/pallets/asset-manager/src/tests.rs
+++ b/pallets/asset-manager/src/tests.rs
@@ -783,7 +783,6 @@ fn test_destroy_foreign_asset_also_removes_everything() {
 			RuntimeOrigin::root(),
 			1,
 			0,
-			1
 		));
 
 		// Mappings are deleted
@@ -830,11 +829,7 @@ fn test_destroy_local_asset_works() {
 				})
 			);
 
-			assert_ok!(AssetManager::destroy_local_asset(
-				RuntimeOrigin::root(),
-				0,
-				0
-			));
+			assert_ok!(AssetManager::destroy_local_asset(RuntimeOrigin::root(), 0,));
 
 			assert_eq!(AssetManager::local_asset_counter(), 1);
 			assert_eq!(AssetManager::local_asset_deposit(asset_id), None);

--- a/pallets/asset-manager/src/tests.rs
+++ b/pallets/asset-manager/src/tests.rs
@@ -814,7 +814,7 @@ fn test_destroy_local_asset_works() {
 		.execute_with(|| {
 			let asset_id = MockLocalAssetIdCreator::create_asset_id_from_metadata(0);
 
-			assert_ok!(AssetManager:: set(
+			assert_ok!(AssetManager::set(
 				RuntimeOrigin::root(),
 				1u64,
 				1u64,

--- a/pallets/asset-manager/src/tests.rs
+++ b/pallets/asset-manager/src/tests.rs
@@ -814,7 +814,7 @@ fn test_destroy_local_asset_works() {
 		.execute_with(|| {
 			let asset_id = MockLocalAssetIdCreator::create_asset_id_from_metadata(0);
 
-			assert_ok!(AssetManager::register_local_asset(
+			assert_ok!(AssetManager:: set(
 				RuntimeOrigin::root(),
 				1u64,
 				1u64,

--- a/pallets/author-mapping/Cargo.toml
+++ b/pallets/author-mapping/Cargo.toml
@@ -10,23 +10,23 @@ log = { version = "0.4", default-features = false }
 serde = { version = "1.0.124", optional = true }
 
 # Substrate
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Nimbus
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 session-keys-primitives = { path = "../../primitives/session-keys", default-features = false }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -39,7 +39,7 @@ mod tests;
 
 pub mod migrations;
 
-#[pallet]
+#[pallet(dev_mode)]
 pub mod pallet {
 	use crate::WeightInfo;
 	use frame_support::pallet_prelude::*;

--- a/pallets/author-mapping/src/lib.rs
+++ b/pallets/author-mapping/src/lib.rs
@@ -39,7 +39,7 @@ mod tests;
 
 pub mod migrations;
 
-#[pallet(dev_mode)]
+#[pallet]
 pub mod pallet {
 	use crate::WeightInfo;
 	use frame_support::pallet_prelude::*;
@@ -143,6 +143,7 @@ pub mod pallet {
 		///
 		/// Users who have been (or will soon be) elected active collators in staking,
 		/// should submit this extrinsic to have their blocks accepted and earn rewards.
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::add_association())]
 		pub fn add_association(origin: OriginFor<T>, nimbus_id: NimbusId) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;
@@ -155,6 +156,7 @@ pub mod pallet {
 		/// This is useful for normal key rotation or for when switching from one physical collator
 		/// machine to another. No new security deposit is required.
 		/// This sets keys to new_nimbus_id.into() by default.
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::update_association())]
 		pub fn update_association(
 			origin: OriginFor<T>,
@@ -175,6 +177,7 @@ pub mod pallet {
 		///
 		/// This is useful when you are no longer an author and would like to re-claim your security
 		/// deposit.
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::clear_association())]
 		pub fn clear_association(origin: OriginFor<T>, nimbus_id: NimbusId) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;
@@ -186,6 +189,7 @@ pub mod pallet {
 		///
 		/// This is useful when you are no longer an author and would like to re-claim your security
 		/// deposit.
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config>::WeightInfo::remove_keys())]
 		pub fn remove_keys(origin: OriginFor<T>) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;
@@ -200,6 +204,7 @@ pub mod pallet {
 		/// This is useful for key rotation to update Nimbus and VRF keys in one call.
 		/// No new security deposit is required. Will replace `update_association` which is kept
 		/// now for backwards compatibility reasons.
+		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_keys())]
 		pub fn set_keys(origin: OriginFor<T>, keys: Vec<u8>) -> DispatchResult {
 			let account_id = ensure_signed(origin)?;

--- a/pallets/ethereum-chain-id/Cargo.toml
+++ b/pallets/ethereum-chain-id/Cargo.toml
@@ -8,8 +8,8 @@ version = "1.0.0"
 serde = { version = "1.0.101", optional = true, features = [ "derive" ] }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
 

--- a/pallets/ethereum-xcm/Cargo.toml
+++ b/pallets/ethereum-xcm/Cargo.toml
@@ -21,35 +21,35 @@ rlp = { version = "0.5", default-features = false }
 scale-info = { version = "2.1.2", default-features = false, features = [ "derive" ] }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", version = "4.0.0-dev", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", version = "4.0.0-dev", default-features = false }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", version = "4.0.0-dev", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", version = "6.0.0", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", version = "6.0.0", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", version = "4.0.0", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", version = "4.0.0-dev", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", version = "4.0.0-dev", default-features = false }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", version = "4.0.0-dev", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", version = "7.0.0", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", version = "7.0.0", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", version = "5.0.0", default-features = false }
 
 # Frontier
-fp-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
 
 [dev-dependencies]
 pallet-evm-precompile-proxy = { path = "../../precompiles/proxy", default-features = false }
 
-pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", features = [ "forbid-evm-reentrancy" ] }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", features = [ "forbid-evm-reentrancy" ] }
-pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", features = [ "forbid-evm-reentrancy" ] }
+pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 hex = "0.4.3"
 # Parity
 libsecp256k1 = { version = "0.7", features = [ "hmac", "static-context" ] }
 # Substrate FRAME
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", version = "4.0.0-dev" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", version = "4.0.0-dev" }
 # Substrate
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", version = "6.0.0" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", version = "7.0.0" }
 
 [features]
 default = [ "std" ]

--- a/pallets/ethereum-xcm/src/lib.rs
+++ b/pallets/ethereum-xcm/src/lib.rs
@@ -83,7 +83,7 @@ impl<O: Into<Result<RawOrigin, O>> + From<RawOrigin>> EnsureOrigin<O>
 
 pub use self::pallet::*;
 
-#[frame_support::pallet]
+#[frame_support::pallet(dev_mode)]
 pub mod pallet {
 	use super::*;
 	use frame_support::pallet_prelude::*;

--- a/pallets/maintenance-mode/Cargo.toml
+++ b/pallets/maintenance-mode/Cargo.toml
@@ -14,19 +14,19 @@ xcm-primitives = { path = "../../primitives/xcm", optional = true, default-featu
 log = "0.4"
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Cumulus
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
 
 [dev-dependencies]
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std", "xcm-support" ]

--- a/pallets/maintenance-mode/src/lib.rs
+++ b/pallets/maintenance-mode/src/lib.rs
@@ -52,7 +52,7 @@ use frame_support::pallet;
 
 pub use pallet::*;
 
-#[pallet(dev_mode)]
+#[pallet]
 pub mod pallet {
 	#[cfg(feature = "xcm-support")]
 	use cumulus_primitives_core::{
@@ -153,6 +153,7 @@ pub mod pallet {
 		/// Weight cost is:
 		/// * One DB read to ensure we're not already in maintenance mode
 		/// * Three DB writes - 1 for the mode, 1 for suspending xcm execution, 1 for the event
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::DbWeight::get().read + 3 * T::DbWeight::get().write)]
 		pub fn enter_maintenance_mode(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			// Ensure Origin
@@ -184,6 +185,7 @@ pub mod pallet {
 		/// Weight cost is:
 		/// * One DB read to ensure we're in maintenance mode
 		/// * Three DB writes - 1 for the mode, 1 for resuming xcm execution, 1 for the event
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::DbWeight::get().read + 3 * T::DbWeight::get().write)]
 		pub fn resume_normal_operation(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			// Ensure Origin

--- a/pallets/maintenance-mode/src/lib.rs
+++ b/pallets/maintenance-mode/src/lib.rs
@@ -52,7 +52,7 @@ use frame_support::pallet;
 
 pub use pallet::*;
 
-#[pallet]
+#[pallet(dev_mode)]
 pub mod pallet {
 	#[cfg(feature = "xcm-support")]
 	use cumulus_primitives_core::{

--- a/pallets/migrations/Cargo.toml
+++ b/pallets/migrations/Cargo.toml
@@ -15,27 +15,27 @@ impl-trait-for-tuples = "0.2.1"
 log = "0.4"
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Benchmarks
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
 
 
 [dev-dependencies]
 environmental = "1.1.2"
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/pallets/migrations/src/lib.rs
+++ b/pallets/migrations/src/lib.rs
@@ -89,7 +89,7 @@ impl GetMigrations for Tuple {
 	}
 }
 
-#[pallet]
+#[pallet(dev_mode)]
 pub mod pallet {
 	use super::*;
 	use crate::weights::WeightInfo;

--- a/pallets/migrations/src/lib.rs
+++ b/pallets/migrations/src/lib.rs
@@ -89,7 +89,7 @@ impl GetMigrations for Tuple {
 	}
 }
 
-#[pallet(dev_mode)]
+#[pallet]
 pub mod pallet {
 	use super::*;
 	use crate::weights::WeightInfo;
@@ -306,6 +306,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(
 			<T as Config>::WeightInfo::migrate_democracy_preimage(*proposal_len_upper_bound)
 		)]

--- a/pallets/moonbeam-orbiters/Cargo.toml
+++ b/pallets/moonbeam-orbiters/Cargo.toml
@@ -9,21 +9,21 @@ version = "0.1.0"
 log = "0.4"
 
 # Substrate
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Nimbus
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/pallets/moonbeam-orbiters/src/lib.rs
+++ b/pallets/moonbeam-orbiters/src/lib.rs
@@ -46,7 +46,7 @@ pub use weights::WeightInfo;
 use frame_support::pallet;
 use nimbus_primitives::{AccountLookup, NimbusId};
 
-#[pallet]
+#[pallet(dev_mode)]
 pub mod pallet {
 	use super::*;
 	use frame_support::pallet_prelude::*;

--- a/pallets/moonbeam-orbiters/src/lib.rs
+++ b/pallets/moonbeam-orbiters/src/lib.rs
@@ -46,7 +46,7 @@ pub use weights::WeightInfo;
 use frame_support::pallet;
 use nimbus_primitives::{AccountLookup, NimbusId};
 
-#[pallet(dev_mode)]
+#[pallet]
 pub mod pallet {
 	use super::*;
 	use frame_support::pallet_prelude::*;
@@ -263,6 +263,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Add an orbiter in a collator pool
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::collator_add_orbiter())]
 		pub fn collator_add_orbiter(
 			origin: OriginFor<T>,
@@ -302,6 +303,7 @@ pub mod pallet {
 		}
 
 		/// Remove an orbiter from the caller collator pool
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::collator_remove_orbiter())]
 		pub fn collator_remove_orbiter(
 			origin: OriginFor<T>,
@@ -314,6 +316,7 @@ pub mod pallet {
 		}
 
 		/// Remove the caller from the specified collator pool
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::orbiter_leave_collator_pool())]
 		pub fn orbiter_leave_collator_pool(
 			origin: OriginFor<T>,
@@ -326,6 +329,7 @@ pub mod pallet {
 		}
 
 		/// Registering as an orbiter
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::orbiter_register())]
 		pub fn orbiter_register(origin: OriginFor<T>) -> DispatchResult {
 			let orbiter = ensure_signed(origin)?;
@@ -350,6 +354,7 @@ pub mod pallet {
 		}
 
 		/// Deregistering from orbiters
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::orbiter_unregister(*collators_pool_count))]
 		pub fn orbiter_unregister(
 			origin: OriginFor<T>,
@@ -379,6 +384,7 @@ pub mod pallet {
 		}
 
 		/// Add a collator to orbiters program.
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::add_collator())]
 		pub fn add_collator(
 			origin: OriginFor<T>,
@@ -398,6 +404,7 @@ pub mod pallet {
 		}
 
 		/// Remove a collator from orbiters program.
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::remove_collator())]
 		pub fn remove_collator(
 			origin: OriginFor<T>,

--- a/pallets/moonbeam-xcm-benchmarks/Cargo.toml
+++ b/pallets/moonbeam-xcm-benchmarks/Cargo.toml
@@ -12,26 +12,26 @@ serde = { version = "1.0.124", optional = true }
 xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", optional = true, default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", optional = true, default-features = false, features = [ "derive" ] }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Polkadot / XCM
-pallet-xcm-benchmarks = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+pallet-xcm-benchmarks = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Benchmarks
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -10,23 +10,23 @@ log = "0.4"
 serde = { version = "1.0.101", optional = true }
 
 # Substrate
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 substrate-fixed = { git = "https://github.com/encointer/substrate-fixed", default-features = false }
 
 # Nimbus
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 similar-asserts = "1.1.0"
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -75,7 +75,7 @@ pub use traits::*;
 pub use types::*;
 pub use RoundIndex;
 
-#[pallet]
+#[pallet(dev_mode)]
 pub mod pallet {
 	use crate::delegation_requests::{
 		CancelledScheduledRequest, DelegationAction, ScheduledRequest,
@@ -751,9 +751,9 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		#[pallet::weight(<T as Config>::WeightInfo::set_staking_expectations())]
 		/// Set the expectations for total staked. These expectations determine the issuance for
 		/// the round according to logic in `fn compute_issuance`
+		#[pallet::weight(<T as Config>::WeightInfo::set_staking_expectations())]
 		pub fn set_staking_expectations(
 			origin: OriginFor<T>,
 			expectations: Range<BalanceOf<T>>,

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -75,7 +75,7 @@ pub use traits::*;
 pub use types::*;
 pub use RoundIndex;
 
-#[pallet(dev_mode)]
+#[pallet]
 pub mod pallet {
 	use crate::delegation_requests::{
 		CancelledScheduledRequest, DelegationAction, ScheduledRequest,
@@ -753,6 +753,7 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Set the expectations for total staked. These expectations determine the issuance for
 		/// the round according to logic in `fn compute_issuance`
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_staking_expectations())]
 		pub fn set_staking_expectations(
 			origin: OriginFor<T>,
@@ -774,8 +775,10 @@ pub mod pallet {
 			<InflationConfig<T>>::put(config);
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::set_inflation())]
+
 		/// Set the annual inflation rate to derive per-round inflation
+		#[pallet::call_index(1)]
+		#[pallet::weight(<T as Config>::WeightInfo::set_inflation())]
 		pub fn set_inflation(
 			origin: OriginFor<T>,
 			schedule: Range<Perbill>,
@@ -797,8 +800,10 @@ pub mod pallet {
 			<InflationConfig<T>>::put(config);
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::set_parachain_bond_account())]
+
 		/// Set the account that will hold funds set aside for parachain bond
+		#[pallet::call_index(2)]
+		#[pallet::weight(<T as Config>::WeightInfo::set_parachain_bond_account())]
 		pub fn set_parachain_bond_account(
 			origin: OriginFor<T>,
 			new: T::AccountId,
@@ -816,8 +821,10 @@ pub mod pallet {
 			Self::deposit_event(Event::ParachainBondAccountSet { old, new });
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::set_parachain_bond_reserve_percent())]
+
 		/// Set the percent of inflation set aside for parachain bond
+		#[pallet::call_index(3)]
+		#[pallet::weight(<T as Config>::WeightInfo::set_parachain_bond_reserve_percent())]
 		pub fn set_parachain_bond_reserve_percent(
 			origin: OriginFor<T>,
 			new: Percent,
@@ -835,9 +842,11 @@ pub mod pallet {
 			Self::deposit_event(Event::ParachainBondReservePercentSet { old, new });
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::set_total_selected())]
+
 		/// Set the total number of collator candidates selected per round
 		/// - changes are not applied until the start of the next round
+		#[pallet::call_index(4)]
+		#[pallet::weight(<T as Config>::WeightInfo::set_total_selected())]
 		pub fn set_total_selected(origin: OriginFor<T>, new: u32) -> DispatchResultWithPostInfo {
 			frame_system::ensure_root(origin)?;
 			ensure!(
@@ -854,8 +863,10 @@ pub mod pallet {
 			Self::deposit_event(Event::TotalSelectedSet { old, new });
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::set_collator_commission())]
+
 		/// Set the commission for all collators
+		#[pallet::call_index(5)]
+		#[pallet::weight(<T as Config>::WeightInfo::set_collator_commission())]
 		pub fn set_collator_commission(
 			origin: OriginFor<T>,
 			new: Perbill,
@@ -867,11 +878,13 @@ pub mod pallet {
 			Self::deposit_event(Event::CollatorCommissionSet { old, new });
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::set_blocks_per_round())]
+
 		/// Set blocks per round
 		/// - if called with `new` less than length of current round, will transition immediately
 		/// in the next block
 		/// - also updates per-round inflation config
+		#[pallet::call_index(6)]
+		#[pallet::weight(<T as Config>::WeightInfo::set_blocks_per_round())]
 		pub fn set_blocks_per_round(origin: OriginFor<T>, new: u32) -> DispatchResultWithPostInfo {
 			frame_system::ensure_root(origin)?;
 			ensure!(
@@ -902,8 +915,10 @@ pub mod pallet {
 			<InflationConfig<T>>::put(inflation_config);
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::join_candidates(*candidate_count))]
+
 		/// Join the set of collator candidates
+		#[pallet::call_index(7)]
+		#[pallet::weight(<T as Config>::WeightInfo::join_candidates(*candidate_count))]
 		pub fn join_candidates(
 			origin: OriginFor<T>,
 			bond: BalanceOf<T>,
@@ -951,9 +966,11 @@ pub mod pallet {
 			});
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::schedule_leave_candidates(*candidate_count))]
+
 		/// Request to leave the set of candidates. If successful, the account is immediately
 		/// removed from the candidate pool to prevent selection as a collator.
+		#[pallet::call_index(8)]
+		#[pallet::weight(<T as Config>::WeightInfo::schedule_leave_candidates(*candidate_count))]
 		pub fn schedule_leave_candidates(
 			origin: OriginFor<T>,
 			candidate_count: u32,
@@ -978,10 +995,11 @@ pub mod pallet {
 			Ok(().into())
 		}
 
+		/// Execute leave candidates request
+		#[pallet::call_index(9)]
 		#[pallet::weight(
 			<T as Config>::WeightInfo::execute_leave_candidates(*candidate_delegation_count)
 		)]
-		/// Execute leave candidates request
 		pub fn execute_leave_candidates(
 			origin: OriginFor<T>,
 			candidate: T::AccountId,
@@ -1058,10 +1076,12 @@ pub mod pallet {
 			});
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::cancel_leave_candidates(*candidate_count))]
+
 		/// Cancel open request to leave candidates
 		/// - only callable by collator account
 		/// - result upon successful call is the candidate is active in the candidate pool
+		#[pallet::call_index(10)]
+		#[pallet::weight(<T as Config>::WeightInfo::cancel_leave_candidates(*candidate_count))]
 		pub fn cancel_leave_candidates(
 			origin: OriginFor<T>,
 			candidate_count: u32,
@@ -1089,8 +1109,10 @@ pub mod pallet {
 			});
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::go_offline())]
+
 		/// Temporarily leave the set of collator candidates without unbonding
+		#[pallet::call_index(11)]
+		#[pallet::weight(<T as Config>::WeightInfo::go_offline())]
 		pub fn go_offline(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let collator = ensure_signed(origin)?;
 			let mut state = <CandidateInfo<T>>::get(&collator).ok_or(Error::<T>::CandidateDNE)?;
@@ -1106,8 +1128,10 @@ pub mod pallet {
 			});
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::go_online())]
+
 		/// Rejoin the set of collator candidates if previously had called `go_offline`
+		#[pallet::call_index(12)]
+		#[pallet::weight(<T as Config>::WeightInfo::go_online())]
 		pub fn go_online(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let collator = ensure_signed(origin)?;
 			let mut state = <CandidateInfo<T>>::get(&collator).ok_or(Error::<T>::CandidateDNE)?;
@@ -1129,8 +1153,10 @@ pub mod pallet {
 			});
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::candidate_bond_more())]
+
 		/// Increase collator candidate self bond by `more`
+		#[pallet::call_index(13)]
+		#[pallet::weight(<T as Config>::WeightInfo::candidate_bond_more())]
 		pub fn candidate_bond_more(
 			origin: OriginFor<T>,
 			more: BalanceOf<T>,
@@ -1145,8 +1171,10 @@ pub mod pallet {
 			}
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::schedule_candidate_bond_less())]
+
 		/// Request by collator candidate to decrease self bond by `less`
+		#[pallet::call_index(14)]
+		#[pallet::weight(<T as Config>::WeightInfo::schedule_candidate_bond_less())]
 		pub fn schedule_candidate_bond_less(
 			origin: OriginFor<T>,
 			less: BalanceOf<T>,
@@ -1162,8 +1190,10 @@ pub mod pallet {
 			});
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::execute_candidate_bond_less())]
+
 		/// Execute pending request to adjust the collator candidate self bond
+		#[pallet::call_index(15)]
+		#[pallet::weight(<T as Config>::WeightInfo::execute_candidate_bond_less())]
 		pub fn execute_candidate_bond_less(
 			origin: OriginFor<T>,
 			candidate: T::AccountId,
@@ -1174,8 +1204,10 @@ pub mod pallet {
 			<CandidateInfo<T>>::insert(&candidate, state);
 			Ok(().into())
 		}
-		#[pallet::weight(<T as Config>::WeightInfo::cancel_candidate_bond_less())]
+
 		/// Cancel pending request to adjust the collator candidate self bond
+		#[pallet::call_index(16)]
+		#[pallet::weight(<T as Config>::WeightInfo::cancel_candidate_bond_less())]
 		pub fn cancel_candidate_bond_less(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let collator = ensure_signed(origin)?;
 			let mut state = <CandidateInfo<T>>::get(&collator).ok_or(Error::<T>::CandidateDNE)?;
@@ -1183,14 +1215,16 @@ pub mod pallet {
 			<CandidateInfo<T>>::insert(&collator, state);
 			Ok(().into())
 		}
+
+		/// If caller is not a delegator and not a collator, then join the set of delegators
+		/// If caller is a delegator, then makes delegation to change their delegation state
+		#[pallet::call_index(17)]
 		#[pallet::weight(
 			<T as Config>::WeightInfo::delegate(
 				*candidate_delegation_count,
 				*delegation_count
 			)
 		)]
-		/// If caller is not a delegator and not a collator, then join the set of delegators
-		/// If caller is a delegator, then makes delegation to change their delegation state
 		pub fn delegate(
 			origin: OriginFor<T>,
 			candidate: T::AccountId,
@@ -1213,6 +1247,7 @@ pub mod pallet {
 		/// If caller is not a delegator and not a collator, then join the set of delegators
 		/// If caller is a delegator, then makes delegation to change their delegation state
 		/// Sets the auto-compound config for the delegation
+		#[pallet::call_index(18)]
 		#[pallet::weight(
 			<T as Config>::WeightInfo::delegate_with_auto_compound(
 				*candidate_delegation_count,
@@ -1245,6 +1280,7 @@ pub mod pallet {
 		/// Request to leave the set of delegators. If successful, the caller is scheduled to be
 		/// allowed to exit via a [DelegationAction::Revoke] towards all existing delegations.
 		/// Success forbids future delegation requests until the request is invoked or cancelled.
+		#[pallet::call_index(19)]
 		#[pallet::weight(<T as Config>::WeightInfo::schedule_leave_delegators())]
 		pub fn schedule_leave_delegators(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let delegator = ensure_signed(origin)?;
@@ -1253,6 +1289,7 @@ pub mod pallet {
 
 		/// DEPRECATED use batch util with execute_delegation_request for all delegations
 		/// Execute the right to exit the set of delegators and revoke all ongoing delegations.
+		#[pallet::call_index(20)]
 		#[pallet::weight(<T as Config>::WeightInfo::execute_leave_delegators(*delegation_count))]
 		pub fn execute_leave_delegators(
 			origin: OriginFor<T>,
@@ -1266,17 +1303,19 @@ pub mod pallet {
 		/// DEPRECATED use batch util with cancel_delegation_request for all delegations
 		/// Cancel a pending request to exit the set of delegators. Success clears the pending exit
 		/// request (thereby resetting the delay upon another `leave_delegators` call).
+		#[pallet::call_index(21)]
 		#[pallet::weight(<T as Config>::WeightInfo::cancel_leave_delegators())]
 		pub fn cancel_leave_delegators(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let delegator = ensure_signed(origin)?;
 			Self::delegator_cancel_scheduled_revoke_all(delegator)
 		}
 
-		#[pallet::weight(<T as Config>::WeightInfo::schedule_revoke_delegation())]
 		/// Request to revoke an existing delegation. If successful, the delegation is scheduled
 		/// to be allowed to be revoked via the `execute_delegation_request` extrinsic.
 		/// The delegation receives no rewards for the rounds while a revoke is pending.
 		/// A revoke may not be performed if any other scheduled request is pending.
+		#[pallet::call_index(22)]
+		#[pallet::weight(<T as Config>::WeightInfo::schedule_revoke_delegation())]
 		pub fn schedule_revoke_delegation(
 			origin: OriginFor<T>,
 			collator: T::AccountId,
@@ -1285,8 +1324,9 @@ pub mod pallet {
 			Self::delegation_schedule_revoke(collator, delegator)
 		}
 
-		#[pallet::weight(<T as Config>::WeightInfo::delegator_bond_more())]
 		/// Bond more for delegators wrt a specific collator candidate.
+		#[pallet::call_index(23)]
+		#[pallet::weight(<T as Config>::WeightInfo::delegator_bond_more())]
 		pub fn delegator_bond_more(
 			origin: OriginFor<T>,
 			candidate: T::AccountId,
@@ -1308,10 +1348,11 @@ pub mod pallet {
 			Ok(().into())
 		}
 
-		#[pallet::weight(<T as Config>::WeightInfo::schedule_delegator_bond_less())]
 		/// Request bond less for delegators wrt a specific collator candidate. The delegation's
 		/// rewards for rounds while the request is pending use the reduced bonded amount.
 		/// A bond less may not be performed if any other scheduled request is pending.
+		#[pallet::call_index(24)]
+		#[pallet::weight(<T as Config>::WeightInfo::schedule_delegator_bond_less())]
 		pub fn schedule_delegator_bond_less(
 			origin: OriginFor<T>,
 			candidate: T::AccountId,
@@ -1321,8 +1362,9 @@ pub mod pallet {
 			Self::delegation_schedule_bond_decrease(candidate, delegator, less)
 		}
 
-		#[pallet::weight(<T as Config>::WeightInfo::execute_delegator_bond_less())]
 		/// Execute pending request to change an existing delegation
+		#[pallet::call_index(25)]
+		#[pallet::weight(<T as Config>::WeightInfo::execute_delegator_bond_less())]
 		pub fn execute_delegation_request(
 			origin: OriginFor<T>,
 			delegator: T::AccountId,
@@ -1332,8 +1374,9 @@ pub mod pallet {
 			Self::delegation_execute_scheduled_request(candidate, delegator)
 		}
 
-		#[pallet::weight(<T as Config>::WeightInfo::cancel_delegator_bond_less())]
 		/// Cancel request to change an existing delegation.
+		#[pallet::call_index(26)]
+		#[pallet::weight(<T as Config>::WeightInfo::cancel_delegator_bond_less())]
 		pub fn cancel_delegation_request(
 			origin: OriginFor<T>,
 			candidate: T::AccountId,
@@ -1343,6 +1386,7 @@ pub mod pallet {
 		}
 
 		/// Sets the auto-compounding reward percentage for a delegation.
+		#[pallet::call_index(27)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_auto_compound(
 			*candidate_auto_compounding_delegation_count_hint,
 			*delegation_count_hint,
@@ -1365,6 +1409,7 @@ pub mod pallet {
 		}
 
 		/// Hotfix to remove existing empty entries for candidates that have left.
+		#[pallet::call_index(28)]
 		#[pallet::weight(
 			T::DbWeight::get().reads_writes(2 * candidates.len() as u64, candidates.len() as u64)
 		)]

--- a/pallets/proxy-genesis-companion/Cargo.toml
+++ b/pallets/proxy-genesis-companion/Cargo.toml
@@ -6,19 +6,19 @@ edition = "2021"
 version = "0.1.0"
 
 [dependencies]
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [dev-dependencies]
 serde = "1.0.124"
 
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 pallet-evm-precompile-proxy = { path = "../../precompiles/proxy", default-features = false }
 

--- a/pallets/randomness/Cargo.toml
+++ b/pallets/randomness/Cargo.toml
@@ -6,29 +6,29 @@ edition = "2018"
 version = "0.1.0"
 
 [dependencies]
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 log = "0.4"
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
 serde = { version = "1.0.101", optional = true }
 session-keys-primitives = { path = "../../primitives/session-keys", default-features = false }
-sp-consensus-vrf = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-consensus-vrf = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = "0.99"
 pallet-author-mapping = { path = "../author-mapping" }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/pallets/randomness/src/lib.rs
+++ b/pallets/randomness/src/lib.rs
@@ -74,7 +74,7 @@ pub trait GetBabeData<EpochIndex, Randomness> {
 	fn get_epoch_randomness() -> Randomness;
 }
 
-#[pallet(dev_mode)]
+#[pallet]
 pub mod pallet {
 	use super::*;
 	use crate::weights::{SubstrateWeight, WeightInfo};
@@ -234,6 +234,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Populates `RandomnessResults` due this epoch with BABE epoch randomness
+		#[pallet::call_index(0)]
 		#[pallet::weight((
 			SubstrateWeight::<T>::set_babe_randomness_results(),
 			DispatchClass::Mandatory

--- a/pallets/randomness/src/lib.rs
+++ b/pallets/randomness/src/lib.rs
@@ -74,7 +74,7 @@ pub trait GetBabeData<EpochIndex, Randomness> {
 	fn get_epoch_randomness() -> Randomness;
 }
 
-#[pallet]
+#[pallet(dev_mode)]
 pub mod pallet {
 	use super::*;
 	use crate::weights::{SubstrateWeight, WeightInfo};

--- a/pallets/xcm-transactor/Cargo.toml
+++ b/pallets/xcm-transactor/Cargo.toml
@@ -12,32 +12,32 @@ serde = { version = "1.0.124", optional = true }
 xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Cumulus
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Polkadot / XCM
-orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Benchmarks
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
 
 [dev-dependencies]
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 parity-scale-codec = { version = "3.0.0" }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -84,7 +84,7 @@ pub mod weights;
 
 type CurrencyIdOf<T> = <T as Config>::CurrencyId;
 
-#[pallet(dev_mode)]
+#[pallet]
 pub mod pallet {
 
 	use crate::weights::WeightInfo;
@@ -384,7 +384,6 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
-		#[pallet::weight(T::WeightInfo::register())]
 		/// Register a derivative index for an account id. Dispatchable by
 		/// DerivativeAddressRegistrationOrigin
 		///
@@ -393,6 +392,8 @@ pub mod pallet {
 		///
 		/// For now an index is registered for all possible destinations and not per-destination.
 		/// We can change this in the future although it would just make things more complicated
+		#[pallet::call_index(0)]
+		#[pallet::weight(T::WeightInfo::register())]
 		pub fn register(origin: OriginFor<T>, who: T::AccountId, index: u16) -> DispatchResult {
 			T::DerivativeAddressRegistrationOrigin::ensure_origin(origin)?;
 
@@ -412,9 +413,10 @@ pub mod pallet {
 			Ok(())
 		}
 
-		#[pallet::weight(T::WeightInfo::deregister())]
 		/// De-Register a derivative index. This prevents an account to use a derivative address
 		/// (represented by an index) from our of our sovereign accounts anymore
+		#[pallet::call_index(1)]
+		#[pallet::weight(T::WeightInfo::deregister())]
 		pub fn deregister(origin: OriginFor<T>, index: u16) -> DispatchResult {
 			T::DerivativeAddressRegistrationOrigin::ensure_origin(origin)?;
 
@@ -432,6 +434,7 @@ pub mod pallet {
 		///
 		/// The caller needs to have the index registered in this pallet. The fee multiasset needs
 		/// to be a reserve asset for the destination transactor::multilocation.
+		#[pallet::call_index(2)]
 		#[pallet::weight(
 			Weight::from_ref_time(Pallet::<T>::weight_of_initiate_reserve_withdraw())
 			.saturating_add(T::WeightInfo::transact_through_derivative())
@@ -515,6 +518,7 @@ pub mod pallet {
 		/// 'fee_payer' pays for the fee
 		///
 		/// SovereignAccountDispatcherOrigin callable only
+		#[pallet::call_index(3)]
 		#[pallet::weight(
 			Weight::from_ref_time(Pallet::<T>::weight_of_initiate_reserve_withdraw())
 			.saturating_add(T::WeightInfo::transact_through_sovereign())
@@ -584,6 +588,7 @@ pub mod pallet {
 		}
 
 		/// Change the transact info of a location
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::set_transact_info())]
 		pub fn set_transact_info(
 			origin: OriginFor<T>,
@@ -611,6 +616,7 @@ pub mod pallet {
 		}
 
 		/// Remove the transact info of a location
+		#[pallet::call_index(5)]
 		#[pallet::weight(T::WeightInfo::remove_transact_info())]
 		pub fn remove_transact_info(
 			origin: OriginFor<T>,
@@ -632,6 +638,7 @@ pub mod pallet {
 		/// by any method implemented in the destination chains runtime
 		///
 		/// This time we are giving the currency as a currencyId instead of multilocation
+		#[pallet::call_index(6)]
 		#[pallet::weight(T::WeightInfo::transact_through_signed())]
 		pub fn transact_through_signed(
 			origin: OriginFor<T>,
@@ -694,6 +701,7 @@ pub mod pallet {
 		}
 
 		/// Set the fee per second of an asset on its reserve chain
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::set_fee_per_second())]
 		pub fn set_fee_per_second(
 			origin: OriginFor<T>,
@@ -714,6 +722,7 @@ pub mod pallet {
 		}
 
 		/// Remove the fee per second of an asset on its reserve chain
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::set_fee_per_second())]
 		pub fn remove_fee_per_second(
 			origin: OriginFor<T>,
@@ -732,6 +741,7 @@ pub mod pallet {
 		}
 
 		/// Manage HRMP operations
+		#[pallet::call_index(9)]
 		#[pallet::weight(T::WeightInfo::hrmp_manage())]
 		pub fn hrmp_manage(
 			origin: OriginFor<T>,

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -84,13 +84,13 @@ pub mod weights;
 
 type CurrencyIdOf<T> = <T as Config>::CurrencyId;
 
-#[pallet]
+#[pallet(dev_mode)]
 pub mod pallet {
 
 	use crate::weights::WeightInfo;
 	use crate::CurrencyIdOf;
 	use cumulus_primitives_core::{relay_chain::v2::HrmpChannelId, ParaId};
-	use frame_support::{pallet_prelude::*, weights::constants::WEIGHT_PER_SECOND};
+	use frame_support::{pallet_prelude::*, weights::constants::WEIGHT_REF_TIME_PER_SECOND};
 	use frame_system::{ensure_signed, pallet_prelude::*};
 	use orml_traits::location::{Parse, Reserve};
 	use sp_runtime::traits::{AtLeast32BitUnsigned, Convert};
@@ -1068,10 +1068,10 @@ pub mod pallet {
 		/// Returns the fee for a given set of parameters
 		/// We always round up in case of fractional division
 		pub fn calculate_fee_per_second(weight: XcmV2Weight, fee_per_second: u128) -> u128 {
-			// grab WEIGHT_PER_SECOND as u128
-			let weight_per_second_u128 = WEIGHT_PER_SECOND.ref_time() as u128;
+			// grab WEIGHT_REF_TIME_PER_SECOND as u128
+			let weight_per_second_u128 = WEIGHT_REF_TIME_PER_SECOND as u128;
 
-			// we add WEIGHT_PER_SECOND -1 after multiplication to make sure that
+			// we add WEIGHT_REF_TIME_PER_SECOND -1 after multiplication to make sure that
 			// if there is a fractional part we round up the result
 			let fee_mul_rounded_up = (fee_per_second.saturating_mul(weight as u128))
 				.saturating_add(weight_per_second_u128 - 1);

--- a/pallets/xcm-transactor/src/tests.rs
+++ b/pallets/xcm-transactor/src/tests.rs
@@ -18,7 +18,7 @@ use crate::mock::*;
 use crate::*;
 use cumulus_primitives_core::relay_chain::v2::HrmpChannelId;
 use frame_support::dispatch::DispatchError;
-use frame_support::{assert_noop, assert_ok, weights::constants::WEIGHT_PER_SECOND};
+use frame_support::{assert_noop, assert_ok, weights::constants::WEIGHT_REF_TIME_PER_SECOND};
 use sp_std::boxed::Box;
 use xcm::latest::prelude::*;
 use xcm_primitives::{UtilityAvailableCalls, UtilityEncodeCall};
@@ -546,7 +546,7 @@ fn test_fee_calculation_works() {
 			assert_eq!(
 				XcmTransactor::calculate_fee_per_second(
 					1000000000,
-					8 * WEIGHT_PER_SECOND.ref_time() as u128
+					8 * WEIGHT_REF_TIME_PER_SECOND as u128
 				),
 				8000000000
 			);

--- a/precompiles/assets-erc20/Cargo.toml
+++ b/precompiles/assets-erc20/Cargo.toml
@@ -16,20 +16,20 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-assets = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-assets = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = { version = "0.99" }
@@ -42,9 +42,9 @@ sha3 = "0.10"
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "max-encoded-len" ] }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -259,7 +259,7 @@ where
 				handle,
 				Some(owner.clone()).into(),
 				pallet_assets::Call::<Runtime, Instance>::cancel_approval {
-					id: asset_id,
+					id: asset_id.into(),
 					delegate: Runtime::Lookup::unlookup(spender.clone()),
 				},
 			)?;
@@ -269,7 +269,7 @@ where
 			handle,
 			Some(owner).into(),
 			pallet_assets::Call::<Runtime, Instance>::approve_transfer {
-				id: asset_id,
+				id: asset_id.into(),
 				delegate: Runtime::Lookup::unlookup(spender),
 				amount,
 			},
@@ -300,7 +300,7 @@ where
 				handle,
 				Some(origin).into(),
 				pallet_assets::Call::<Runtime, Instance>::transfer {
-					id: asset_id,
+					id: asset_id.into(),
 					target: Runtime::Lookup::unlookup(to),
 					amount: value,
 				},
@@ -346,7 +346,7 @@ where
 					handle,
 					Some(caller).into(),
 					pallet_assets::Call::<Runtime, Instance>::transfer_approved {
-						id: asset_id,
+						id: asset_id.into(),
 						owner: Runtime::Lookup::unlookup(from),
 						destination: Runtime::Lookup::unlookup(to),
 						amount: value,
@@ -358,7 +358,7 @@ where
 					handle,
 					Some(from).into(),
 					pallet_assets::Call::<Runtime, Instance>::transfer {
-						id: asset_id,
+						id: asset_id.into(),
 						target: Runtime::Lookup::unlookup(to),
 						amount: value,
 					},
@@ -509,7 +509,7 @@ where
 				handle,
 				Some(origin).into(),
 				pallet_assets::Call::<Runtime, Instance>::mint {
-					id: asset_id,
+					id: asset_id.into(),
 					beneficiary: Runtime::Lookup::unlookup(to),
 					amount: value,
 				},
@@ -554,7 +554,7 @@ where
 				handle,
 				Some(origin).into(),
 				pallet_assets::Call::<Runtime, Instance>::burn {
-					id: asset_id,
+					id: asset_id.into(),
 					who: Runtime::Lookup::unlookup(from),
 					amount: value,
 				},
@@ -595,7 +595,7 @@ where
 				handle,
 				Some(origin).into(),
 				pallet_assets::Call::<Runtime, Instance>::freeze {
-					id: asset_id,
+					id: asset_id.into(),
 					who: Runtime::Lookup::unlookup(account),
 				},
 			)?;
@@ -626,7 +626,7 @@ where
 				handle,
 				Some(origin).into(),
 				pallet_assets::Call::<Runtime, Instance>::thaw {
-					id: asset_id,
+					id: asset_id.into(),
 					who: Runtime::Lookup::unlookup(account),
 				},
 			)?;
@@ -653,7 +653,9 @@ where
 			RuntimeHelper::<Runtime>::try_dispatch(
 				handle,
 				Some(origin).into(),
-				pallet_assets::Call::<Runtime, Instance>::freeze_asset { id: asset_id },
+				pallet_assets::Call::<Runtime, Instance>::freeze_asset {
+					id: asset_id.into(),
+				},
 			)?;
 		}
 
@@ -678,7 +680,9 @@ where
 			RuntimeHelper::<Runtime>::try_dispatch(
 				handle,
 				Some(origin).into(),
-				pallet_assets::Call::<Runtime, Instance>::thaw_asset { id: asset_id },
+				pallet_assets::Call::<Runtime, Instance>::thaw_asset {
+					id: asset_id.into(),
+				},
 			)?;
 		}
 
@@ -709,7 +713,7 @@ where
 				handle,
 				Some(origin).into(),
 				pallet_assets::Call::<Runtime, Instance>::transfer_ownership {
-					id: asset_id,
+					id: asset_id.into(),
 					owner: Runtime::Lookup::unlookup(owner),
 				},
 			)?;
@@ -747,7 +751,7 @@ where
 				handle,
 				Some(origin).into(),
 				pallet_assets::Call::<Runtime, Instance>::set_team {
-					id: asset_id,
+					id: asset_id.into(),
 					issuer: Runtime::Lookup::unlookup(issuer),
 					admin: Runtime::Lookup::unlookup(admin),
 					freezer: Runtime::Lookup::unlookup(freezer),
@@ -780,7 +784,7 @@ where
 				handle,
 				Some(origin).into(),
 				pallet_assets::Call::<Runtime, Instance>::set_metadata {
-					id: asset_id,
+					id: asset_id.into(),
 					name: name.into(),
 					symbol: symbol.into(),
 					decimals,
@@ -809,7 +813,9 @@ where
 			RuntimeHelper::<Runtime>::try_dispatch(
 				handle,
 				Some(origin).into(),
-				pallet_assets::Call::<Runtime, Instance>::clear_metadata { id: asset_id },
+				pallet_assets::Call::<Runtime, Instance>::clear_metadata {
+					id: asset_id.into(),
+				},
 			)?;
 		}
 

--- a/precompiles/assets-erc20/src/mock.rs
+++ b/precompiles/assets-erc20/src/mock.rs
@@ -18,9 +18,13 @@
 
 use super::*;
 
-use frame_support::{construct_runtime, parameter_types, traits::Everything, weights::Weight};
+use frame_support::{
+	construct_runtime, parameter_types,
+	traits::{AsEnsureOriginWithArg, Everything},
+	weights::Weight,
+};
 
-use frame_system::EnsureRoot;
+use frame_system::{EnsureRoot, EnsureSigned};
 use pallet_evm::{EnsureAddressNever, EnsureAddressRoot};
 use precompile_utils::{
 	mock_account,
@@ -28,7 +32,7 @@ use precompile_utils::{
 	testing::{AddressInPrefixedSet, MockAccount},
 };
 use sp_core::{H160, H256};
-use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
+use sp_runtime::traits::{BlakeTwo256, ConstU32, IdentityLookup};
 
 pub type AccountId = MockAccount;
 pub type AssetId = u128;
@@ -225,6 +229,10 @@ impl pallet_assets::Config<ForeignAssetInstance> for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = AssetAccountDeposit;
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = AssetId;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 impl pallet_assets::Config<LocalAssetInstance> for Runtime {
@@ -242,6 +250,10 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = AssetAccountDeposit;
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = AssetId;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 // Configure a mock runtime to test the pallet.

--- a/precompiles/assets-erc20/src/mock.rs
+++ b/precompiles/assets-erc20/src/mock.rs
@@ -24,7 +24,7 @@ use frame_support::{
 	weights::Weight,
 };
 
-use frame_system::{EnsureRoot, EnsureSigned};
+use frame_system::{EnsureNever, EnsureRoot};
 use pallet_evm::{EnsureAddressNever, EnsureAddressRoot};
 use precompile_utils::{
 	mock_account,
@@ -231,7 +231,7 @@ impl pallet_assets::Config<ForeignAssetInstance> for Runtime {
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = AssetId;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
 	type CallbackHandle = ();
 }
 
@@ -252,7 +252,7 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = AssetId;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
 	type CallbackHandle = ();
 }
 

--- a/precompiles/assets-erc20/src/tests.rs
+++ b/precompiles/assets-erc20/src/tests.rs
@@ -267,7 +267,7 @@ fn approve() {
 						value: 500.into(),
 					},
 				)
-				.expect_cost(46033756u64)
+				.expect_cost(46005756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -308,7 +308,7 @@ fn approve_saturating() {
 						value: U256::MAX,
 					},
 				)
-				.expect_cost(46033756u64)
+				.expect_cost(46005756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -437,7 +437,7 @@ fn transfer() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(58180756u64) // 1 weight => 1 gas in mock
+				.expect_cost(59448756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -564,7 +564,7 @@ fn transfer_from() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(73187756u64) // 1 weight => 1 gas in mock
+				.expect_cost(71723756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -642,7 +642,7 @@ fn transfer_from_non_incremental_approval() {
 						value: 500.into(),
 					},
 				)
-				.expect_cost(46033756u64)
+				.expect_cost(46005756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -665,7 +665,7 @@ fn transfer_from_non_incremental_approval() {
 						value: 300.into(),
 					},
 				)
-				.expect_cost(93745756u64)
+				.expect_cost(92915756)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -773,7 +773,7 @@ fn transfer_from_self() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(58180756u64) // 1 weight => 1 gas in mock
+				.expect_cost(59448756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -940,7 +940,7 @@ fn mint_local_assets() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(36218756u64) // 1 weight => 1 gas in mock
+				.expect_cost(37341756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					LocalAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -1001,7 +1001,7 @@ fn burn_local_assets() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(45808756u64) // 1 weight => 1 gas in mock
+				.expect_cost(45486756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					LocalAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -1061,7 +1061,7 @@ fn freeze_local_assets() {
 						account: Address(Bob.into()),
 					},
 				)
-				.expect_cost(27689000u64) // 1 weight => 1 gas in mock
+				.expect_cost(27373000) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1119,7 +1119,7 @@ fn thaw_local_assets() {
 						account: Address(Bob.into()),
 					},
 				)
-				.expect_cost(27689000u64) // 1 weight => 1 gas in mock
+				.expect_cost(27373000) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1131,7 +1131,7 @@ fn thaw_local_assets() {
 						account: Address(Bob.into()),
 					},
 				)
-				.expect_cost(27591000u64) // 1 weight => 1 gas in mock
+				.expect_cost(26854000) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1144,7 +1144,7 @@ fn thaw_local_assets() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(58180756u64) // 1 weight => 1 gas in mock
+				.expect_cost(59448756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					LocalAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -1190,7 +1190,7 @@ fn freeze_asset_local_asset() {
 					LocalAssetId(0u128),
 					LocalPCall::freeze_asset {},
 				)
-				.expect_cost(24269000u64) // 1 weight => 1 gas in mock
+				.expect_cost(23613000) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1207,7 +1207,7 @@ fn freeze_asset_local_asset() {
 					from_utf8(&output)
 						.unwrap()
 						.contains("Dispatched call failed with error: ")
-						&& from_utf8(&output).unwrap().contains("Frozen")
+						&& from_utf8(&output).unwrap().contains("AssetNotLive")
 				});
 		});
 }
@@ -1246,13 +1246,13 @@ fn thaw_asset_local_assets() {
 					LocalAssetId(0u128),
 					LocalPCall::freeze_asset {},
 				)
-				.expect_cost(24269000u64) // 1 weight => 1 gas in mock
+				.expect_cost(23613000) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
 			precompiles()
 				.prepare_test(CryptoAlith, LocalAssetId(0u128), LocalPCall::thaw_asset {})
-				.expect_cost(23527000u64) // 1 weight => 1 gas in mock
+				.expect_cost(24121000) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1265,7 +1265,7 @@ fn thaw_asset_local_assets() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(58180756u64) // 1 weight => 1 gas in mock
+				.expect_cost(59448756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					LocalAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -1307,7 +1307,7 @@ fn transfer_ownership_local_assets() {
 						owner: Address(Bob.into()),
 					},
 				)
-				.expect_cost(24597000u64) // 1 weight => 1 gas in mock
+				.expect_cost(24347000) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1335,7 +1335,7 @@ fn transfer_ownership_local_assets() {
 						owner: Address(CryptoAlith.into()),
 					},
 				)
-				.expect_cost(24597000u64) // 1 weight => 1 gas in mock
+				.expect_cost(24347000) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 		});
@@ -1373,7 +1373,7 @@ fn set_team_local_assets() {
 						freezer: Address(Bob.into()),
 					},
 				)
-				.expect_cost(23173000u64) // 1 weight => 1 gas in mock
+				.expect_cost(23518000) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1403,7 +1403,7 @@ fn set_team_local_assets() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(36218756u64) // 1 weight => 1 gas in mock
+				.expect_cost(37341756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					LocalAssetId(0u128),
 					SELECTOR_LOG_TRANSFER,
@@ -1459,7 +1459,7 @@ fn set_metadata() {
 						decimals: 12,
 					},
 				)
-				.expect_cost(42869113u64) // 1 weight => 1 gas in mock
+				.expect_cost(42853124) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1523,7 +1523,7 @@ fn clear_metadata() {
 						decimals: 12,
 					},
 				)
-				.expect_cost(42869113u64) // 1 weight => 1 gas in mock
+				.expect_cost(42853124) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1533,7 +1533,7 @@ fn clear_metadata() {
 					LocalAssetId(0u128),
 					LocalPCall::clear_metadata {},
 				)
-				.expect_cost(42912000u64) // 1 weight => 1 gas in mock
+				.expect_cost(42957000) // 1 weight => 1 gas in mock
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1630,7 +1630,7 @@ fn permit_valid() {
 						s: H256::from(rs.s.b32()),
 					},
 				)
-				.expect_cost(46032000u64)
+				.expect_cost(46004000)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -1739,7 +1739,7 @@ fn permit_valid_named_asset() {
 						s: H256::from(rs.s.b32()),
 					},
 				)
-				.expect_cost(46032000u64)
+				.expect_cost(46004000)
 				.expect_log(log3(
 					ForeignAssetId(0u128),
 					SELECTOR_LOG_APPROVAL,
@@ -2217,7 +2217,7 @@ fn permit_valid_with_metamask_signed_data() {
 						s: H256::from(s_real),
 					},
 				)
-				.expect_cost(46032000u64)
+				.expect_cost(46004000)
 				.expect_log(log3(
 					ForeignAssetId(1u128),
 					SELECTOR_LOG_APPROVAL,

--- a/precompiles/author-mapping/Cargo.toml
+++ b/precompiles/author-mapping/Cargo.toml
@@ -15,18 +15,18 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 # Nimbus
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -38,11 +38,11 @@ pallet-author-mapping = { path = "../../pallets/author-mapping" }
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 # Substrate
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/precompiles/balances-erc20/Cargo.toml
+++ b/precompiles/balances-erc20/Cargo.toml
@@ -16,17 +16,17 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = { version = "0.99" }
@@ -38,9 +38,9 @@ sha3 = "0.10"
 # Moonbeam
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -280,7 +280,7 @@ fn transfer() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(166861756u64) // 1 weight => 1 gas in mock
+				.expect_cost(173812756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_TRANSFER,
@@ -367,7 +367,7 @@ fn transfer_from() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(166861756u64) // 1 weight => 1 gas in mock
+				.expect_cost(173812756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_TRANSFER,
@@ -463,7 +463,7 @@ fn transfer_from_self() {
 						value: 400.into(),
 					},
 				)
-				.expect_cost(166861756u64) // 1 weight => 1 gas in mock
+				.expect_cost(173812756) // 1 weight => 1 gas in mock
 				.expect_log(log3(
 					Precompile1,
 					SELECTOR_LOG_TRANSFER,

--- a/precompiles/batch/Cargo.toml
+++ b/precompiles/batch/Cargo.toml
@@ -16,16 +16,16 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
 evm = { version = "0.37.0", default-features = false, features = [ "with-codec" ] }
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = { version = "0.99" }
@@ -34,11 +34,11 @@ serde = { version = "1.0.100" }
 sha3 = "0.10"
 
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/precompiles/batch/src/tests.rs
+++ b/precompiles/batch/src/tests.rs
@@ -24,7 +24,7 @@ use crate::{
 use evm::ExitReason;
 use fp_evm::{ExitError, ExitRevert, ExitSucceed};
 use frame_support::{
-	assert_err, assert_err_ignore_postinfo, assert_ok,
+	assert_ok,
 	dispatch::{DispatchError, Dispatchable},
 };
 use pallet_evm::Call as EvmCall;

--- a/precompiles/batch/src/tests.rs
+++ b/precompiles/batch/src/tests.rs
@@ -23,10 +23,14 @@ use crate::{
 };
 use evm::ExitReason;
 use fp_evm::{ExitError, ExitRevert, ExitSucceed};
-use frame_support::{assert_ok, dispatch::Dispatchable};
+use frame_support::{
+	assert_err, assert_err_ignore_postinfo, assert_ok,
+	dispatch::{DispatchError, Dispatchable},
+};
 use pallet_evm::Call as EvmCall;
 use precompile_utils::{costs::call_cost, prelude::*, revert::RevertSelector, testing::*};
 use sp_core::{H160, H256, U256};
+use sp_runtime::{DispatchErrorWithPostInfo, ModuleError};
 
 fn precompiles() -> Precompiles<Runtime> {
 	PrecompilesValue::get()
@@ -1034,11 +1038,17 @@ fn batch_not_callable_by_smart_contract() {
 			}
 			.into();
 
-			assert_ok!(RuntimeCall::Evm(evm_call(Alice, input)).dispatch(RuntimeOrigin::root()));
-
-			// batch failed so state is same
-			assert_eq!(balance(Alice), 10_000);
-			assert_eq!(balance(Bob), 0);
+			match RuntimeCall::Evm(evm_call(Alice, input)).dispatch(RuntimeOrigin::root()) {
+				Err(DispatchErrorWithPostInfo {
+					error:
+						DispatchError::Module(ModuleError {
+							message: Some(err_msg),
+							..
+						}),
+					..
+				}) => assert_eq!("TransactionMustComeFromEOA", err_msg),
+				_ => panic!("expected error 'TransactionMustComeFromEOA'"),
+			}
 		})
 }
 
@@ -1072,11 +1082,17 @@ fn batch_is_callable_by_dummy_code() {
 			}
 			.into();
 
-			assert_ok!(RuntimeCall::Evm(evm_call(Alice, input)).dispatch(RuntimeOrigin::root()));
-
-			// batch succeeds
-			assert_eq!(balance(Alice), 9_000);
-			assert_eq!(balance(Bob), 1_000);
+			match RuntimeCall::Evm(evm_call(Alice, input)).dispatch(RuntimeOrigin::root()) {
+				Err(DispatchErrorWithPostInfo {
+					error:
+						DispatchError::Module(ModuleError {
+							message: Some(err_msg),
+							..
+						}),
+					..
+				}) => assert_eq!("TransactionMustComeFromEOA", err_msg),
+				_ => panic!("expected error 'TransactionMustComeFromEOA'"),
+			}
 		})
 }
 

--- a/precompiles/batch/src/tests.rs
+++ b/precompiles/batch/src/tests.rs
@@ -1053,7 +1053,7 @@ fn batch_not_callable_by_smart_contract() {
 }
 
 #[test]
-fn batch_is_callable_by_dummy_code() {
+fn batch_is_not_callable_by_dummy_code() {
 	ExtBuilder::default()
 		.with_balances(vec![(Alice.into(), 10_000)])
 		.build()

--- a/precompiles/call-permit/Cargo.toml
+++ b/precompiles/call-permit/Cargo.toml
@@ -16,17 +16,17 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
 evm = { version = "0.37.0", default-features = false, features = [ "with-codec" ] }
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = { version = "0.99" }
@@ -36,11 +36,11 @@ serde = { version = "1.0.100" }
 sha3 = "0.10"
 
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/precompiles/collective/Cargo.toml
+++ b/precompiles/collective/Cargo.toml
@@ -16,17 +16,17 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-collective = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-collective = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
 evm = { version = "0.37.0", default-features = false, features = [ "with-codec" ] }
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = { version = "0.99" }
@@ -36,12 +36,12 @@ sha3 = "0.10"
 similar-asserts = "1.1.0"
 
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-treasury = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-treasury = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/precompiles/conviction-voting/Cargo.toml
+++ b/precompiles/conviction-voting/Cargo.toml
@@ -14,17 +14,17 @@ rustc-hex = { version = "2.0.1", default-features = false }
 precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-conviction-voting = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-conviction-voting = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -36,10 +36,10 @@ sha3 = "0.9"
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 # Substrate
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/precompiles/crowdloan-rewards/Cargo.toml
+++ b/precompiles/crowdloan-rewards/Cargo.toml
@@ -11,18 +11,18 @@ num_enum = { version = "0.5.3", default-features = false }
 rustc-hex = { version = "2.0.1", default-features = false }
 
 # Moonbeam
-pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -34,18 +34,18 @@ precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Cumulus
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/precompiles/pallet-democracy/Cargo.toml
+++ b/precompiles/pallet-democracy/Cargo.toml
@@ -14,18 +14,18 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -36,13 +36,13 @@ serde = "1.0.100"
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 # Substrate
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [
 	"derive",
 ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/precompiles/parachain-staking/Cargo.toml
+++ b/precompiles/parachain-staking/Cargo.toml
@@ -16,16 +16,16 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -36,10 +36,10 @@ sha3 = "0.10"
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 # Substrate
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/precompiles/preimage/Cargo.toml
+++ b/precompiles/preimage/Cargo.toml
@@ -14,17 +14,17 @@ rustc-hex = { version = "2.0.1", default-features = false }
 precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -36,10 +36,10 @@ sha3 = "0.9"
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 # Substrate
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/precompiles/proxy/Cargo.toml
+++ b/precompiles/proxy/Cargo.toml
@@ -14,18 +14,18 @@ rustc-hex = { version = "2.0.1", default-features = false }
 precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
 evm = { version = "0.37.0", default-features = false, features = [ "with-codec" ] }
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -37,10 +37,10 @@ sha3 = "0.10"
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 # Substrate
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/precompiles/randomness/Cargo.toml
+++ b/precompiles/randomness/Cargo.toml
@@ -15,19 +15,19 @@ precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 # Nimbus
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -39,11 +39,11 @@ precompile-utils = { path = "../utils", features = [ "testing" ] }
 session-keys-primitives = { path = "../../primitives/session-keys" }
 
 # Substrate
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/precompiles/referenda/Cargo.toml
+++ b/precompiles/referenda/Cargo.toml
@@ -14,23 +14,23 @@ rustc-hex = { version = "2.0.1", default-features = false }
 precompile-utils = { path = "../utils", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-referenda = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-referenda = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [dev-dependencies]
 derive_more = "0.99"
 hex-literal = "0.3.3"
-pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 serde = "1.0.100"
 sha3 = "0.9"
 
@@ -38,10 +38,10 @@ sha3 = "0.9"
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 # Substrate
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/precompiles/relay-encoder/Cargo.toml
+++ b/precompiles/relay-encoder/Cargo.toml
@@ -15,20 +15,20 @@ precompile-utils = { path = "../utils", default-features = false }
 xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-staking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-staking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 # Cumulus
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -40,16 +40,16 @@ sha3 = "0.10"
 precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 # Substrate
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Cumulus
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Polkadot
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/precompiles/utils/Cargo.toml
+++ b/precompiles/utils/Cargo.toml
@@ -25,19 +25,19 @@ precompile-utils-macro = { path = "macro" }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
 evm = { version = "0.37.0", default-features = false, features = [ "with-codec" ] }
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 # Polkadot / XCM
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3.1"

--- a/precompiles/utils/macro/Cargo.toml
+++ b/precompiles/utils/macro/Cargo.toml
@@ -31,7 +31,7 @@ trybuild = "1.0"
 
 precompile-utils = { path = "../", features = [ "testing" ] }
 
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32" }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37" }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }

--- a/precompiles/xcm-transactor/Cargo.toml
+++ b/precompiles/xcm-transactor/Cargo.toml
@@ -16,22 +16,22 @@ precompile-utils = { path = "../utils", default-features = false }
 xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
 evm = { version = "0.37.0", default-features = false, features = [ "with-codec" ] }
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 # Polkadot
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Cumulus
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -44,18 +44,18 @@ xcm-primitives = { path = "../../primitives/xcm/" }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Polkadot
-pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 
 # ORML
-orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32" }
+orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/precompiles/xcm-utils/Cargo.toml
+++ b/precompiles/xcm-utils/Cargo.toml
@@ -14,19 +14,19 @@ xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 # Polkadot
-pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -38,21 +38,21 @@ precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Cumulus
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Polkadot
-polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 
 # ORML
-orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32" }
+orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/precompiles/xtokens/Cargo.toml
+++ b/precompiles/xtokens/Cargo.toml
@@ -15,19 +15,19 @@ precompile-utils = { path = "../utils", default-features = false }
 xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 # Polkadot / XCM
-orml-xtokens = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+orml-xtokens = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [dev-dependencies]
 derive_more = "0.99"
@@ -39,19 +39,19 @@ precompile-utils = { path = "../utils", features = [ "testing" ] }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 scale-info = { version = "2.0", features = [ "derive" ] }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Cumulus
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32" }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37" }
 
 # Polkadot
-orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -22,11 +22,11 @@ sha3 = { version = "0.10", default-features = false }
 # Substrate
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime-interface = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime-interface = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/primitives/ext/Cargo.toml
+++ b/primitives/ext/Cargo.toml
@@ -15,9 +15,9 @@ evm-tracing-events = { path = "../rpc/evm-tracing-events", default-features = fa
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-externalities = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime-interface = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-externalities = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime-interface = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/primitives/rpc/debug/Cargo.toml
+++ b/primitives/rpc/debug/Cargo.toml
@@ -17,11 +17,11 @@ serde_json = { version = "1.0", optional = true }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/primitives/rpc/evm-tracing-events/Cargo.toml
+++ b/primitives/rpc/evm-tracing-events/Cargo.toml
@@ -12,7 +12,7 @@ environmental = { version = "1.1.2", default-features = false }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-runtime-interface = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-runtime-interface = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Ethereum
 ethereum = { version = "0.14.0", default-features = false, features = [ "with-codec" ] }

--- a/primitives/rpc/txpool/Cargo.toml
+++ b/primitives/rpc/txpool/Cargo.toml
@@ -12,10 +12,10 @@ ethereum = { version = "0.14.0", default-features = false, features = [ "with-co
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/primitives/session-keys/Cargo.toml
+++ b/primitives/session-keys/Cargo.toml
@@ -7,19 +7,19 @@ version = "0.1.0"
 
 [dependencies]
 async-trait = { version = "0.1", optional = true }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-application-crypto = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-consensus-babe = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-consensus-vrf = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-application-crypto = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-consensus-babe = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-consensus-vrf = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-keystore = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/primitives/session-keys/src/inherent.rs
+++ b/primitives/session-keys/src/inherent.rs
@@ -54,7 +54,7 @@ pub struct InherentDataProvider;
 #[cfg(feature = "std")]
 #[async_trait::async_trait]
 impl sp_inherents::InherentDataProvider for InherentDataProvider {
-	fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), Error> {
+	async fn provide_inherent_data(&self, inherent_data: &mut InherentData) -> Result<(), Error> {
 		inherent_data.put_data(INHERENT_IDENTIFIER, &())
 	}
 

--- a/primitives/xcm/Cargo.toml
+++ b/primitives/xcm/Cargo.toml
@@ -20,22 +20,22 @@ serde = { version = "1.0.101", optional = true, default-features = false, featur
 sha3 = { version = "0.10", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Cumulus
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Polkadot / XCM
-orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [features]
 default = [ "std" ]

--- a/primitives/xcm/src/fee_handlers.rs
+++ b/primitives/xcm/src/fee_handlers.rs
@@ -22,7 +22,7 @@
 
 use frame_support::{
 	traits::{tokens::fungibles::Mutate, Get},
-	weights::constants::WEIGHT_PER_SECOND,
+	weights::constants::WEIGHT_REF_TIME_PER_SECOND,
 };
 use sp_runtime::traits::Zero;
 use sp_std::marker::PhantomData;
@@ -83,7 +83,7 @@ impl<
 				if let Some(units_per_second) = AssetIdInfoGetter::get_units_per_second(asset_type)
 				{
 					let amount = units_per_second.saturating_mul(weight as u128)
-						/ (WEIGHT_PER_SECOND.ref_time() as u128);
+						/ (WEIGHT_REF_TIME_PER_SECOND as u128);
 
 					// We dont need to proceed if the amount is 0
 					// For cases (specially tests) where the asset is very cheap with respect
@@ -117,8 +117,7 @@ impl<
 		if let Some((id, prev_amount, units_per_second)) = self.1.clone() {
 			let weight = weight.min(self.0);
 			self.0 -= weight;
-			let amount =
-				units_per_second * (weight as u128) / (WEIGHT_PER_SECOND.ref_time() as u128);
+			let amount = units_per_second * (weight as u128) / (WEIGHT_REF_TIME_PER_SECOND as u128);
 			let amount = amount.min(prev_amount);
 			self.1 = Some((
 				id.clone(),
@@ -205,9 +204,9 @@ mod test {
 			true
 		}
 		fn get_units_per_second(_asset_type: MultiLocation) -> Option<u128> {
-			// return WEIGHT_PER_SECOND to cancel the division out in buy_weight()
+			// return WEIGHT_REF_TIME_PER_SECOND to cancel the division out in buy_weight()
 			// this should make weight and payment amounts directly comparable
-			Some(WEIGHT_PER_SECOND.ref_time() as u128)
+			Some(WEIGHT_REF_TIME_PER_SECOND as u128)
 		}
 	}
 
@@ -258,7 +257,7 @@ mod test {
 					interior: Junctions::X1(Junction::Parachain(1000))
 				},
 				100,
-				WEIGHT_PER_SECOND.ref_time() as u128
+				WEIGHT_REF_TIME_PER_SECOND as u128
 			))
 		);
 
@@ -286,7 +285,7 @@ mod test {
 					interior: Junctions::X1(Junction::Parachain(1000))
 				},
 				100,
-				WEIGHT_PER_SECOND.ref_time() as u128
+				WEIGHT_REF_TIME_PER_SECOND as u128
 			))
 		);
 	}

--- a/runtime/common/Cargo.toml
+++ b/runtime/common/Cargo.toml
@@ -21,26 +21,26 @@ pallet-randomness = { path = "../../pallets/randomness", default-features = fals
 pallet-xcm-transactor = { path = "../../pallets/xcm-transactor", default-features = false }
 
 # Substrate
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-collective = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-collective = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 # Nimbus
-pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Polkadot
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [features]
 std = [

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -350,6 +350,8 @@ macro_rules! impl_runtime_apis_plus_common {
 				fn elasticity() -> Option<Permill> {
 					None
 				}
+
+				fn gas_limit_multiplier_support() {}
 			}
 
 			impl fp_rpc::ConvertTransactionRuntimeApi<Block> for Runtime {

--- a/runtime/evm_tracer/Cargo.toml
+++ b/runtime/evm_tracer/Cargo.toml
@@ -15,18 +15,18 @@ moonbeam-primitives-ext = { path = "../../primitives/ext", default-features = fa
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
 ethereum-types = { version = "0.14", default-features = false }
 evm = { version = "0.37.0", default-features = false, features = [ "with-codec" ] }
 evm-gasometer = { version = "0.37.0", default-features = false }
 evm-runtime = { version = "0.37.0", default-features = false }
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
 
 [features]
 default = [ "std" ]

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -30,7 +30,7 @@ xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
 moonbeam-xcm-benchmarks = { path = "../../pallets/moonbeam-xcm-benchmarks", default-features = false }
 pallet-asset-manager = { path = "../../pallets/asset-manager", default-features = false }
 pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
-pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
 pallet-ethereum-xcm = { path = "../../pallets/ethereum-xcm", default-features = false }
 pallet-maintenance-mode = { path = "../../pallets/maintenance-mode", default-features = false, features = [ "xcm-support" ] }
@@ -68,103 +68,103 @@ moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-f
 moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
 
 # Substrate
-frame-executive = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-assets = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-collective = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-conviction-voting = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-identity = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-referenda = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-society = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-sudo = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-treasury = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-utility = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-whitelist = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-executive = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-assets = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-collective = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-conviction-voting = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-identity = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-referenda = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-society = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-sudo = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-treasury = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-utility = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-whitelist = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive", "max-encoded-len" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-debug-derive = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-offchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-session = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-version = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-debug-derive = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-offchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-session = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-version = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
-pallet-evm-precompile-blake2 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm-precompile-blake2 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Cumulus / Nimbus
-cumulus-pallet-dmp-queue = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-parachain-info = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+cumulus-pallet-dmp-queue = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+parachain-info = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Polkadot / XCM
-orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-orml-xcm-support = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-orml-xtokens = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-xcm-benchmarks = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-polkadot-core-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+orml-xcm-support = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+orml-xtokens = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-xcm-benchmarks = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+polkadot-core-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Benchmarking
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-frame-system-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-frame-try-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+frame-system-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+frame-try-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
 
 [dev-dependencies]
 ethereum = { version = "0.14.0" }
 hex = "0.4"
 sha3 = "0.10"
 
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
-polkadot-runtime-parachains = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-xcm-simulator = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+polkadot-runtime-parachains = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+xcm-simulator = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 
 precompile-utils = { path = "../../precompiles/utils", default-features = false, features = [ "testing" ] }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -82,6 +82,7 @@ pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "mo
 pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-referenda = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-root-testing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-society = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-sudo = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
@@ -233,6 +234,7 @@ std = [
 	"pallet-randomness-collective-flip/std",
 	"pallet-randomness/std",
 	"pallet-referenda/std",
+	"pallet-root-testing/std",
 	"pallet-scheduler/std",
 	"pallet-society/std",
 	"pallet-sudo/std",
@@ -333,6 +335,7 @@ try-runtime = [
 	"pallet-parachain-staking/try-runtime",
 	"pallet-preimage/try-runtime",
 	"pallet-referenda/try-runtime",
+	"pallet-root-testing/try-runtime",
 	"pallet-scheduler/try-runtime",
 	"pallet-society/try-runtime",
 	"pallet-timestamp/try-runtime",

--- a/runtime/moonbase/src/asset_config.rs
+++ b/runtime/moonbase/src/asset_config.rs
@@ -29,14 +29,14 @@ use sp_runtime::traits::Hash as THash;
 use frame_support::{
 	dispatch::GetDispatchInfo,
 	parameter_types,
-	traits::{ConstU128, EitherOfDiverse},
+	traits::{AsEnsureOriginWithArg, ConstU128, ConstU32, EitherOfDiverse},
 	weights::Weight,
 };
 
-use frame_system::EnsureRoot;
+use frame_system::{EnsureRoot, EnsureSigned};
 use sp_core::{H160, H256};
 
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::{Compact, Decode, Encode};
 use scale_info::TypeInfo;
 
 use sp_std::{
@@ -86,6 +86,10 @@ impl pallet_assets::Config<ForeignAssetInstance> for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = ConstU128<{ currency::deposit(1, 18) }>;
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = Compact<AssetId>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 // Local assets
@@ -104,6 +108,10 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = ConstU128<{ currency::deposit(1, 18) }>;
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = Compact<AssetId>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 // We instruct how to register the Assets
@@ -121,7 +129,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	) -> DispatchResult {
 		Assets::force_create(
 			RuntimeOrigin::root(),
-			asset,
+			asset.into(),
 			AssetManager::account_id(),
 			is_sufficient,
 			min_balance,
@@ -139,7 +147,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// Lastly, the metadata
 		Assets::force_set_metadata(
 			RuntimeOrigin::root(),
-			asset,
+			asset.into(),
 			metadata.name,
 			metadata.symbol,
 			metadata.decimals,
@@ -160,7 +168,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// in pallet-assets
 		LocalAssets::force_create(
 			RuntimeOrigin::root(),
-			asset,
+			asset.into(),
 			owner,
 			is_sufficient,
 			min_balance,
@@ -180,13 +188,19 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	}
 
 	#[transactional]
-	fn destroy_foreign_asset(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchResult {
+	fn destroy_foreign_asset(asset: AssetId) -> DispatchResult {
 		// First destroy the asset
-		Assets::destroy(RuntimeOrigin::root(), asset, asset_destroy_witness)
-			.map_err(|info| info.error)?;
+		Assets::freeze_asset(RuntimeOrigin::root(), asset.into())
+			.and_then(|_| Assets::start_destroy(RuntimeOrigin::root(), asset.into()))
+			.and_then(|_| {
+				Assets::destroy_accounts(RuntimeOrigin::root(), asset.into())
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| {
+				Assets::destroy_approvals(RuntimeOrigin::root(), asset.into())
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| Assets::finish_destroy(RuntimeOrigin::root(), asset.into()))?;
 
 		// We remove the EVM revert code
 		// This does not panick even if there is no code in the address
@@ -197,13 +211,19 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	}
 
 	#[transactional]
-	fn destroy_local_asset(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchResult {
+	fn destroy_local_asset(asset: AssetId) -> DispatchResult {
 		// First destroy the asset
-		LocalAssets::destroy(RuntimeOrigin::root(), asset, asset_destroy_witness)
-			.map_err(|info| info.error)?;
+		LocalAssets::freeze_asset(RuntimeOrigin::root(), asset.into())
+			.and_then(|_| LocalAssets::start_destroy(RuntimeOrigin::root(), asset.into()))
+			.and_then(|_| {
+				LocalAssets::destroy_accounts(RuntimeOrigin::root(), asset.into())
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| {
+				LocalAssets::destroy_approvals(RuntimeOrigin::root(), asset.into())
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| LocalAssets::finish_destroy(RuntimeOrigin::root(), asset.into()))?;
 
 		// We remove the EVM revert code
 		// This does not panick even if there is no code in the address
@@ -213,10 +233,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		Ok(())
 	}
 
-	fn destroy_asset_dispatch_info_weight(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> Weight {
+	fn destroy_asset_dispatch_info_weight(asset: AssetId) -> Weight {
 		// For us both of them (Foreign and Local) have the same annotated weight for a given
 		// witness
 		// We need to take the dispatch info from the destroy call, which is already annotated in
@@ -225,17 +242,40 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// EVM
 
 		// This is the dispatch info of destroy
-		let call = RuntimeCall::Assets(
-			pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy {
-				id: asset,
-				witness: asset_destroy_witness,
-			},
-		);
+		let call_weight = [
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::freeze_asset {
+					id: asset.into(),
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy {
+					id: asset.into(),
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_accounts {
+					id: asset.into(),
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_approvals {
+					id: asset.into(),
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::finish_destroy {
+					id: asset.into(),
+				},
+			),
+		]
+		.into_iter()
+		.fold(Weight::zero(), |acc, call| {
+			acc.saturating_add(call.get_dispatch_info().weight)
+		});
 
 		// This is the db write
-		call.get_dispatch_info()
-			.weight
-			.saturating_add(<Runtime as frame_system::Config>::DbWeight::get().writes(1))
+		call_weight.saturating_add(<Runtime as frame_system::Config>::DbWeight::get().writes(1))
 	}
 }
 
@@ -285,7 +325,6 @@ impl pallet_asset_manager::Config for Runtime {
 	type ForeignAssetModifierOrigin = ForeignAssetModifierOrigin;
 	type LocalAssetModifierOrigin = LocalAssetModifierOrigin;
 	type LocalAssetIdCreator = LocalAssetIdCreator;
-	type AssetDestroyWitness = pallet_assets::DestroyWitness;
 	type Currency = Balances;
 	type LocalAssetDeposit = AssetDeposit;
 	type WeightInfo = pallet_asset_manager::weights::SubstrateWeight<Runtime>;

--- a/runtime/moonbase/src/governance/referenda.rs
+++ b/runtime/moonbase/src/governance/referenda.rs
@@ -71,7 +71,7 @@ impl pallet_whitelist::Config for Runtime {
 		>,
 	>;
 	type DispatchWhitelistedOrigin = EitherOf<EnsureRoot<Self::AccountId>, WhitelistedCaller>;
-	type PreimageProvider = Preimage;
+	type Preimages = Preimage;
 }
 
 pallet_referenda::impl_tracksinfo_get!(TracksInfo, Balance, BlockNumber);

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1054,7 +1054,6 @@ impl Contains<RuntimeCall> for NormalFilter {
 			// substrate side of things
 			RuntimeCall::LocalAssets(method) => match method {
 				pallet_assets::Call::create { .. } => false,
-				pallet_assets::Call::freeze_asset { .. } => false,
 				pallet_assets::Call::start_destroy { .. } => false,
 				pallet_assets::Call::destroy_accounts { .. } => false,
 				pallet_assets::Call::destroy_approvals { .. } => false,

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1045,6 +1045,9 @@ impl Contains<RuntimeCall> for NormalFilter {
 				pallet_assets::Call::approve_transfer { .. } => true,
 				pallet_assets::Call::transfer_approved { .. } => true,
 				pallet_assets::Call::cancel_approval { .. } => true,
+				pallet_assets::Call::destroy_accounts { .. } => true,
+				pallet_assets::Call::destroy_approvals { .. } => true,
+				pallet_assets::Call::finish_destroy { .. } => true,
 				_ => false,
 			},
 			// We want to disable create, as we dont want users to be choosing the
@@ -1055,9 +1058,6 @@ impl Contains<RuntimeCall> for NormalFilter {
 			RuntimeCall::LocalAssets(method) => match method {
 				pallet_assets::Call::create { .. } => false,
 				pallet_assets::Call::start_destroy { .. } => false,
-				pallet_assets::Call::destroy_accounts { .. } => false,
-				pallet_assets::Call::destroy_approvals { .. } => false,
-				pallet_assets::Call::finish_destroy { .. } => false,
 				_ => true,
 			},
 			// We filter anonymous proxy as they make "reserve" inconsistent

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1268,6 +1268,8 @@ impl pallet_randomness::Config for Runtime {
 	type EpochExpirationDelay = ConstU64<10_000>;
 }
 
+impl pallet_root_testing::Config for Runtime {}
+
 construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
@@ -1324,6 +1326,7 @@ construct_runtime! {
 		Whitelist: pallet_whitelist::{Pallet, Call, Storage, Event<T>} = 45,
 		OpenTechCommitteeCollective:
 			pallet_collective::<Instance4>::{Pallet, Call, Storage, Event<T>, Origin<T>, Config<T>} = 46,
+		RootTesting: pallet_root_testing::{Pallet, Call, Storage} = 47,
 	}
 }
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -49,7 +49,7 @@ use frame_support::{
 		OnUnbalanced,
 	},
 	weights::{
-		constants::{RocksDbWeight, WEIGHT_PER_SECOND},
+		constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND},
 		ConstantMultiplier, Weight, WeightToFeeCoefficient, WeightToFeeCoefficients,
 		WeightToFeePolynomial,
 	},
@@ -144,7 +144,7 @@ pub mod currency {
 }
 
 /// Maximum weight per block
-pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
+pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_ref_time(WEIGHT_REF_TIME_PER_SECOND)
 	.saturating_div(2)
 	.set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);
 
@@ -379,7 +379,7 @@ pub const GAS_PER_SECOND: u64 = 40_000_000;
 
 /// Approximate ratio of the amount of Weight per Gas.
 /// u64 works for approximations because Weight is a very small unit compared to gas.
-pub const WEIGHT_PER_GAS: u64 = WEIGHT_PER_SECOND.ref_time() / GAS_PER_SECOND;
+pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND / GAS_PER_SECOND;
 
 parameter_types! {
 	pub BlockGasLimit: U256
@@ -1054,7 +1054,11 @@ impl Contains<RuntimeCall> for NormalFilter {
 			// substrate side of things
 			RuntimeCall::LocalAssets(method) => match method {
 				pallet_assets::Call::create { .. } => false,
-				pallet_assets::Call::destroy { .. } => false,
+				pallet_assets::Call::freeze_asset { .. } => false,
+				pallet_assets::Call::start_destroy { .. } => false,
+				pallet_assets::Call::destroy_accounts { .. } => false,
+				pallet_assets::Call::destroy_approvals { .. } => false,
+				pallet_assets::Call::finish_destroy { .. } => false,
 				_ => true,
 			},
 			// We filter anonymous proxy as they make "reserve" inconsistent

--- a/runtime/moonbase/tests/common/mod.rs
+++ b/runtime/moonbase/tests/common/mod.rs
@@ -308,9 +308,10 @@ impl ExtBuilder {
 		ext.execute_with(|| {
 			// If any local assets specified, we create them here
 			for (asset_id, balances, owner) in local_assets.clone() {
-				LocalAssets::force_create(root_origin(), asset_id, owner, true, 1).unwrap();
+				LocalAssets::force_create(root_origin(), asset_id.into(), owner, true, 1).unwrap();
 				for (account, balance) in balances {
-					LocalAssets::mint(origin_of(owner.into()), asset_id, account, balance).unwrap();
+					LocalAssets::mint(origin_of(owner.into()), asset_id.into(), account, balance)
+						.unwrap();
 				}
 			}
 			// If any xcm assets specified, we register them here
@@ -327,7 +328,7 @@ impl ExtBuilder {
 				for (account, balance) in xcm_asset_initialization.balances {
 					Assets::mint(
 						origin_of(AssetManager::account_id()),
-						asset_id,
+						asset_id.into(),
 						account,
 						balance,
 					)

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -29,7 +29,7 @@ use frame_support::{
 		fungible::Inspect, fungibles::Inspect as FungiblesInspect, Currency as CurrencyT,
 		EnsureOrigin, PalletInfo, StorageInfo, StorageInfoTrait,
 	},
-	weights::{constants::WEIGHT_PER_SECOND, Weight},
+	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 	StorageHasher, Twox128,
 };
 use moonbase_runtime::{
@@ -1201,7 +1201,7 @@ fn local_assets_cannot_be_create_by_signed_origins() {
 			assert_noop!(
 				RuntimeCall::LocalAssets(
 					pallet_assets::Call::<Runtime, LocalAssetInstance>::create {
-						id: 11u128,
+						id: 11u128.into(),
 						admin: AccountId::from(ALICE),
 						min_balance: 1u128
 					}
@@ -1625,18 +1625,18 @@ fn asset_erc20_precompiles_freeze_set_team() {
 			// Bob should be able to mint, freeze, and thaw
 			assert_ok!(LocalAssets::mint(
 				origin_of(AccountId::from(BOB)),
-				0u128,
+				0u128.into(),
 				AccountId::from(BOB),
 				1_000 * UNIT
 			));
 			assert_ok!(LocalAssets::freeze(
 				origin_of(AccountId::from(BOB)),
-				0u128,
+				0u128.into(),
 				AccountId::from(ALICE)
 			));
 			assert_ok!(LocalAssets::thaw(
 				origin_of(AccountId::from(BOB)),
-				0u128,
+				0u128.into(),
 				AccountId::from(ALICE)
 			));
 		});
@@ -2930,7 +2930,7 @@ fn test_xcm_utils_get_units_per_second() {
 		let input = XcmUtilsPCall::get_units_per_second { multilocation };
 
 		let expected_units =
-			WEIGHT_PER_SECOND.ref_time() as u128 * moonbase_runtime::currency::WEIGHT_FEE;
+			WEIGHT_REF_TIME_PER_SECOND as u128 * moonbase_runtime::currency::WEIGHT_FEE;
 
 		Precompiles::new()
 			.prepare_test(ALICE, xcm_utils_precompile_address, input)

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -219,6 +219,13 @@ fn verify_pallet_prefixes() {
 			},
 			StorageInfo {
 				pallet_name: b"Balances".to_vec(),
+				storage_name: b"InactiveIssuance".to_vec(),
+				prefix: prefix(b"Balances", b"InactiveIssuance"),
+				max_values: Some(1),
+				max_size: Some(16),
+			},
+			StorageInfo {
+				pallet_name: b"Balances".to_vec(),
 				storage_name: b"Account".to_vec(),
 				prefix: prefix(b"Balances", b"Account"),
 				max_values: None,
@@ -238,13 +245,6 @@ fn verify_pallet_prefixes() {
 				max_values: None,
 				max_size: Some(1037),
 			},
-			StorageInfo {
-				pallet_name: b"Balances".to_vec(),
-				storage_name: b"StorageVersion".to_vec(),
-				prefix: prefix(b"Balances", b"StorageVersion"),
-				max_values: Some(1),
-				max_size: Some(1),
-			}
 		]
 	);
 	assert_eq!(
@@ -1284,7 +1284,7 @@ fn asset_erc20_precompiles_transfer() {
 						value: { 400 * UNIT }.into(),
 					},
 				)
-				.expect_cost(24083u64)
+				.expect_cost(24133)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1336,7 +1336,7 @@ fn asset_erc20_precompiles_approve() {
 						value: { 400 * UNIT }.into(),
 					},
 				)
-				.expect_cost(14597)
+				.expect_cost(14596)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_APPROVAL,
@@ -1357,7 +1357,7 @@ fn asset_erc20_precompiles_approve() {
 						value: { 400 * UNIT }.into(),
 					},
 				)
-				.expect_cost(29683)
+				.expect_cost(29624)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1409,7 +1409,7 @@ fn asset_erc20_precompiles_mint_burn() {
 						value: { 1000 * UNIT }.into(),
 					},
 				)
-				.expect_cost(13204)
+				.expect_cost(13249)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1436,7 +1436,7 @@ fn asset_erc20_precompiles_mint_burn() {
 						value: { 500 * UNIT }.into(),
 					},
 				)
-				.expect_cost(13588)
+				.expect_cost(13575)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1481,7 +1481,7 @@ fn asset_erc20_precompiles_freeze_thaw_account() {
 						account: Address(ALICE.into()),
 					},
 				)
-				.expect_cost(7107)
+				.expect_cost(7094)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1500,7 +1500,7 @@ fn asset_erc20_precompiles_freeze_thaw_account() {
 						account: Address(ALICE.into()),
 					},
 				)
-				.expect_cost(7103)
+				.expect_cost(7074)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1535,7 +1535,7 @@ fn asset_erc20_precompiles_freeze_thaw_asset() {
 					asset_precompile_address,
 					LocalAssetsPCall::freeze_asset {},
 				)
-				.expect_cost(5970)
+				.expect_cost(5944)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1552,7 +1552,7 @@ fn asset_erc20_precompiles_freeze_thaw_asset() {
 					asset_precompile_address,
 					LocalAssetsPCall::thaw_asset {},
 				)
-				.expect_cost(5941)
+				.expect_cost(5964)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 		});
@@ -1584,7 +1584,7 @@ fn asset_erc20_precompiles_freeze_transfer_ownership() {
 						owner: Address(BOB.into()),
 					},
 				)
-				.expect_cost(6983)
+				.expect_cost(6973)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 		});
@@ -1618,7 +1618,7 @@ fn asset_erc20_precompiles_freeze_set_team() {
 						freezer: Address(BOB.into()),
 					},
 				)
-				.expect_cost(5926)
+				.expect_cost(5940)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1739,7 +1739,7 @@ fn xcm_asset_erc20_precompiles_transfer() {
 						value: { 400 * UNIT }.into(),
 					},
 				)
-				.expect_cost(24083)
+				.expect_cost(24133)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1803,7 +1803,7 @@ fn xcm_asset_erc20_precompiles_approve() {
 						value: { 400 * UNIT }.into(),
 					},
 				)
-				.expect_cost(14597)
+				.expect_cost(14596)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_APPROVAL,
@@ -1824,7 +1824,7 @@ fn xcm_asset_erc20_precompiles_approve() {
 						value: { 400 * UNIT }.into(),
 					},
 				)
-				.expect_cost(29683)
+				.expect_cost(29624)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,

--- a/runtime/moonbase/tests/xcm_mock/mod.rs
+++ b/runtime/moonbase/tests/xcm_mock/mod.rs
@@ -25,7 +25,9 @@ use xcm_simulator::{decl_test_network, decl_test_parachain, decl_test_relay_chai
 use polkadot_runtime_parachains::configuration::{
 	GenesisConfig as ConfigurationGenesisConfig, HostConfiguration,
 };
-use polkadot_runtime_parachains::paras::{GenesisConfig as ParasGenesisConfig, ParaGenesisArgs};
+use polkadot_runtime_parachains::paras::{
+	GenesisConfig as ParasGenesisConfig, ParaGenesisArgs, ParaKind,
+};
 
 use sp_core::{H160, U256};
 use std::{collections::BTreeMap, str::FromStr};
@@ -53,7 +55,7 @@ pub fn mock_para_genesis_info() -> ParaGenesisArgs {
 	ParaGenesisArgs {
 		genesis_head: vec![1u8].into(),
 		validation_code: vec![1u8].into(),
-		parachain: true,
+		para_kind: ParaKind::Parachain,
 	}
 }
 

--- a/runtime/moonbase/tests/xcm_mock/statemint_like.rs
+++ b/runtime/moonbase/tests/xcm_mock/statemint_like.rs
@@ -18,14 +18,14 @@
 
 use frame_support::{
 	construct_runtime, match_types, parameter_types,
-	traits::{Everything, Nothing},
+	traits::{AsEnsureOriginWithArg, Everything, Nothing},
 	weights::Weight,
 };
-use frame_system::EnsureRoot;
+use frame_system::{EnsureRoot, EnsureSigned};
 
 use sp_core::H256;
 use sp_runtime::{
-	traits::{BlakeTwo256, Hash, IdentityLookup},
+	traits::{BlakeTwo256, ConstU32, Hash, IdentityLookup},
 	AccountId32,
 };
 
@@ -131,6 +131,10 @@ impl pallet_assets::Config for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = AssetAccountDeposit;
 	type WeightInfo = ();
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = AssetId;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 parameter_types! {

--- a/runtime/moonbase/tests/xcm_mock/statemint_like.rs
+++ b/runtime/moonbase/tests/xcm_mock/statemint_like.rs
@@ -21,7 +21,7 @@ use frame_support::{
 	traits::{AsEnsureOriginWithArg, Everything, Nothing},
 	weights::Weight,
 };
-use frame_system::{EnsureRoot, EnsureSigned};
+use frame_system::{EnsureNever, EnsureRoot};
 
 use sp_core::H256;
 use sp_runtime::{
@@ -133,7 +133,7 @@ impl pallet_assets::Config for Runtime {
 	type WeightInfo = ();
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = AssetId;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
 	type CallbackHandle = ();
 }
 

--- a/runtime/moonbase/tests/xcm_mock/statemint_like.rs
+++ b/runtime/moonbase/tests/xcm_mock/statemint_like.rs
@@ -21,7 +21,7 @@ use frame_support::{
 	traits::{AsEnsureOriginWithArg, Everything, Nothing},
 	weights::Weight,
 };
-use frame_system::{EnsureNever, EnsureRoot};
+use frame_system::{EnsureRoot, EnsureSigned};
 
 use sp_core::H256;
 use sp_runtime::{
@@ -133,7 +133,7 @@ impl pallet_assets::Config for Runtime {
 	type WeightInfo = ();
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = AssetId;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type CallbackHandle = ();
 }
 

--- a/runtime/moonbase/tests/xcm_tests.rs
+++ b/runtime/moonbase/tests/xcm_tests.rs
@@ -20,7 +20,7 @@ mod xcm_mock;
 use frame_support::{
 	assert_ok,
 	traits::{ConstU32, PalletInfo, PalletInfoAccess},
-	weights::constants::WEIGHT_PER_SECOND,
+	weights::constants::WEIGHT_REF_TIME_PER_SECOND,
 	BoundedVec,
 };
 use pallet_asset_manager::LocalAssetIdCreator;
@@ -970,7 +970,7 @@ fn transact_through_derivative_multilocation() {
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
 			Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
-			WEIGHT_PER_SECOND.ref_time() as u128,
+			WEIGHT_REF_TIME_PER_SECOND as u128,
 		));
 	});
 
@@ -1290,7 +1290,7 @@ fn transact_through_sovereign() {
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
 			Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
-			WEIGHT_PER_SECOND.ref_time() as u128,
+			WEIGHT_REF_TIME_PER_SECOND as u128,
 		));
 	});
 
@@ -2507,7 +2507,7 @@ fn transact_through_signed_multilocation() {
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
 			Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
-			WEIGHT_PER_SECOND.ref_time() as u128,
+			WEIGHT_REF_TIME_PER_SECOND as u128,
 		));
 		ancestry = parachain::Ancestry::get();
 	});

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -29,7 +29,7 @@ xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
 moonbeam-xcm-benchmarks = { path = "../../pallets/moonbeam-xcm-benchmarks", default-features = false }
 pallet-asset-manager = { path = "../../pallets/asset-manager", default-features = false }
 pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
-pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
 pallet-maintenance-mode = { path = "../../pallets/maintenance-mode", default-features = false, features = [ "xcm-support" ] }
 pallet-migrations = { path = "../../pallets/migrations", default-features = false }
@@ -63,98 +63,98 @@ moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-f
 moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
 
 # Substrate
-frame-executive = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-assets = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-collective = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-identity = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-society = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-treasury = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-utility = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-executive = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-assets = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-collective = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-identity = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-society = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-treasury = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-utility = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive", "max-encoded-len" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-offchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-session = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-version = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-offchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-session = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-version = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
-pallet-evm-precompile-blake2 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm-precompile-blake2 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Cumulus / Nimbus
-cumulus-pallet-dmp-queue = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-parachain-info = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+cumulus-pallet-dmp-queue = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+parachain-info = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Polkadot / XCM
-orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-orml-xcm-support = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-orml-xtokens = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-xcm-benchmarks = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-polkadot-core-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+orml-xcm-support = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+orml-xtokens = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-xcm-benchmarks = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+polkadot-core-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Benchmarking
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-frame-system-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-frame-try-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+frame-system-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+frame-try-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
 
 [dev-dependencies]
 ethereum = { version = "0.14.0" }
 hex = "0.4"
 sha3 = "0.10"
 
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
-polkadot-runtime-parachains = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-xcm-simulator = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+polkadot-runtime-parachains = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+xcm-simulator = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 
 precompile-utils = { path = "../../precompiles/utils", default-features = false, features = [ "testing" ] }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -75,6 +75,7 @@ pallet-identity = { git = "https://github.com/purestake/substrate", branch = "mo
 pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-root-testing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-society = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
@@ -218,6 +219,7 @@ std = [
 	"pallet-proxy/std",
 	"pallet-randomness-collective-flip/std",
 	"pallet-randomness/std",
+	"pallet-root-testing/std",
 	"pallet-scheduler/std",
 	"pallet-society/std",
 	"pallet-timestamp/std",
@@ -306,6 +308,7 @@ try-runtime = [
 	"pallet-migrations/try-runtime",
 	"pallet-parachain-staking/try-runtime",
 	"pallet-preimage/try-runtime",
+	"pallet-root-testing/try-runtime",
 	"pallet-scheduler/try-runtime",
 	"pallet-society/try-runtime",
 	"pallet-timestamp/try-runtime",

--- a/runtime/moonbeam/src/asset_config.rs
+++ b/runtime/moonbeam/src/asset_config.rs
@@ -29,14 +29,14 @@ use sp_runtime::traits::Hash as THash;
 use frame_support::{
 	dispatch::GetDispatchInfo,
 	parameter_types,
-	traits::{ConstU128, EitherOfDiverse},
+	traits::{AsEnsureOriginWithArg, ConstU128, ConstU32, EitherOfDiverse},
 	weights::Weight,
 };
 
-use frame_system::EnsureRoot;
+use frame_system::{EnsureRoot, EnsureSigned};
 use sp_core::{H160, H256};
 
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::{Compact, Decode, Encode};
 use scale_info::TypeInfo;
 
 use sp_std::{
@@ -83,6 +83,10 @@ impl pallet_assets::Config<ForeignAssetInstance> for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = ConstU128<{ currency::deposit(1, 18) }>;
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = Compact<AssetId>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 // Local assets
@@ -101,6 +105,10 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = ConstU128<{ currency::deposit(1, 18) }>;
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = Compact<AssetId>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 // We instruct how to register the Assets
@@ -118,7 +126,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	) -> DispatchResult {
 		Assets::force_create(
 			RuntimeOrigin::root(),
-			asset,
+			asset.into(),
 			AssetManager::account_id(),
 			is_sufficient,
 			min_balance,
@@ -136,7 +144,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// Lastly, the metadata
 		Assets::force_set_metadata(
 			RuntimeOrigin::root(),
-			asset,
+			asset.into(),
 			metadata.name,
 			metadata.symbol,
 			metadata.decimals,
@@ -157,7 +165,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// in pallet-assets
 		LocalAssets::force_create(
 			RuntimeOrigin::root(),
-			asset,
+			asset.into(),
 			owner,
 			is_sufficient,
 			min_balance,
@@ -176,13 +184,19 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	}
 
 	#[transactional]
-	fn destroy_foreign_asset(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchResult {
+	fn destroy_foreign_asset(asset: AssetId) -> DispatchResult {
 		// First destroy the asset
-		Assets::destroy(RuntimeOrigin::root(), asset, asset_destroy_witness)
-			.map_err(|info| info.error)?;
+		Assets::freeze_asset(RuntimeOrigin::root(), asset.into())
+			.and_then(|_| Assets::start_destroy(RuntimeOrigin::root(), asset.into()))
+			.and_then(|_| {
+				Assets::destroy_accounts(RuntimeOrigin::root(), asset.into())
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| {
+				Assets::destroy_approvals(RuntimeOrigin::root(), asset.into())
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| Assets::finish_destroy(RuntimeOrigin::root(), asset.into()))?;
 
 		// We remove the EVM revert code
 		// This does not panick even if there is no code in the address
@@ -193,13 +207,19 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	}
 
 	#[transactional]
-	fn destroy_local_asset(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchResult {
+	fn destroy_local_asset(asset: AssetId) -> DispatchResult {
 		// First destroy the asset
-		LocalAssets::destroy(RuntimeOrigin::root(), asset, asset_destroy_witness)
-			.map_err(|info| info.error)?;
+		LocalAssets::freeze_asset(RuntimeOrigin::root(), asset.into())
+			.and_then(|_| LocalAssets::start_destroy(RuntimeOrigin::root(), asset.into()))
+			.and_then(|_| {
+				LocalAssets::destroy_accounts(RuntimeOrigin::root(), asset.into())
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| {
+				LocalAssets::destroy_approvals(RuntimeOrigin::root(), asset.into())
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| LocalAssets::finish_destroy(RuntimeOrigin::root(), asset.into()))?;
 
 		// We remove the EVM revert code
 		// This does not panick even if there is no code in the address
@@ -209,10 +229,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		Ok(())
 	}
 
-	fn destroy_asset_dispatch_info_weight(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> Weight {
+	fn destroy_asset_dispatch_info_weight(asset: AssetId) -> Weight {
 		// For us both of them (Foreign and Local) have the same annotated weight for a given
 		// witness
 		// We need to take the dispatch info from the destroy call, which is already annotated in
@@ -221,17 +238,40 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// EVM
 
 		// This is the dispatch info of destroy
-		let call = RuntimeCall::Assets(
-			pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy {
-				id: asset,
-				witness: asset_destroy_witness,
-			},
-		);
+		let call_weight = [
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::freeze_asset {
+					id: asset.into(),
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy {
+					id: asset.into(),
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_accounts {
+					id: asset.into(),
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_approvals {
+					id: asset.into(),
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::finish_destroy {
+					id: asset.into(),
+				},
+			),
+		]
+		.into_iter()
+		.fold(Weight::zero(), |acc, call| {
+			acc.saturating_add(call.get_dispatch_info().weight)
+		});
 
 		// This is the db write
-		call.get_dispatch_info()
-			.weight
-			.saturating_add(<Runtime as frame_system::Config>::DbWeight::get().writes(1))
+		call_weight.saturating_add(<Runtime as frame_system::Config>::DbWeight::get().writes(1))
 	}
 }
 
@@ -266,7 +306,6 @@ impl pallet_asset_manager::Config for Runtime {
 	type ForeignAssetModifierOrigin = EnsureRoot<AccountId>;
 	type LocalAssetModifierOrigin = EnsureRoot<AccountId>;
 	type LocalAssetIdCreator = LocalAssetIdCreator;
-	type AssetDestroyWitness = pallet_assets::DestroyWitness;
 	type Currency = Balances;
 	type LocalAssetDeposit = AssetDeposit;
 	type WeightInfo = pallet_asset_manager::weights::SubstrateWeight<Runtime>;

--- a/runtime/moonbeam/src/asset_config.rs
+++ b/runtime/moonbeam/src/asset_config.rs
@@ -23,17 +23,16 @@ use super::{
 	FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX, LOCAL_ASSET_PRECOMPILE_ADDRESS_PREFIX,
 };
 
-use pallet_evm_precompileset_assets_erc20::AccountIdAssetIdConversion;
-use sp_runtime::traits::Hash as THash;
-
 use frame_support::{
 	dispatch::GetDispatchInfo,
 	parameter_types,
 	traits::{AsEnsureOriginWithArg, ConstU128, ConstU32, EitherOfDiverse},
 	weights::Weight,
 };
+use pallet_evm_precompileset_assets_erc20::AccountIdAssetIdConversion;
+use sp_runtime::traits::Hash as THash;
 
-use frame_system::{EnsureRoot, EnsureSigned};
+use frame_system::{EnsureNever, EnsureRoot};
 use sp_core::{H160, H256};
 
 use parity_scale_codec::{Compact, Decode, Encode};
@@ -85,7 +84,7 @@ impl pallet_assets::Config<ForeignAssetInstance> for Runtime {
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = Compact<AssetId>;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
 	type CallbackHandle = ();
 }
 
@@ -107,7 +106,7 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = Compact<AssetId>;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
 	type CallbackHandle = ();
 }
 
@@ -185,18 +184,8 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 
 	#[transactional]
 	fn destroy_foreign_asset(asset: AssetId) -> DispatchResult {
-		// First destroy the asset
-		Assets::freeze_asset(RuntimeOrigin::root(), asset.into())
-			.and_then(|_| Assets::start_destroy(RuntimeOrigin::root(), asset.into()))
-			.and_then(|_| {
-				Assets::destroy_accounts(RuntimeOrigin::root(), asset.into())
-					.map_err(|info| info.error)
-			})
-			.and_then(|_| {
-				Assets::destroy_approvals(RuntimeOrigin::root(), asset.into())
-					.map_err(|info| info.error)
-			})
-			.and_then(|_| Assets::finish_destroy(RuntimeOrigin::root(), asset.into()))?;
+		// Mark the asset as destroying
+		Assets::start_destroy(RuntimeOrigin::root(), asset.into())?;
 
 		// We remove the EVM revert code
 		// This does not panick even if there is no code in the address
@@ -208,18 +197,8 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 
 	#[transactional]
 	fn destroy_local_asset(asset: AssetId) -> DispatchResult {
-		// First destroy the asset
-		LocalAssets::freeze_asset(RuntimeOrigin::root(), asset.into())
-			.and_then(|_| LocalAssets::start_destroy(RuntimeOrigin::root(), asset.into()))
-			.and_then(|_| {
-				LocalAssets::destroy_accounts(RuntimeOrigin::root(), asset.into())
-					.map_err(|info| info.error)
-			})
-			.and_then(|_| {
-				LocalAssets::destroy_approvals(RuntimeOrigin::root(), asset.into())
-					.map_err(|info| info.error)
-			})
-			.and_then(|_| LocalAssets::finish_destroy(RuntimeOrigin::root(), asset.into()))?;
+		// Mark the asset as destroying
+		LocalAssets::start_destroy(RuntimeOrigin::root(), asset.into())?;
 
 		// We remove the EVM revert code
 		// This does not panick even if there is no code in the address
@@ -238,37 +217,13 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// EVM
 
 		// This is the dispatch info of destroy
-		let call_weight = [
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::freeze_asset {
-					id: asset.into(),
-				},
-			),
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy {
-					id: asset.into(),
-				},
-			),
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_accounts {
-					id: asset.into(),
-				},
-			),
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_approvals {
-					id: asset.into(),
-				},
-			),
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::finish_destroy {
-					id: asset.into(),
-				},
-			),
-		]
-		.into_iter()
-		.fold(Weight::zero(), |acc, call| {
-			acc.saturating_add(call.get_dispatch_info().weight)
-		});
+		let call_weight = RuntimeCall::Assets(
+			pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy {
+				id: asset.into(),
+			},
+		)
+		.get_dispatch_info()
+		.weight;
 
 		// This is the db write
 		call_weight.saturating_add(<Runtime as frame_system::Config>::DbWeight::get().writes(1))

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -975,6 +975,9 @@ impl Contains<RuntimeCall> for NormalFilter {
 				pallet_assets::Call::approve_transfer { .. } => true,
 				pallet_assets::Call::transfer_approved { .. } => true,
 				pallet_assets::Call::cancel_approval { .. } => true,
+				pallet_assets::Call::destroy_accounts { .. } => true,
+				pallet_assets::Call::destroy_approvals { .. } => true,
+				pallet_assets::Call::finish_destroy { .. } => true,
 				_ => false,
 			},
 			// We want to disable create, as we dont want users to be choosing the
@@ -985,9 +988,6 @@ impl Contains<RuntimeCall> for NormalFilter {
 			RuntimeCall::LocalAssets(method) => match method {
 				pallet_assets::Call::create { .. } => false,
 				pallet_assets::Call::start_destroy { .. } => false,
-				pallet_assets::Call::destroy_accounts { .. } => false,
-				pallet_assets::Call::destroy_approvals { .. } => false,
-				pallet_assets::Call::finish_destroy { .. } => false,
 				_ => true,
 			},
 			// We just want to enable this in case of live chains, since the default version

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -49,7 +49,7 @@ use frame_support::{
 		OffchainWorker, OnFinalize, OnIdle, OnInitialize, OnRuntimeUpgrade, OnUnbalanced,
 	},
 	weights::{
-		constants::{RocksDbWeight, WEIGHT_PER_SECOND},
+		constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND},
 		ConstantMultiplier, Weight, WeightToFeeCoefficient, WeightToFeeCoefficients,
 		WeightToFeePolynomial,
 	},
@@ -134,7 +134,7 @@ pub mod currency {
 }
 
 /// Maximum weight per block
-pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
+pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_ref_time(WEIGHT_REF_TIME_PER_SECOND)
 	.saturating_div(2)
 	.set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);
 
@@ -361,7 +361,7 @@ pub const GAS_PER_SECOND: u64 = 40_000_000;
 
 /// Approximate ratio of the amount of Weight per Gas.
 /// u64 works for approximations because Weight is a very small unit compared to gas.
-pub const WEIGHT_PER_GAS: u64 = WEIGHT_PER_SECOND.ref_time() / GAS_PER_SECOND;
+pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND / GAS_PER_SECOND;
 
 parameter_types! {
 	pub BlockGasLimit: U256
@@ -984,7 +984,11 @@ impl Contains<RuntimeCall> for NormalFilter {
 			// substrate side of things
 			RuntimeCall::LocalAssets(method) => match method {
 				pallet_assets::Call::create { .. } => false,
-				pallet_assets::Call::destroy { .. } => false,
+				pallet_assets::Call::freeze_asset { .. } => false,
+				pallet_assets::Call::start_destroy { .. } => false,
+				pallet_assets::Call::destroy_accounts { .. } => false,
+				pallet_assets::Call::destroy_approvals { .. } => false,
+				pallet_assets::Call::finish_destroy { .. } => false,
 				_ => true,
 			},
 			// We just want to enable this in case of live chains, since the default version

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -984,7 +984,6 @@ impl Contains<RuntimeCall> for NormalFilter {
 			// substrate side of things
 			RuntimeCall::LocalAssets(method) => match method {
 				pallet_assets::Call::create { .. } => false,
-				pallet_assets::Call::freeze_asset { .. } => false,
 				pallet_assets::Call::start_destroy { .. } => false,
 				pallet_assets::Call::destroy_accounts { .. } => false,
 				pallet_assets::Call::destroy_approvals { .. } => false,

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1202,6 +1202,8 @@ impl pallet_randomness::Config for Runtime {
 	type EpochExpirationDelay = ConstU64<10_000>;
 }
 
+impl pallet_root_testing::Config for Runtime {}
+
 construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
@@ -1214,6 +1216,7 @@ construct_runtime! {
 		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage} = 2,
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent} = 3,
 		ParachainInfo: parachain_info::{Pallet, Storage, Config} = 4,
+		RootTesting: pallet_root_testing::{Pallet, Call, Storage} = 5,
 
 		// Monetary stuff.
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>} = 10,

--- a/runtime/moonbeam/tests/common/mod.rs
+++ b/runtime/moonbeam/tests/common/mod.rs
@@ -309,9 +309,10 @@ impl ExtBuilder {
 		ext.execute_with(|| {
 			// If any local assets specified, we create them here
 			for (asset_id, balances, owner) in local_assets.clone() {
-				LocalAssets::force_create(root_origin(), asset_id, owner, true, 1).unwrap();
+				LocalAssets::force_create(root_origin(), asset_id.into(), owner, true, 1).unwrap();
 				for (account, balance) in balances {
-					LocalAssets::mint(origin_of(owner.into()), asset_id, account, balance).unwrap();
+					LocalAssets::mint(origin_of(owner.into()), asset_id.into(), account, balance)
+						.unwrap();
 				}
 			}
 			// If any xcm assets specified, we register them here
@@ -328,7 +329,7 @@ impl ExtBuilder {
 				for (account, balance) in xcm_asset_initialization.balances {
 					Assets::mint(
 						origin_of(AssetManager::account_id()),
-						asset_id,
+						asset_id.into(),
 						account,
 						balance,
 					)

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -29,7 +29,7 @@ use frame_support::{
 		fungible::Inspect, fungibles::Inspect as FungiblesInspect, Currency as CurrencyT,
 		EnsureOrigin, PalletInfo, StorageInfo, StorageInfoTrait,
 	},
-	weights::{constants::WEIGHT_PER_SECOND, Weight},
+	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 	StorageHasher, Twox128,
 };
 
@@ -1504,7 +1504,7 @@ fn local_assets_cannot_be_create_by_signed_origins() {
 			assert_noop!(
 				RuntimeCall::LocalAssets(
 					pallet_assets::Call::<Runtime, LocalAssetInstance>::create {
-						id: 11u128,
+						id: 11u128.into(),
 						admin: AccountId::from(ALICE),
 						min_balance: 1u128
 					}
@@ -1900,7 +1900,7 @@ fn asset_erc20_precompiles_freeze_transfer_ownership() {
 			// e.g., transfer_ownership again
 			assert_ok!(LocalAssets::transfer_ownership(
 				origin_of(AccountId::from(BOB)),
-				0u128,
+				0u128.into(),
 				AccountId::from(ALICE)
 			));
 		});
@@ -1941,18 +1941,18 @@ fn asset_erc20_precompiles_freeze_set_team() {
 			// Bob should be able to mint, freeze, and thaw
 			assert_ok!(LocalAssets::mint(
 				origin_of(AccountId::from(BOB)),
-				0u128,
+				0u128.into(),
 				AccountId::from(BOB),
 				1_000 * GLMR
 			));
 			assert_ok!(LocalAssets::freeze(
 				origin_of(AccountId::from(BOB)),
-				0u128,
+				0u128.into(),
 				AccountId::from(ALICE)
 			));
 			assert_ok!(LocalAssets::thaw(
 				origin_of(AccountId::from(BOB)),
-				0u128,
+				0u128.into(),
 				AccountId::from(ALICE)
 			));
 		});
@@ -2808,7 +2808,7 @@ fn test_xcm_utils_get_units_per_second() {
 		let input = XcmUtilsPCall::get_units_per_second { multilocation };
 
 		let expected_units =
-			WEIGHT_PER_SECOND.ref_time() as u128 * moonbeam_runtime::currency::WEIGHT_FEE;
+			WEIGHT_REF_TIME_PER_SECOND as u128 * moonbeam_runtime::currency::WEIGHT_FEE;
 
 		Precompiles::new()
 			.prepare_test(ALICE, xcm_utils_precompile_address, input)

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -180,6 +180,13 @@ fn verify_pallet_prefixes() {
 			},
 			StorageInfo {
 				pallet_name: b"Balances".to_vec(),
+				storage_name: b"InactiveIssuance".to_vec(),
+				prefix: prefix(b"Balances", b"InactiveIssuance"),
+				max_values: Some(1),
+				max_size: Some(16),
+			},
+			StorageInfo {
+				pallet_name: b"Balances".to_vec(),
 				storage_name: b"Account".to_vec(),
 				prefix: prefix(b"Balances", b"Account"),
 				max_values: None,
@@ -199,13 +206,6 @@ fn verify_pallet_prefixes() {
 				max_values: None,
 				max_size: Some(1037),
 			},
-			StorageInfo {
-				pallet_name: b"Balances".to_vec(),
-				storage_name: b"StorageVersion".to_vec(),
-				prefix: prefix(b"Balances", b"StorageVersion"),
-				max_values: Some(1),
-				max_size: Some(1),
-			}
 		]
 	);
 	assert_eq!(
@@ -1587,7 +1587,7 @@ fn asset_erc20_precompiles_transfer() {
 						value: { 400 * GLMR }.into(),
 					},
 				)
-				.expect_cost(24083u64)
+				.expect_cost(24133)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1639,7 +1639,7 @@ fn asset_erc20_precompiles_approve() {
 						value: { 400 * GLMR }.into(),
 					},
 				)
-				.expect_cost(14597)
+				.expect_cost(14596)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_APPROVAL,
@@ -1660,7 +1660,7 @@ fn asset_erc20_precompiles_approve() {
 						value: { 400 * GLMR }.into(),
 					},
 				)
-				.expect_cost(29683)
+				.expect_cost(29624)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1712,7 +1712,7 @@ fn asset_erc20_precompiles_mint_burn() {
 						value: { 1000 * GLMR }.into(),
 					},
 				)
-				.expect_cost(13204)
+				.expect_cost(13249)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1739,7 +1739,7 @@ fn asset_erc20_precompiles_mint_burn() {
 						value: { 500 * GLMR }.into(),
 					},
 				)
-				.expect_cost(13588)
+				.expect_cost(13575)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1784,7 +1784,7 @@ fn asset_erc20_precompiles_freeze_thaw_account() {
 						account: Address(ALICE.into()),
 					},
 				)
-				.expect_cost(7107)
+				.expect_cost(7094)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1803,7 +1803,7 @@ fn asset_erc20_precompiles_freeze_thaw_account() {
 						account: Address(ALICE.into()),
 					},
 				)
-				.expect_cost(7103)
+				.expect_cost(7074)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1838,7 +1838,7 @@ fn asset_erc20_precompiles_freeze_thaw_asset() {
 					asset_precompile_address,
 					LocalAssetsPCall::freeze_asset {},
 				)
-				.expect_cost(5970)
+				.expect_cost(5944)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1855,7 +1855,7 @@ fn asset_erc20_precompiles_freeze_thaw_asset() {
 					asset_precompile_address,
 					LocalAssetsPCall::thaw_asset {},
 				)
-				.expect_cost(5941)
+				.expect_cost(5964)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1892,7 +1892,7 @@ fn asset_erc20_precompiles_freeze_transfer_ownership() {
 						owner: Address(BOB.into()),
 					},
 				)
-				.expect_cost(6983)
+				.expect_cost(6973)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1934,7 +1934,7 @@ fn asset_erc20_precompiles_freeze_set_team() {
 						issuer: Address(BOB.into()),
 					},
 				)
-				.expect_cost(5926)
+				.expect_cost(5940)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -2057,7 +2057,7 @@ fn xcm_asset_erc20_precompiles_transfer() {
 						value: { 400 * GLMR }.into(),
 					},
 				)
-				.expect_cost(24083)
+				.expect_cost(24133)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -2122,7 +2122,7 @@ fn xcm_asset_erc20_precompiles_approve() {
 						value: { 400 * GLMR }.into(),
 					},
 				)
-				.expect_cost(14597)
+				.expect_cost(14596)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_APPROVAL,
@@ -2143,7 +2143,7 @@ fn xcm_asset_erc20_precompiles_approve() {
 						value: { 400 * GLMR }.into(),
 					},
 				)
-				.expect_cost(29683)
+				.expect_cost(29624)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,

--- a/runtime/moonbeam/tests/xcm_mock/mod.rs
+++ b/runtime/moonbeam/tests/xcm_mock/mod.rs
@@ -26,7 +26,9 @@ use xcm_simulator::{decl_test_network, decl_test_parachain, decl_test_relay_chai
 use polkadot_runtime_parachains::configuration::{
 	GenesisConfig as ConfigurationGenesisConfig, HostConfiguration,
 };
-use polkadot_runtime_parachains::paras::{GenesisConfig as ParasGenesisConfig, ParaGenesisArgs};
+use polkadot_runtime_parachains::paras::{
+	GenesisConfig as ParasGenesisConfig, ParaGenesisArgs, ParaKind,
+};
 use sp_core::{H160, U256};
 use std::{collections::BTreeMap, str::FromStr};
 
@@ -49,7 +51,7 @@ pub fn mock_para_genesis_info() -> ParaGenesisArgs {
 	ParaGenesisArgs {
 		genesis_head: vec![1u8].into(),
 		validation_code: vec![1u8].into(),
-		parachain: true,
+		para_kind: ParaKind::Parachain,
 	}
 }
 

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -20,18 +20,18 @@ use frame_support::{
 	construct_runtime,
 	dispatch::GetDispatchInfo,
 	parameter_types,
-	traits::{Everything, Get, Nothing, PalletInfoAccess},
+	traits::{AsEnsureOriginWithArg, Everything, Get, Nothing, PalletInfoAccess},
 	weights::Weight,
 	PalletId,
 };
 
 use cumulus_primitives_core::relay_chain::v2::HrmpChannelId;
-use frame_system::EnsureRoot;
+use frame_system::{EnsureRoot, EnsureSigned};
 use orml_traits::parameter_type_with_key;
 use parity_scale_codec::{Decode, Encode};
 use sp_core::H256;
 use sp_runtime::{
-	traits::{BlakeTwo256, Hash, IdentityLookup},
+	traits::{BlakeTwo256, ConstU32, Hash, IdentityLookup},
 	Permill,
 };
 use sp_std::{convert::TryFrom, prelude::*};
@@ -143,6 +143,10 @@ impl pallet_assets::Config<ForeignAssetInstance> for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = AssetAccountDeposit;
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = AssetId;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 impl pallet_assets::Config<LocalAssetInstance> for Runtime {
@@ -160,6 +164,10 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = AssetAccountDeposit;
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = AssetId;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -762,39 +770,65 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		Ok(())
 	}
 
-	fn destroy_foreign_asset(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchResult {
+	fn destroy_foreign_asset(asset: AssetId) -> DispatchResult {
 		// First destroy the asset
-		Assets::destroy(RuntimeOrigin::root(), asset, asset_destroy_witness)
-			.map_err(|info| info.error)?;
+		Assets::freeze_asset(RuntimeOrigin::root(), asset)
+			.and_then(|_| Assets::start_destroy(RuntimeOrigin::root(), asset))
+			.and_then(|_| {
+				Assets::destroy_accounts(RuntimeOrigin::root(), asset).map_err(|info| info.error)
+			})
+			.and_then(|_| {
+				Assets::destroy_approvals(RuntimeOrigin::root(), asset).map_err(|info| info.error)
+			})
+			.and_then(|_| Assets::finish_destroy(RuntimeOrigin::root(), asset))?;
 
 		Ok(())
 	}
 
-	fn destroy_local_asset(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchResult {
+	fn destroy_local_asset(asset: AssetId) -> DispatchResult {
 		// First destroy the asset
-		LocalAssets::destroy(RuntimeOrigin::root(), asset, asset_destroy_witness)
-			.map_err(|info| info.error)?;
+		LocalAssets::freeze_asset(RuntimeOrigin::root(), asset)
+			.and_then(|_| LocalAssets::start_destroy(RuntimeOrigin::root(), asset))
+			.and_then(|_| {
+				LocalAssets::destroy_accounts(RuntimeOrigin::root(), asset)
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| {
+				LocalAssets::destroy_approvals(RuntimeOrigin::root(), asset)
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| LocalAssets::finish_destroy(RuntimeOrigin::root(), asset))?;
 
 		Ok(())
 	}
 
-	fn destroy_asset_dispatch_info_weight(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> Weight {
-		let call = RuntimeCall::Assets(
-			pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy {
-				id: asset,
-				witness: asset_destroy_witness,
-			},
-		);
-		call.get_dispatch_info().weight
+	fn destroy_asset_dispatch_info_weight(asset: AssetId) -> Weight {
+		let call_weight = [
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::freeze_asset { id: asset },
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy { id: asset },
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_accounts {
+					id: asset,
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_approvals {
+					id: asset,
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::finish_destroy { id: asset },
+			),
+		]
+		.into_iter()
+		.fold(Weight::zero(), |acc, call| {
+			acc.saturating_add(call.get_dispatch_info().weight)
+		});
+		call_weight
 	}
 }
 
@@ -828,7 +862,6 @@ impl pallet_asset_manager::Config for Runtime {
 	type ForeignAssetModifierOrigin = EnsureRoot<AccountId>;
 	type LocalAssetModifierOrigin = EnsureRoot<AccountId>;
 	type LocalAssetIdCreator = LocalAssetIdCreator;
-	type AssetDestroyWitness = pallet_assets::DestroyWitness;
 	type Currency = Balances;
 	type LocalAssetDeposit = AssetDeposit;
 	type WeightInfo = ();

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -26,7 +26,7 @@ use frame_support::{
 };
 
 use cumulus_primitives_core::relay_chain::v2::HrmpChannelId;
-use frame_system::{EnsureRoot, EnsureSigned};
+use frame_system::{EnsureNever, EnsureRoot};
 use orml_traits::parameter_type_with_key;
 use parity_scale_codec::{Decode, Encode};
 use sp_core::H256;
@@ -145,7 +145,7 @@ impl pallet_assets::Config<ForeignAssetInstance> for Runtime {
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = AssetId;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
 	type CallbackHandle = ();
 }
 
@@ -166,7 +166,7 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = AssetId;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
 	type CallbackHandle = ();
 }
 
@@ -771,64 +771,27 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	}
 
 	fn destroy_foreign_asset(asset: AssetId) -> DispatchResult {
-		// First destroy the asset
-		Assets::freeze_asset(RuntimeOrigin::root(), asset)
-			.and_then(|_| Assets::start_destroy(RuntimeOrigin::root(), asset))
-			.and_then(|_| {
-				Assets::destroy_accounts(RuntimeOrigin::root(), asset).map_err(|info| info.error)
-			})
-			.and_then(|_| {
-				Assets::destroy_approvals(RuntimeOrigin::root(), asset).map_err(|info| info.error)
-			})
-			.and_then(|_| Assets::finish_destroy(RuntimeOrigin::root(), asset))?;
+		// Mark the asset as destroying
+		Assets::start_destroy(RuntimeOrigin::root(), asset)?;
 
 		Ok(())
 	}
 
 	fn destroy_local_asset(asset: AssetId) -> DispatchResult {
-		// First destroy the asset
-		LocalAssets::freeze_asset(RuntimeOrigin::root(), asset)
-			.and_then(|_| LocalAssets::start_destroy(RuntimeOrigin::root(), asset))
-			.and_then(|_| {
-				LocalAssets::destroy_accounts(RuntimeOrigin::root(), asset)
-					.map_err(|info| info.error)
-			})
-			.and_then(|_| {
-				LocalAssets::destroy_approvals(RuntimeOrigin::root(), asset)
-					.map_err(|info| info.error)
-			})
-			.and_then(|_| LocalAssets::finish_destroy(RuntimeOrigin::root(), asset))?;
+		// Mark the asset as destroying
+		LocalAssets::start_destroy(RuntimeOrigin::root(), asset)?;
 
 		Ok(())
 	}
 
 	fn destroy_asset_dispatch_info_weight(asset: AssetId) -> Weight {
-		let call_weight = [
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::freeze_asset { id: asset },
-			),
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy { id: asset },
-			),
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_accounts {
-					id: asset,
-				},
-			),
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_approvals {
-					id: asset,
-				},
-			),
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::finish_destroy { id: asset },
-			),
-		]
-		.into_iter()
-		.fold(Weight::zero(), |acc, call| {
-			acc.saturating_add(call.get_dispatch_info().weight)
-		});
-		call_weight
+		RuntimeCall::Assets(
+			pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy {
+				id: asset.into(),
+			},
+		)
+		.get_dispatch_info()
+		.weight
 	}
 }
 

--- a/runtime/moonbeam/tests/xcm_mock/statemint_like.rs
+++ b/runtime/moonbeam/tests/xcm_mock/statemint_like.rs
@@ -18,14 +18,14 @@
 
 use frame_support::{
 	construct_runtime, match_types, parameter_types,
-	traits::{Everything, Nothing},
+	traits::{AsEnsureOriginWithArg, Everything, Nothing},
 	weights::Weight,
 };
-use frame_system::EnsureRoot;
+use frame_system::{EnsureRoot, EnsureSigned};
 
 use sp_core::H256;
 use sp_runtime::{
-	traits::{BlakeTwo256, Hash, IdentityLookup},
+	traits::{BlakeTwo256, ConstU32, Hash, IdentityLookup},
 	AccountId32,
 };
 
@@ -131,6 +131,10 @@ impl pallet_assets::Config for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = AssetAccountDeposit;
 	type WeightInfo = ();
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = AssetId;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 parameter_types! {

--- a/runtime/moonbeam/tests/xcm_mock/statemint_like.rs
+++ b/runtime/moonbeam/tests/xcm_mock/statemint_like.rs
@@ -21,7 +21,7 @@ use frame_support::{
 	traits::{AsEnsureOriginWithArg, Everything, Nothing},
 	weights::Weight,
 };
-use frame_system::{EnsureRoot, EnsureSigned};
+use frame_system::{EnsureNever, EnsureRoot};
 
 use sp_core::H256;
 use sp_runtime::{
@@ -133,7 +133,7 @@ impl pallet_assets::Config for Runtime {
 	type WeightInfo = ();
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = AssetId;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
 	type CallbackHandle = ();
 }
 

--- a/runtime/moonbeam/tests/xcm_mock/statemint_like.rs
+++ b/runtime/moonbeam/tests/xcm_mock/statemint_like.rs
@@ -21,7 +21,7 @@ use frame_support::{
 	traits::{AsEnsureOriginWithArg, Everything, Nothing},
 	weights::Weight,
 };
-use frame_system::{EnsureNever, EnsureRoot};
+use frame_system::{EnsureRoot, EnsureSigned};
 
 use sp_core::H256;
 use sp_runtime::{
@@ -133,7 +133,7 @@ impl pallet_assets::Config for Runtime {
 	type WeightInfo = ();
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = AssetId;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type CallbackHandle = ();
 }
 

--- a/runtime/moonbeam/tests/xcm_tests.rs
+++ b/runtime/moonbeam/tests/xcm_tests.rs
@@ -20,7 +20,7 @@ mod xcm_mock;
 use frame_support::{
 	assert_ok,
 	traits::{PalletInfo, PalletInfoAccess},
-	weights::constants::WEIGHT_PER_SECOND,
+	weights::constants::WEIGHT_REF_TIME_PER_SECOND,
 };
 use xcm::{VersionedMultiLocation, WrapVersion};
 use xcm_mock::parachain;
@@ -860,7 +860,7 @@ fn transact_through_derivative_multilocation() {
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
 			Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
-			WEIGHT_PER_SECOND.ref_time() as u128,
+			WEIGHT_REF_TIME_PER_SECOND as u128,
 		));
 	});
 
@@ -1170,7 +1170,7 @@ fn transact_through_sovereign() {
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
 			Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
-			WEIGHT_PER_SECOND.ref_time() as u128,
+			WEIGHT_REF_TIME_PER_SECOND as u128,
 		));
 	});
 
@@ -2231,7 +2231,7 @@ fn transact_through_signed_multilocation() {
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
 			Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
-			WEIGHT_PER_SECOND.ref_time() as u128,
+			WEIGHT_REF_TIME_PER_SECOND as u128,
 		));
 		ancestry = parachain::Ancestry::get();
 	});

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -29,7 +29,7 @@ xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
 moonbeam-xcm-benchmarks = { path = "../../pallets/moonbeam-xcm-benchmarks", default-features = false }
 pallet-asset-manager = { path = "../../pallets/asset-manager", default-features = false }
 pallet-author-mapping = { path = "../../pallets/author-mapping", default-features = false }
-pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+pallet-crowdloan-rewards = { git = "https://github.com/purestake/crowdloan-rewards", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-ethereum-chain-id = { path = "../../pallets/ethereum-chain-id", default-features = false }
 pallet-maintenance-mode = { path = "../../pallets/maintenance-mode", default-features = false, features = [ "xcm-support" ] }
 pallet-migrations = { path = "../../pallets/migrations", default-features = false }
@@ -66,102 +66,102 @@ moonbeam-rpc-primitives-debug = { path = "../../primitives/rpc/debug", default-f
 moonbeam-rpc-primitives-txpool = { path = "../../primitives/rpc/txpool", default-features = false }
 
 # Substrate
-frame-executive = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-assets = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-collective = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-conviction-voting = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-identity = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-referenda = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-society = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-treasury = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-utility = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-whitelist = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-executive = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+frame-system-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-assets = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-balances = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-collective = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-conviction-voting = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-democracy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-identity = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-referenda = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-society = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-treasury = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-utility = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-whitelist = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive", "max-encoded-len" ] }
 scale-info = { version = "2.0", default-features = false, features = [ "derive" ] }
-sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-debug-derive = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-offchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-session = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-version = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-api = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-block-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-core = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-debug-derive = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-inherents = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-io = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-offchain = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-session = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-transaction-pool = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-version = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Frontier
-fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
-pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false, features = [ "forbid-evm-reentrancy" ] }
-pallet-evm-precompile-blake2 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-base-fee = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-ethereum = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
+pallet-evm-precompile-blake2 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Cumulus / Nimbus
-cumulus-pallet-dmp-queue = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-pallet-xcm = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-pallet-xcmp-queue = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-primitives-utility = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-author-slot-filter = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-parachain-info = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+cumulus-pallet-dmp-queue = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-pallet-parachain-system = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-pallet-xcm = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-pallet-xcmp-queue = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-primitives-timestamp = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-primitives-utility = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+nimbus-primitives = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-author-inherent = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-author-slot-filter = { git = "https://github.com/purestake/nimbus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+parachain-info = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Polkadot / XCM
-orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-orml-xcm-support = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-orml-xtokens = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-xcm-benchmarks = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-polkadot-core-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+orml-traits = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+orml-xcm-support = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+orml-xtokens = { git = "https://github.com/purestake/open-runtime-module-library", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-xcm-benchmarks = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+polkadot-core-primitives = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+polkadot-parachain = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm-builder = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+xcm-executor = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Benchmarking
-frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-frame-system-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
-frame-try-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", optional = true, default-features = false }
+frame-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+frame-system-benchmarking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
+frame-try-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", optional = true, default-features = false }
 
 [dev-dependencies]
 ethereum = { version = "0.14.0" }
 hex = "0.4"
 sha3 = "0.10"
 
-cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+cumulus-primitives-parachain-inherent = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+cumulus-test-relay-sproof-builder = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
-polkadot-runtime-parachains = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-xcm-simulator = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+polkadot-runtime-parachains = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+xcm-simulator = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 
 precompile-utils = { path = "../../precompiles/utils", default-features = false, features = [ "testing" ] }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+substrate-wasm-builder = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -80,6 +80,7 @@ pallet-preimage = { git = "https://github.com/purestake/substrate", branch = "mo
 pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-randomness-collective-flip = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-referenda = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-root-testing = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-scheduler = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-society = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-timestamp = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
@@ -228,6 +229,7 @@ std = [
 	"pallet-randomness-collective-flip/std",
 	"pallet-randomness/std",
 	"pallet-referenda/std",
+	"pallet-root-testing/std",
 	"pallet-scheduler/std",
 	"pallet-society/std",
 	"pallet-timestamp/std",
@@ -326,6 +328,7 @@ try-runtime = [
 	"pallet-parachain-staking/try-runtime",
 	"pallet-preimage/try-runtime",
 	"pallet-referenda/try-runtime",
+	"pallet-root-testing/try-runtime",
 	"pallet-scheduler/try-runtime",
 	"pallet-society/try-runtime",
 	"pallet-timestamp/try-runtime",

--- a/runtime/moonriver/src/asset_config.rs
+++ b/runtime/moonriver/src/asset_config.rs
@@ -29,14 +29,14 @@ use sp_runtime::traits::Hash as THash;
 use frame_support::{
 	dispatch::GetDispatchInfo,
 	parameter_types,
-	traits::{ConstU128, EitherOfDiverse},
+	traits::{AsEnsureOriginWithArg, ConstU128, ConstU32, EitherOfDiverse},
 	weights::Weight,
 };
 
-use frame_system::EnsureRoot;
+use frame_system::{EnsureRoot, EnsureSigned};
 use sp_core::{H160, H256};
 
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::{Compact, Decode, Encode};
 use scale_info::TypeInfo;
 
 use sp_std::{
@@ -86,6 +86,10 @@ impl pallet_assets::Config<ForeignAssetInstance> for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = ConstU128<{ currency::deposit(1, 18) }>;
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = Compact<AssetId>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 // Local assets
@@ -104,6 +108,10 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = ConstU128<{ currency::deposit(1, 18) }>;
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = Compact<AssetId>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 // We instruct how to register the Assets
@@ -121,7 +129,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	) -> DispatchResult {
 		Assets::force_create(
 			RuntimeOrigin::root(),
-			asset,
+			asset.into(),
 			AssetManager::account_id(),
 			is_sufficient,
 			min_balance,
@@ -139,7 +147,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// Lastly, the metadata
 		Assets::force_set_metadata(
 			RuntimeOrigin::root(),
-			asset,
+			asset.into(),
 			metadata.name,
 			metadata.symbol,
 			metadata.decimals,
@@ -160,7 +168,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// in pallet-assets
 		LocalAssets::force_create(
 			RuntimeOrigin::root(),
-			asset,
+			asset.into(),
 			owner,
 			is_sufficient,
 			min_balance,
@@ -180,13 +188,19 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	}
 
 	#[transactional]
-	fn destroy_foreign_asset(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchResult {
+	fn destroy_foreign_asset(asset: AssetId) -> DispatchResult {
 		// First destroy the asset
-		Assets::destroy(RuntimeOrigin::root(), asset, asset_destroy_witness)
-			.map_err(|info| info.error)?;
+		Assets::freeze_asset(RuntimeOrigin::root(), asset.into())
+			.and_then(|_| Assets::start_destroy(RuntimeOrigin::root(), asset.into()))
+			.and_then(|_| {
+				Assets::destroy_accounts(RuntimeOrigin::root(), asset.into())
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| {
+				Assets::destroy_approvals(RuntimeOrigin::root(), asset.into())
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| Assets::finish_destroy(RuntimeOrigin::root(), asset.into()))?;
 
 		// We remove the EVM revert code
 		// This does not panick even if there is no code in the address
@@ -197,13 +211,19 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 	}
 
 	#[transactional]
-	fn destroy_local_asset(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchResult {
+	fn destroy_local_asset(asset: AssetId) -> DispatchResult {
 		// First destroy the asset
-		LocalAssets::destroy(RuntimeOrigin::root(), asset, asset_destroy_witness)
-			.map_err(|info| info.error)?;
+		LocalAssets::freeze_asset(RuntimeOrigin::root(), asset.into())
+			.and_then(|_| LocalAssets::start_destroy(RuntimeOrigin::root(), asset.into()))
+			.and_then(|_| {
+				LocalAssets::destroy_accounts(RuntimeOrigin::root(), asset.into())
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| {
+				LocalAssets::destroy_approvals(RuntimeOrigin::root(), asset.into())
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| LocalAssets::finish_destroy(RuntimeOrigin::root(), asset.into()))?;
 
 		// We remove the EVM revert code
 		// This does not panick even if there is no code in the address
@@ -213,10 +233,7 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		Ok(())
 	}
 
-	fn destroy_asset_dispatch_info_weight(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> Weight {
+	fn destroy_asset_dispatch_info_weight(asset: AssetId) -> Weight {
 		// For us both of them (Foreign and Local) have the same annotated weight for a given
 		// witness
 		// We need to take the dispatch info from the destroy call, which is already annotated in
@@ -225,17 +242,40 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		// EVM
 
 		// This is the dispatch info of destroy
-		let call = RuntimeCall::Assets(
-			pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy {
-				id: asset,
-				witness: asset_destroy_witness,
-			},
-		);
+		let call_weight = [
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::freeze_asset {
+					id: asset.into(),
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy {
+					id: asset.into(),
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_accounts {
+					id: asset.into(),
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_approvals {
+					id: asset.into(),
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::finish_destroy {
+					id: asset.into(),
+				},
+			),
+		]
+		.into_iter()
+		.fold(Weight::zero(), |acc, call| {
+			acc.saturating_add(call.get_dispatch_info().weight)
+		});
 
 		// This is the db write
-		call.get_dispatch_info()
-			.weight
-			.saturating_add(<Runtime as frame_system::Config>::DbWeight::get().writes(1))
+		call_weight.saturating_add(<Runtime as frame_system::Config>::DbWeight::get().writes(1))
 	}
 }
 
@@ -285,7 +325,6 @@ impl pallet_asset_manager::Config for Runtime {
 	type ForeignAssetModifierOrigin = ForeignAssetModifierOrigin;
 	type LocalAssetModifierOrigin = LocalAssetModifierOrigin;
 	type LocalAssetIdCreator = LocalAssetIdCreator;
-	type AssetDestroyWitness = pallet_assets::DestroyWitness;
 	type Currency = Balances;
 	type LocalAssetDeposit = AssetDeposit;
 	type WeightInfo = pallet_asset_manager::weights::SubstrateWeight<Runtime>;

--- a/runtime/moonriver/src/governance/referenda.rs
+++ b/runtime/moonriver/src/governance/referenda.rs
@@ -72,7 +72,7 @@ impl pallet_whitelist::Config for Runtime {
 		>,
 	>;
 	type DispatchWhitelistedOrigin = EitherOf<EnsureRoot<Self::AccountId>, WhitelistedCaller>;
-	type PreimageProvider = Preimage;
+	type Preimages = Preimage;
 }
 
 pallet_referenda::impl_tracksinfo_get!(TracksInfo, Balance, BlockNumber);

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -890,6 +890,9 @@ impl Contains<RuntimeCall> for NormalFilter {
 				pallet_assets::Call::approve_transfer { .. } => true,
 				pallet_assets::Call::transfer_approved { .. } => true,
 				pallet_assets::Call::cancel_approval { .. } => true,
+				pallet_assets::Call::destroy_accounts { .. } => true,
+				pallet_assets::Call::destroy_approvals { .. } => true,
+				pallet_assets::Call::finish_destroy { .. } => true,
 				_ => false,
 			},
 			// We want to disable create, as we dont want users to be choosing the
@@ -900,9 +903,6 @@ impl Contains<RuntimeCall> for NormalFilter {
 			RuntimeCall::LocalAssets(method) => match method {
 				pallet_assets::Call::create { .. } => false,
 				pallet_assets::Call::start_destroy { .. } => false,
-				pallet_assets::Call::destroy_accounts { .. } => false,
-				pallet_assets::Call::destroy_approvals { .. } => false,
-				pallet_assets::Call::finish_destroy { .. } => false,
 				_ => true,
 			},
 			// We just want to enable this in case of live chains, since the default version

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -899,7 +899,6 @@ impl Contains<RuntimeCall> for NormalFilter {
 			// substrate side of things
 			RuntimeCall::LocalAssets(method) => match method {
 				pallet_assets::Call::create { .. } => false,
-				pallet_assets::Call::freeze_asset { .. } => false,
 				pallet_assets::Call::start_destroy { .. } => false,
 				pallet_assets::Call::destroy_accounts { .. } => false,
 				pallet_assets::Call::destroy_approvals { .. } => false,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1122,6 +1122,8 @@ impl pallet_randomness::Config for Runtime {
 	type EpochExpirationDelay = ConstU64<10_000>;
 }
 
+impl pallet_root_testing::Config for Runtime {}
+
 construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
@@ -1134,6 +1136,7 @@ construct_runtime! {
 		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Pallet, Storage} = 2,
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent} = 3,
 		ParachainInfo: parachain_info::{Pallet, Storage, Config} = 4,
+		RootTesting: pallet_root_testing::{Pallet, Call, Storage} = 5,
 
 		// Monetary stuff.
 		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>} = 10,

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -48,7 +48,7 @@ use frame_support::{
 		OffchainWorker, OnFinalize, OnIdle, OnInitialize, OnRuntimeUpgrade, OnUnbalanced,
 	},
 	weights::{
-		constants::{RocksDbWeight, WEIGHT_PER_SECOND},
+		constants::{RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND},
 		ConstantMultiplier, Weight, WeightToFeeCoefficient, WeightToFeeCoefficients,
 		WeightToFeePolynomial,
 	},
@@ -138,7 +138,7 @@ pub mod currency {
 }
 
 /// Maximum weight per block
-pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
+pub const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_ref_time(WEIGHT_REF_TIME_PER_SECOND)
 	.saturating_div(2)
 	.set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);
 
@@ -364,7 +364,7 @@ pub const GAS_PER_SECOND: u64 = 40_000_000;
 
 /// Approximate ratio of the amount of Weight per Gas.
 /// u64 works for approximations because Weight is a very small unit compared to gas.
-pub const WEIGHT_PER_GAS: u64 = WEIGHT_PER_SECOND.ref_time() / GAS_PER_SECOND;
+pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND / GAS_PER_SECOND;
 
 parameter_types! {
 	pub BlockGasLimit: U256
@@ -899,7 +899,11 @@ impl Contains<RuntimeCall> for NormalFilter {
 			// substrate side of things
 			RuntimeCall::LocalAssets(method) => match method {
 				pallet_assets::Call::create { .. } => false,
-				pallet_assets::Call::destroy { .. } => false,
+				pallet_assets::Call::freeze_asset { .. } => false,
+				pallet_assets::Call::start_destroy { .. } => false,
+				pallet_assets::Call::destroy_accounts { .. } => false,
+				pallet_assets::Call::destroy_approvals { .. } => false,
+				pallet_assets::Call::finish_destroy { .. } => false,
 				_ => true,
 			},
 			// We just want to enable this in case of live chains, since the default version

--- a/runtime/moonriver/tests/common/mod.rs
+++ b/runtime/moonriver/tests/common/mod.rs
@@ -309,9 +309,10 @@ impl ExtBuilder {
 		ext.execute_with(|| {
 			// If any local assets specified, we create them here
 			for (asset_id, balances, owner) in local_assets.clone() {
-				LocalAssets::force_create(root_origin(), asset_id, owner, true, 1).unwrap();
+				LocalAssets::force_create(root_origin(), asset_id.into(), owner, true, 1).unwrap();
 				for (account, balance) in balances {
-					LocalAssets::mint(origin_of(owner.into()), asset_id, account, balance).unwrap();
+					LocalAssets::mint(origin_of(owner.into()), asset_id.into(), account, balance)
+						.unwrap();
 				}
 			}
 			// If any xcm assets specified, we register them here
@@ -328,7 +329,7 @@ impl ExtBuilder {
 				for (account, balance) in xcm_asset_initialization.balances {
 					Assets::mint(
 						origin_of(AssetManager::account_id()),
-						asset_id,
+						asset_id.into(),
 						account,
 						balance,
 					)

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -29,7 +29,7 @@ use frame_support::{
 		fungible::Inspect, fungibles::Inspect as FungiblesInspect, Currency as CurrencyT,
 		EnsureOrigin, PalletInfo, StorageInfo, StorageInfoTrait,
 	},
-	weights::{constants::WEIGHT_PER_SECOND, Weight},
+	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
 	StorageHasher, Twox128,
 };
 use moonriver_runtime::{
@@ -1493,7 +1493,7 @@ fn local_assets_cannot_be_create_by_signed_origins() {
 			assert_noop!(
 				RuntimeCall::LocalAssets(
 					pallet_assets::Call::<Runtime, LocalAssetInstance>::create {
-						id: 11u128,
+						id: 11u128.into(),
 						admin: AccountId::from(ALICE),
 						min_balance: 1u128
 					}
@@ -1892,7 +1892,7 @@ fn asset_erc20_precompiles_freeze_transfer_ownership() {
 			// e.g., transfer_ownership again
 			assert_ok!(LocalAssets::transfer_ownership(
 				origin_of(AccountId::from(BOB)),
-				0u128,
+				0u128.into(),
 				AccountId::from(ALICE)
 			));
 		});
@@ -1933,18 +1933,18 @@ fn asset_erc20_precompiles_freeze_set_team() {
 			// Bob should be able to mint, freeze, and thaw
 			assert_ok!(LocalAssets::mint(
 				origin_of(AccountId::from(BOB)),
-				0u128,
+				0u128.into(),
 				AccountId::from(BOB),
 				1_000 * MOVR
 			));
 			assert_ok!(LocalAssets::freeze(
 				origin_of(AccountId::from(BOB)),
-				0u128,
+				0u128.into(),
 				AccountId::from(ALICE)
 			));
 			assert_ok!(LocalAssets::thaw(
 				origin_of(AccountId::from(BOB)),
-				0u128,
+				0u128.into(),
 				AccountId::from(ALICE)
 			));
 		});
@@ -2732,7 +2732,7 @@ fn test_xcm_utils_get_units_per_second() {
 		let input = XcmUtilsPCall::get_units_per_second { multilocation };
 
 		let expected_units =
-			WEIGHT_PER_SECOND.ref_time() as u128 * moonriver_runtime::currency::WEIGHT_FEE;
+			WEIGHT_REF_TIME_PER_SECOND as u128 * moonriver_runtime::currency::WEIGHT_FEE;
 
 		Precompiles::new()
 			.prepare_test(ALICE, xcm_utils_precompile_address, input)

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -181,6 +181,13 @@ fn verify_pallet_prefixes() {
 			},
 			StorageInfo {
 				pallet_name: b"Balances".to_vec(),
+				storage_name: b"InactiveIssuance".to_vec(),
+				prefix: prefix(b"Balances", b"InactiveIssuance"),
+				max_values: Some(1),
+				max_size: Some(16),
+			},
+			StorageInfo {
+				pallet_name: b"Balances".to_vec(),
 				storage_name: b"Account".to_vec(),
 				prefix: prefix(b"Balances", b"Account"),
 				max_values: None,
@@ -200,13 +207,6 @@ fn verify_pallet_prefixes() {
 				max_values: None,
 				max_size: Some(1037),
 			},
-			StorageInfo {
-				pallet_name: b"Balances".to_vec(),
-				storage_name: b"StorageVersion".to_vec(),
-				prefix: prefix(b"Balances", b"StorageVersion"),
-				max_values: Some(1),
-				max_size: Some(1),
-			}
 		]
 	);
 	assert_eq!(
@@ -1579,7 +1579,7 @@ fn asset_erc20_precompiles_transfer() {
 						value: { 400 * MOVR }.into(),
 					},
 				)
-				.expect_cost(24083u64)
+				.expect_cost(24133)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1631,7 +1631,7 @@ fn asset_erc20_precompiles_approve() {
 						value: { 400 * MOVR }.into(),
 					},
 				)
-				.expect_cost(14597)
+				.expect_cost(14596)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_APPROVAL,
@@ -1652,7 +1652,7 @@ fn asset_erc20_precompiles_approve() {
 						value: { 400 * MOVR }.into(),
 					},
 				)
-				.expect_cost(29683)
+				.expect_cost(29624)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1704,7 +1704,7 @@ fn asset_erc20_precompiles_mint_burn() {
 						value: { 1000 * MOVR }.into(),
 					},
 				)
-				.expect_cost(13204)
+				.expect_cost(13249)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1731,7 +1731,7 @@ fn asset_erc20_precompiles_mint_burn() {
 						value: { 500 * MOVR }.into(),
 					},
 				)
-				.expect_cost(13588)
+				.expect_cost(13575)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -1776,7 +1776,7 @@ fn asset_erc20_precompiles_freeze_thaw_account() {
 						account: Address(ALICE.into()),
 					},
 				)
-				.expect_cost(7107)
+				.expect_cost(7094)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1795,7 +1795,7 @@ fn asset_erc20_precompiles_freeze_thaw_account() {
 						account: Address(ALICE.into()),
 					},
 				)
-				.expect_cost(7103)
+				.expect_cost(7074)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1830,7 +1830,7 @@ fn asset_erc20_precompiles_freeze_thaw_asset() {
 					asset_precompile_address,
 					LocalAssetsPCall::freeze_asset {},
 				)
-				.expect_cost(5970)
+				.expect_cost(5944)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1847,7 +1847,7 @@ fn asset_erc20_precompiles_freeze_thaw_asset() {
 					asset_precompile_address,
 					LocalAssetsPCall::thaw_asset {},
 				)
-				.expect_cost(5941)
+				.expect_cost(5964)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1884,7 +1884,7 @@ fn asset_erc20_precompiles_freeze_transfer_ownership() {
 						owner: Address(BOB.into()),
 					},
 				)
-				.expect_cost(6983)
+				.expect_cost(6973)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -1926,7 +1926,7 @@ fn asset_erc20_precompiles_freeze_set_team() {
 						freezer: Address(BOB.into()),
 					},
 				)
-				.expect_cost(5926)
+				.expect_cost(5940)
 				.expect_no_logs()
 				.execute_returns_encoded(true);
 
@@ -2047,7 +2047,7 @@ fn xcm_asset_erc20_precompiles_transfer() {
 						value: { 400 * MOVR }.into(),
 					},
 				)
-				.expect_cost(24083)
+				.expect_cost(24133)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,
@@ -2111,7 +2111,7 @@ fn xcm_asset_erc20_precompiles_approve() {
 						value: { 400 * MOVR }.into(),
 					},
 				)
-				.expect_cost(14597)
+				.expect_cost(14596)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_APPROVAL,
@@ -2132,7 +2132,7 @@ fn xcm_asset_erc20_precompiles_approve() {
 						value: { 400 * MOVR }.into(),
 					},
 				)
-				.expect_cost(29683)
+				.expect_cost(29624)
 				.expect_log(log3(
 					asset_precompile_address,
 					SELECTOR_LOG_TRANSFER,

--- a/runtime/moonriver/tests/xcm_mock/mod.rs
+++ b/runtime/moonriver/tests/xcm_mock/mod.rs
@@ -26,7 +26,9 @@ use xcm_simulator::{decl_test_network, decl_test_parachain, decl_test_relay_chai
 use polkadot_runtime_parachains::configuration::{
 	GenesisConfig as ConfigurationGenesisConfig, HostConfiguration,
 };
-use polkadot_runtime_parachains::paras::{GenesisConfig as ParasGenesisConfig, ParaGenesisArgs};
+use polkadot_runtime_parachains::paras::{
+	GenesisConfig as ParasGenesisConfig, ParaGenesisArgs, ParaKind,
+};
 use sp_core::{H160, U256};
 use std::{collections::BTreeMap, str::FromStr};
 
@@ -49,7 +51,7 @@ pub fn mock_para_genesis_info() -> ParaGenesisArgs {
 	ParaGenesisArgs {
 		genesis_head: vec![1u8].into(),
 		validation_code: vec![1u8].into(),
-		parachain: true,
+		para_kind: ParaKind::Parachain,
 	}
 }
 

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -20,16 +20,16 @@ use frame_support::{
 	construct_runtime,
 	dispatch::GetDispatchInfo,
 	parameter_types,
-	traits::{Everything, Get, Nothing, PalletInfoAccess},
+	traits::{AsEnsureOriginWithArg, Everything, Get, Nothing, PalletInfoAccess},
 	weights::Weight,
 	PalletId,
 };
 
-use frame_system::EnsureRoot;
+use frame_system::{EnsureRoot, EnsureSigned};
 use parity_scale_codec::{Decode, Encode};
 use sp_core::H256;
 use sp_runtime::{
-	traits::{BlakeTwo256, Hash, IdentityLookup},
+	traits::{BlakeTwo256, ConstU32, Hash, IdentityLookup},
 	Permill,
 };
 use sp_std::{convert::TryFrom, prelude::*};
@@ -143,6 +143,10 @@ impl pallet_assets::Config<ForeignAssetInstance> for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = AssetAccountDeposit;
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = AssetId;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 impl pallet_assets::Config<LocalAssetInstance> for Runtime {
@@ -160,6 +164,10 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = AssetAccountDeposit;
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = AssetId;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -774,39 +782,66 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		);*/
 		Ok(())
 	}
-	fn destroy_foreign_asset(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchResult {
+	fn destroy_foreign_asset(asset: AssetId) -> DispatchResult {
 		// First destroy the asset
-		Assets::destroy(RuntimeOrigin::root(), asset, asset_destroy_witness)
-			.map_err(|info| info.error)?;
+		Assets::freeze_asset(RuntimeOrigin::root(), asset)
+			.and_then(|_| Assets::start_destroy(RuntimeOrigin::root(), asset))
+			.and_then(|_| {
+				Assets::destroy_accounts(RuntimeOrigin::root(), asset).map_err(|info| info.error)
+			})
+			.and_then(|_| {
+				Assets::destroy_approvals(RuntimeOrigin::root(), asset).map_err(|info| info.error)
+			})
+			.and_then(|_| Assets::finish_destroy(RuntimeOrigin::root(), asset))?;
 
 		Ok(())
 	}
 
-	fn destroy_local_asset(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> DispatchResult {
+	fn destroy_local_asset(asset: AssetId) -> DispatchResult {
 		// First destroy the asset
-		LocalAssets::destroy(RuntimeOrigin::root(), asset, asset_destroy_witness)
-			.map_err(|info| info.error)?;
+		LocalAssets::freeze_asset(RuntimeOrigin::root(), asset)
+			.and_then(|_| LocalAssets::start_destroy(RuntimeOrigin::root(), asset))
+			.and_then(|_| {
+				LocalAssets::destroy_accounts(RuntimeOrigin::root(), asset)
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| {
+				LocalAssets::destroy_approvals(RuntimeOrigin::root(), asset)
+					.map_err(|info| info.error)
+			})
+			.and_then(|_| LocalAssets::finish_destroy(RuntimeOrigin::root(), asset))?;
 
 		Ok(())
 	}
 
-	fn destroy_asset_dispatch_info_weight(
-		asset: AssetId,
-		asset_destroy_witness: pallet_assets::DestroyWitness,
-	) -> Weight {
-		let call = RuntimeCall::Assets(
-			pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy {
-				id: asset,
-				witness: asset_destroy_witness,
-			},
-		);
-		call.get_dispatch_info().weight
+	fn destroy_asset_dispatch_info_weight(asset: AssetId) -> Weight {
+		let call_weight = [
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::freeze_asset { id: asset },
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy { id: asset },
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_accounts {
+					id: asset,
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_approvals {
+					id: asset,
+				},
+			),
+			RuntimeCall::Assets(
+				pallet_assets::Call::<Runtime, ForeignAssetInstance>::finish_destroy { id: asset },
+			),
+		]
+		.into_iter()
+		.fold(Weight::zero(), |acc, call| {
+			acc.saturating_add(call.get_dispatch_info().weight)
+		});
+
+		call_weight
 	}
 }
 
@@ -839,7 +874,6 @@ impl pallet_asset_manager::Config for Runtime {
 	type ForeignAssetModifierOrigin = EnsureRoot<AccountId>;
 	type LocalAssetModifierOrigin = EnsureRoot<AccountId>;
 	type LocalAssetIdCreator = LocalAssetIdCreator;
-	type AssetDestroyWitness = pallet_assets::DestroyWitness;
 	type Currency = Balances;
 	type LocalAssetDeposit = AssetDeposit;
 	type WeightInfo = ();

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -24,8 +24,7 @@ use frame_support::{
 	weights::Weight,
 	PalletId,
 };
-
-use frame_system::{EnsureRoot, EnsureSigned};
+use frame_system::{EnsureNever, EnsureRoot};
 use parity_scale_codec::{Decode, Encode};
 use sp_core::H256;
 use sp_runtime::{
@@ -145,7 +144,7 @@ impl pallet_assets::Config<ForeignAssetInstance> for Runtime {
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = AssetId;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
 	type CallbackHandle = ();
 }
 
@@ -166,7 +165,7 @@ impl pallet_assets::Config<LocalAssetInstance> for Runtime {
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = AssetId;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
 	type CallbackHandle = ();
 }
 
@@ -783,65 +782,25 @@ impl pallet_asset_manager::AssetRegistrar<Runtime> for AssetRegistrar {
 		Ok(())
 	}
 	fn destroy_foreign_asset(asset: AssetId) -> DispatchResult {
-		// First destroy the asset
-		Assets::freeze_asset(RuntimeOrigin::root(), asset)
-			.and_then(|_| Assets::start_destroy(RuntimeOrigin::root(), asset))
-			.and_then(|_| {
-				Assets::destroy_accounts(RuntimeOrigin::root(), asset).map_err(|info| info.error)
-			})
-			.and_then(|_| {
-				Assets::destroy_approvals(RuntimeOrigin::root(), asset).map_err(|info| info.error)
-			})
-			.and_then(|_| Assets::finish_destroy(RuntimeOrigin::root(), asset))?;
+		// Mark the asset as destroying
+		Assets::start_destroy(RuntimeOrigin::root(), asset)?;
 
 		Ok(())
 	}
 
 	fn destroy_local_asset(asset: AssetId) -> DispatchResult {
-		// First destroy the asset
-		LocalAssets::freeze_asset(RuntimeOrigin::root(), asset)
-			.and_then(|_| LocalAssets::start_destroy(RuntimeOrigin::root(), asset))
-			.and_then(|_| {
-				LocalAssets::destroy_accounts(RuntimeOrigin::root(), asset)
-					.map_err(|info| info.error)
-			})
-			.and_then(|_| {
-				LocalAssets::destroy_approvals(RuntimeOrigin::root(), asset)
-					.map_err(|info| info.error)
-			})
-			.and_then(|_| LocalAssets::finish_destroy(RuntimeOrigin::root(), asset))?;
+		// Mark the asset as destroying
+		LocalAssets::start_destroy(RuntimeOrigin::root(), asset)?;
 
 		Ok(())
 	}
 
 	fn destroy_asset_dispatch_info_weight(asset: AssetId) -> Weight {
-		let call_weight = [
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::freeze_asset { id: asset },
-			),
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy { id: asset },
-			),
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_accounts {
-					id: asset,
-				},
-			),
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::destroy_approvals {
-					id: asset,
-				},
-			),
-			RuntimeCall::Assets(
-				pallet_assets::Call::<Runtime, ForeignAssetInstance>::finish_destroy { id: asset },
-			),
-		]
-		.into_iter()
-		.fold(Weight::zero(), |acc, call| {
-			acc.saturating_add(call.get_dispatch_info().weight)
-		});
-
-		call_weight
+		RuntimeCall::Assets(
+			pallet_assets::Call::<Runtime, ForeignAssetInstance>::start_destroy { id: asset },
+		)
+		.get_dispatch_info()
+		.weight
 	}
 }
 

--- a/runtime/moonriver/tests/xcm_mock/statemine_like.rs
+++ b/runtime/moonriver/tests/xcm_mock/statemine_like.rs
@@ -18,14 +18,14 @@
 
 use frame_support::{
 	construct_runtime, match_types, parameter_types,
-	traits::{Everything, Nothing},
+	traits::{AsEnsureOriginWithArg, Everything, Nothing},
 	weights::Weight,
 };
-use frame_system::EnsureRoot;
+use frame_system::{EnsureRoot, EnsureSigned};
 
 use sp_core::H256;
 use sp_runtime::{
-	traits::{BlakeTwo256, Hash, IdentityLookup},
+	traits::{BlakeTwo256, ConstU32, Hash, IdentityLookup},
 	AccountId32,
 };
 
@@ -131,6 +131,10 @@ impl pallet_assets::Config for Runtime {
 	type Extra = ();
 	type AssetAccountDeposit = AssetAccountDeposit;
 	type WeightInfo = ();
+	type RemoveItemsLimit = ConstU32<1000>;
+	type AssetIdParameter = AssetId;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CallbackHandle = ();
 }
 
 parameter_types! {

--- a/runtime/moonriver/tests/xcm_mock/statemine_like.rs
+++ b/runtime/moonriver/tests/xcm_mock/statemine_like.rs
@@ -21,7 +21,7 @@ use frame_support::{
 	traits::{AsEnsureOriginWithArg, Everything, Nothing},
 	weights::Weight,
 };
-use frame_system::{EnsureRoot, EnsureSigned};
+use frame_system::{EnsureNever, EnsureRoot};
 
 use sp_core::H256;
 use sp_runtime::{
@@ -133,7 +133,7 @@ impl pallet_assets::Config for Runtime {
 	type WeightInfo = ();
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = AssetId;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
 	type CallbackHandle = ();
 }
 

--- a/runtime/moonriver/tests/xcm_mock/statemine_like.rs
+++ b/runtime/moonriver/tests/xcm_mock/statemine_like.rs
@@ -21,7 +21,7 @@ use frame_support::{
 	traits::{AsEnsureOriginWithArg, Everything, Nothing},
 	weights::Weight,
 };
-use frame_system::{EnsureNever, EnsureRoot};
+use frame_system::{EnsureRoot, EnsureSigned};
 
 use sp_core::H256;
 use sp_runtime::{
@@ -133,7 +133,7 @@ impl pallet_assets::Config for Runtime {
 	type WeightInfo = ();
 	type RemoveItemsLimit = ConstU32<1000>;
 	type AssetIdParameter = AssetId;
-	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<AccountId>>;
 	type CallbackHandle = ();
 }
 

--- a/runtime/moonriver/tests/xcm_tests.rs
+++ b/runtime/moonriver/tests/xcm_tests.rs
@@ -20,7 +20,7 @@ mod xcm_mock;
 use frame_support::{
 	assert_ok,
 	traits::{PalletInfo, PalletInfoAccess},
-	weights::constants::WEIGHT_PER_SECOND,
+	weights::constants::WEIGHT_REF_TIME_PER_SECOND,
 };
 use pallet_asset_manager::LocalAssetIdCreator;
 use xcm::latest::prelude::*;
@@ -1014,7 +1014,7 @@ fn transact_through_derivative_multilocation() {
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
 			Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
-			WEIGHT_PER_SECOND.ref_time() as u128,
+			WEIGHT_REF_TIME_PER_SECOND as u128,
 		));
 	});
 
@@ -1324,7 +1324,7 @@ fn transact_through_sovereign() {
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
 			Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
-			WEIGHT_PER_SECOND.ref_time() as u128,
+			WEIGHT_REF_TIME_PER_SECOND as u128,
 		));
 	});
 
@@ -2541,7 +2541,7 @@ fn transact_through_signed_multilocation() {
 		assert_ok!(XcmTransactor::set_fee_per_second(
 			parachain::RuntimeOrigin::root(),
 			Box::new(xcm::VersionedMultiLocation::V1(MultiLocation::parent())),
-			WEIGHT_PER_SECOND.ref_time() as u128,
+			WEIGHT_REF_TIME_PER_SECOND as u128,
 		));
 		ancestry = parachain::Ancestry::get();
 	});

--- a/runtime/relay-encoder/Cargo.toml
+++ b/runtime/relay-encoder/Cargo.toml
@@ -14,28 +14,28 @@ pallet-evm-precompile-relay-encoder = { path = "../../precompiles/relay-encoder/
 xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # Substrate
-frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-pallet-staking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+frame-system = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+pallet-staking = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = [ "derive" ] }
-sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
-sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+sp-runtime = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
+sp-std = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Cumulus
-cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+cumulus-primitives-core = { git = "https://github.com/purestake/cumulus", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 # Polkadot
-xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32", default-features = false }
+xcm = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 
 [dev-dependencies]
-frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
-pallet-utility = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.32" }
+frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-proxy = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
+pallet-utility = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37" }
 
-kusama-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-polkadot-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-polkadot-runtime-parachains = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-rococo-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
-westend-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.32" }
+kusama-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+polkadot-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+polkadot-runtime-parachains = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+rococo-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
+westend-runtime = { git = "https://github.com/purestake/polkadot", branch = "moonbeam-polkadot-v0.9.37" }
 
 [features]
 default = [ "std" ]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-09-10"
+channel = "nightly-2022-11-14"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"

--- a/tests/tests/test-fees/test-fee-multiplier.ts
+++ b/tests/tests/test-fees/test-fee-multiplier.ts
@@ -92,7 +92,7 @@ describeDevMoonbeam("Max Fee Multiplier", (context) => {
     let fillAmount = 600_000_000; // equal to 60% Perbill
 
     const { block, result } = await context.createBlock(
-      context.polkadotApi.tx.system.fillBlock(fillAmount)
+      context.polkadotApi.tx.rootTesting.fillBlock(fillAmount)
     );
 
     // grab the first withdraw event and hope it's the right one...
@@ -207,7 +207,9 @@ describeDevMoonbeam("Fee Multiplier - XCM Executions", (context) => {
   it("should not decay when block size at target amount", async function () {
     const initialValue = await context.polkadotApi.query.transactionPayment.nextFeeMultiplier();
     await context.createBlock(
-      context.polkadotApi.tx.sudo.sudo(context.polkadotApi.tx.system.fillBlock(TARGET_FILL_AMOUNT))
+      context.polkadotApi.tx.sudo.sudo(
+        context.polkadotApi.tx.rootTesting.fillBlock(TARGET_FILL_AMOUNT)
+      )
     );
     const postValue = await context.polkadotApi.query.transactionPayment.nextFeeMultiplier();
     expect(initialValue.eq(postValue), "Fee multiplier not static on ideal fill ratio").to.be.true;
@@ -219,7 +221,7 @@ describeDevMoonbeam("Fee Multiplier - XCM Executions", (context) => {
       .transfer(BALTATHAR_ADDRESS, 1_000_000_000_000_000_000n)
       .signAndSend(alith, { nonce: -1 });
     await context.polkadotApi.tx.sudo
-      .sudo(context.polkadotApi.tx.system.fillBlock(TARGET_FILL_AMOUNT))
+      .sudo(context.polkadotApi.tx.rootTesting.fillBlock(TARGET_FILL_AMOUNT))
       .signAndSend(alith, { nonce: -1 });
     await context.createBlock();
 
@@ -241,7 +243,7 @@ describeDevMoonbeam("Fee Multiplier - XCM Executions", (context) => {
     ).block.header.number.toNumber();
 
     await context.polkadotApi.tx.sudo
-      .sudo(context.polkadotApi.tx.system.fillBlock(TARGET_FILL_AMOUNT))
+      .sudo(context.polkadotApi.tx.rootTesting.fillBlock(TARGET_FILL_AMOUNT))
       .signAndSend(alith, { nonce: -1 });
     const xcmMessage = new XcmFragment({
       fees: {
@@ -352,7 +354,7 @@ describeDevMoonbeam("Fee Multiplier - XCM Executions", (context) => {
     ).block.header.number.toNumber();
 
     await context.polkadotApi.tx.sudo
-      .sudo(context.polkadotApi.tx.system.fillBlock(TARGET_FILL_AMOUNT))
+      .sudo(context.polkadotApi.tx.rootTesting.fillBlock(TARGET_FILL_AMOUNT))
       .signAndSend(alith, { nonce: -1 });
     const xcmMessage = new XcmFragment({
       fees: {

--- a/tests/tests/test-fees/test-length-fees.ts
+++ b/tests/tests/test-fees/test-length-fees.ts
@@ -12,7 +12,7 @@ describeDevMoonbeam(
   (context) => {
     it("should have low balance transfer fees", async () => {
       const fee = await testBalanceTransfer(context);
-      expect(fee).to.equal(79359001520875n);
+      expect(fee).to.equal(82139401520875n);
     });
   },
   "Legacy",
@@ -36,7 +36,7 @@ describeDevMoonbeam(
   (context) => {
     it("should have low balance transfer fees", async () => {
       const fee = await testBalanceTransfer(context);
-      expect(fee).to.equal(79_359_001_520_875n);
+      expect(fee).to.equal(82139401520875n);
     });
   },
   "Legacy",
@@ -60,7 +60,7 @@ describeDevMoonbeam(
   (context) => {
     it("should have low balance transfer fees", async () => {
       const fee = await testBalanceTransfer(context);
-      expect(fee).to.equal(7_935_900_152_087_500n);
+      expect(fee).to.equal(82139401520875n);
     });
   },
   "Legacy",

--- a/tests/tests/test-fees/test-length-fees.ts
+++ b/tests/tests/test-fees/test-length-fees.ts
@@ -60,7 +60,7 @@ describeDevMoonbeam(
   (context) => {
     it("should have low balance transfer fees", async () => {
       const fee = await testBalanceTransfer(context);
-      expect(fee).to.equal(82139401520875n);
+      expect(fee).to.equal(8213940152087500n);
     });
   },
   "Legacy",

--- a/tests/tests/test-maintenance/test-maintenance-filter.ts
+++ b/tests/tests/test-maintenance/test-maintenance-filter.ts
@@ -247,7 +247,7 @@ describeDevMoonbeam("Maintenance Mode - Filter", (context) => {
       name: "FOREIGN",
       symbol: "FOREIGN",
       decimals: new BN(12),
-      status: "Live",
+      isFroze: false,
     };
 
     const sourceLocation = {

--- a/tests/tests/test-maintenance/test-maintenance-filter.ts
+++ b/tests/tests/test-maintenance/test-maintenance-filter.ts
@@ -247,7 +247,7 @@ describeDevMoonbeam("Maintenance Mode - Filter", (context) => {
       name: "FOREIGN",
       symbol: "FOREIGN",
       decimals: new BN(12),
-      isFrozen: false,
+      status: "Live",
     };
 
     const sourceLocation = {

--- a/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
+++ b/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
@@ -1048,7 +1048,7 @@ describeDevMoonbeamAllEthTxTypes(
 
       const registeredAsset = (await context.polkadotApi.query.localAssets.asset(assetId)).unwrap();
 
-      expect(registeredAsset.isFrozen.isTrue).to.be.true;
+      expect(registeredAsset.status.isFrozen).to.be.true;
     });
   },
   true

--- a/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
+++ b/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
@@ -1004,7 +1004,7 @@ describeDevMoonbeamAllEthTxTypes(
         alith.address
       );
 
-      expect(baltatharFrozen.unwrap().isFrozen.isTrue).to.be.true;
+      expect(baltatharFrozen.unwrap().isFrozen.isFalse).to.be.true;
     });
   },
   true

--- a/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
+++ b/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
@@ -955,7 +955,7 @@ describeDevMoonbeamAllEthTxTypes(
 
       let alithFrozen = await context.polkadotApi.query.localAssets.account(assetId, alith.address);
 
-      expect(alithFrozen.unwrap()["status"].isFrozen).to.be.true;
+      expect(alithFrozen.unwrap().isFrozen.isTrue).to.be.true;
     });
   },
   true
@@ -1004,7 +1004,7 @@ describeDevMoonbeamAllEthTxTypes(
         alith.address
       );
 
-      expect(baltatharFrozen.unwrap()["status"].isFrozen).to.be.true;
+      expect(baltatharFrozen.unwrap().isFrozen.isTrue).to.be.true;
     });
   },
   true

--- a/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
+++ b/tests/tests/test-precompile/test-precompile-local-assets-erc20.ts
@@ -955,7 +955,7 @@ describeDevMoonbeamAllEthTxTypes(
 
       let alithFrozen = await context.polkadotApi.query.localAssets.account(assetId, alith.address);
 
-      expect(alithFrozen.unwrap()["isFrozen"].toHuman()).to.be.true;
+      expect(alithFrozen.unwrap()["status"].isFrozen).to.be.true;
     });
   },
   true
@@ -1004,7 +1004,7 @@ describeDevMoonbeamAllEthTxTypes(
         alith.address
       );
 
-      expect(baltatharFrozen.unwrap().isFrozen.isFalse).to.be.true;
+      expect(baltatharFrozen.unwrap()["status"].isFrozen).to.be.true;
     });
   },
   true
@@ -1093,7 +1093,7 @@ describeDevMoonbeamAllEthTxTypes(
 
       const registeredAsset = (await context.polkadotApi.query.localAssets.asset(assetId)).unwrap();
 
-      expect(registeredAsset.isFrozen.toHuman()).to.be.false;
+      expect(registeredAsset.status.isFrozen).to.be.false;
     });
   },
   true


### PR DESCRIPTION
### What does it do?
upgrades moonbeam to v0.9.37

### Notes
# Substrate

## Pallet Assets
* https://github.com/paritytech/substrate/pull/12310
  * 🛠️ [#12275](https://github.com/paritytech/substrate/issues/12275) - an asset with too many accounts would've exceeded the block weight making it un-destroyable
  * Removes `destroy()` in favor of `freeze_asset()`, `start_destroy()`, `destroy_accounts()`, `destroy_approvals()` and `finish_destroy()`.
  * `AssetDetails` new field `status` in lieu of `is_frozen`.
  * Removes `DestroyWitness` parameter.
  * Adds `RemoveItemsLimit` to config.
  * Affects `moonbeam`.
* https://github.com/paritytech/substrate/pull/12586
  * 🛠️ allows the runtime to configure who may create asset classes
  * Adds `CreateOrigin`
  * Affects `moonbeam`.
* https://github.com/paritytech/substrate/pull/12307
  * 🛠️ register callbacks that are invoked when a new asset is created or an existing one destroyed
  * Adds `CallbackHandle`
  * Affects `moonbeam`.
* https://github.com/paritytech/substrate/pull/12740
  * 🛠️ [#12740](https://github.com/paritytech/substrate/pull/12740) - prevent breaking changes on `AssetId` resulting from the removal of `HasCompact` trait bound
  * Adds `AssetIdParameter`
  * Affects `moonbeam`.
  
## Inherents
* https://github.com/paritytech/substrate/pull/8526
  * 🛠️ changes the inherent data system to be more flexible.
  * `InherentDataProvider::create_inherent_data()` is now `async`
  * Affects `nimbus`.
* https://github.com/paritytech/substrate/pull/12749
  * 🛠️ improve provisioner performance.
  * `InherentDataProvider::provide_inherent_data()` is now `async`
  * Affects `nimbus`.

## Others
* https://github.com/paritytech/substrate/pull/11381
  * 🛠️ [#10408](https://github.com/paritytech/substrate/issues/10408) - explicit ordering of calls.
  * Introduce `#[pallet::call_index]` attribute to dispatchables.
* https://github.com/paritytech/substrate/pull/12813
  * 🛠️ total issuance not including the treasury funds and any other funds marked as inactive with deactivate. This should generally be used rather than TotalIssuance.
  * New `pallet_balances` item `InactiveIssuance`.
* https://github.com/paritytech/substrate/pull/12840
  * 🛠️ `pallet_balances` was missing to set the storage_version attribute for the Pallet struct. Besides that it also removes the old StorageVersion representation.
  * Removes `pallet_balances` storage item `StorageVersion`.
* https://github.com/paritytech/substrate/pull/12451
  * 🛠️ [#11352](https://github.com/paritytech/substrate/issues/11352) - generic testing pallet.
  * Moves `system.fillBlock()` to `pallet-root-testing`
  

# Polkadot

* https://github.com/paritytech/polkadot/pull/6198
  * 🛠️ distinguishes between Parachain and Parathread
  * Replace `ParaGenesisArgs` field `parachain: bool` by enum field `para_kind: ParaKind`
  * Used in `xcm_mocks`
  * Affects `moonbeam`.

# Cumulus
* https://github.com/paritytech/cumulus/pull/1559
  * 🛠️ [#432](https://github.com/paritytech/cumulus/issues/432) - helps pruning "dead" leaves while importing new blocks
  * `ParachainBlockImport` now includes `Block` and `Backend` parameters
  * Affects `nimbus`.
* https://github.com/paritytech/cumulus/pull/1930, https://github.com/paritytech/substrate/pull/12764
  * Removes `SharedImportQueue` in favor of `ImportQueueService`.
  * Affects `nimbus`.
  
# Nimbus

# Frontier

## Refactor `BlockId::Number`  in favor of `BlockId::Hash`
https://github.com/paritytech/substrate/issues/11292
 
* https://github.com/paritytech/substrate/pull/12510
  * `Backend::StorageProvider` 
* https://github.com/paritytech/substrate/pull/12519
  * `ProofProvider`
* https://github.com/paritytech/substrate/pull/12528
  * `Finalizer`
* https://github.com/paritytech/substrate/pull/12981, https://github.com/paritytech/substrate/pull/12874
  * `HeaderBackend::status|header`
* https://github.com/paritytech/substrate/pull/13014
  * `BlockBackend::block|block_status`
* https://github.com/paritytech/substrate/pull/12602
  * `Backend::justifications`

## Others
* https://github.com/paritytech/frontier/pull/956
  * Rename feature `rpc_binary_search_estimate` => `rpc-binary-search-estimate`

# Moonbeam




### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
