### PR TITLE
Workspace dependencies followup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15872,18 +15872,3 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[patch.unused]]
-name = "jsonrpsee"
-version = "0.15.1"
-source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"
-
-[[patch.unused]]
-name = "jsonrpsee-core"
-version = "0.15.1"
-source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"
-
-[[patch.unused]]
-name = "jsonrpsee-types"
-version = "0.15.1"
-source = "git+https://github.com/PureStake/jsonrpsee?branch=moonbeam-v0.15.1#7c2a0149c3a134c6d84d0fccc94efd455f314f80"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,9 +346,6 @@ evm = { git = "https://github.com/rust-blockchain/evm", rev = "842e03d068ddb6a31
 evm-core = { git = "https://github.com/rust-blockchain/evm", rev = "842e03d068ddb6a3195a2dedc4a9b63caadb3355" }
 evm-gasometer = { git = "https://github.com/rust-blockchain/evm", rev = "842e03d068ddb6a3195a2dedc4a9b63caadb3355" }
 evm-runtime = { git = "https://github.com/rust-blockchain/evm", rev = "842e03d068ddb6a3195a2dedc4a9b63caadb3355" }
-jsonrpsee = { git = "https://github.com/PureStake/jsonrpsee", branch = "moonbeam-v0.15.1" }
-jsonrpsee-core = { git = "https://github.com/PureStake/jsonrpsee", branch = "moonbeam-v0.15.1" }
-jsonrpsee-types = { git = "https://github.com/PureStake/jsonrpsee", branch = "moonbeam-v0.15.1" }
 
 # make sure dev builds with backtrace do
 # not slow us down

--- a/docs/workspace-dependencies.md
+++ b/docs/workspace-dependencies.md
@@ -1,0 +1,27 @@
+## Workspace dependencies
+
+## How dependencies features resolution works?
+
+Features listed in the root-level `Cargo.toml` and in individual crates `Cargo.toml` are additive
+(union of all sets of features). Also note that features may be enabled by other crates built to the
+same target (wasm vs client have distinct feature sets however). Features listed in the root-level
+`Cargo.toml` are enabled for all targets (hense the need for `default-features = false` for crates
+used in a runtime crate.
+
+Prefer adding features in individual crates, unless it is a security flag feature like
+`forbid-evm-reentrancy` in which case it should be added to the root-level `Cargo.toml` to ensure it
+is never disabled by mistake.
+
+Note that `default-features = false` only have an effect inside the root-level Cargo.toml, and
+should be added to any dependency that defaults to std if it is used in at least one runtime/wasm
+crate.
+
+## How to add a dependency ?
+1. Add `my-dependency = { workspace = true }` in your crate.
+2. Look at the root-level `Cargo.toml` to see if the dependency is listed in it :
+  - If it is not, add it in the proper section (Substrate/Frontier/etc) and subsection
+    (wasm/client). Don't forget to add `default-features = false` if in wasm if necessary.
+  - If it is, make sure it respects the std rule. If your crate is a runtime crate and the
+    dependency was previously only used outside of the runtime, move the dependency in the "wasm"
+    section and add `default-features = false`. It may require adding `features = ["std"]` in
+    non-runtime crates `Cargo.toml`, however it is not necessary most of the time.

--- a/precompiles/xtokens/Cargo.toml
+++ b/precompiles/xtokens/Cargo.toml
@@ -41,7 +41,7 @@ precompile-utils = { workspace = true, features = [ "testing" ] }
 pallet-balances = { workspace = true }
 pallet-timestamp = { workspace = true }
 parity-scale-codec = { workspace = true, features = [ "max-encoded-len" ] }
-scale-info = { features = [ "derive" ], workspace = true }
+scale-info = { workspace = true, features = [ "derive" ] }
 sp-io = { workspace = true }
 
 # Cumulus

--- a/precompiles/xtokens/Cargo.toml
+++ b/precompiles/xtokens/Cargo.toml
@@ -41,7 +41,7 @@ precompile-utils = { workspace = true, features = [ "testing" ] }
 pallet-balances = { workspace = true }
 pallet-timestamp = { workspace = true }
 parity-scale-codec = { workspace = true, features = [ "max-encoded-len" ] }
-scale-info = { features = [ "derive" ], vworkspace = true }
+scale-info = { features = [ "derive" ], workspace = true }
 sp-io = { workspace = true }
 
 # Cumulus


### PR DESCRIPTION
### What does it do?

- Fix typo in one crate Cargo.toml
- Removed outdated jsonrpsee patches
- Add docs about workspace dependencies

### Is there something left for follow-up PRs?

Review dependencies features, and determine which ones should be be listed in the root-level Cargo.toml or in individual crates. Should duplicate features be avoided?
