### PR TITLE
Update macro expansion test

### DIFF
--- a/precompiles/utils/macro/tests/precompile/expand/returns_tuple.expanded.rs
+++ b/precompiles/utils/macro/tests/precompile/expand/returns_tuple.expanded.rs
@@ -23,7 +23,7 @@ impl ExamplePrecompile {
 pub enum ExamplePrecompileCall {
     example {},
     #[doc(hidden)]
-    __phantom(PhantomData<()>, ::core::convert::Infallible),
+    __phantom(::core::marker::PhantomData<()>, ::core::convert::Infallible),
 }
 impl ExamplePrecompileCall {
     pub fn parse_call_data(


### PR DESCRIPTION
### What does it do?

- #2034 changed slightly the precompile macro to fully qualify `PhantomData`, avoiding a `use` at call site.
- #2068 added a new expansion test for tuples
- since it was based on `master` before #2034 was merged, it doesn't include the expansion change
- thus after merging #2068 in master, the test no longer pas

### Is there something left for follow-up PRs?

Is there some way to protect against this kind of issues?
