### PR TITLE
fix {moonriver,moonbeam}-runtime build (std feature)

### DIFF
--- a/runtime/moonbeam/Cargo.toml
+++ b/runtime/moonbeam/Cargo.toml
@@ -184,6 +184,7 @@ std = [
 	"moonbeam-rpc-primitives-debug/std",
 	"moonbeam-rpc-primitives-txpool/std",
 	"moonbeam-runtime-common/std",
+	"moonbeam-xcm-benchmarks/std",
 	"nimbus-primitives/std",
 	"orml-xtokens/std",
 	"pallet-asset-manager/std",

--- a/runtime/moonriver/Cargo.toml
+++ b/runtime/moonriver/Cargo.toml
@@ -191,6 +191,7 @@ std = [
 	"moonbeam-rpc-primitives-debug/std",
 	"moonbeam-rpc-primitives-txpool/std",
 	"moonbeam-runtime-common/std",
+	"moonbeam-xcm-benchmarks/std",
 	"nimbus-primitives/std",
 	"orml-xtokens/std",
 	"pallet-asset-manager/std",


### PR DESCRIPTION
### What does it do?

moonriver and moonbeam runtimes fail to build due to a bad resolution of the optional compilation feature `std`.

This error is not encountered when building the entire moonbeam project (what our build workflow does) because cargo then relies on the entire project to resolve which optional features to enable or not.
Maybe we should add a check to the CI (at least on master) to catch these errors before the release.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
