### PR TITLE
Update collator candidate self-bond in Moonriver

### DIFF
--- a/node/service/src/chain_spec/moonriver.rs
+++ b/node/service/src/chain_spec/moonriver.rs
@@ -73,7 +73,7 @@ pub fn development_chain_spec(mnemonic: Option<String>, num_accounts: Option<u32
 				vec![(
 					AccountId::from(hex!("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac")),
 					get_from_seed::<NimbusId>("Alice"),
-					1_000 * MOVR,
+					100_000 * MOVR,
 				)],
 				// Delegations
 				vec![],
@@ -146,13 +146,13 @@ pub fn get_chain_spec(para_id: ParaId) -> ChainSpec {
 					(
 						AccountId::from(hex!("f24FF3a9CF04c71Dbc94D0b566f7A27B94566cac")),
 						get_from_seed::<NimbusId>("Alice"),
-						1_000 * MOVR,
+						100_000 * MOVR,
 					),
 					// Bob -> Baltathar
 					(
 						AccountId::from(hex!("3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0")),
 						get_from_seed::<NimbusId>("Bob"),
-						1_000 * MOVR,
+						100_000 * MOVR,
 					),
 				],
 				// Delegations

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -672,7 +672,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	/// Maximum delegations per delegator
 	type MaxDelegationsPerDelegator = ConstU32<100>;
 	/// Minimum stake required to become a collator
-	type MinCollatorStk = ConstU128<{ 1000 * currency::MOVR * currency::SUPPLY_FACTOR }>;
+	type MinCollatorStk = ConstU128<{ 10000 * currency::MOVR * currency::SUPPLY_FACTOR }>;
 	/// Minimum stake required to be reserved to be a candidate
 	type MinCandidateStk = ConstU128<{ 10000 * currency::MOVR * currency::SUPPLY_FACTOR }>;
 	/// Minimum stake required to be reserved to be a delegator
@@ -1571,11 +1571,11 @@ mod tests {
 		// staking minimums
 		assert_eq!(
 			get!(pallet_parachain_staking, MinCollatorStk, u128),
-			Balance::from(1 * KILOMOVR)
+			Balance::from(10 * KILOMOVR)
 		);
 		assert_eq!(
 			get!(pallet_parachain_staking, MinCandidateStk, u128),
-			Balance::from(500 * MOVR)
+			Balance::from(10 * KILOMOVR)
 		);
 		assert_eq!(
 			get!(pallet_parachain_staking, MinDelegation, u128),

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -674,7 +674,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	/// Minimum stake required to become a collator
 	type MinCollatorStk = ConstU128<{ 1000 * currency::MOVR * currency::SUPPLY_FACTOR }>;
 	/// Minimum stake required to be reserved to be a candidate
-	type MinCandidateStk = ConstU128<{ 500 * currency::MOVR * currency::SUPPLY_FACTOR }>;
+	type MinCandidateStk = ConstU128<{ 10000 * currency::MOVR * currency::SUPPLY_FACTOR }>;
 	/// Minimum stake required to be reserved to be a delegator
 	type MinDelegation = ConstU128<{ 5 * currency::MOVR * currency::SUPPLY_FACTOR }>;
 	/// Minimum stake required to be reserved to be a delegator

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -358,14 +358,14 @@ fn verify_proxy_type_indices() {
 fn join_collator_candidates() {
 	ExtBuilder::default()
 		.with_balances(vec![
-			(AccountId::from(ALICE), 2_000 * MOVR),
-			(AccountId::from(BOB), 2_000 * MOVR),
-			(AccountId::from(CHARLIE), 1_100 * MOVR),
-			(AccountId::from(DAVE), 1_000 * MOVR),
+			(AccountId::from(ALICE), 20_000 * MOVR),
+			(AccountId::from(BOB), 20_000 * MOVR),
+			(AccountId::from(CHARLIE), 10_100 * MOVR),
+			(AccountId::from(DAVE), 10_000 * MOVR),
 		])
 		.with_collators(vec![
-			(AccountId::from(ALICE), 1_000 * MOVR),
-			(AccountId::from(BOB), 1_000 * MOVR),
+			(AccountId::from(ALICE), 10_000 * MOVR),
+			(AccountId::from(BOB), 10_000 * MOVR),
 		])
 		.with_delegations(vec![
 			(AccountId::from(CHARLIE), AccountId::from(ALICE), 50 * MOVR),
@@ -376,7 +376,7 @@ fn join_collator_candidates() {
 			assert_noop!(
 				ParachainStaking::join_candidates(
 					origin_of(AccountId::from(ALICE)),
-					1_000 * MOVR,
+					10_000 * MOVR,
 					2u32
 				),
 				pallet_parachain_staking::Error::<Runtime>::CandidateExists
@@ -384,7 +384,7 @@ fn join_collator_candidates() {
 			assert_noop!(
 				ParachainStaking::join_candidates(
 					origin_of(AccountId::from(CHARLIE)),
-					1_000 * MOVR,
+					10_000 * MOVR,
 					2u32
 				),
 				pallet_parachain_staking::Error::<Runtime>::DelegatorExists
@@ -392,7 +392,7 @@ fn join_collator_candidates() {
 			assert!(System::events().is_empty());
 			assert_ok!(ParachainStaking::join_candidates(
 				origin_of(AccountId::from(DAVE)),
-				1_000 * MOVR,
+				10_000 * MOVR,
 				2u32
 			));
 			assert_eq!(
@@ -400,32 +400,32 @@ fn join_collator_candidates() {
 				RuntimeEvent::ParachainStaking(
 					pallet_parachain_staking::Event::JoinedCollatorCandidates {
 						account: AccountId::from(DAVE),
-						amount_locked: 1_000 * MOVR,
-						new_total_amt_locked: 3_100 * MOVR
+						amount_locked: 10_000 * MOVR,
+						new_total_amt_locked: 30_100 * MOVR
 					}
 				)
 			);
 			let candidates = ParachainStaking::candidate_pool();
 			assert_eq!(candidates.0[0].owner, AccountId::from(ALICE));
-			assert_eq!(candidates.0[0].amount, 1_050 * MOVR);
+			assert_eq!(candidates.0[0].amount, 10_050 * MOVR);
 			assert_eq!(candidates.0[1].owner, AccountId::from(BOB));
-			assert_eq!(candidates.0[1].amount, 1_050 * MOVR);
+			assert_eq!(candidates.0[1].amount, 10_050 * MOVR);
 			assert_eq!(candidates.0[2].owner, AccountId::from(DAVE));
-			assert_eq!(candidates.0[2].amount, 1_000 * MOVR);
+			assert_eq!(candidates.0[2].amount, 10_000 * MOVR);
 		});
 }
 
 #[test]
 fn transfer_through_evm_to_stake() {
 	ExtBuilder::default()
-		.with_balances(vec![(AccountId::from(ALICE), 2_000 * MOVR)])
+		.with_balances(vec![(AccountId::from(ALICE), 20_000 * MOVR)])
 		.build()
 		.execute_with(|| {
 			// Charlie has no balance => fails to stake
 			assert_noop!(
 				ParachainStaking::join_candidates(
 					origin_of(AccountId::from(CHARLIE)),
-					1_000 * MOVR,
+					10_000 * MOVR,
 					2u32
 				),
 				DispatchError::Module(ModuleError {
@@ -434,22 +434,22 @@ fn transfer_through_evm_to_stake() {
 					message: Some("InsufficientBalance")
 				})
 			);
-			// Alice transfer from free balance 2000 MOVR to Bob
+			// Alice transfer from free balance 20000 MOVR to Bob
 			assert_ok!(Balances::transfer(
 				origin_of(AccountId::from(ALICE)),
 				AccountId::from(BOB),
-				2_000 * MOVR,
+				20_000 * MOVR,
 			));
-			assert_eq!(Balances::free_balance(AccountId::from(BOB)), 2_000 * MOVR);
+			assert_eq!(Balances::free_balance(AccountId::from(BOB)), 20_000 * MOVR);
 
 			let gas_limit = 100000u64;
 			let gas_price: U256 = BASE_FEE_GENESIS.into();
-			// Bob transfers 1000 MOVR to Charlie via EVM
+			// Bob transfers 10000 MOVR to Charlie via EVM
 			assert_ok!(RuntimeCall::EVM(pallet_evm::Call::<Runtime>::call {
 				source: H160::from(BOB),
 				target: H160::from(CHARLIE),
 				input: vec![],
-				value: (1_000 * MOVR).into(),
+				value: (10_000 * MOVR).into(),
 				gas_limit,
 				max_fee_per_gas: gas_price,
 				max_priority_fee_per_gas: None,
@@ -459,18 +459,18 @@ fn transfer_through_evm_to_stake() {
 			.dispatch(<Runtime as frame_system::Config>::RuntimeOrigin::root()));
 			assert_eq!(
 				Balances::free_balance(AccountId::from(CHARLIE)),
-				1_000 * MOVR,
+				10_000 * MOVR,
 			);
 
 			// Charlie can stake now
 			assert_ok!(ParachainStaking::join_candidates(
 				origin_of(AccountId::from(CHARLIE)),
-				1_000 * MOVR,
+				10_000 * MOVR,
 				2u32,
 			),);
 			let candidates = ParachainStaking::candidate_pool();
 			assert_eq!(candidates.0[0].owner, AccountId::from(CHARLIE));
-			assert_eq!(candidates.0[0].amount, 1_000 * MOVR);
+			assert_eq!(candidates.0[0].amount, 10_000 * MOVR);
 		});
 }
 
@@ -479,10 +479,10 @@ fn reward_block_authors() {
 	ExtBuilder::default()
 		.with_balances(vec![
 			// Alice gets 100 extra tokens for her mapping deposit
-			(AccountId::from(ALICE), 2_100 * MOVR),
-			(AccountId::from(BOB), 1_000 * MOVR),
+			(AccountId::from(ALICE), 20_100 * MOVR),
+			(AccountId::from(BOB), 10_000 * MOVR),
 		])
-		.with_collators(vec![(AccountId::from(ALICE), 1_000 * MOVR)])
+		.with_collators(vec![(AccountId::from(ALICE), 10_000 * MOVR)])
 		.with_delegations(vec![(
 			AccountId::from(BOB),
 			AccountId::from(ALICE),
@@ -501,18 +501,18 @@ fn reward_block_authors() {
 			// no rewards doled out yet
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(ALICE)),
-				1_000 * MOVR,
+				10_000 * MOVR,
 			);
-			assert_eq!(Balances::usable_balance(AccountId::from(BOB)), 500 * MOVR,);
+			assert_eq!(Balances::usable_balance(AccountId::from(BOB)), 9500 * MOVR,);
 			run_to_block(1201, Some(NimbusId::from_slice(&ALICE_NIMBUS).unwrap()));
 			// rewards minted and distributed
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(ALICE)),
-				1113666666584000000000,
+				11447666666208000000000,
 			);
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(BOB)),
-				541333333292000000000,
+				9557333332588000000000,
 			);
 		});
 }
@@ -522,11 +522,11 @@ fn reward_block_authors_with_parachain_bond_reserved() {
 	ExtBuilder::default()
 		.with_balances(vec![
 			// Alice gets 100 extra tokens for her mapping deposit
-			(AccountId::from(ALICE), 2_100 * MOVR),
-			(AccountId::from(BOB), 1_000 * MOVR),
+			(AccountId::from(ALICE), 20_100 * MOVR),
+			(AccountId::from(BOB), 10_000 * MOVR),
 			(AccountId::from(CHARLIE), MOVR),
 		])
-		.with_collators(vec![(AccountId::from(ALICE), 1_000 * MOVR)])
+		.with_collators(vec![(AccountId::from(ALICE), 10_000 * MOVR)])
 		.with_delegations(vec![(
 			AccountId::from(BOB),
 			AccountId::from(ALICE),
@@ -549,24 +549,24 @@ fn reward_block_authors_with_parachain_bond_reserved() {
 			// no rewards doled out yet
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(ALICE)),
-				1_000 * MOVR,
+				10_000 * MOVR,
 			);
-			assert_eq!(Balances::usable_balance(AccountId::from(BOB)), 500 * MOVR,);
+			assert_eq!(Balances::usable_balance(AccountId::from(BOB)), 9500 * MOVR,);
 			assert_eq!(Balances::usable_balance(AccountId::from(CHARLIE)), MOVR,);
 			run_to_block(1201, Some(NimbusId::from_slice(&ALICE_NIMBUS).unwrap()));
 			// rewards minted and distributed
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(ALICE)),
-				1082693333281650000000,
+				11017700475903800000000,
 			);
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(BOB)),
-				525841666640825000000,
+				9535834523343675000000,
 			);
 			// 30% reserved for parachain bond
 			assert_eq!(
 				Balances::usable_balance(AccountId::from(CHARLIE)),
-				47515000000000000000,
+				452515000000000000000,
 			);
 		});
 }


### PR DESCRIPTION
### What does it do?

According to this referenda https://moonriver.polkassembly.network/referenda/1, the change proposed in this PR is the one that refers to update the bond to 10,000 MOVR in order the collator to be considered eligible and become a collator candidate. The current bond is 500 MOVR.

### :warning: Breaking Changes :warning: 

* All changes are moonriver only.
* Changed both `MinCandidateStk` and `MinCollatorStk` constants to the value of 10,000 MOVR.

### Notes
* `MinCandidateStk` refers to the minimum stake required to be reserved to be a candidate. Located in the moonriver runtime `Config` (lib file).
* `MinCollatorStk` refers to the minimum stake required to become a collator. Located in the moonriver runtime `Config` (lib file).

