### PR TITLE
Add conviction voting Split, SplitAbstain vote options

### DIFF
--- a/precompiles/conviction-voting/ConvictionVoting.sol
+++ b/precompiles/conviction-voting/ConvictionVoting.sol
@@ -55,6 +55,26 @@ interface ConvictionVoting {
         Conviction conviction
     ) external;
 
+    /// @dev Vote split in a poll.
+    /// @custom:selector dd6c52a4
+    /// @param pollIndex Index of poll
+    /// @param aye Balance locked for aye vote
+    /// @param nay Balance locked for nay vote
+    function voteSplit(uint32 pollIndex, uint256 aye, uint256 nay) external;
+
+    /// @dev Vote split abstain in a poll.
+    /// @custom:selector 52004540
+    /// @param pollIndex Index of poll
+    /// @param aye Balance locked for aye vote
+    /// @param nay Balance locked for nay vote
+    /// @param abstain Balance locked for abstain vote (support)
+    function voteSplitAbstain(
+        uint32 pollIndex,
+        uint256 aye,
+        uint256 nay,
+        uint256 abstain
+    ) external;
+
     /// @dev Remove vote in poll
     /// @custom:selector 79cae220
     /// @param pollIndex Index of the poll

--- a/precompiles/conviction-voting/ConvictionVoting.sol
+++ b/precompiles/conviction-voting/ConvictionVoting.sol
@@ -130,6 +130,34 @@ interface ConvictionVoting {
         uint8 conviction
     );
 
+    /// @dev An account made a split vote in a poll.
+    /// @custom:selector 022787093a8aa26fe59d28969068711f73e0e78ae67d9359c71058b6a21f7ef0
+    /// @param pollIndex uint32 Index of the poll.
+    /// @param voter address Address of the voter.
+    /// @param aye uint256 Amount for aye vote.
+    /// @param nay uint256 Amount for nay vote.
+    event VoteSplit(
+        uint32 indexed pollIndex,
+        address voter,
+        uint256 aye,
+        uint256 nay
+    );
+
+    /// @dev An account made a split abstain vote in a poll.
+    /// @custom:selector 476e687ab5e38fc714552f3acc083d7d83ccaa12ea11dd5f3393478d158c6fd4
+    /// @param pollIndex uint32 Index of the poll.
+    /// @param voter address Address of the voter.
+    /// @param aye uint256 Amount for aye vote.
+    /// @param nay uint256 Amount for nay vote.
+    /// @param abstain uint256 Amount for abstained.
+    event VoteSplitAbstained(
+        uint32 indexed pollIndex,
+        address voter,
+        uint256 aye,
+        uint256 nay,
+        uint256 abstain
+    );
+
     /// @dev An account removed its vote from an ongoing poll.
     /// @custom:selector 49fc1dd929f126e1d88cbb9c135625e30c2deba291adeea4740e446098b9957b
     /// @param pollIndex uint32 Index of the poll.

--- a/precompiles/conviction-voting/src/lib.rs
+++ b/precompiles/conviction-voting/src/lib.rs
@@ -136,7 +136,7 @@ where
 			AccountVote::Standard {
 				vote: Vote {
 					aye: true,
-					conviction: Self::u8_to_conviction(conviction)?,
+					conviction: Self::u8_to_conviction(conviction).in_field("conviction")?,
 				},
 				balance: vote_amount,
 			},

--- a/precompiles/conviction-voting/src/lib.rs
+++ b/precompiles/conviction-voting/src/lib.rs
@@ -476,6 +476,8 @@ where
 					event,
 				)
 			}
+			#[allow(unreachable_patterns)] // in case a new vote variant is added then still works
+			_ => return Err(RevertReason::custom("Vote variant unsupported").into()),
 		};
 		handle.record_log_costs(&[&event])?;
 		Ok((Self::u32_to_index(poll_index)?, vote, event))

--- a/precompiles/conviction-voting/src/lib.rs
+++ b/precompiles/conviction-voting/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) const SELECTOR_LOG_VOTE_SPLIT: [u8; 32] =
 
 /// Solidity selector of the Vote Split Abstained log, which is the Keccak of the Log signature.
 pub(crate) const SELECTOR_LOG_VOTE_SPLIT_ABSTAINED: [u8; 32] =
-	keccak256!("VoteSplit(uint32,address,uint256,uint256,uint256)");
+	keccak256!("VoteSplitAbstained(uint32,address,uint256,uint256,uint256)");
 
 /// Solidity selector of the VoteRemove log, which is the Keccak of the Log signature.
 pub(crate) const SELECTOR_LOG_VOTE_REMOVED: [u8; 32] = keccak256!("VoteRemoved(uint32,address)");

--- a/precompiles/conviction-voting/src/lib.rs
+++ b/precompiles/conviction-voting/src/lib.rs
@@ -476,8 +476,6 @@ where
 					event,
 				)
 			}
-			#[allow(unreachable_patterns)] // in case a new vote variant is added then still works
-			_ => return Err(RevertReason::custom("Vote variant unsupported").into()),
 		};
 		handle.record_log_costs(&[&event])?;
 		Ok((Self::u32_to_index(poll_index)?, vote, event))

--- a/precompiles/conviction-voting/src/lib.rs
+++ b/precompiles/conviction-voting/src/lib.rs
@@ -162,7 +162,7 @@ where
 			AccountVote::Standard {
 				vote: Vote {
 					aye: false,
-					conviction: Self::u8_to_conviction(conviction)?,
+					conviction: Self::u8_to_conviction(conviction).in_field("conviction")?,
 				},
 				balance: vote_amount,
 			},
@@ -431,7 +431,7 @@ where
 				(
 					AccountVote::Standard {
 						vote,
-						balance: Self::u256_to_amount(balance)?,
+						balance: Self::u256_to_amount(balance).in_field("voteAmount")?,
 					},
 					event,
 				)
@@ -449,8 +449,8 @@ where
 				);
 				(
 					AccountVote::Split {
-						aye: Self::u256_to_amount(aye)?,
-						nay: Self::u256_to_amount(nay)?,
+						aye: Self::u256_to_amount(aye).in_field("aye")?,
+						nay: Self::u256_to_amount(nay).in_field("nay")?,
 					},
 					event,
 				)
@@ -469,9 +469,9 @@ where
 				);
 				(
 					AccountVote::SplitAbstain {
-						aye: Self::u256_to_amount(aye)?,
-						nay: Self::u256_to_amount(nay)?,
-						abstain: Self::u256_to_amount(abstain)?,
+						aye: Self::u256_to_amount(aye).in_field("aye")?,
+						nay: Self::u256_to_amount(nay).in_field("nay")?,
+						abstain: Self::u256_to_amount(abstain).in_field("abstain")?,
 					},
 					event,
 				)

--- a/precompiles/conviction-voting/src/lib.rs
+++ b/precompiles/conviction-voting/src/lib.rs
@@ -105,7 +105,7 @@ where
 		vote: AccountVote<U256>,
 	) -> EvmResult {
 		let caller = handle.context().caller;
-		let (poll_index, vote, event) = Self::log_vote_event(handle, caller, poll_index, vote)?;
+		let (poll_index, vote, event) = Self::log_vote_event(handle, poll_index, vote)?;
 
 		let origin = Runtime::AddressMapping::into_account_id(caller);
 		let call = ConvictionVotingCall::<Runtime>::vote { poll_index, vote }.into();
@@ -411,14 +411,14 @@ where
 	}
 	fn log_vote_event(
 		handle: &mut impl PrecompileHandle,
-		caller: H160,
 		poll_index: u32,
 		vote: AccountVote<U256>,
 	) -> EvmResult<(IndexOf<Runtime>, AccountVote<BalanceOf<Runtime>>, Log)> {
+		let (contract_addr, caller) = (handle.context().address, handle.context().caller);
 		let (vote, event) = match vote {
 			AccountVote::Standard { vote, balance } => {
 				let event = log2(
-					caller,
+					contract_addr,
 					SELECTOR_LOG_VOTED,
 					H256::from_low_u64_be(poll_index as u64),
 					EvmDataWriter::new()
@@ -438,7 +438,7 @@ where
 			}
 			AccountVote::Split { aye, nay } => {
 				let event = log2(
-					caller,
+					contract_addr,
 					SELECTOR_LOG_VOTE_SPLIT,
 					H256::from_low_u64_be(poll_index as u64),
 					EvmDataWriter::new()
@@ -457,7 +457,7 @@ where
 			}
 			AccountVote::SplitAbstain { aye, nay, abstain } => {
 				let event = log2(
-					caller,
+					contract_addr,
 					SELECTOR_LOG_VOTE_SPLIT_ABSTAINED,
 					H256::from_low_u64_be(poll_index as u64),
 					EvmDataWriter::new()

--- a/precompiles/conviction-voting/src/tests.rs
+++ b/precompiles/conviction-voting/src/tests.rs
@@ -227,11 +227,6 @@ fn split_vote_logs_work() {
 		})
 }
 
-// #[test]
-// fn split_abstain_vote_logs_work() {
-
-// }
-
 #[test]
 fn remove_vote_logs_work() {
 	ExtBuilder::default()

--- a/precompiles/conviction-voting/src/tests.rs
+++ b/precompiles/conviction-voting/src/tests.rs
@@ -107,10 +107,10 @@ fn vote_logs_work() {
 			assert_ok!(vote(false, 99_000.into(), 1.into()));
 
 			// Assert vote events are emitted.
-			assert!(vec![
+			let expected_events = vec![
 				EvmEvent::Log {
 					log: log2(
-						Precompile1,
+						Precompile1, // why is this here instead of the caller address
 						SELECTOR_LOG_VOTED,
 						H256::from_low_u64_be(ONGOING_POLL_INDEX as u64),
 						EvmDataWriter::new()
@@ -135,10 +135,16 @@ fn vote_logs_work() {
 							.build(),
 					),
 				}
-				.into()
-			]
-			.iter()
-			.all(|log| events().contains(log)));
+				.into(),
+			];
+			for log in expected_events {
+				assert!(
+					events().contains(&log),
+					"Expected event not found: {:?}\nAll events:\n{:?}",
+					log,
+					events()
+				);
+			}
 		})
 }
 


### PR DESCRIPTION
Adds precompile method coverage for all possible votes expressible by `pallet_conviction::AccountVote`:
```rust
/// A vote for a referendum of a particular account.
#[derive(Encode, Decode, Copy, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
pub enum AccountVote<Balance> {
	/// A standard vote, one-way (approve or reject) with a given amount of conviction.
	Standard { vote: Vote, balance: Balance },
	/// A split vote with balances given for both ways, and with no conviction, useful for
	/// parachains when voting.
	Split { aye: Balance, nay: Balance },
	/// A split vote with balances given for both ways as well as abstentions, and with no
	/// conviction, useful for parachains when voting, other off-chain aggregate accounts and
	/// individuals who wish to abstain.
	SplitAbstain { aye: Balance, nay: Balance, abstain: Balance },
}
```
This PR also makes use of this type inside the conviction voting precompile to simplify the code.

**The idea behind SplitAbstain is to vote to end the referendum soon without expressing an opinion on it**. [substrate PR](https://github.com/paritytech/substrate/pull/12842)
