### PR TITLE
Improve Collective precompile call decoding

### DIFF
--- a/precompiles/collective/src/lib.rs
+++ b/precompiles/collective/src/lib.rs
@@ -18,6 +18,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use codec::DecodeLimit;
 use core::marker::PhantomData;
 use fp_evm::Log;
 use frame_support::{
@@ -29,7 +30,7 @@ use frame_support::{
 };
 use pallet_evm::AddressMapping;
 use precompile_utils::prelude::*;
-use sp_core::{Decode, H160, H256};
+use sp_core::{Decode, Get, H160, H256};
 use sp_std::{boxed::Box, vec::Vec};
 
 #[cfg(test)]
@@ -86,10 +87,12 @@ pub fn log_closed(address: impl Into<H160>, hash: H256) -> Log {
 
 type GetProposalLimit = ConstU32<{ 2u32.pow(16) }>;
 
-pub struct CollectivePrecompile<Runtime, Instance: 'static>(PhantomData<(Runtime, Instance)>);
+pub struct CollectivePrecompile<Runtime, Instance: 'static, DecodeLimit = ConstU32<8>>(
+	PhantomData<(Runtime, Instance, DecodeLimit)>,
+);
 
 #[precompile_utils::precompile]
-impl<Runtime, Instance> CollectivePrecompile<Runtime, Instance>
+impl<Runtime, Instance, DecodeLimit> CollectivePrecompile<Runtime, Instance, DecodeLimit>
 where
 	Instance: 'static,
 	Runtime: pallet_collective::Config<Instance> + pallet_evm::Config,
@@ -100,6 +103,7 @@ where
 	Runtime::AccountId: Into<H160>,
 	H256: From<<Runtime as frame_system::Config>::Hash>
 		+ Into<<Runtime as frame_system::Config>::Hash>,
+	DecodeLimit: Get<u32>,
 {
 	#[precompile::public("execute(bytes)")]
 	fn execute(
@@ -114,9 +118,12 @@ where
 				.in_field("proposal")
 		})?;
 
-		let proposal = Runtime::RuntimeCall::decode(&mut &*proposal)
-			.map_err(|_| RevertReason::custom("Failed to decode proposal").in_field("proposal"))?
-			.into();
+		let proposal =
+			Runtime::RuntimeCall::decode_with_depth_limit(DecodeLimit::get(), &mut &*proposal)
+				.map_err(|_| {
+					RevertReason::custom("Failed to decode proposal").in_field("proposal")
+				})?
+				.into();
 		let proposal = Box::new(proposal);
 
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
@@ -154,9 +161,12 @@ where
 
 		let proposal_index = pallet_collective::Pallet::<Runtime, Instance>::proposal_count();
 		let proposal_hash: H256 = hash::<Runtime>(&proposal);
-		let proposal = Runtime::RuntimeCall::decode(&mut &*proposal)
-			.map_err(|_| RevertReason::custom("Failed to decode proposal").in_field("proposal"))?
-			.into();
+		let proposal =
+			Runtime::RuntimeCall::decode_with_depth_limit(DecodeLimit::get(), &mut &*proposal)
+				.map_err(|_| {
+					RevertReason::custom("Failed to decode proposal").in_field("proposal")
+				})?
+				.into();
 		let proposal = Box::new(proposal);
 
 		{

--- a/precompiles/collective/src/lib.rs
+++ b/precompiles/collective/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use codec::DecodeLimit;
+use codec::DecodeLimit as _;
 use core::marker::PhantomData;
 use fp_evm::Log;
 use frame_support::{
@@ -86,13 +86,12 @@ pub fn log_closed(address: impl Into<H160>, hash: H256) -> Log {
 }
 
 type GetProposalLimit = ConstU32<{ 2u32.pow(16) }>;
+type DecodeLimit = ConstU32<8>;
 
-pub struct CollectivePrecompile<Runtime, Instance: 'static, DecodeLimit = ConstU32<8>>(
-	PhantomData<(Runtime, Instance, DecodeLimit)>,
-);
+pub struct CollectivePrecompile<Runtime, Instance: 'static>(PhantomData<(Runtime, Instance)>);
 
 #[precompile_utils::precompile]
-impl<Runtime, Instance, DecodeLimit> CollectivePrecompile<Runtime, Instance, DecodeLimit>
+impl<Runtime, Instance> CollectivePrecompile<Runtime, Instance>
 where
 	Instance: 'static,
 	Runtime: pallet_collective::Config<Instance> + pallet_evm::Config,
@@ -103,7 +102,6 @@ where
 	Runtime::AccountId: Into<H160>,
 	H256: From<<Runtime as frame_system::Config>::Hash>
 		+ Into<<Runtime as frame_system::Config>::Hash>,
-	DecodeLimit: Get<u32>,
 {
 	#[precompile::public("execute(bytes)")]
 	fn execute(


### PR DESCRIPTION
### What does it do?

`decode_with_depth_limit` is preferred over `decode`