### PR TITLE
Record some weight in min_gas_price

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -420,7 +420,8 @@ impl FeeCalculator for TransactionPaymentAsGasPrice {
 		// is computed in frontier, but that's currently unavoidable.
 		let min_gas_price = TransactionPayment::next_fee_multiplier()
 			.saturating_mul_int(currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128));
-		(min_gas_price.into(), Weight::zero())
+		(min_gas_price.into(), <Runtime as frame_system::Config>::DbWeight::get().reads(1))
+		
 	}
 }
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -421,7 +421,6 @@ impl FeeCalculator for TransactionPaymentAsGasPrice {
 		let min_gas_price = TransactionPayment::next_fee_multiplier()
 			.saturating_mul_int(currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128));
 		(min_gas_price.into(), <Runtime as frame_system::Config>::DbWeight::get().reads(1))
-		
 	}
 }
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -420,7 +420,10 @@ impl FeeCalculator for TransactionPaymentAsGasPrice {
 		// is computed in frontier, but that's currently unavoidable.
 		let min_gas_price = TransactionPayment::next_fee_multiplier()
 			.saturating_mul_int(currency::WEIGHT_FEE.saturating_mul(WEIGHT_PER_GAS as u128));
-		(min_gas_price.into(), <Runtime as frame_system::Config>::DbWeight::get().reads(1))
+		(
+			min_gas_price.into(),
+			<Runtime as frame_system::Config>::DbWeight::get().reads(1),
+		)
 	}
 }
 

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -2168,7 +2168,10 @@ fn initial_gas_fee_is_correct() {
 
 		assert_eq!(
 			TransactionPaymentAsGasPrice::min_gas_price(),
-			(10_000_000_000u128.into(), Weight::from_ref_time(25_000_000u64))
+			(
+				10_000_000_000u128.into(),
+				Weight::from_ref_time(25_000_000u64)
+			)
 		);
 	});
 }

--- a/runtime/moonbase/tests/integration_test.rs
+++ b/runtime/moonbase/tests/integration_test.rs
@@ -2168,7 +2168,7 @@ fn initial_gas_fee_is_correct() {
 
 		assert_eq!(
 			TransactionPaymentAsGasPrice::min_gas_price(),
-			(10_000_000_000u128.into(), Weight::zero())
+			(10_000_000_000u128.into(), Weight::from_ref_time(25_000_000u64))
 		);
 	});
 }

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -390,7 +390,7 @@ impl FeeCalculator for FixedGasPrice {
 	fn min_gas_price() -> (U256, Weight) {
 		(
 			(1 * currency::GIGAWEI * currency::SUPPLY_FACTOR).into(),
-			Weight::zero(),
+			<Runtime as frame_system::Config>::DbWeight::get().reads(1),
 		)
 	}
 }

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -393,7 +393,7 @@ impl FeeCalculator for FixedGasPrice {
 	fn min_gas_price() -> (U256, Weight) {
 		(
 			(1 * currency::GIGAWEI * currency::SUPPLY_FACTOR).into(),
-			Weight::zero(),
+			<Runtime as frame_system::Config>::DbWeight::get().reads(1),
 		)
 	}
 }


### PR DESCRIPTION
### What does it do?

Records some weight in `min_gas_price`. I chose to record a db read not so much because that's what it is actually doing but because that happens to be a reasonable amount of weight in this case. The storage item being read (`TransactionPayment::next_fee_multiplier()`) is read and written in each block, so it's going to be a cached read, but this is a reasonable amount to charge anyway.

It's important to know what this weight is actually used for. In most cases, it's not used for anything; it's only used when there is some *unexpected* error (not a revert, etc.) in the [evm stack runner](https://github.com/paritytech/frontier/blob/ab0f4a47e42ad17e4d8551fb9b3c3a6b4c5df2db/frame/evm/src/runner/stack.rs#L77 ). Basically, it should never be relevant unless there is some bug that triggers it.

If/when this occurs, this weight will end up being recorded for the Substrate extrinsic, allowing the block to fill a bit rather than recording 0 weight and potentially allowing for an unbounded block.

A [db read](https://crates.parity.io/src/frame_support/weights.rs.html#170) is `25usec`, which works out to a limit of `15_000` of these transactions maximum per block.