### PR TITLE
Fix trackId=>Origin conversion, support submit for root track

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5317,6 +5317,8 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
+ "strum",
+ "strum_macros",
  "substrate-wasm-builder",
  "xcm",
  "xcm-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6101,6 +6101,8 @@ dependencies = [
  "sp-std",
  "sp-transaction-pool",
  "sp-version",
+ "strum",
+ "strum_macros",
  "substrate-wasm-builder",
  "xcm",
  "xcm-builder",

--- a/precompiles/referenda/src/lib.rs
+++ b/precompiles/referenda/src/lib.rs
@@ -24,10 +24,10 @@ use frame_support::traits::{
 };
 use pallet_evm::AddressMapping;
 use pallet_referenda::{Call as ReferendaCall, DecidingCount, ReferendumCount, TracksInfo};
-use parity_scale_codec::{alloc::string::ToString, Encode};
+use parity_scale_codec::Encode;
 use precompile_utils::{data::String, prelude::*};
 use sp_core::{Hasher, H256, U256};
-use sp_std::{boxed::Box, marker::PhantomData, vec::Vec};
+use sp_std::{boxed::Box, marker::PhantomData, str::FromStr, vec::Vec};
 
 #[cfg(test)]
 mod mock;
@@ -166,7 +166,7 @@ where
 	Runtime::BlockNumber: Into<U256>,
 	TrackIdOf<Runtime>: TryFrom<u16> + TryInto<u16>,
 	BalanceOf<Runtime>: Into<U256>,
-	GovOrigin: TryFrom<String>,
+	GovOrigin: FromStr,
 {
 	// The accessors are first. They directly return their result.
 	#[precompile::public("referendumCount()")]
@@ -268,7 +268,7 @@ where
 			if track_name == "root" {
 				Ok(frame_system::RawOrigin::Root.into())
 			} else {
-				Ok(<String as TryInto<GovOrigin>>::try_into(track_name)
+				Ok(GovOrigin::from_str(track_name)
 					.map_err(|_| {
 						RevertReason::custom("Custom origin does not exist for track_info.name")
 							.in_field("trackId")
@@ -276,7 +276,7 @@ where
 					.into())
 			}
 		};
-		Ok(Box::new(name_to_origin(track_info.name.to_string())?))
+		Ok(Box::new(name_to_origin(track_info.name)?))
 	}
 
 	// Helper function for submitAt and submitAfter

--- a/precompiles/referenda/src/lib.rs
+++ b/precompiles/referenda/src/lib.rs
@@ -277,19 +277,17 @@ where
 
 	// Helper function for submit precompile functions
 	fn track_id_to_origin(track_id: u16) -> EvmResult<Box<OriginOf<Runtime>>> {
-		if track_id == 0 {
-			return Ok(Box::new(frame_system::RawOrigin::Root.try_into().map_err(
-				|_| {
-					// We should never see this error if the above conversion is done correctly
-					RevertReason::custom("Failed to convert root origin into runtime origin")
+		let origin: OriginOf<Runtime> = if track_id == 0 {
+			frame_system::RawOrigin::Root.into()
+		} else {
+			<u16 as TryInto<GovOrigin>>::try_into(track_id)
+				.map_err(|_| {
+					RevertReason::custom("Custom origin does not exist for TrackId")
 						.in_field("trackId")
-				},
-			)?));
-		}
-		let origin: GovOrigin = track_id.try_into().map_err(|_| {
-			RevertReason::custom("Custom origin does not exist for TrackId").in_field("trackId")
-		})?;
-		Ok(Box::new(origin.into()))
+				})?
+				.into()
+		};
+		Ok(Box::new(origin))
 	}
 
 	/// Propose a referendum on a privileged action.

--- a/precompiles/referenda/src/lib.rs
+++ b/precompiles/referenda/src/lib.rs
@@ -217,8 +217,8 @@ where
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
 		let track_ids: Vec<u16> = Runtime::Tracks::tracks()
 			.into_iter()
-			.filter_map(|x| {
-				if let Ok(track_id) = x.0.try_into() {
+			.filter_map(|(id, _)| {
+				if let Ok(track_id) = (*id).try_into() {
 					Some(track_id)
 				} else {
 					None
@@ -240,9 +240,9 @@ where
 			.in_field("trackId")?;
 		let tracks = Runtime::Tracks::tracks();
 		let index = tracks
-			.binary_search_by_key(&track_id, |x| x.0)
+			.binary_search_by_key(&track_id, |(id, _)| *id)
 			.unwrap_or_else(|x| x);
-		let track_info = &tracks[index].1;
+		let (_, track_info) = &tracks[index];
 
 		Ok(TrackInfo {
 			name: track_info.name.into(),
@@ -261,9 +261,9 @@ where
 	fn track_id_to_origin(track_id: TrackIdOf<Runtime>) -> EvmResult<Box<OriginOf<Runtime>>> {
 		let tracks = Runtime::Tracks::tracks();
 		let index = tracks
-			.binary_search_by_key(&track_id, |x| x.0)
+			.binary_search_by_key(&track_id, |(id, _)| *id)
 			.unwrap_or_else(|x| x);
-		let track_info = &tracks[index].1;
+		let (_, track_info) = &tracks[index];
 		let origin = if track_info.name == "root" {
 			frame_system::RawOrigin::Root.into()
 		} else {

--- a/precompiles/referenda/src/lib.rs
+++ b/precompiles/referenda/src/lib.rs
@@ -134,7 +134,6 @@ impl EvmData for TrackInfo {
 }
 
 /// A precompile to wrap the functionality from pallet-referenda.
-// TODO: remove GovOrigins usage in code and then remove the trait bound and usage
 pub struct ReferendaPrecompile<Runtime, GovOrigin>(PhantomData<(Runtime, GovOrigin)>);
 
 #[precompile_utils::precompile]

--- a/precompiles/referenda/src/mock.rs
+++ b/precompiles/referenda/src/mock.rs
@@ -329,10 +329,10 @@ impl pallet_referenda::Config for Runtime {
 }
 
 pub struct GovOrigin;
-impl TryFrom<u16> for GovOrigin {
-	type Error = ();
-	fn try_from(_i: u16) -> Result<GovOrigin, ()> {
-		Ok(GovOrigin)
+impl FromStr for GovOrigin {
+	type Err = ();
+	fn from_str(_s: &str) -> Result<Self, Self::Err> {
+		Err(())
 	}
 }
 

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -16,6 +16,8 @@ rlp = { version = "0.5", optional = true, default-features = false }
 serde = { version = "1.0.101", optional = true, default-features = false, features = [ "derive" ] }
 sha3 = { version = "0.10", optional = true, default-features = false }
 smallvec = "1.8.0"
+strum = { version = "0.24", default-features = false, features = [ "derive" ] }
+strum_macros = "0.24"
 
 # Moonbeam
 account = { path = "../../primitives/account/", default-features = false }
@@ -263,6 +265,7 @@ std = [
 	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",
+	"strum/std",
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm-primitives/std",

--- a/runtime/moonbase/src/governance/origins.rs
+++ b/runtime/moonbase/src/governance/origins.rs
@@ -19,7 +19,7 @@ pub use custom_origins::*;
 #[frame_support::pallet]
 pub mod custom_origins {
 	use frame_support::pallet_prelude::*;
-	use scale_info::prelude::string::String;
+	use strum_macros::EnumString;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}
@@ -27,7 +27,10 @@ pub mod custom_origins {
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
 
-	#[derive(PartialEq, Eq, Clone, MaxEncodedLen, Encode, Decode, TypeInfo, RuntimeDebug)]
+	#[derive(
+		PartialEq, Eq, Clone, MaxEncodedLen, Encode, Decode, TypeInfo, RuntimeDebug, EnumString,
+	)]
+	#[strum(serialize_all = "snake_case")]
 	#[pallet::origin]
 	pub enum Origin {
 		/// Origin able to dispatch a whitelisted call.
@@ -38,19 +41,6 @@ pub mod custom_origins {
 		ReferendumCanceller,
 		/// Origin able to kill referenda.
 		ReferendumKiller,
-	}
-
-	impl TryFrom<String> for Origin {
-		type Error = ();
-		fn try_from(value: String) -> Result<Origin, ()> {
-			match &value[..] {
-				"whitelisted_caller" => Ok(Origin::WhitelistedCaller),
-				"general_admin" => Ok(Origin::GeneralAdmin),
-				"referendum_canceller" => Ok(Origin::ReferendumCanceller),
-				"referendum_killer" => Ok(Origin::ReferendumKiller),
-				_ => Err(()),
-			}
-		}
 	}
 
 	macro_rules! decl_unit_ensures {

--- a/runtime/moonbase/src/governance/origins.rs
+++ b/runtime/moonbase/src/governance/origins.rs
@@ -19,6 +19,7 @@ pub use custom_origins::*;
 #[frame_support::pallet]
 pub mod custom_origins {
 	use frame_support::pallet_prelude::*;
+	use scale_info::prelude::string::String;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}
@@ -39,45 +40,17 @@ pub mod custom_origins {
 		ReferendumKiller,
 	}
 
-	impl TryFrom<u16> for Origin {
+	impl TryFrom<String> for Origin {
 		type Error = ();
-		/// TrackId => Origin
-		fn try_from(value: u16) -> Result<Origin, ()> {
-			match value {
-				1 => Ok(Origin::WhitelistedCaller),
-				2 => Ok(Origin::GeneralAdmin),
-				3 => Ok(Origin::ReferendumCanceller),
-				4 => Ok(Origin::ReferendumKiller),
+		fn try_from(value: String) -> Result<Origin, ()> {
+			match &value[..] {
+				"whitelisted_caller" => Ok(Origin::WhitelistedCaller),
+				"general_admin" => Ok(Origin::GeneralAdmin),
+				"referendum_canceller" => Ok(Origin::ReferendumCanceller),
+				"referendum_killer" => Ok(Origin::ReferendumKiller),
 				_ => Err(()),
 			}
 		}
-	}
-
-	impl Into<u16> for Origin {
-		/// Origin => TrackId
-		fn into(self) -> u16 {
-			match self {
-				Origin::WhitelistedCaller => 1,
-				Origin::GeneralAdmin => 2,
-				Origin::ReferendumCanceller => 3,
-				Origin::ReferendumKiller => 4,
-			}
-		}
-	}
-
-	#[test]
-	fn origin_track_conversion_is_consistent() {
-		macro_rules! has_consistent_conversions {
-			( $o:expr ) => {
-				let origin_as_u16 = <Origin as Into<u16>>::into($o);
-				let u16_as_origin: Origin = origin_as_u16.try_into().unwrap();
-				assert_eq!($o, u16_as_origin);
-			};
-		}
-		has_consistent_conversions!(Origin::WhitelistedCaller);
-		has_consistent_conversions!(Origin::GeneralAdmin);
-		has_consistent_conversions!(Origin::ReferendumCanceller);
-		has_consistent_conversions!(Origin::ReferendumKiller);
 	}
 
 	macro_rules! decl_unit_ensures {

--- a/runtime/moonbase/src/governance/tracks.rs
+++ b/runtime/moonbase/src/governance/tracks.rs
@@ -18,7 +18,7 @@
 
 use super::*;
 use crate::currency::{KILOUNIT, SUPPLY_FACTOR, UNIT};
-use parity_scale_codec::alloc::string::ToString;
+use sp_std::str::FromStr;
 
 const fn percent(x: i32) -> sp_runtime::FixedI64 {
 	sp_runtime::FixedI64::from_rational(x as u128, 100)
@@ -135,7 +135,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 			}
 		} else if let Ok(custom_origin) = custom_origins::Origin::try_from(id.clone()) {
 			for track in &TRACKS_DATA[..] {
-				if let Ok(track_custom_origin) = track.1.name.to_string().try_into() {
+				if let Ok(track_custom_origin) = custom_origins::Origin::from_str(track.1.name) {
 					if custom_origin == track_custom_origin {
 						return Ok(track.0);
 					}

--- a/runtime/moonbase/src/governance/tracks.rs
+++ b/runtime/moonbase/src/governance/tracks.rs
@@ -148,3 +148,14 @@ fn vote_locking_always_longer_than_enactment_period() {
 		);
 	}
 }
+
+#[test]
+/// Precompile assumes the root origin corresponds to trackId 0 for submit* functions
+fn root_origin_has_track_id_0() {
+	for (id, track) in TRACKS_DATA {
+		if track.name == "root" {
+			assert_eq!(id, 0);
+			return;
+		}
+	}
+}

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -16,6 +16,8 @@ rlp = { version = "0.5", optional = true, default-features = false }
 serde = { version = "1.0.101", optional = true, default-features = false, features = [ "derive" ] }
 sha3 = { version = "0.10", optional = true, default-features = false }
 smallvec = "1.8.0"
+strum = { version = "0.24", default-features = false, features = [ "derive" ] }
+strum_macros = "0.24"
 
 # Moonbeam
 account = { path = "../../primitives/account/", default-features = false }
@@ -258,6 +260,7 @@ std = [
 	"sp-std/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",
+	"strum/std",
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm-primitives/std",

--- a/runtime/moonriver/src/governance/origins.rs
+++ b/runtime/moonriver/src/governance/origins.rs
@@ -19,7 +19,7 @@ pub use custom_origins::*;
 #[frame_support::pallet]
 pub mod custom_origins {
 	use frame_support::pallet_prelude::*;
-	use scale_info::prelude::string::String;
+	use strum_macros::EnumString;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}
@@ -27,7 +27,10 @@ pub mod custom_origins {
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
 
-	#[derive(PartialEq, Eq, Clone, MaxEncodedLen, Encode, Decode, TypeInfo, RuntimeDebug)]
+	#[derive(
+		PartialEq, Eq, Clone, MaxEncodedLen, Encode, Decode, TypeInfo, RuntimeDebug, EnumString,
+	)]
+	#[strum(serialize_all = "snake_case")]
 	#[pallet::origin]
 	pub enum Origin {
 		/// Origin able to dispatch a whitelisted call.
@@ -38,19 +41,6 @@ pub mod custom_origins {
 		ReferendumCanceller,
 		/// Origin able to kill referenda.
 		ReferendumKiller,
-	}
-
-	impl TryFrom<String> for Origin {
-		type Error = ();
-		fn try_from(value: String) -> Result<Origin, ()> {
-			match &value[..] {
-				"whitelisted_caller" => Ok(Origin::WhitelistedCaller),
-				"general_admin" => Ok(Origin::GeneralAdmin),
-				"referendum_canceller" => Ok(Origin::ReferendumCanceller),
-				"referendum_killer" => Ok(Origin::ReferendumKiller),
-				_ => Err(()),
-			}
-		}
 	}
 
 	macro_rules! decl_unit_ensures {

--- a/runtime/moonriver/src/governance/origins.rs
+++ b/runtime/moonriver/src/governance/origins.rs
@@ -19,6 +19,7 @@ pub use custom_origins::*;
 #[frame_support::pallet]
 pub mod custom_origins {
 	use frame_support::pallet_prelude::*;
+	use scale_info::prelude::string::String;
 
 	#[pallet::config]
 	pub trait Config: frame_system::Config {}
@@ -39,45 +40,17 @@ pub mod custom_origins {
 		ReferendumKiller,
 	}
 
-	impl TryFrom<u16> for Origin {
+	impl TryFrom<String> for Origin {
 		type Error = ();
-		/// TrackId => Origin
-		fn try_from(value: u16) -> Result<Origin, ()> {
-			match value {
-				1 => Ok(Origin::WhitelistedCaller),
-				2 => Ok(Origin::GeneralAdmin),
-				3 => Ok(Origin::ReferendumCanceller),
-				4 => Ok(Origin::ReferendumKiller),
+		fn try_from(value: String) -> Result<Origin, ()> {
+			match &value[..] {
+				"whitelisted_caller" => Ok(Origin::WhitelistedCaller),
+				"general_admin" => Ok(Origin::GeneralAdmin),
+				"referendum_canceller" => Ok(Origin::ReferendumCanceller),
+				"referendum_killer" => Ok(Origin::ReferendumKiller),
 				_ => Err(()),
 			}
 		}
-	}
-
-	impl Into<u16> for Origin {
-		/// Origin => TrackId
-		fn into(self) -> u16 {
-			match self {
-				Origin::WhitelistedCaller => 1,
-				Origin::GeneralAdmin => 2,
-				Origin::ReferendumCanceller => 3,
-				Origin::ReferendumKiller => 4,
-			}
-		}
-	}
-
-	#[test]
-	fn origin_track_conversion_is_consistent() {
-		macro_rules! has_consistent_conversions {
-			( $o:expr ) => {
-				let origin_as_u16 = <Origin as Into<u16>>::into($o);
-				let u16_as_origin: Origin = origin_as_u16.try_into().unwrap();
-				assert_eq!($o, u16_as_origin);
-			};
-		}
-		has_consistent_conversions!(Origin::WhitelistedCaller);
-		has_consistent_conversions!(Origin::GeneralAdmin);
-		has_consistent_conversions!(Origin::ReferendumCanceller);
-		has_consistent_conversions!(Origin::ReferendumKiller);
 	}
 
 	macro_rules! decl_unit_ensures {

--- a/runtime/moonriver/src/governance/tracks.rs
+++ b/runtime/moonriver/src/governance/tracks.rs
@@ -18,6 +18,7 @@
 
 use super::*;
 use crate::currency::{KILOMOVR, MOVR, SUPPLY_FACTOR};
+use parity_scale_codec::alloc::string::ToString;
 
 const fn percent(x: i32) -> sp_runtime::FixedI64 {
 	sp_runtime::FixedI64::from_rational(x as u128, 100)
@@ -122,12 +123,25 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 	fn track_for(id: &Self::RuntimeOrigin) -> Result<Self::Id, ()> {
 		if let Ok(system_origin) = frame_system::RawOrigin::try_from(id.clone()) {
 			match system_origin {
-				frame_system::RawOrigin::Root => Ok(0),
+				frame_system::RawOrigin::Root => {
+					for track in &TRACKS_DATA[..] {
+						if track.1.name == "root" {
+							return Ok(track.0);
+						}
+					}
+					Err(())
+				}
 				_ => Err(()),
 			}
 		} else if let Ok(custom_origin) = custom_origins::Origin::try_from(id.clone()) {
-			// Origins => TrackId defined in Into<u16> for Origin
-			Ok(custom_origin.into())
+			for track in &TRACKS_DATA[..] {
+				if let Ok(track_custom_origin) = track.1.name.to_string().try_into() {
+					if custom_origin == track_custom_origin {
+						return Ok(track.0);
+					}
+				}
+			}
+			Err(())
 		} else {
 			Err(())
 		}
@@ -146,16 +160,5 @@ fn vote_locking_always_longer_than_enactment_period() {
 			track.min_enactment_period,
 			<Runtime as pallet_conviction_voting::Config>::VoteLockingPeriod::get(),
 		);
-	}
-}
-
-#[test]
-/// Precompile assumes the root origin corresponds to trackId 0 for submit* functions
-fn root_origin_has_track_id_0() {
-	for (id, track) in TRACKS_DATA {
-		if track.name == "root" {
-			assert_eq!(id, 0);
-			return;
-		}
 	}
 }

--- a/runtime/moonriver/src/governance/tracks.rs
+++ b/runtime/moonriver/src/governance/tracks.rs
@@ -148,3 +148,14 @@ fn vote_locking_always_longer_than_enactment_period() {
 		);
 	}
 }
+
+#[test]
+/// Precompile assumes the root origin corresponds to trackId 0 for submit* functions
+fn root_origin_has_track_id_0() {
+	for (id, track) in TRACKS_DATA {
+		if track.name == "root" {
+			assert_eq!(id, 0);
+			return;
+		}
+	}
+}

--- a/runtime/moonriver/src/governance/tracks.rs
+++ b/runtime/moonriver/src/governance/tracks.rs
@@ -18,7 +18,7 @@
 
 use super::*;
 use crate::currency::{KILOMOVR, MOVR, SUPPLY_FACTOR};
-use parity_scale_codec::alloc::string::ToString;
+use sp_std::str::FromStr;
 
 const fn percent(x: i32) -> sp_runtime::FixedI64 {
 	sp_runtime::FixedI64::from_rational(x as u128, 100)
@@ -135,7 +135,7 @@ impl pallet_referenda::TracksInfo<Balance, BlockNumber> for TracksInfo {
 			}
 		} else if let Ok(custom_origin) = custom_origins::Origin::try_from(id.clone()) {
 			for track in &TRACKS_DATA[..] {
-				if let Ok(track_custom_origin) = track.1.name.to_string().try_into() {
+				if let Ok(track_custom_origin) = custom_origins::Origin::from_str(track.1.name) {
 					if custom_origin == track_custom_origin {
 						return Ok(track.0);
 					}


### PR DESCRIPTION
Fixes referenda::submit for root track. We were previously relying on the `TryFrom<TrackId = u16>` impl for custom origins, but this did not support the root origin/track.

We replace `TryFrom<TrackId = u16>` with a derived `FromStr` impl and use this in conjunction with Runtime::Tracks::tracks() to get the TrackId => Origin mapping.

If Runtime::Tracks::tracks() grows big enough, we will change it back to use a TryFrom impl.