### PR TITLE
Add HRMP Cancel variant to hrmp_manage

### DIFF
--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -225,9 +225,14 @@ pub mod pallet {
 	#[derive(Clone, Encode, Decode, Eq, PartialEq, RuntimeDebug, scale_info::TypeInfo)]
 	pub enum HrmpOperation {
 		InitOpen(HrmpInitParams),
-		Accept { para_id: ParaId },
+		Accept {
+			para_id: ParaId,
+		},
 		Close(HrmpChannelId),
-		Cancel { para_id: ParaId },
+		Cancel {
+			channel_id: HrmpChannelId,
+			open_requests: u32,
+		},
 	}
 
 	#[derive(
@@ -771,9 +776,13 @@ pub mod pallet {
 				HrmpOperation::Close(close_params) => {
 					T::HrmpEncoder::hrmp_encode_call(HrmpAvailableCalls::CloseChannel(close_params))
 				}
-				HrmpOperation::Cancel { para_id } => {
-					T::HrmpEncoder::hrmp_encode_call(HrmpAvailableCalls::CancelOpenChannel(para_id))
-				}
+				HrmpOperation::Cancel {
+					channel_id,
+					open_requests,
+				} => T::HrmpEncoder::hrmp_encode_call(HrmpAvailableCalls::CancelOpenChannel(
+					channel_id,
+					open_requests,
+				)),
 			}
 			.map_err(|_| Error::<T>::HrmpHandlerNotImplemented)?;
 

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -227,7 +227,7 @@ pub mod pallet {
 		InitOpen(HrmpInitParams),
 		Accept { para_id: ParaId },
 		Close(HrmpChannelId),
-		Decline { para_id: ParaId },
+		Cancel { para_id: ParaId },
 	}
 
 	#[derive(
@@ -771,9 +771,9 @@ pub mod pallet {
 				HrmpOperation::Close(close_params) => {
 					T::HrmpEncoder::hrmp_encode_call(HrmpAvailableCalls::CloseChannel(close_params))
 				}
-				HrmpOperation::Decline { para_id } => T::HrmpEncoder::hrmp_encode_call(
-					HrmpAvailableCalls::DeclineOpenChannel(para_id),
-				),
+				HrmpOperation::Cancel { para_id } => {
+					T::HrmpEncoder::hrmp_encode_call(HrmpAvailableCalls::CancelOpenChannel(para_id))
+				}
 			}
 			.map_err(|_| Error::<T>::HrmpHandlerNotImplemented)?;
 

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -227,6 +227,7 @@ pub mod pallet {
 		InitOpen(HrmpInitParams),
 		Accept { para_id: ParaId },
 		Close(HrmpChannelId),
+		Decline { para_id: ParaId },
 	}
 
 	#[derive(
@@ -770,6 +771,9 @@ pub mod pallet {
 				HrmpOperation::Close(close_params) => {
 					T::HrmpEncoder::hrmp_encode_call(HrmpAvailableCalls::CloseChannel(close_params))
 				}
+				HrmpOperation::Decline { para_id } => T::HrmpEncoder::hrmp_encode_call(
+					HrmpAvailableCalls::DeclineOpenChannel(para_id),
+				),
 			}
 			.map_err(|_| Error::<T>::HrmpHandlerNotImplemented)?;
 

--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -228,7 +228,7 @@ pub enum HrmpCall {
 	#[codec(index = 2u8)]
 	Close(),
 	#[codec(index = 3u8)]
-	Decline(),
+	Cancel(),
 }
 
 // Transactors for the mock runtime. Only relay chain
@@ -279,8 +279,8 @@ impl HrmpEncodeCall for MockHrmpEncoder {
 				Ok(RelayCall::Hrmp(HrmpCall::Accept()).encode())
 			}
 			HrmpAvailableCalls::CloseChannel(_) => Ok(RelayCall::Hrmp(HrmpCall::Close()).encode()),
-			HrmpAvailableCalls::DeclineOpenChannel(_) => {
-				Ok(RelayCall::Hrmp(HrmpCall::Decline()).encode())
+			HrmpAvailableCalls::CancelOpenChannel(_) => {
+				Ok(RelayCall::Hrmp(HrmpCall::Cancel()).encode())
 			}
 		}
 	}

--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -227,7 +227,7 @@ pub enum HrmpCall {
 	Accept(),
 	#[codec(index = 2u8)]
 	Close(),
-	#[codec(index = 3u8)]
+	#[codec(index = 6u8)]
 	Cancel(),
 }
 
@@ -279,7 +279,7 @@ impl HrmpEncodeCall for MockHrmpEncoder {
 				Ok(RelayCall::Hrmp(HrmpCall::Accept()).encode())
 			}
 			HrmpAvailableCalls::CloseChannel(_) => Ok(RelayCall::Hrmp(HrmpCall::Close()).encode()),
-			HrmpAvailableCalls::CancelOpenChannel(_) => {
+			HrmpAvailableCalls::CancelOpenChannel(_, _) => {
 				Ok(RelayCall::Hrmp(HrmpCall::Cancel()).encode())
 			}
 		}

--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -227,6 +227,8 @@ pub enum HrmpCall {
 	Accept(),
 	#[codec(index = 2u8)]
 	Close(),
+	#[codec(index = 3u8)]
+	Decline(),
 }
 
 // Transactors for the mock runtime. Only relay chain
@@ -277,6 +279,9 @@ impl HrmpEncodeCall for MockHrmpEncoder {
 				Ok(RelayCall::Hrmp(HrmpCall::Accept()).encode())
 			}
 			HrmpAvailableCalls::CloseChannel(_) => Ok(RelayCall::Hrmp(HrmpCall::Close()).encode()),
+			HrmpAvailableCalls::DeclineOpenChannel(_) => {
+				Ok(RelayCall::Hrmp(HrmpCall::Decline()).encode())
+			}
 		}
 	}
 }

--- a/pallets/xcm-transactor/src/tests.rs
+++ b/pallets/xcm-transactor/src/tests.rs
@@ -1195,11 +1195,17 @@ fn test_hrmp_manipulator_cancel() {
 			let total_weight = 10_100u64;
 			let tx_weight = 100_u64;
 			let total_fee = 100u128;
+			let channel_id = HrmpChannelId {
+				sender: 1u32.into(),
+				recipient: 1u32.into(),
+			};
+			let open_requests: u32 = 1;
 
 			assert_ok!(XcmTransactor::hrmp_manage(
 				RuntimeOrigin::root(),
 				HrmpOperation::Cancel {
-					para_id: 1u32.into()
+					channel_id,
+					open_requests
 				},
 				CurrencyPayment {
 					currency: Currency::AsMultiLocation(Box::new(xcm::VersionedMultiLocation::V1(
@@ -1226,7 +1232,7 @@ fn test_hrmp_manipulator_cancel() {
 			assert!(sent_message.0.contains(&Transact {
 				origin_type: OriginKind::Native,
 				require_weight_at_most: tx_weight,
-				call: vec![1u8, 3u8].into(),
+				call: vec![1u8, 6u8].into(),
 			}));
 		})
 }

--- a/pallets/xcm-transactor/src/tests.rs
+++ b/pallets/xcm-transactor/src/tests.rs
@@ -1227,7 +1227,7 @@ fn test_hrmp_manipulator_cancel() {
 				origin_type: OriginKind::Native,
 				require_weight_at_most: tx_weight,
 				call: vec![1u8, 3u8].into(),
-			})); 
+			}));
 		})
 }
 

--- a/pallets/xcm-transactor/src/tests.rs
+++ b/pallets/xcm-transactor/src/tests.rs
@@ -1185,6 +1185,53 @@ fn test_hrmp_manipulator_accept() {
 }
 
 #[test]
+fn test_hrmp_manipulator_cancel() {
+	ExtBuilder::default()
+		.with_balances(vec![])
+		.build()
+		.execute_with(|| {
+			// We are gonna use a total weight of 10_100, a tx weight of 100,
+			// and a total fee of 100
+			let total_weight = 10_100u64;
+			let tx_weight = 100_u64;
+			let total_fee = 100u128;
+
+			assert_ok!(XcmTransactor::hrmp_manage(
+				RuntimeOrigin::root(),
+				HrmpOperation::Cancel {
+					para_id: 1u32.into()
+				},
+				CurrencyPayment {
+					currency: Currency::AsMultiLocation(Box::new(xcm::VersionedMultiLocation::V1(
+						MultiLocation::parent()
+					))),
+					fee_amount: Some(total_fee)
+				},
+				TransactWeights {
+					transact_required_weight_at_most: tx_weight,
+					overall_weight: Some(total_weight)
+				}
+			));
+
+			let sent_messages = mock::sent_xcm();
+			let (_, sent_message) = sent_messages.first().unwrap();
+			// Lets make sure the message is as expected
+			assert!(sent_message
+				.0
+				.contains(&WithdrawAsset((MultiLocation::here(), total_fee).into())));
+			assert!(sent_message.0.contains(&BuyExecution {
+				fees: (MultiLocation::here(), total_fee).into(),
+				weight_limit: Limited(total_weight),
+			}));
+			assert!(sent_message.0.contains(&Transact {
+				origin_type: OriginKind::Native,
+				require_weight_at_most: tx_weight,
+				call: vec![1u8, 3u8].into(),
+			})); 
+		})
+}
+
+#[test]
 fn test_hrmp_manipulator_close() {
 	ExtBuilder::default()
 		.with_balances(vec![])

--- a/precompiles/relay-encoder/src/test_relay_runtime.rs
+++ b/precompiles/relay-encoder/src/test_relay_runtime.rs
@@ -69,7 +69,7 @@ pub enum HrmpCall {
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
 	#[codec(index = 3u8)]
-	CancelOpenChannel(ParaId),
+	CancelOpenChannel(HrmpChannelId, u32),
 }
 
 pub struct TestEncoder;
@@ -130,8 +130,8 @@ impl xcm_primitives::HrmpEncodeCall for TestEncoder {
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
-			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a, b) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone(), b.clone())).encode())
 			}
 		}
 	}

--- a/precompiles/relay-encoder/src/test_relay_runtime.rs
+++ b/precompiles/relay-encoder/src/test_relay_runtime.rs
@@ -68,6 +68,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
+	#[codec(index = 3u8)]
+	DeclineOpenChannel(ParaId),
 }
 
 pub struct TestEncoder;
@@ -127,6 +129,9 @@ impl xcm_primitives::HrmpEncodeCall for TestEncoder {
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
+			}
+			xcm_primitives::HrmpAvailableCalls::DeclineOpenChannel(a) => {
+				Ok(RelayCall::Hrmp(HrmpCall::DeclineOpenChannel(a.clone())).encode())
 			}
 		}
 	}

--- a/precompiles/relay-encoder/src/test_relay_runtime.rs
+++ b/precompiles/relay-encoder/src/test_relay_runtime.rs
@@ -69,7 +69,7 @@ pub enum HrmpCall {
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
 	#[codec(index = 3u8)]
-	DeclineOpenChannel(ParaId),
+	CancelOpenChannel(ParaId),
 }
 
 pub struct TestEncoder;
@@ -130,8 +130,8 @@ impl xcm_primitives::HrmpEncodeCall for TestEncoder {
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
-			xcm_primitives::HrmpAvailableCalls::DeclineOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::DeclineOpenChannel(a.clone())).encode())
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
 			}
 		}
 	}

--- a/precompiles/relay-encoder/src/test_relay_runtime.rs
+++ b/precompiles/relay-encoder/src/test_relay_runtime.rs
@@ -68,7 +68,7 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
-	#[codec(index = 3u8)]
+	#[codec(index = 6u8)]
 	CancelOpenChannel(HrmpChannelId, u32),
 }
 

--- a/primitives/xcm/src/transactor_traits.rs
+++ b/primitives/xcm/src/transactor_traits.rs
@@ -31,7 +31,7 @@ pub enum HrmpAvailableCalls {
 	InitOpenChannel(ParaId, u32, u32),
 	AcceptOpenChannel(ParaId),
 	CloseChannel(HrmpChannelId),
-	CancelOpenChannel(ParaId),
+	CancelOpenChannel(HrmpChannelId, u32),
 }
 
 // Trait that the ensures we can encode a call with utility functions.

--- a/primitives/xcm/src/transactor_traits.rs
+++ b/primitives/xcm/src/transactor_traits.rs
@@ -31,6 +31,7 @@ pub enum HrmpAvailableCalls {
 	InitOpenChannel(ParaId, u32, u32),
 	AcceptOpenChannel(ParaId),
 	CloseChannel(HrmpChannelId),
+	DeclineOpenChannel(ParaId),
 }
 
 // Trait that the ensures we can encode a call with utility functions.

--- a/primitives/xcm/src/transactor_traits.rs
+++ b/primitives/xcm/src/transactor_traits.rs
@@ -31,7 +31,7 @@ pub enum HrmpAvailableCalls {
 	InitOpenChannel(ParaId, u32, u32),
 	AcceptOpenChannel(ParaId),
 	CloseChannel(HrmpChannelId),
-	DeclineOpenChannel(ParaId),
+	CancelOpenChannel(ParaId),
 }
 
 // Trait that the ensures we can encode a call with utility functions.

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -962,6 +962,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
+	#[codec(index = 3u8)]
+	DeclineOpenChannel(ParaId),
 }
 
 #[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -1007,6 +1009,9 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
+			}
+			xcm_primitives::HrmpAvailableCalls::DeclineOpenChannel(a) => {
+				Ok(RelayCall::Hrmp(HrmpCall::DeclineOpenChannel(a.clone())).encode())
 			}
 		}
 	}

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -963,7 +963,7 @@ pub enum HrmpCall {
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
 	#[codec(index = 3u8)]
-	DeclineOpenChannel(ParaId),
+	CancelOpenChannel(ParaId),
 }
 
 #[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -1010,8 +1010,8 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
-			xcm_primitives::HrmpAvailableCalls::DeclineOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::DeclineOpenChannel(a.clone())).encode())
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
 			}
 		}
 	}

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -962,8 +962,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
-	#[codec(index = 3u8)]
-	CancelOpenChannel(ParaId),
+	#[codec(index = 6u8)]
+	CancelOpenChannel(HrmpChannelId, u32),
 }
 
 #[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -1010,8 +1010,8 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
-			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a, b) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone(), b.clone())).encode())
 			}
 		}
 	}

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -932,8 +932,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
-	#[codec(index = 3u8)]
-	CancelOpenChannel(ParaId),
+	#[codec(index = 6u8)]
+	CancelOpenChannel(HrmpChannelId, u32),
 }
 
 #[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -980,8 +980,8 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
-			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a, b) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone(), b.clone())).encode())
 			}
 		}
 	}

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -932,6 +932,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
+	#[codec(index = 3u8)]
+	CancelOpenChannel(ParaId),
 }
 
 #[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -977,6 +979,9 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
+			}
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
 			}
 		}
 	}

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -940,8 +940,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
-	#[codec(index = 1u8)]
-	CancelOpenChannel(ParaId),
+	#[codec(index = 6u8)]
+	CancelOpenChannel(HrmpChannelId, u32),
 }
 
 #[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -988,8 +988,8 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
-			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a, b) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone(), b.clone())).encode())
 			}
 		}
 	}

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -940,6 +940,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
+	#[codec(index = 1u8)]
+	CancelOpenChannel(ParaId),
 }
 
 #[derive(Clone, Eq, Debug, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
@@ -985,6 +987,9 @@ impl xcm_primitives::HrmpEncodeCall for MockHrmpEncoder {
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
+			}
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
 			}
 		}
 	}

--- a/runtime/relay-encoder/src/kusama.rs
+++ b/runtime/relay-encoder/src/kusama.rs
@@ -552,4 +552,40 @@ mod tests {
 			Ok(expected_encoded)
 		);
 	}
+
+	#[test]
+	fn test_hrmp_cancel() {
+		let mut expected_encoded: Vec<u8> = Vec::new();
+
+		let index = <kusama_runtime::Runtime as frame_system::Config>::PalletInfo::index::<
+			kusama_runtime::Hrmp,
+		>()
+		.unwrap() as u8;
+		expected_encoded.push(index);
+
+		let channel_id = HrmpChannelId {
+			sender: 1u32.into(),
+			recipient: 1u32.into(),
+		};
+		let open_requests: u32 = 1;
+
+		let mut expected = polkadot_runtime_parachains::hrmp::Call::<
+			kusama_runtime::Runtime
+		>::hrmp_cancel_open_request {
+			channel_id: channel_id.clone(),
+			open_requests
+		}
+		.encode();
+		expected_encoded.append(&mut expected);
+
+		assert_eq!(
+			<KusamaEncoder as xcm_primitives::HrmpEncodeCall>::hrmp_encode_call(
+				xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(
+					channel_id.clone(),
+					open_requests
+				)
+			),
+			Ok(expected_encoded)
+		);
+	}
 }

--- a/runtime/relay-encoder/src/kusama.rs
+++ b/runtime/relay-encoder/src/kusama.rs
@@ -80,6 +80,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
+	#[codec(index = 3u8)]
+	DeclineOpenChannel(ParaId),
 }
 
 pub struct KusamaEncoder;
@@ -112,6 +114,9 @@ impl xcm_primitives::HrmpEncodeCall for KusamaEncoder {
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
+			}
+			xcm_primitives::HrmpAvailableCalls::DeclineOpenChannel(a) => {
+				Ok(RelayCall::Hrmp(HrmpCall::DeclineOpenChannel(a.clone())).encode())
 			}
 		}
 	}

--- a/runtime/relay-encoder/src/kusama.rs
+++ b/runtime/relay-encoder/src/kusama.rs
@@ -81,7 +81,7 @@ pub enum HrmpCall {
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
 	#[codec(index = 3u8)]
-	DeclineOpenChannel(ParaId),
+	CancelOpenChannel(ParaId),
 }
 
 pub struct KusamaEncoder;
@@ -115,8 +115,8 @@ impl xcm_primitives::HrmpEncodeCall for KusamaEncoder {
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
-			xcm_primitives::HrmpAvailableCalls::DeclineOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::DeclineOpenChannel(a.clone())).encode())
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
 			}
 		}
 	}

--- a/runtime/relay-encoder/src/kusama.rs
+++ b/runtime/relay-encoder/src/kusama.rs
@@ -80,8 +80,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
-	#[codec(index = 3u8)]
-	CancelOpenChannel(ParaId),
+	#[codec(index = 6u8)]
+	CancelOpenChannel(HrmpChannelId, u32),
 }
 
 pub struct KusamaEncoder;
@@ -115,8 +115,8 @@ impl xcm_primitives::HrmpEncodeCall for KusamaEncoder {
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
-			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a, b) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone(), b.clone())).encode())
 			}
 		}
 	}

--- a/runtime/relay-encoder/src/polkadot.rs
+++ b/runtime/relay-encoder/src/polkadot.rs
@@ -83,7 +83,7 @@ pub enum HrmpCall {
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
 	#[codec(index = 3u8)]
-	DeclineOpenChannel(ParaId),
+	CancelOpenChannel(ParaId),
 }
 
 pub struct PolkadotEncoder;
@@ -117,8 +117,8 @@ impl xcm_primitives::HrmpEncodeCall for PolkadotEncoder {
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
-			xcm_primitives::HrmpAvailableCalls::DeclineOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::DeclineOpenChannel(a.clone())).encode())
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
 			}
 		}
 	}

--- a/runtime/relay-encoder/src/polkadot.rs
+++ b/runtime/relay-encoder/src/polkadot.rs
@@ -82,8 +82,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
-	#[codec(index = 3u8)]
-	CancelOpenChannel(ParaId),
+	#[codec(index = 6u8)]
+	CancelOpenChannel(HrmpChannelId, u32),
 }
 
 pub struct PolkadotEncoder;
@@ -117,8 +117,8 @@ impl xcm_primitives::HrmpEncodeCall for PolkadotEncoder {
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
-			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a, b) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone(), b.clone())).encode())
 			}
 		}
 	}

--- a/runtime/relay-encoder/src/polkadot.rs
+++ b/runtime/relay-encoder/src/polkadot.rs
@@ -82,6 +82,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
+	#[codec(index = 3u8)]
+	DeclineOpenChannel(ParaId),
 }
 
 pub struct PolkadotEncoder;
@@ -114,6 +116,9 @@ impl xcm_primitives::HrmpEncodeCall for PolkadotEncoder {
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
+			}
+			xcm_primitives::HrmpAvailableCalls::DeclineOpenChannel(a) => {
+				Ok(RelayCall::Hrmp(HrmpCall::DeclineOpenChannel(a.clone())).encode())
 			}
 		}
 	}

--- a/runtime/relay-encoder/src/polkadot.rs
+++ b/runtime/relay-encoder/src/polkadot.rs
@@ -554,4 +554,40 @@ mod tests {
 			Ok(expected_encoded)
 		);
 	}
+
+	#[test]
+	fn test_hrmp_cancel() {
+		let mut expected_encoded: Vec<u8> = Vec::new();
+
+		let index = <polkadot_runtime::Runtime as frame_system::Config>::PalletInfo::index::<
+			polkadot_runtime::Hrmp,
+		>()
+		.unwrap() as u8;
+		expected_encoded.push(index);
+
+		let channel_id = HrmpChannelId {
+			sender: 1u32.into(),
+			recipient: 1u32.into(),
+		};
+		let open_requests: u32 = 1;
+
+		let mut expected = polkadot_runtime_parachains::hrmp::Call::<
+			polkadot_runtime::Runtime
+		>::hrmp_cancel_open_request {
+			channel_id: channel_id.clone(),
+			open_requests
+		}
+		.encode();
+		expected_encoded.append(&mut expected);
+
+		assert_eq!(
+			<PolkadotEncoder as xcm_primitives::HrmpEncodeCall>::hrmp_encode_call(
+				xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(
+					channel_id.clone(),
+					open_requests
+				)
+			),
+			Ok(expected_encoded)
+		);
+	}
 }

--- a/runtime/relay-encoder/src/westend.rs
+++ b/runtime/relay-encoder/src/westend.rs
@@ -81,8 +81,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
-	#[codec(index = 3u8)]
-	CancelOpenChannel(ParaId),
+	#[codec(index = 6u8)]
+	CancelOpenChannel(HrmpChannelId, u32),
 }
 
 pub struct WestendEncoder;
@@ -116,8 +116,8 @@ impl xcm_primitives::HrmpEncodeCall for WestendEncoder {
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
-			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a, b) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone(), b.clone())).encode())
 			}
 		}
 	}

--- a/runtime/relay-encoder/src/westend.rs
+++ b/runtime/relay-encoder/src/westend.rs
@@ -82,7 +82,7 @@ pub enum HrmpCall {
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
 	#[codec(index = 3u8)]
-	DeclineOpenChannel(ParaId),
+	CancelOpenChannel(ParaId),
 }
 
 pub struct WestendEncoder;
@@ -116,8 +116,8 @@ impl xcm_primitives::HrmpEncodeCall for WestendEncoder {
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
 			}
-			xcm_primitives::HrmpAvailableCalls::DeclineOpenChannel(a) => {
-				Ok(RelayCall::Hrmp(HrmpCall::DeclineOpenChannel(a.clone())).encode())
+			xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(a) => {
+				Ok(RelayCall::Hrmp(HrmpCall::CancelOpenChannel(a.clone())).encode())
 			}
 		}
 	}

--- a/runtime/relay-encoder/src/westend.rs
+++ b/runtime/relay-encoder/src/westend.rs
@@ -552,4 +552,40 @@ mod tests {
 			Ok(expected_encoded)
 		);
 	}
+
+	#[test]
+	fn test_hrmp_cancel() {
+		let mut expected_encoded: Vec<u8> = Vec::new();
+
+		let index = <westend_runtime::Runtime as frame_system::Config>::PalletInfo::index::<
+			westend_runtime::Hrmp,
+		>()
+		.unwrap() as u8;
+		expected_encoded.push(index);
+
+		let channel_id = HrmpChannelId {
+			sender: 1u32.into(),
+			recipient: 1u32.into(),
+		};
+		let open_requests: u32 = 1;
+
+		let mut expected = polkadot_runtime_parachains::hrmp::Call::<
+			westend_runtime::Runtime
+		>::hrmp_cancel_open_request {
+			channel_id: channel_id.clone(),
+			open_requests
+		}
+		.encode();
+		expected_encoded.append(&mut expected);
+
+		assert_eq!(
+			<WestendEncoder as xcm_primitives::HrmpEncodeCall>::hrmp_encode_call(
+				xcm_primitives::HrmpAvailableCalls::CancelOpenChannel(
+					channel_id.clone(),
+					open_requests
+				)
+			),
+			Ok(expected_encoded)
+		);
+	}
 }

--- a/runtime/relay-encoder/src/westend.rs
+++ b/runtime/relay-encoder/src/westend.rs
@@ -81,6 +81,8 @@ pub enum HrmpCall {
 	AcceptOpenChannel(ParaId),
 	#[codec(index = 2u8)]
 	CloseChannel(HrmpChannelId),
+	#[codec(index = 3u8)]
+	DeclineOpenChannel(ParaId),
 }
 
 pub struct WestendEncoder;
@@ -113,6 +115,9 @@ impl xcm_primitives::HrmpEncodeCall for WestendEncoder {
 			}
 			xcm_primitives::HrmpAvailableCalls::CloseChannel(a) => {
 				Ok(RelayCall::Hrmp(HrmpCall::CloseChannel(a.clone())).encode())
+			}
+			xcm_primitives::HrmpAvailableCalls::DeclineOpenChannel(a) => {
+				Ok(RelayCall::Hrmp(HrmpCall::DeclineOpenChannel(a.clone())).encode())
 			}
 		}
 	}


### PR DESCRIPTION
### What does it do?

This PR introduces the possibility to cancel a request within `hrmp_manage()` extrinsic present in `xcm-transactor` pallet.

### Changes 
* Added `Cancel` variant to `HrmpOperation` enum.
```rust
pub enum HrmpOperation {
		InitOpen(HrmpInitParams),
		Accept {
			para_id: ParaId,
		},
		Close(HrmpChannelId),
		Cancel {
			channel_id: HrmpChannelId,
			open_requests: u32,
		},
	}
```
* Added `CancelOpenChannel` variant to `HrmpAvailableCalls` enum.
```rust
pub enum HrmpAvailableCalls {
	InitOpenChannel(ParaId, u32, u32),
	AcceptOpenChannel(ParaId),
	CloseChannel(HrmpChannelId),
	CancelOpenChannel(HrmpChannelId, u32),
}

```
* Also modified `hrmp_encode_call()` implementation of ***polkadot***, ***kusama*** and ***westend*** relay encoders to accept these new variants. 