### PR TITLE
Add test to ensure moonbeam binary exists

### DIFF
--- a/node/src/tests.rs
+++ b/node/src/tests.rs
@@ -47,6 +47,20 @@ pub fn wait_for(child: &mut Child, secs: usize) -> Option<ExitStatus> {
 
 #[test]
 #[cfg(unix)]
+fn moonbeam_binary_exists() {
+	// Ensure that the moonbeam binary, which is used by the other tests, exists
+	let path = cargo_bin("moonbeam");
+
+	if !path.exists() {
+		panic!(
+			"Command not found: {}\nHelp: compile the binary using cargo build --release",
+			path.display()
+		);
+	}
+}
+
+#[test]
+#[cfg(unix)]
 fn purge_chain_purges_relay_and_para() {
 	fn run_node_and_stop() -> tempfile::TempDir {
 		use nix::{


### PR DESCRIPTION
Currently, when running `cargo test` without having previously run `cargo build`, some tests fail with a rather generic error message "No such file or directory":

<details>
 <summary>Expand</summary>

```
     Running unittests src/main.rs (target/release/deps/moonbeam-2c2b7102d68c8412)

running 4 tests
test tests::export_current_state ... ignored
test tests::builds_specs_based_on_mnemonic ... FAILED
test tests::export_genesis_state ... FAILED
test tests::purge_chain_purges_relay_and_para ... FAILED

failures:

---- tests::builds_specs_based_on_mnemonic stdout ----
thread 'tests::builds_specs_based_on_mnemonic' panicked at 'Failed to start moonbeam: Os { code: 2, kind: NotFound, message: "No such file or directory" }', node/src/tests.rs:123:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::export_genesis_state stdout ----
thread 'tests::export_genesis_state' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', node/src/tests.rs:164:10

---- tests::purge_chain_purges_relay_and_para stdout ----
thread 'tests::purge_chain_purges_relay_and_para' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', node/src/tests.rs:65:14


failures:
    tests::builds_specs_based_on_mnemonic
    tests::export_genesis_state
    tests::purge_chain_purges_relay_and_para

test result: FAILED. 0 passed; 3 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass `-p moonbeam --bin moonbeam`
```

</details>

This PR adds a test that checks that case and prints a better error message, including the path of the file that does not exist, as well as a suggestion on how to fix the error:

```
failures:

---- tests::moonbeam_binary_exists stdout ----
thread 'tests::moonbeam_binary_exists' panicked at 'Command not found: /home/tomasz/projects/moonbeam/target/release/moonbeam
Help: compile the binary using cargo build --release', node/src/tests.rs:55:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```