### PR TITLE
Introduce num_selected_candidates genesis config param

### DIFF
--- a/node/service/src/chain_spec/moonbase.rs
+++ b/node/service/src/chain_spec/moonbase.rs
@@ -199,6 +199,7 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 const COLLATOR_COMMISSION: Perbill = Perbill::from_percent(20);
 const PARACHAIN_BOND_RESERVE_PERCENT: Percent = Percent::from_percent(30);
 const BLOCKS_PER_ROUND: u32 = 2 * HOURS;
+const NUM_SELECTED_CANDIDATES: u32 = 8;
 pub fn moonbase_inflation_config() -> InflationInfo<Balance> {
 	fn to_round_inflation(annual: Range<Perbill>) -> Range<Perbill> {
 		use pallet_parachain_staking::inflation::{
@@ -300,6 +301,7 @@ pub fn testnet_genesis(
 			collator_commission: COLLATOR_COMMISSION,
 			parachain_bond_reserve_percent: PARACHAIN_BOND_RESERVE_PERCENT,
 			blocks_per_round: BLOCKS_PER_ROUND,
+			num_selected_candidates: NUM_SELECTED_CANDIDATES,
 		},
 		council_collective: CouncilCollectiveConfig {
 			phantom: Default::default(),

--- a/node/service/src/chain_spec/moonbeam.rs
+++ b/node/service/src/chain_spec/moonbeam.rs
@@ -187,6 +187,7 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 const COLLATOR_COMMISSION: Perbill = Perbill::from_percent(20);
 const PARACHAIN_BOND_RESERVE_PERCENT: Percent = Percent::from_percent(30);
 const BLOCKS_PER_ROUND: u32 = 6 * HOURS;
+const NUM_SELECTED_CANDIDATES: u32 = 8;
 pub fn moonbeam_inflation_config() -> InflationInfo<Balance> {
 	fn to_round_inflation(annual: Range<Perbill>) -> Range<Perbill> {
 		use pallet_parachain_staking::inflation::{
@@ -283,6 +284,7 @@ pub fn testnet_genesis(
 			collator_commission: COLLATOR_COMMISSION,
 			parachain_bond_reserve_percent: PARACHAIN_BOND_RESERVE_PERCENT,
 			blocks_per_round: BLOCKS_PER_ROUND,
+			num_selected_candidates: NUM_SELECTED_CANDIDATES,
 		},
 		council_collective: CouncilCollectiveConfig {
 			phantom: Default::default(),

--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -195,6 +195,7 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 const COLLATOR_COMMISSION: Perbill = Perbill::from_percent(20);
 const PARACHAIN_BOND_RESERVE_PERCENT: Percent = Percent::from_percent(30);
 const BLOCKS_PER_ROUND: u32 = 2 * HOURS;
+const NUM_SELECTED_CANDIDATES: u32 = 8;
 pub fn moonriver_inflation_config() -> InflationInfo<Balance> {
 	fn to_round_inflation(annual: Range<Perbill>) -> Range<Perbill> {
 		use pallet_parachain_staking::inflation::{
@@ -292,6 +293,7 @@ pub fn testnet_genesis(
 			collator_commission: COLLATOR_COMMISSION,
 			parachain_bond_reserve_percent: PARACHAIN_BOND_RESERVE_PERCENT,
 			blocks_per_round: BLOCKS_PER_ROUND,
+			num_selected_candidates: NUM_SELECTED_CANDIDATES,
 		},
 		council_collective: CouncilCollectiveConfig {
 			phantom: Default::default(),

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -85,7 +85,7 @@ pub mod pallet {
 	use frame_support::pallet_prelude::*;
 	use frame_support::traits::{
 		tokens::WithdrawReasons, Currency, Get, Imbalance, LockIdentifier, LockableCurrency,
-		OriginTrait, ReservableCurrency,
+		ReservableCurrency,
 	};
 	use frame_system::pallet_prelude::*;
 	use sp_runtime::{
@@ -734,8 +734,12 @@ pub mod pallet {
 				percent: self.parachain_bond_reserve_percent,
 			});
 			// Set total selected candidates to value from config
-			<Pallet<T>>::set_total_selected(T::RuntimeOrigin::root(), self.num_selected_candidates)
-				.expect("set_total_selected failed");
+			assert!(
+				self.num_selected_candidates >= T::MinSelectedCandidates::get(),
+				"{:?}",
+				Error::<T>::CannotSetBelowMin
+			);
+			<TotalSelected<T>>::put(self.num_selected_candidates);
 			// Choose top TotalSelected collator candidates
 			let (_, v_count, _, total_staked) = <Pallet<T>>::select_top_candidates(1u32);
 			// Start Round 1 at Block 0

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -85,7 +85,7 @@ pub mod pallet {
 	use frame_support::pallet_prelude::*;
 	use frame_support::traits::{
 		tokens::WithdrawReasons, Currency, Get, Imbalance, LockIdentifier, LockableCurrency,
-		ReservableCurrency,
+		OriginTrait, ReservableCurrency,
 	};
 	use frame_system::pallet_prelude::*;
 	use sp_runtime::{
@@ -629,6 +629,8 @@ pub mod pallet {
 		pub parachain_bond_reserve_percent: Percent,
 		/// Default number of blocks in a round
 		pub blocks_per_round: u32,
+		/// Number of selected candidates every round. Cannot be lower than MinSelectedCandidates
+		pub num_selected_candidates: u32,
 	}
 
 	#[cfg(feature = "std")]
@@ -641,6 +643,7 @@ pub mod pallet {
 				collator_commission: Default::default(),
 				parachain_bond_reserve_percent: Default::default(),
 				blocks_per_round: 1u32,
+				num_selected_candidates: T::MinSelectedCandidates::get(),
 			}
 		}
 	}
@@ -730,8 +733,9 @@ pub mod pallet {
 					.expect("infinite length input; no invalid inputs for type; qed"),
 				percent: self.parachain_bond_reserve_percent,
 			});
-			// Set total selected candidates to minimum config
-			<TotalSelected<T>>::put(T::MinSelectedCandidates::get());
+			// Set total selected candidates to value from config
+			<Pallet<T>>::set_total_selected(T::RuntimeOrigin::root(), self.num_selected_candidates)
+				.expect("set_total_selected failed");
 			// Choose top TotalSelected collator candidates
 			let (_, v_count, _, total_staked) = <Pallet<T>>::select_top_candidates(1u32);
 			// Start Round 1 at Block 0

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -104,6 +104,7 @@ impl block_author::Config for Test {}
 const GENESIS_BLOCKS_PER_ROUND: u32 = 5;
 const GENESIS_COLLATOR_COMMISSION: Perbill = Perbill::from_percent(20);
 const GENESIS_PARACHAIN_BOND_RESERVE_PERCENT: Percent = Percent::from_percent(30);
+const GENESIS_NUM_SELECTED_CANDIDATES: u32 = 5;
 parameter_types! {
 	pub const MinBlocksPerRound: u32 = 3;
 	pub const LeaveCandidatesDelay: u32 = 2;
@@ -112,7 +113,7 @@ parameter_types! {
 	pub const RevokeDelegationDelay: u32 = 2;
 	pub const DelegationBondLessDelay: u32 = 2;
 	pub const RewardPaymentDelay: u32 = 2;
-	pub const MinSelectedCandidates: u32 = 5;
+	pub const MinSelectedCandidates: u32 = GENESIS_NUM_SELECTED_CANDIDATES;
 	pub const MaxTopDelegationsPerCandidate: u32 = 4;
 	pub const MaxBottomDelegationsPerCandidate: u32 = 4;
 	pub const MaxDelegationsPerDelegator: u32 = 4;
@@ -239,6 +240,7 @@ impl ExtBuilder {
 			collator_commission: GENESIS_COLLATOR_COMMISSION,
 			parachain_bond_reserve_percent: GENESIS_PARACHAIN_BOND_RESERVE_PERCENT,
 			blocks_per_round: GENESIS_BLOCKS_PER_ROUND,
+			num_selected_candidates: GENESIS_NUM_SELECTED_CANDIDATES,
 		}
 		.assimilate_storage(&mut t)
 		.expect("Parachain Staking's storage can be assimilated");

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -146,6 +146,7 @@ impl pallet_timestamp::Config for Runtime {
 const GENESIS_BLOCKS_PER_ROUND: u32 = 5;
 const GENESIS_COLLATOR_COMMISSION: Perbill = Perbill::from_percent(20);
 const GENESIS_PARACHAIN_BOND_RESERVE_PERCENT: Percent = Percent::from_percent(30);
+const GENESIS_NUM_SELECTED_CANDIDATES: u32 = 5;
 parameter_types! {
 	pub const MinBlocksPerRound: u32 = 3;
 	pub const LeaveCandidatesDelay: u32 = 2;
@@ -154,7 +155,7 @@ parameter_types! {
 	pub const RevokeDelegationDelay: u32 = 2;
 	pub const DelegationBondLessDelay: u32 = 2;
 	pub const RewardPaymentDelay: u32 = 2;
-	pub const MinSelectedCandidates: u32 = 5;
+	pub const MinSelectedCandidates: u32 = GENESIS_NUM_SELECTED_CANDIDATES;
 	pub const MaxTopDelegationsPerCandidate: u32 = 2;
 	pub const MaxBottomDelegationsPerCandidate: u32 = 4;
 	pub const MaxDelegationsPerDelegator: u32 = 4;
@@ -285,6 +286,7 @@ impl ExtBuilder {
 			collator_commission: GENESIS_COLLATOR_COMMISSION,
 			parachain_bond_reserve_percent: GENESIS_PARACHAIN_BOND_RESERVE_PERCENT,
 			blocks_per_round: GENESIS_BLOCKS_PER_ROUND,
+			num_selected_candidates: GENESIS_NUM_SELECTED_CANDIDATES,
 		}
 		.assimilate_storage(&mut t)
 		.expect("Parachain Staking's storage can be assimilated");

--- a/runtime/moonbase/tests/common/mod.rs
+++ b/runtime/moonbase/tests/common/mod.rs
@@ -246,6 +246,7 @@ impl ExtBuilder {
 			collator_commission: Perbill::from_percent(20),
 			parachain_bond_reserve_percent: Percent::from_percent(30),
 			blocks_per_round: 2 * HOURS,
+			num_selected_candidates: 8,
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();

--- a/runtime/moonbeam/tests/common/mod.rs
+++ b/runtime/moonbeam/tests/common/mod.rs
@@ -257,6 +257,7 @@ impl ExtBuilder {
 			collator_commission: Perbill::from_percent(20),
 			parachain_bond_reserve_percent: Percent::from_percent(30),
 			blocks_per_round: 6 * HOURS,
+			num_selected_candidates: 8,
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();

--- a/runtime/moonriver/tests/common/mod.rs
+++ b/runtime/moonriver/tests/common/mod.rs
@@ -258,6 +258,7 @@ impl ExtBuilder {
 			collator_commission: Perbill::from_percent(20),
 			parachain_bond_reserve_percent: Percent::from_percent(30),
 			blocks_per_round: 2 * HOURS,
+			num_selected_candidates: 8,
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();


### PR DESCRIPTION
### What does it do?

Introduce num_selected_candidates genesis config param. This is equivalent to a call to set_total_selected.

### What important points reviewers should know?

This changes the format of the genesis config struct.
