### PR TITLE
Improve compilation error message in precompile macro

### DIFF
--- a/precompiles/utils/macro/tests/compile-fail/precompile/test-gen/generic-arg.rs
+++ b/precompiles/utils/macro/tests/compile-fail/precompile/test-gen/generic-arg.rs
@@ -14,11 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use {
-	core::marker::PhantomData,
-	frame_support::pallet_prelude::Get,
-	precompile_utils::prelude::*,
-};
+use core::marker::PhantomData;
 
 pub struct Precompile<R>(PhantomData<R>);
 
@@ -30,4 +26,4 @@ impl<R: Get<u32>> Precompile<R> {
 	}
 }
 
-fn main() { }
+fn main() {}

--- a/precompiles/utils/macro/tests/compile-fail/precompile/test-gen/generic-arg.stderr
+++ b/precompiles/utils/macro/tests/compile-fail/precompile/test-gen/generic-arg.stderr
@@ -1,8 +1,11 @@
-error[E0412]: cannot find type `R` in this scope
-  --> tests/compile-fail/precompile/test-gen/generic-arg.rs:28:63
+error: impl type parameter is used in functions arguments. Arguments should not have a type
+       depending on a type parameter, unless it is a length bound for BoundedBytes,
+       BoundedString or alike, which doesn't affect the Solidity type.
+
+       In that case, you must add a #[precompile::test_concrete_types(...)] attribute on the impl
+       block to provide concrete types that will be used to run the automatically generated tests
+       ensuring the Solidity function signatures are correct.
+  --> tests/compile-fail/precompile/test-gen/generic-arg.rs:24:63
    |
-26 | impl<R: Get<u32>> Precompile<R> {
-   |                             - help: you might be missing a type parameter: `<R>`
-27 |     #[precompile::public("foo(bytes)")]
-28 |     fn foo(handle: &mut impl PrecompileHandle, arg: BoundedBytes<R>) -> EvmResult {
-   |                                                                  ^ not found in this scope
+24 |     fn foo(handle: &mut impl PrecompileHandle, arg: BoundedBytes<R>) -> EvmResult {
+   |                                                                  ^


### PR DESCRIPTION
### What does it do?

Improve compile time error message when writing a precompile in which an argument of a function depends on one of the type parameters of the impl block. This doesn't compile because the macro generates a test to ensure the Solidity signatures are correct, which require concrete types for any type parameter.
