### PR TITLE
fix github workflow "Publish Docker runtime"

### DIFF
--- a/.github/workflows/publish-docker-runtime.yml
+++ b/.github/workflows/publish-docker-runtime.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Publish runtime docker image
         run: |
           DOCKER_IMAGE=purestake/moonbeam
-          DOCKER_TAG="${{ github.event.inputs.to }}"
+          DOCKER_TAG="${{ github.event.inputs.tag }}"
           COMMIT=`git rev-list -n 1 '${{ github.event.inputs.tag }}'`
           SHA=sha-${COMMIT::8}
           echo tagging "${DOCKER_IMAGE}:${SHA}"


### PR DESCRIPTION
### What does it do?

This new GH workflow fail due to a typo: 
https://github.com/PureStake/moonbeam/actions/runs/4254513726/jobs/7400864431

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
