### PR TITLE
Timbo bal test update

### DIFF
--- a/tests/smoke-tests/test-balances-consistency.ts
+++ b/tests/smoke-tests/test-balances-consistency.ts
@@ -115,10 +115,10 @@ describeSmokeSuite("S300", `Verifying balances consistency`, (context, testIt) =
       specVersion < 2000
         ? apiAt.query.democracy.preimages.entries()
         : ([] as [StorageKey<[H256]>, Option<any>][]),
-      (specVersion >= 1900 && runtimeName == "moonbase") || specVersion >= 2000
+      specVersion >= 2000
         ? apiAt.query.preimage.statusFor.entries()
         : ([] as [StorageKey<[H256]>, Option<PalletPreimageRequestStatus>][]),
-      specVersion >= 1900 && runtimeName == "moonbase"
+      specVersion >= 2100 && runtimeName == ("moonbase" || "moonriver")
         ? apiAt.query.referenda.referendumInfoFor.entries()
         : ([] as [StorageKey<[u32]>, Option<any>][]),
       apiAt.query.assets.asset.entries(),

--- a/tests/smoke-tests/test-balances-consistency.ts
+++ b/tests/smoke-tests/test-balances-consistency.ts
@@ -118,7 +118,7 @@ describeSmokeSuite("S300", `Verifying balances consistency`, (context, testIt) =
       specVersion >= 2000
         ? apiAt.query.preimage.statusFor.entries()
         : ([] as [StorageKey<[H256]>, Option<PalletPreimageRequestStatus>][]),
-      specVersion >= 2100 && runtimeName == ("moonbase" || "moonriver")
+      specVersion >= 2100 && (runtimeName == "moonbase" || runtimeName == "moonriver")
         ? apiAt.query.referenda.referendumInfoFor.entries()
         : ([] as [StorageKey<[u32]>, Option<any>][]),
       apiAt.query.assets.asset.entries(),


### PR DESCRIPTION
### What does it do?
Updated balance consistency smoke tests to account for opengov referenda deposits.

### What value does it bring to the blockchain users?
Improved test coverage of Moonriver
