### PR TITLE
fix tracing runtime build

### DIFF
--- a/pallets/asset-manager/Cargo.toml
+++ b/pallets/asset-manager/Cargo.toml
@@ -9,7 +9,7 @@ log = { version = "0.4", default-features = false }
 serde = { version = "1.0.124", optional = true }
 
 # Moonbeam
-xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
+xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # Substrate
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }

--- a/pallets/ethereum-xcm/Cargo.toml
+++ b/pallets/ethereum-xcm/Cargo.toml
@@ -34,7 +34,7 @@ fp-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-pol
 fp-rpc = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 fp-self-contained = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
 pallet-evm = { git = "https://github.com/purestake/frontier", branch = "moonbeam-polkadot-v0.9.37", default-features = false, features = [ "forbid-evm-reentrancy" ] }
-xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
+xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 [dev-dependencies]
 pallet-evm-precompile-proxy = { path = "../../precompiles/proxy", default-features = false }

--- a/pallets/moonbeam-xcm-benchmarks/Cargo.toml
+++ b/pallets/moonbeam-xcm-benchmarks/Cargo.toml
@@ -10,7 +10,7 @@ serde = { version = "1.0.124", optional = true }
 
 # Moonbeam
 pallet-erc20-xcm-bridge = { path = "../erc20-xcm-bridge/", default-features = false }
-xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
+xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # Substrate
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }

--- a/pallets/xcm-transactor/Cargo.toml
+++ b/pallets/xcm-transactor/Cargo.toml
@@ -9,7 +9,7 @@ log = { version = "0.4", default-features = false }
 serde = { version = "1.0.124", optional = true }
 
 # Moonbeam
-xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
+xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # Substrate
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }

--- a/precompiles/xcm-transactor/Cargo.toml
+++ b/precompiles/xcm-transactor/Cargo.toml
@@ -13,7 +13,7 @@ rustc-hex = { version = "2.0.1", default-features = false }
 # Moonbeam
 pallet-xcm-transactor = { path = "../../pallets/xcm-transactor", default-features = false }
 precompile-utils = { path = "../utils", default-features = false }
-xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
+xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # Substrate
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }
@@ -40,7 +40,7 @@ sha3 = "0.10"
 
 # Moonbeam
 precompile-utils = { path = "../utils", features = [ "testing" ] }
-xcm-primitives = { path = "../../primitives/xcm/" }
+xcm-primitives = { path = "../../primitives/xcm" }
 
 # Substrate
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [ "max-encoded-len" ] }

--- a/precompiles/xtokens/Cargo.toml
+++ b/precompiles/xtokens/Cargo.toml
@@ -12,7 +12,7 @@ rustc-hex = { version = "2.0.1", default-features = false }
 
 # Moonbeam
 precompile-utils = { path = "../utils", default-features = false }
-xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
+xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # Substrate
 frame-support = { git = "https://github.com/purestake/substrate", branch = "moonbeam-polkadot-v0.9.37", default-features = false }

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -20,13 +20,13 @@ strum = { version = "0.24", default-features = false, features = [ "derive" ] }
 strum_macros = "0.24"
 
 # Moonbeam
-account = { path = "../../primitives/account/", default-features = false }
+account = { path = "../../primitives/account", default-features = false }
 moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
 moonbeam-relay-encoder = { path = "../relay-encoder", default-features = false }
 moonbeam-runtime-common = { path = "../common", default-features = false }
 precompile-utils = { path = "../../precompiles/utils", default-features = false }
 session-keys-primitives = { path = "../../primitives/session-keys", default-features = false }
-xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
+xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # Moonbeam pallets
 moonbeam-xcm-benchmarks = { path = "../../pallets/moonbeam-xcm-benchmarks", default-features = false }

--- a/runtime/moonbase/Cargo.toml
+++ b/runtime/moonbase/Cargo.toml
@@ -207,6 +207,7 @@ std = [
 	"pallet-conviction-voting/std",
 	"pallet-crowdloan-rewards/std",
 	"pallet-democracy/std",
+	"pallet-erc20-xcm-bridge/std",
 	"pallet-ethereum-chain-id/std",
 	"pallet-ethereum-xcm/std",
 	"pallet-ethereum/std",

--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -18,13 +18,13 @@ sha3 = { version = "0.10", optional = true, default-features = false }
 smallvec = "1.8.0"
 
 # Moonbeam
-account = { path = "../../primitives/account/", default-features = false }
+account = { path = "../../primitives/account", default-features = false }
 moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
 moonbeam-relay-encoder = { path = "../relay-encoder", default-features = false }
 moonbeam-runtime-common = { path = "../common", default-features = false }
 precompile-utils = { path = "../../precompiles/utils", default-features = false }
 session-keys-primitives = { path = "../../primitives/session-keys", default-features = false }
-xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
+xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # Moonbeam pallets
 moonbeam-xcm-benchmarks = { path = "../../pallets/moonbeam-xcm-benchmarks", default-features = false }

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -20,13 +20,13 @@ strum = { version = "0.24", default-features = false, features = [ "derive" ] }
 strum_macros = "0.24"
 
 # Moonbeam
-account = { path = "../../primitives/account/", default-features = false }
+account = { path = "../../primitives/account", default-features = false }
 moonbeam-core-primitives = { path = "../../core-primitives", default-features = false }
 moonbeam-relay-encoder = { path = "../relay-encoder", default-features = false }
 moonbeam-runtime-common = { path = "../common", default-features = false }
 precompile-utils = { path = "../../precompiles/utils", default-features = false }
 session-keys-primitives = { path = "../../primitives/session-keys", default-features = false }
-xcm-primitives = { path = "../../primitives/xcm/", default-features = false }
+xcm-primitives = { path = "../../primitives/xcm", default-features = false }
 
 # Moonbeam pallets
 moonbeam-xcm-benchmarks = { path = "../../pallets/moonbeam-xcm-benchmarks", default-features = false }


### PR DESCRIPTION
### What does it do?

Our dependencies path use trailing slash sometimes, that break the dependencies override for tracing runtime build 

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
