### PR TITLE
added root in moonbase and moonriver referenda

### DIFF
--- a/runtime/moonbase/src/governance/referenda.rs
+++ b/runtime/moonbase/src/governance/referenda.rs
@@ -83,8 +83,8 @@ impl pallet_referenda::Config for Runtime {
 	type Scheduler = Scheduler;
 	type Currency = Balances;
 	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
-	type CancelOrigin = ReferendumCanceller;
-	type KillOrigin = ReferendumKiller;
+	type CancelOrigin = EitherOf<EnsureRoot<Self::AccountId>, ReferendumCanceller>;
+	type KillOrigin = EitherOf<EnsureRoot<Self::AccountId>, ReferendumKiller>;
 	type Slash = Treasury;
 	type Votes = pallet_conviction_voting::VotesOf<Runtime>;
 	type Tally = pallet_conviction_voting::TallyOf<Runtime>;

--- a/runtime/moonriver/src/governance/referenda.rs
+++ b/runtime/moonriver/src/governance/referenda.rs
@@ -84,8 +84,8 @@ impl pallet_referenda::Config for Runtime {
 	type Scheduler = Scheduler;
 	type Currency = Balances;
 	type SubmitOrigin = frame_system::EnsureSigned<AccountId>;
-	type CancelOrigin = ReferendumCanceller;
-	type KillOrigin = ReferendumKiller;
+	type CancelOrigin = EitherOf<EnsureRoot<Self::AccountId>, ReferendumCanceller>;
+	type KillOrigin = EitherOf<EnsureRoot<Self::AccountId>, ReferendumKiller>;
 	type Slash = Treasury;
 	type Votes = pallet_conviction_voting::VotesOf<Runtime>;
 	type Tally = pallet_conviction_voting::TallyOf<Runtime>;


### PR DESCRIPTION
### What does it do?

Currently, Root origin is not able to kill or cancel an OpenGov referendum in Moonbase/Moonriver. Then, this PR allows Root origin to kill or cancel OpenGov-type referendums within Moonbase and Moonriver.

### :warning: Breaking Changes :warning: 
* All changes are Moonbase and Moonriver only.
* Changed `CancelOrigin` and `KillOrigin` types within `pallet_referenda::Config for Runtime` located in
`runtime/moonbase/src/governance/referenda.rs` for Moonbase and `runtime/moonriver/src/governance/referenda.rs`
for Moonriver.

   #### Previous values
   ```rust
    type CancelOrigin = ReferendumCanceller;
    type KillOrigin = ReferendumKiller;
   ```
   #### Updated values
  ```rust
    type CancelOrigin = EitherOf<EnsureRoot<Self::AccountId>, ReferendumCanceller>;
    type KillOrigin = EitherOf<EnsureRoot<Self::AccountId>, ReferendumKiller>;
   ```
  
