### PR TITLE
Allows Ethereum Tracing with Collator

### DIFF
--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -151,8 +151,6 @@ pub struct RunCmd {
 	/// Enable EVM tracing module on a non-authority node.
 	#[clap(
 		long,
-		conflicts_with = "collator",
-		conflicts_with = "validator",
 		value_delimiter = ','
 	)]
 	pub ethapi: Vec<EthApi>,

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -149,10 +149,7 @@ pub struct RunCmd {
 	// pub author_id: Option<NimbusId>,
 
 	/// Enable EVM tracing module on a non-authority node.
-	#[clap(
-		long,
-		value_delimiter = ','
-	)]
+	#[clap(long, value_delimiter = ',')]
 	pub ethapi: Vec<EthApi>,
 
 	/// Number of concurrent tracing tasks. Meant to be shared by both "debug" and "trace" modules.


### PR DESCRIPTION
Currently it is not possible to debug a forked node (running as collator) with tracing.
I'm not sure what is the reason to prevent it except that if a collator is overriding runtime while producing a block, it will produce an invalid one. But this can be done with `--wasm-runtime-overrides` so preventing `--ethapi` is not really a good solution. 