### PR TITLE
PrecompileRegistry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7651,6 +7651,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-evm-precompile-registry"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "fp-evm",
+ "frame-support",
+ "frame-system",
+ "hex-literal",
+ "log",
+ "pallet-balances",
+ "pallet-evm",
+ "pallet-scheduler",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "precompile-utils",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-evm-precompile-relay-encoder"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
 	"precompiles/crowdloan-rewards",
 	"precompiles/pallet-democracy",
 	"precompiles/parachain-staking",
+	"precompiles/precompile-registry",
 	"precompiles/preimage",
 	"precompiles/proxy",
 	"precompiles/randomness",

--- a/precompiles/precompile-registry/Cargo.toml
+++ b/precompiles/precompile-registry/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "pallet-evm-precompile-registry"
+authors = { workspace = true }
+description = "Registry of active precompiles"
+edition = "2021"
+version = "0.1.0"
+
+[dependencies]
+log = { workspace = true }
+
+# Moonbeam
+precompile-utils = { workspace = true }
+
+# Substrate
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+parity-scale-codec = { workspace = true }
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-std = { workspace = true }
+
+# Frontier
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true, features = [ "forbid-evm-reentrancy" ] }
+
+[dev-dependencies]
+derive_more = { workspace = true }
+hex-literal = { workspace = true }
+serde = { workspace = true }
+
+# Moonbeam
+precompile-utils = { workspace = true, features = [ "std", "testing" ] }
+
+# Substrate
+pallet-balances = { workspace = true, features = ["std"] }
+pallet-scheduler = { workspace = true }
+pallet-timestamp = { workspace = true }
+scale-info = { workspace = true, features = [ "derive" ] }
+sp-runtime = { workspace = true }
+
+[features]
+default = [ "std" ]
+std = [
+	"fp-evm/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-evm/std",
+	"parity-scale-codec/std",
+	"precompile-utils/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-std/std",
+]

--- a/precompiles/precompile-registry/Cargo.toml
+++ b/precompiles/precompile-registry/Cargo.toml
@@ -32,7 +32,7 @@ serde = { workspace = true }
 precompile-utils = { workspace = true, features = [ "std", "testing" ] }
 
 # Substrate
-pallet-balances = { workspace = true, features = ["std"] }
+pallet-balances = { workspace = true, features = [ "std" ] }
 pallet-scheduler = { workspace = true }
 pallet-timestamp = { workspace = true }
 scale-info = { workspace = true, features = [ "derive" ] }

--- a/precompiles/precompile-registry/PrecompileRegistry.sol
+++ b/precompiles/precompile-registry/PrecompileRegistry.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity >=0.8.3;
+
+/// @author The Moonbeam Team
+/// @title Precompile Registry
+/// @dev Interface to the set of available precompiles.
+interface PrecompileRegistry {
+    /// @dev Query if the given address is a precompile. Note that deactivated precompiles
+    /// are still considered precompiles and will return `true`.
+    /// @param a: Address to query
+    /// @return output Is this address a precompile?
+    /// @custom:selector 446b450e
+    function isPrecompile(address a) external returns (bool);
+
+    /// @dev Query if the given address is an active precompile. Will return false if the
+    /// address is not a precompile or if this precompile is deactivated.
+    /// @param a: Address to query
+    /// @return output Is this address an active precompile?
+    /// @custom:selector 6f5e23cf
+    function isActivePrecompile(address a) external returns (bool);
+
+    /// @dev Update the account code of a precompile address.
+    /// As precompiles are implemented inside the Runtime, they don't have a bytecode, and
+    /// their account code is empty by default. However in Solidity calling a function of a
+    /// contract often automatically adds a check that the contract bytecode is non-empty.
+    /// For that reason a dummy code (0x60006000fd) can be inserted at the precompile address
+    /// to pass that check. This function allows any user to insert that code to precompile address
+    /// if they need it.
+    /// @param a: Address of the precompile.
+    /// @custom:selector 48ceb1b4
+    function updateAccountCode(address a) external;
+}

--- a/precompiles/precompile-registry/src/lib.rs
+++ b/precompiles/precompile-registry/src/lib.rs
@@ -1,0 +1,71 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+use core::marker::PhantomData;
+use fp_evm::PrecompileSet;
+use precompile_utils::{precompile_set::IsActivePrecompile, prelude::*};
+use sp_core::Get;
+
+const DUMMY_CODE: [u8; 5] = [0x60, 0x00, 0x60, 0x00, 0xfd];
+
+pub struct PrecompileRegistry<Runtime>(PhantomData<Runtime>);
+
+#[precompile_utils::precompile]
+impl<Runtime> PrecompileRegistry<Runtime>
+where
+	Runtime: pallet_evm::Config,
+	Runtime::PrecompilesType: IsActivePrecompile,
+{
+	#[precompile::public("isPrecompile(address)")]
+	#[precompile::view]
+	fn is_precompile(_handle: &mut impl PrecompileHandle, address: Address) -> EvmResult<bool> {
+		// TODO: what cost?
+		let active = <Runtime::PrecompilesValue>::get().is_precompile(address.0);
+		Ok(active)
+	}
+
+	#[precompile::public("isActivePrecompile(address)")]
+	#[precompile::view]
+	fn is_active_precompile(
+		_handle: &mut impl PrecompileHandle,
+		address: Address,
+	) -> EvmResult<bool> {
+		// TODO: what cost?
+		let active = <Runtime::PrecompilesValue>::get().is_active_precompile(address.0);
+		Ok(active)
+	}
+
+	#[precompile::public("updateAccountCode(address)")]
+	fn update_account_code(handle: &mut impl PrecompileHandle, address: Address) -> EvmResult<()> {
+		handle.record_cost(RuntimeHelper::<Runtime>::db_write_gas_cost())?;
+
+		// Prevent touching addresses that are not precompiles.
+		if !<Runtime::PrecompilesValue>::get().is_precompile(address.0) {
+			return Err(revert("provided address is not a precompile"));
+		}
+
+		pallet_evm::Pallet::<Runtime>::create_account(address.0, DUMMY_CODE.to_vec());
+
+		Ok(())
+	}
+}

--- a/precompiles/precompile-registry/src/mock.rs
+++ b/precompiles/precompile-registry/src/mock.rs
@@ -1,0 +1,186 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Test utilities
+use super::*;
+
+use frame_support::traits::Everything;
+use frame_support::{construct_runtime, pallet_prelude::*, parameter_types};
+use pallet_evm::{EnsureAddressNever, EnsureAddressRoot};
+use precompile_utils::{mock_account, precompile_set::*, testing::MockAccount};
+use sp_core::H160;
+use sp_core::H256;
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	Perbill,
+};
+
+pub type AccountId = MockAccount;
+pub type Balance = u128;
+pub type BlockNumber = u32;
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type Block = frame_system::mocking::MockBlock<Runtime>;
+
+construct_runtime!(
+	pub enum Runtime where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+		Evm: pallet_evm::{Pallet, Call, Storage, Event<T>},
+		Timestamp: pallet_timestamp::{Pallet, Call, Storage, Inherent},
+	}
+);
+
+parameter_types! {
+	pub const BlockHashCount: u32 = 250;
+	pub const MaximumBlockWeight: Weight = Weight::from_ref_time(1024);
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::one();
+	pub const SS58Prefix: u8 = 42;
+}
+
+impl frame_system::Config for Runtime {
+	type BaseCallFilter = Everything;
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type Index = u64;
+	type BlockNumber = BlockNumber;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = sp_runtime::generic::Header<BlockNumber, BlakeTwo256>;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type BlockWeights = ();
+	type BlockLength = ();
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+parameter_types! {
+	pub const ExistentialDeposit: u128 = 1;
+}
+impl pallet_balances::Config for Runtime {
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 4];
+	type MaxLocks = ();
+	type Balance = Balance;
+	type RuntimeEvent = RuntimeEvent;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+}
+
+mock_account!(Registry, |_| MockAccount::from_u64(1));
+mock_account!(Removed, |_| MockAccount::from_u64(2));
+mock_account!(SmartContract, |_| MockAccount::from_u64(3));
+
+pub type Precompiles<R> = PrecompileSetBuilder<
+	R,
+	(
+		PrecompileAt<AddressU64<1>, PrecompileRegistry<R>>,
+		RemovedPrecompileAt<AddressU64<2>>,
+	),
+>;
+
+pub type PCall = PrecompileRegistryCall<Runtime>;
+
+parameter_types! {
+	pub PrecompilesValue: Precompiles<Runtime> = Precompiles::new();
+	pub const WeightPerGas: Weight = Weight::from_ref_time(1);
+}
+
+impl pallet_evm::Config for Runtime {
+	type FeeCalculator = ();
+	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
+	type WeightPerGas = WeightPerGas;
+	type CallOrigin = EnsureAddressRoot<AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<AccountId>;
+	type AddressMapping = AccountId;
+	type Currency = Balances;
+	type RuntimeEvent = RuntimeEvent;
+	type Runner = pallet_evm::runner::stack::Runner<Self>;
+	type PrecompilesType = Precompiles<Runtime>;
+	type PrecompilesValue = PrecompilesValue;
+	type ChainId = ();
+	type OnChargeTransaction = ();
+	type BlockGasLimit = ();
+	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
+	type FindAuthor = ();
+}
+
+parameter_types! {
+	pub const MinimumPeriod: u64 = 5;
+}
+impl pallet_timestamp::Config for Runtime {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+pub(crate) struct ExtBuilder {
+	// endowed accounts with balances
+	balances: Vec<(AccountId, Balance)>,
+}
+
+impl Default for ExtBuilder {
+	fn default() -> ExtBuilder {
+		ExtBuilder { balances: vec![] }
+	}
+}
+
+impl ExtBuilder {
+	pub(crate) fn with_balances(mut self, balances: Vec<(AccountId, Balance)>) -> Self {
+		self.balances = balances;
+		self
+	}
+
+	pub(crate) fn build(self) -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.expect("Frame system builds valid default genesis config");
+
+		pallet_balances::GenesisConfig::<Runtime> {
+			balances: self.balances,
+		}
+		.assimilate_storage(&mut t)
+		.expect("Pallet balances storage can be assimilated");
+
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| {
+			System::set_block_number(1);
+			pallet_evm::Pallet::<Runtime>::create_account(
+				SmartContract.into(),
+				b"SmartContract".to_vec(),
+			);
+		});
+		ext
+	}
+}

--- a/precompiles/precompile-registry/src/tests.rs
+++ b/precompiles/precompile-registry/src/tests.rs
@@ -1,0 +1,219 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::mock::{
+	ExtBuilder, PCall, Precompiles, PrecompilesValue, Registry, Removed, Runtime, SmartContract,
+};
+use precompile_utils::{prelude::*, testing::*};
+use sp_core::H160;
+
+fn precompiles() -> Precompiles<Runtime> {
+	PrecompilesValue::get()
+}
+
+mod selectors {
+	use super::*;
+
+	#[test]
+	fn selectors() {
+		assert!(PCall::is_precompile_selectors().contains(&0x446b450e));
+		assert!(PCall::is_active_precompile_selectors().contains(&0x6f5e23cf));
+		assert!(PCall::update_account_code_selectors().contains(&0x48ceb1b4));
+	}
+
+	#[test]
+	fn modifiers() {
+		ExtBuilder::default()
+			.with_balances(vec![(CryptoAlith.into(), 1000)])
+			.build()
+			.execute_with(|| {
+				let mut tester =
+					PrecompilesModifierTester::new(precompiles(), CryptoAlith, Registry);
+
+				tester.test_view_modifier(PCall::is_precompile_selectors());
+				tester.test_view_modifier(PCall::is_active_precompile_selectors());
+				tester.test_default_modifier(PCall::update_account_code_selectors());
+			});
+	}
+}
+
+mod is_precompile {
+
+	use super::*;
+
+	fn call(target_address: impl Into<H160>, output: bool) {
+		ExtBuilder::default()
+			.with_balances(vec![(CryptoAlith.into(), 1000)])
+			.build()
+			.execute_with(|| {
+				precompiles()
+					.prepare_test(
+						Alice, // can be anyone,*$
+						Registry,
+						PCall::is_precompile {
+							address: Address(target_address.into()),
+						},
+					)
+					.expect_no_logs()
+					.execute_returns_encoded(output);
+			});
+	}
+
+	#[test]
+	fn works_on_precompile() {
+		call(Registry, true);
+	}
+
+	#[test]
+	fn works_on_removed_precompile() {
+		call(Removed, true);
+	}
+
+	#[test]
+	fn works_on_eoa() {
+		call(CryptoAlith, false);
+	}
+
+	#[test]
+	fn works_on_smart_contract() {
+		call(SmartContract, false);
+	}
+}
+
+mod is_active_precompile {
+
+	use super::*;
+
+	fn call(target_address: impl Into<H160>, output: bool) {
+		ExtBuilder::default()
+			.with_balances(vec![(CryptoAlith.into(), 1000)])
+			.build()
+			.execute_with(|| {
+				precompiles()
+					.prepare_test(
+						Alice, // can be anyone,*$
+						Registry,
+						PCall::is_active_precompile {
+							address: Address(target_address.into()),
+						},
+					)
+					.expect_no_logs()
+					.execute_returns_encoded(output);
+			});
+	}
+
+	#[test]
+	fn works_on_precompile() {
+		call(Registry, true);
+	}
+
+	#[test]
+	fn works_on_removed_precompile() {
+		call(Removed, false);
+	}
+
+	#[test]
+	fn works_on_eoa() {
+		call(CryptoAlith, false);
+	}
+
+	#[test]
+	fn works_on_smart_contract() {
+		call(SmartContract, false);
+	}
+}
+
+mod update_account_code {
+	use super::*;
+
+	fn call(target_address: impl Into<H160>, expect_changes: bool) {
+		ExtBuilder::default()
+			.with_balances(vec![(CryptoAlith.into(), 1000)])
+			.build()
+			.execute_with(|| {
+				let target_address = target_address.into();
+
+				let precompiles = precompiles();
+				let tester = precompiles.prepare_test(
+					Alice, // can be anyone,*$
+					Registry,
+					PCall::update_account_code {
+						address: Address(target_address),
+					},
+				);
+
+				if expect_changes {
+					tester.execute_returns_encoded(());
+					let new_code = pallet_evm::AccountCodes::<Runtime>::get(target_address);
+					assert_eq!(&new_code, &[0x60, 0x00, 0x60, 0x00, 0xfd]);
+				} else {
+					let current_code = pallet_evm::AccountCodes::<Runtime>::get(target_address);
+
+					tester.execute_reverts(|revert| {
+						revert == b"provided address is not a precompile"
+					});
+
+					let new_code = pallet_evm::AccountCodes::<Runtime>::get(target_address);
+					assert_eq!(current_code, new_code);
+				}
+			});
+	}
+
+	#[test]
+	fn works_on_precompile() {
+		call(Registry, true);
+	}
+
+	#[test]
+	fn works_on_removed_precompile() {
+		call(Removed, true);
+	}
+
+	#[test]
+	fn works_on_eoa() {
+		call(CryptoAlith, false);
+	}
+
+	#[test]
+	fn works_on_smart_contract() {
+		call(SmartContract, false);
+	}
+}
+
+#[test]
+fn test_solidity_interface() {
+	for file in ["PrecompileRegistry.sol"] {
+		for solidity_fn in solidity::get_selectors(file) {
+			assert_eq!(
+				solidity_fn.compute_selector_hex(),
+				solidity_fn.docs_selector,
+				"documented selector for '{}' did not match for file '{}'",
+				solidity_fn.signature(),
+				file,
+			);
+
+			let selector = solidity_fn.compute_selector();
+			if !PCall::supports_selector(selector) {
+				panic!(
+					"unsupported selector 0x{:x} => '{}' for file '{}'",
+					selector,
+					solidity_fn.signature(),
+					file,
+				)
+			}
+		}
+	}
+}

--- a/precompiles/utils/src/precompile_set.rs
+++ b/precompiles/utils/src/precompile_set.rs
@@ -29,10 +29,6 @@ use sp_std::{
 	vec::Vec,
 };
 
-mod sealed {
-	pub trait Sealed {}
-}
-
 /// Trait representing checks that can be made on a precompile call.
 /// Types implementing this trait are made to be chained in a tuple.
 ///
@@ -405,6 +401,16 @@ impl<'a, H: PrecompileHandle> PrecompileHandle for RestrictiveHandle<'a, H> {
 	}
 }
 
+/// Allows to know if a precompile is active or not.
+/// This allows to detect deactivated precompile, that are still considered precompiles by
+/// the EVM but that will always revert when called.
+pub trait IsActivePrecompile {
+	/// Is the provided address an active precompile, a precompile that has
+	/// not be deactivated. Note that a deactivated precompile is still considered a precompile
+	/// for the EVM, but it will always revert when called.
+	fn is_active_precompile(&self, address: H160) -> bool;
+}
+
 // INDIVIDUAL PRECOMPILE(SET)
 
 /// A fragment of a PrecompileSet. Should be implemented as is it
@@ -538,6 +544,16 @@ where
 	}
 }
 
+impl<A, P, C> IsActivePrecompile for PrecompileAt<A, P, C>
+where
+	A: Get<H160>,
+{
+	#[inline(always)]
+	fn is_active_precompile(&self, address: H160) -> bool {
+		address == A::get()
+	}
+}
+
 /// Wraps an inner PrecompileSet with all its addresses starting with
 /// a common prefix.
 /// Type parameters allow to define:
@@ -655,9 +671,20 @@ where
 	}
 }
 
+impl<A, P, C> IsActivePrecompile for PrecompileSetStartingWith<A, P, C>
+where
+	Self: PrecompileSetFragment,
+{
+	#[inline(always)]
+	fn is_active_precompile(&self, address: H160) -> bool {
+		self.is_precompile(address)
+	}
+}
+
 /// Make a precompile that always revert.
 /// Can be useful when writing tests.
 pub struct RevertPrecompile<A>(PhantomData<A>);
+pub type RemovedPrecompileAt<A> = RevertPrecompile<A>;
 
 impl<A> PrecompileSetFragment for RevertPrecompile<A>
 where
@@ -699,6 +726,13 @@ where
 			callable_by_smart_contract: "Reverts in all cases".into(),
 			callable_by_precompile: "Reverts in all cases".into(),
 		}]
+	}
+}
+
+impl<A> IsActivePrecompile for RevertPrecompile<A> {
+	#[inline(always)]
+	fn is_active_precompile(&self, _address: H160) -> bool {
+		false
 	}
 }
 
@@ -761,6 +795,20 @@ impl PrecompileSetFragment for Tuple {
 	}
 }
 
+#[impl_for_tuples(1, 100)]
+impl IsActivePrecompile for Tuple {
+	#[inline(always)]
+	fn is_active_precompile(&self, address: H160) -> bool {
+		for_tuples!(#(
+			if self.Tuple.is_active_precompile(address) {
+				return true;
+			}
+		)*);
+
+		false
+	}
+}
+
 /// Wraps a precompileset fragment into a range, and will skip processing it if the address
 /// is out of the range.
 pub struct PrecompilesInRangeInclusive<R, P> {
@@ -811,6 +859,20 @@ where
 	}
 }
 
+impl<S, E, P> IsActivePrecompile for PrecompilesInRangeInclusive<(S, E), P>
+where
+	Self: PrecompileSetFragment,
+	P: IsActivePrecompile,
+{
+	fn is_active_precompile(&self, address: H160) -> bool {
+		if self.range.contains(&address) {
+			self.inner.is_active_precompile(address)
+		} else {
+			false
+		}
+	}
+}
+
 /// Wraps a tuple of `PrecompileSetFragment` to make a real `PrecompileSet`.
 pub struct PrecompileSetBuilder<R, P> {
 	inner: P,
@@ -824,6 +886,12 @@ impl<R: pallet_evm::Config, P: PrecompileSetFragment> PrecompileSet for Precompi
 
 	fn is_precompile(&self, address: H160) -> bool {
 		self.inner.is_precompile(address)
+	}
+}
+
+impl<R, P: IsActivePrecompile> IsActivePrecompile for PrecompileSetBuilder<R, P> {
+	fn is_active_precompile(&self, address: H160) -> bool {
+		self.inner.is_active_precompile(address)
 	}
 }
 


### PR DESCRIPTION
### What does it do?

Implements this proposal: https://forum.moonbeam.foundation/t/proposal-status-idea-precompile-to-check-active-precompiles/384

It also allows for any user to set the "dummy code" of precompiles to make them callable from Solidity (which adds an empty code check). This is currently done through democracy with set_storage, which is far from ideal.

### For audit

Ensure that it is not possible to change the code of non-precompile addresses.
