### PR TITLE
Rename `submitAt.hash` and `submitAfter.hash` to `proposal`

### DIFF
--- a/precompiles/referenda/Referenda.sol
+++ b/precompiles/referenda/Referenda.sol
@@ -52,11 +52,11 @@ interface Referenda {
     /// @custom:selector 95f9ed68
     /// @param trackId The trackId corresponding to the origin from which the proposal is to be
     /// dispatched. The trackId => origin mapping lives in `runtime/governance/tracks.rs`
-    /// @param hash Hash of the proposal preimage
+    /// @param proposal The proposed runtime call
     /// @param block Block number at which this will be executed
     function submitAt(
         uint16 trackId,
-        bytes memory hash,
+        bytes memory proposal,
         uint32 block
     ) external;
 
@@ -64,11 +64,11 @@ interface Referenda {
     /// @custom:selector 0a1ecbe9
     /// @param trackId The trackId corresponding to the origin from which the proposal is to be
     /// dispatched. The trackId => origin mapping lives in `runtime/governance/tracks.rs`
-    /// @param hash Hash of the proposal preimage
+    /// @param proposal The proposed runtime call
     /// @param block Block number after which this will be executed
     function submitAfter(
         uint16 trackId,
-        bytes memory hash,
+        bytes memory proposal,
         uint32 block
     ) external;
 


### PR DESCRIPTION
### What does it do?

We only support `Bounded::Inline` in referenda precompile `submit*`. Solidity interface needs to be updated.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
