### PR TITLE
Fix github workflows that generate releases issues

### DIFF
--- a/.github/workflows/client-release-issue.yml
+++ b/.github/workflows/client-release-issue.yml
@@ -21,6 +21,7 @@ jobs:
           path: tools
 
   create_client_ticket:
+    needs: ["setup-scripts"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -24,6 +24,7 @@ jobs:
           path: tools
 
   build-binary:
+    needs: ["setup-scripts"]
     runs-on: self-hosted
     strategy:
       matrix:

--- a/.github/workflows/runtime-release-issue.yml
+++ b/.github/workflows/runtime-release-issue.yml
@@ -13,7 +13,18 @@ on:
         required: true
 
 jobs:
+  setup-scripts:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v3
+      - name: Upload tools
+        uses: actions/upload-artifact@v3
+        with:
+          name: original-tools
+          path: tools
+
   create_runtime_ticket:
+    needs: ["setup-scripts"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### What does it do?

Releases issues generation workflows randomly fails because we not wait the end of `setup-scripts` job:
https://github.com/PureStake/moonbeam/actions/runs/4251460771

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
