### PR TITLE
[MOON-2307] Precompile method conviction_voting::removeVoteForTrack

### DIFF
--- a/precompiles/conviction-voting/ConvictionVoting.sol
+++ b/precompiles/conviction-voting/ConvictionVoting.sol
@@ -80,11 +80,11 @@ interface ConvictionVoting {
     /// @param pollIndex Index of the poll
     function removeVote(uint32 pollIndex) external;
 
-    /// @dev Remove vote in poll with track
-    /// @custom:selector dd0988a6
+    /// @dev Remove vote in poll for track
+    /// @custom:selector cc3aee1a
     /// @param pollIndex Index of the poll
     /// @param trackId Id of the track
-    function removeSomeVote(uint32 pollIndex, uint16 trackId) external;
+    function removeVoteForTrack(uint32 pollIndex, uint16 trackId) external;
 
     /// @dev Remove vote in poll for other voter
     /// @custom:selector cbcb9276
@@ -175,7 +175,7 @@ interface ConvictionVoting {
     /// @param pollIndex uint32 Index of the poll.
     /// @param trackId uint32 TrackId of the poll.
     /// @param voter address Address of the voter.
-    event SomeVoteRemoved(
+    event VoteRemovedForTrack(
         uint32 indexed pollIndex,
         uint16 trackId,
         address voter

--- a/precompiles/conviction-voting/ConvictionVoting.sol
+++ b/precompiles/conviction-voting/ConvictionVoting.sol
@@ -170,6 +170,17 @@ interface ConvictionVoting {
     /// @param voter address Address of the voter.
     event VoteRemoved(uint32 indexed pollIndex, address voter);
 
+    /// @dev An account removed its vote from an ongoing poll.
+    /// @custom:selector 49fc1dd929f126e1d88cbb9c135625e30c2deba291adeea4740e446098b9957b
+    /// @param pollIndex uint32 Index of the poll.
+    /// @param trackId uint32 TrackId of the poll.
+    /// @param voter address Address of the voter.
+    event SomeVoteRemoved(
+        uint32 indexed pollIndex,
+        uint16 trackId,
+        address voter
+    );
+
     /// @dev An account removed a vote from a poll.
     /// @custom:selector c1d068675720ab00d0c8792a0cbc7e198c0d2202111f0280f039f2c09c50491b
     /// @param pollIndex uint32 Index of the poll.

--- a/precompiles/conviction-voting/ConvictionVoting.sol
+++ b/precompiles/conviction-voting/ConvictionVoting.sol
@@ -80,6 +80,12 @@ interface ConvictionVoting {
     /// @param pollIndex Index of the poll
     function removeVote(uint32 pollIndex) external;
 
+    /// @dev Remove vote in poll with track
+    /// @custom:selector dd0988a6
+    /// @param pollIndex Index of the poll
+    /// @param trackId Id of the track
+    function removeSomeVote(uint32 pollIndex, uint16 trackId) external;
+
     /// @dev Remove vote in poll for other voter
     /// @custom:selector cbcb9276
     //// @param target The voter to have vote removed. The removed vote must already be expired.

--- a/precompiles/conviction-voting/src/lib.rs
+++ b/precompiles/conviction-voting/src/lib.rs
@@ -68,6 +68,10 @@ pub(crate) const SELECTOR_LOG_VOTE_SPLIT_ABSTAINED: [u8; 32] =
 /// Solidity selector of the VoteRemove log, which is the Keccak of the Log signature.
 pub(crate) const SELECTOR_LOG_VOTE_REMOVED: [u8; 32] = keccak256!("VoteRemoved(uint32,address)");
 
+/// Solidity selector of the SomeVoteRemove log, which is the Keccak of the Log signature.
+pub(crate) const SELECTOR_LOG_SOME_VOTE_REMOVED: [u8; 32] =
+	keccak256!("SomeVoteRemoved(uint32,uint16,address)");
+
 /// Solidity selector of the VoteRemoveOther log, which is the Keccak of the Log signature.
 pub(crate) const SELECTOR_LOG_VOTE_REMOVED_OTHER: [u8; 32] =
 	keccak256!("VoteRemovedOther(uint32,address,address,uint16)");
@@ -208,33 +212,7 @@ where
 
 	#[precompile::public("removeVote(uint32)")]
 	fn remove_vote(handle: &mut impl PrecompileHandle, poll_index: u32) -> EvmResult {
-		let caller = handle.context().caller;
-		let event = log2(
-			handle.context().address,
-			SELECTOR_LOG_VOTE_REMOVED,
-			H256::from_low_u64_be(poll_index as u64), // poll index,
-			EvmDataWriter::new()
-				.write::<Address>(Address(caller))
-				.build(),
-		);
-		handle.record_log_costs(&[&event])?;
-
-		let index = Self::u32_to_index(poll_index).in_field("pollIndex")?;
-
-		log::trace!(
-			target: "conviction-voting-precompile",
-			"Removing vote from poll {:?}",
-			index
-		);
-
-		let origin = Runtime::AddressMapping::into_account_id(caller);
-		let call = ConvictionVotingCall::<Runtime>::remove_vote { class: None, index };
-
-		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
-
-		event.record(handle)?;
-
-		Ok(())
+		Self::rm_vote(handle, poll_index, None)
 	}
 
 	#[precompile::public("removeSomeVote(uint32,uint16)")]
@@ -243,33 +221,57 @@ where
 		poll_index: u32,
 		track_id: u16,
 	) -> EvmResult {
+		Self::rm_vote(handle, poll_index, Some(track_id))
+	}
+
+	/// Helper function for common code between remove_vote and remove_some_vote
+	fn rm_vote(
+		handle: &mut impl PrecompileHandle,
+		poll_index: u32,
+		maybe_track_id: Option<u16>,
+	) -> EvmResult {
 		let caller = handle.context().caller;
-		let event = log2(
-			handle.context().address,
-			SELECTOR_LOG_VOTE_REMOVED,
-			H256::from_low_u64_be(poll_index as u64), // poll index,
-			EvmDataWriter::new()
-				.write::<Address>(Address(caller))
-				.write::<u16>(track_id)
-				.build(),
-		);
-		handle.record_log_costs(&[&event])?;
-
-		let class = Self::u16_to_track_id(track_id).in_field("trackId")?;
 		let index = Self::u32_to_index(poll_index).in_field("pollIndex")?;
-
-		log::trace!(
-			target: "conviction-voting-precompile",
-			"Removing vote from poll {:?}, track {:?}",
-			index,
-			class,
-		);
+		let (event, class) = if let Some(track_id) = maybe_track_id {
+			log::trace!(
+				target: "conviction-voting-precompile",
+				"Removing vote from poll {:?}, track {:?}",
+				index,
+				track_id,
+			);
+			(
+				log2(
+					handle.context().address,
+					SELECTOR_LOG_SOME_VOTE_REMOVED,
+					H256::from_low_u64_be(poll_index as u64),
+					EvmDataWriter::new()
+						.write::<Address>(Address(caller))
+						.write::<u16>(track_id)
+						.build(),
+				),
+				Some(Self::u16_to_track_id(track_id).in_field("trackId")?),
+			)
+		} else {
+			log::trace!(
+				target: "conviction-voting-precompile",
+				"Removing vote from poll {:?}",
+				index,
+			);
+			(
+				log2(
+					handle.context().address,
+					SELECTOR_LOG_VOTE_REMOVED,
+					H256::from_low_u64_be(poll_index as u64),
+					EvmDataWriter::new()
+						.write::<Address>(Address(caller))
+						.build(),
+				),
+				None,
+			)
+		};
 
 		let origin = Runtime::AddressMapping::into_account_id(caller);
-		let call = ConvictionVotingCall::<Runtime>::remove_vote {
-			class: Some(class),
-			index,
-		};
+		let call = ConvictionVotingCall::<Runtime>::remove_vote { class, index };
 
 		RuntimeHelper::<Runtime>::try_dispatch(handle, Some(origin).into(), call)?;
 

--- a/precompiles/conviction-voting/src/lib.rs
+++ b/precompiles/conviction-voting/src/lib.rs
@@ -69,8 +69,8 @@ pub(crate) const SELECTOR_LOG_VOTE_SPLIT_ABSTAINED: [u8; 32] =
 pub(crate) const SELECTOR_LOG_VOTE_REMOVED: [u8; 32] = keccak256!("VoteRemoved(uint32,address)");
 
 /// Solidity selector of the SomeVoteRemove log, which is the Keccak of the Log signature.
-pub(crate) const SELECTOR_LOG_SOME_VOTE_REMOVED: [u8; 32] =
-	keccak256!("SomeVoteRemoved(uint32,uint16,address)");
+pub(crate) const SELECTOR_LOG_VOTE_REMOVED_FOR_TRACK: [u8; 32] =
+	keccak256!("VoteRemovedForTrack(uint32,uint16,address)");
 
 /// Solidity selector of the VoteRemoveOther log, which is the Keccak of the Log signature.
 pub(crate) const SELECTOR_LOG_VOTE_REMOVED_OTHER: [u8; 32] =
@@ -215,8 +215,8 @@ where
 		Self::rm_vote(handle, poll_index, None)
 	}
 
-	#[precompile::public("removeSomeVote(uint32,uint16)")]
-	fn remove_some_vote(
+	#[precompile::public("removeVoteForTrack(uint32,uint16)")]
+	fn remove_vote_for_track(
 		handle: &mut impl PrecompileHandle,
 		poll_index: u32,
 		track_id: u16,
@@ -235,18 +235,18 @@ where
 		let (event, class) = if let Some(track_id) = maybe_track_id {
 			log::trace!(
 				target: "conviction-voting-precompile",
-				"Removing vote from poll {:?}, track {:?}",
+				"Removing vote from poll {:?} for track {:?}",
 				index,
 				track_id,
 			);
 			(
 				log2(
 					handle.context().address,
-					SELECTOR_LOG_SOME_VOTE_REMOVED,
+					SELECTOR_LOG_VOTE_REMOVED_FOR_TRACK,
 					H256::from_low_u64_be(poll_index as u64),
 					EvmDataWriter::new()
-						.write::<Address>(Address(caller))
 						.write::<u16>(track_id)
+						.write::<Address>(Address(caller))
 						.build(),
 				),
 				Some(Self::u16_to_track_id(track_id).in_field("trackId")?),

--- a/precompiles/conviction-voting/src/tests.rs
+++ b/precompiles/conviction-voting/src/tests.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 use crate::{
-	mock::*, SELECTOR_LOG_DELEGATED, SELECTOR_LOG_SOME_VOTE_REMOVED, SELECTOR_LOG_UNDELEGATED,
-	SELECTOR_LOG_UNLOCKED, SELECTOR_LOG_VOTED, SELECTOR_LOG_VOTE_REMOVED,
+	mock::*, SELECTOR_LOG_DELEGATED, SELECTOR_LOG_UNDELEGATED, SELECTOR_LOG_UNLOCKED,
+	SELECTOR_LOG_VOTED, SELECTOR_LOG_VOTE_REMOVED, SELECTOR_LOG_VOTE_REMOVED_FOR_TRACK,
 	SELECTOR_LOG_VOTE_REMOVED_OTHER, SELECTOR_LOG_VOTE_SPLIT, SELECTOR_LOG_VOTE_SPLIT_ABSTAINED,
 };
 use precompile_utils::{prelude::*, testing::*, EvmDataWriter};
@@ -261,7 +261,7 @@ fn remove_vote_logs_work() {
 }
 
 #[test]
-fn remove_some_vote_logs_work() {
+fn remove_vote_for_track_logs_work() {
 	ExtBuilder::default()
 		.with_balances(vec![(Alice.into(), 100_000)])
 		.build()
@@ -270,7 +270,7 @@ fn remove_some_vote_logs_work() {
 			assert_ok!(standard_vote(true, 100_000.into(), 0.into()));
 
 			// ..and remove
-			let input = PCall::remove_some_vote {
+			let input = PCall::remove_vote_for_track {
 				poll_index: ONGOING_POLL_INDEX,
 				track_id: 0u16,
 			}
@@ -282,11 +282,11 @@ fn remove_some_vote_logs_work() {
 				&EvmEvent::Log {
 					log: log2(
 						Precompile1,
-						SELECTOR_LOG_SOME_VOTE_REMOVED,
+						SELECTOR_LOG_VOTE_REMOVED_FOR_TRACK,
 						H256::from_low_u64_be(ONGOING_POLL_INDEX as u64),
 						EvmDataWriter::new()
-							.write::<Address>(H160::from(Alice).into()) // caller
 							.write::<u16>(0u16)
+							.write::<Address>(H160::from(Alice).into()) // caller
 							.build(),
 					),
 				}

--- a/tests/contracts/compiled/ConvictionVoting.json
+++ b/tests/contracts/compiled/ConvictionVoting.json
@@ -107,6 +107,31 @@
           },
           {
             "indexed": false,
+            "internalType": "uint16",
+            "name": "trackId",
+            "type": "uint16"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "voter",
+            "type": "address"
+          }
+        ],
+        "name": "VoteRemovedForTrack",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "uint32",
+            "name": "pollIndex",
+            "type": "uint32"
+          },
+          {
+            "indexed": false,
             "internalType": "address",
             "name": "caller",
             "type": "address"
@@ -125,6 +150,74 @@
           }
         ],
         "name": "VoteRemovedOther",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "uint32",
+            "name": "pollIndex",
+            "type": "uint32"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "voter",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "aye",
+            "type": "uint256"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "nay",
+            "type": "uint256"
+          }
+        ],
+        "name": "VoteSplit",
+        "type": "event"
+      },
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "internalType": "uint32",
+            "name": "pollIndex",
+            "type": "uint32"
+          },
+          {
+            "indexed": false,
+            "internalType": "address",
+            "name": "voter",
+            "type": "address"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "aye",
+            "type": "uint256"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "nay",
+            "type": "uint256"
+          },
+          {
+            "indexed": false,
+            "internalType": "uint256",
+            "name": "abstain",
+            "type": "uint256"
+          }
+        ],
+        "name": "VoteSplitAbstained",
         "type": "event"
       },
       {
@@ -206,6 +299,16 @@
       },
       {
         "inputs": [
+          { "internalType": "uint32", "name": "pollIndex", "type": "uint32" },
+          { "internalType": "uint16", "name": "trackId", "type": "uint16" }
+        ],
+        "name": "removeVoteForTrack",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
           { "internalType": "uint16", "name": "trackId", "type": "uint16" }
         ],
         "name": "undelegate",
@@ -238,6 +341,29 @@
           }
         ],
         "name": "voteNo",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          { "internalType": "uint32", "name": "pollIndex", "type": "uint32" },
+          { "internalType": "uint256", "name": "aye", "type": "uint256" },
+          { "internalType": "uint256", "name": "nay", "type": "uint256" }
+        ],
+        "name": "voteSplit",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+      },
+      {
+        "inputs": [
+          { "internalType": "uint32", "name": "pollIndex", "type": "uint32" },
+          { "internalType": "uint256", "name": "aye", "type": "uint256" },
+          { "internalType": "uint256", "name": "nay", "type": "uint256" },
+          { "internalType": "uint256", "name": "abstain", "type": "uint256" }
+        ],
+        "name": "voteSplitAbstain",
         "outputs": [],
         "stateMutability": "nonpayable",
         "type": "function"
@@ -301,6 +427,15 @@
             "voter": "address Address of the voter."
           }
         },
+        "VoteRemovedForTrack(uint32,uint16,address)": {
+          "custom:selector": "49fc1dd929f126e1d88cbb9c135625e30c2deba291adeea4740e446098b9957b",
+          "details": "An account removed its vote from an ongoing poll.",
+          "params": {
+            "pollIndex": "uint32 Index of the poll.",
+            "trackId": "uint32 TrackId of the poll.",
+            "voter": "address Address of the voter."
+          }
+        },
         "VoteRemovedOther(uint32,address,address,uint16)": {
           "custom:selector": "c1d068675720ab00d0c8792a0cbc7e198c0d2202111f0280f039f2c09c50491b",
           "details": "An account removed a vote from a poll.",
@@ -309,6 +444,27 @@
             "pollIndex": "uint32 Index of the poll.",
             "target": "address Address of the address which's vote is being removed.",
             "trackId": "uint16 The trackId."
+          }
+        },
+        "VoteSplit(uint32,address,uint256,uint256)": {
+          "custom:selector": "022787093a8aa26fe59d28969068711f73e0e78ae67d9359c71058b6a21f7ef0",
+          "details": "An account made a split vote in a poll.",
+          "params": {
+            "aye": "uint256 Amount for aye vote.",
+            "nay": "uint256 Amount for nay vote.",
+            "pollIndex": "uint32 Index of the poll.",
+            "voter": "address Address of the voter."
+          }
+        },
+        "VoteSplitAbstained(uint32,address,uint256,uint256,uint256)": {
+          "custom:selector": "476e687ab5e38fc714552f3acc083d7d83ccaa12ea11dd5f3393478d158c6fd4",
+          "details": "An account made a split abstain vote in a poll.",
+          "params": {
+            "abstain": "uint256 Amount for abstained.",
+            "aye": "uint256 Amount for aye vote.",
+            "nay": "uint256 Amount for nay vote.",
+            "pollIndex": "uint32 Index of the poll.",
+            "voter": "address Address of the voter."
           }
         },
         "Voted(uint32,address,bool,uint256,uint8)": {
@@ -343,6 +499,14 @@
           "details": "Remove vote in poll",
           "params": { "pollIndex": "Index of the poll" }
         },
+        "removeVoteForTrack(uint32,uint16)": {
+          "custom:selector": "cc3aee1a",
+          "details": "Remove vote in poll for track",
+          "params": {
+            "pollIndex": "Index of the poll",
+            "trackId": "Id of the track"
+          }
+        },
         "undelegate(uint16)": {
           "custom:selector": "98be4094",
           "details": "Undelegate for the trackId",
@@ -360,6 +524,25 @@
             "conviction": "Conviction multiplier for length of vote lock",
             "pollIndex": "Index of poll",
             "voteAmount": "Balance locked for vote"
+          }
+        },
+        "voteSplit(uint32,uint256,uint256)": {
+          "custom:selector": "dd6c52a4",
+          "details": "Vote split in a poll.",
+          "params": {
+            "aye": "Balance locked for aye vote",
+            "nay": "Balance locked for nay vote",
+            "pollIndex": "Index of poll"
+          }
+        },
+        "voteSplitAbstain(uint32,uint256,uint256,uint256)": {
+          "custom:selector": "52004540",
+          "details": "Vote split abstain in a poll.",
+          "params": {
+            "abstain": "Balance locked for abstain vote (support)",
+            "aye": "Balance locked for aye vote",
+            "nay": "Balance locked for nay vote",
+            "pollIndex": "Index of poll"
           }
         },
         "voteYes(uint32,uint256,uint8)": {
@@ -400,16 +583,19 @@
         "delegate(uint16,address,uint8,uint256)": "681750e8",
         "removeOtherVote(address,uint16,uint32)": "cbcb9276",
         "removeVote(uint32)": "79cae220",
+        "removeVoteForTrack(uint32,uint16)": "cc3aee1a",
         "undelegate(uint16)": "98be4094",
         "unlock(uint16,address)": "4259d98c",
         "voteNo(uint32,uint256,uint8)": "cc600eba",
+        "voteSplit(uint32,uint256,uint256)": "dd6c52a4",
+        "voteSplitAbstain(uint32,uint256,uint256,uint256)": "52004540",
         "voteYes(uint32,uint256,uint8)": "da9df518"
       }
     },
     "ewasm": { "wasm": "" },
-    "metadata": "{\"compiler\":{\"version\":\"0.8.17+commit.8df45f5f\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"delegatedAmount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"conviction\",\"type\":\"uint8\"}],\"name\":\"Delegated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"caller\",\"type\":\"address\"}],\"name\":\"Undelegated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"caller\",\"type\":\"address\"}],\"name\":\"Unlocked\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"voter\",\"type\":\"address\"}],\"name\":\"VoteRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"caller\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"}],\"name\":\"VoteRemovedOther\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"voter\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"aye\",\"type\":\"bool\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"voteAmount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"conviction\",\"type\":\"uint8\"}],\"name\":\"Voted\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"internalType\":\"address\",\"name\":\"representative\",\"type\":\"address\"},{\"internalType\":\"enum ConvictionVoting.Conviction\",\"name\":\"conviction\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"delegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"}],\"name\":\"removeOtherVote\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"}],\"name\":\"removeVote\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"}],\"name\":\"undelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"unlock\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"voteAmount\",\"type\":\"uint256\"},{\"internalType\":\"enum ConvictionVoting.Conviction\",\"name\":\"conviction\",\"type\":\"uint8\"}],\"name\":\"voteNo\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"voteAmount\",\"type\":\"uint256\"},{\"internalType\":\"enum ConvictionVoting.Conviction\",\"name\":\"conviction\",\"type\":\"uint8\"}],\"name\":\"voteYes\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"author\":\"The Moonbeam Team\",\"custom:address\":\"0x0000000000000000000000000000000000000812\",\"events\":{\"Delegated(uint16,address,address,uint256,uint8)\":{\"custom:selector\":\"6cc151d547592e227b1e85a264ac3699c6f1014112b08bb3832de1f23b9c66db\",\"details\":\"An account delegated for the given trackId.\",\"params\":{\"conviction\":\"uint8 Conviction being delegated.\",\"delegatedAmount\":\"uint256 Amount being delegated.\",\"from\":\"address Address of the caller.\",\"to\":\"address Address of the representative.\",\"trackId\":\"uint16 The trackId.\"}},\"Undelegated(uint16,address)\":{\"custom:selector\":\"1053303328f6db14014ccced6297bcad2b3897157ce46070711ab995a05dfa14\",\"details\":\"An account undelegated for the given trackId.\",\"params\":{\"caller\":\"address Address of the caller.\",\"trackId\":\"uint16 The trackId.\"}},\"Unlocked(uint16,address)\":{\"custom:selector\":\"dcf72fa65ca7fb720b9ccc8ee28e0188edc3d943115124cdd4086c49f836a128\",\"details\":\"An account called to unlock tokens for the given trackId.\",\"params\":{\"caller\":\"address Address of the caller.\",\"trackId\":\"uint16 The trackId.\"}},\"VoteRemoved(uint32,address)\":{\"custom:selector\":\"49fc1dd929f126e1d88cbb9c135625e30c2deba291adeea4740e446098b9957b\",\"details\":\"An account removed its vote from an ongoing poll.\",\"params\":{\"pollIndex\":\"uint32 Index of the poll.\",\"voter\":\"address Address of the voter.\"}},\"VoteRemovedOther(uint32,address,address,uint16)\":{\"custom:selector\":\"c1d068675720ab00d0c8792a0cbc7e198c0d2202111f0280f039f2c09c50491b\",\"details\":\"An account removed a vote from a poll.\",\"params\":{\"caller\":\"address Address of the origin caller.\",\"pollIndex\":\"uint32 Index of the poll.\",\"target\":\"address Address of the address which's vote is being removed.\",\"trackId\":\"uint16 The trackId.\"}},\"Voted(uint32,address,bool,uint256,uint8)\":{\"custom:selector\":\"3839f7832b2a6263aa1fd5040f37d10fd4f9e9c4a9ef07ec384cb1cef9fb4c0e\",\"details\":\"An account made a vote in a poll.\",\"params\":{\"aye\":\"bool Is it a vote for or against the poll.\",\"conviction\":\"uint8 Conviction of the vote.\",\"pollIndex\":\"uint32 Index of the poll.\",\"voteAmount\":\"uint256 Amount used to vote.\",\"voter\":\"address Address of the voter.\"}}},\"kind\":\"dev\",\"methods\":{\"delegate(uint16,address,uint8,uint256)\":{\"custom:selector\":\"681750e8\",\"details\":\"Delegate to a representative for the vote trackId\",\"params\":{\"amount\":\"delegated to representative for this vote trackId\",\"conviction\":\"The conviction multiplier\",\"representative\":\"The representative for the trackId\",\"trackId\":\"The trackId\"}},\"removeOtherVote(address,uint16,uint32)\":{\"params\":{\"pollIndex\":\"the poll index\",\"trackId\":\"The trackId\"}},\"removeVote(uint32)\":{\"custom:selector\":\"79cae220\",\"details\":\"Remove vote in poll\",\"params\":{\"pollIndex\":\"Index of the poll\"}},\"undelegate(uint16)\":{\"custom:selector\":\"98be4094\",\"details\":\"Undelegate for the trackId\",\"params\":{\"trackId\":\"The trackId\"}},\"unlock(uint16,address)\":{\"custom:selector\":\"4259d98c\",\"details\":\"Unlock tokens locked for trackId\",\"params\":{\"target\":\"The target address\",\"trackId\":\"The trackId\"}},\"voteNo(uint32,uint256,uint8)\":{\"custom:selector\":\"cc600eba\",\"details\":\"Vote no in a poll.\",\"params\":{\"conviction\":\"Conviction multiplier for length of vote lock\",\"pollIndex\":\"Index of poll\",\"voteAmount\":\"Balance locked for vote\"}},\"voteYes(uint32,uint256,uint8)\":{\"custom:selector\":\"da9df518\",\"details\":\"Vote yes in a poll.\",\"params\":{\"conviction\":\"Conviction multiplier for length of vote lock\",\"pollIndex\":\"Index of poll\",\"voteAmount\":\"Balance locked for vote\"}}},\"title\":\"Pallet Conviction Voting InterfaceThe interface through which solidity contracts will interact with the Conviction Voting pallet\",\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"main.sol\":\"ConvictionVoting\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"main.sol\":{\"keccak256\":\"0x2ee018e2de05f175dc13f1eada66c145ee9b86c79eabcea8475681d840e2374d\",\"license\":\"GPL-3.0-only\",\"urls\":[\"bzz-raw://9f57de4887b65be5bb52e848513bd3471c4275ff6df34d2a647dc421054122b3\",\"dweb:/ipfs/QmYt2F5e6VHUc5MdhsaSsTcZbctSNeUH9ncgCihSx37uc3\"]}},\"version\":1}",
+    "metadata": "{\"compiler\":{\"version\":\"0.8.19+commit.7dd6d404\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"delegatedAmount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"conviction\",\"type\":\"uint8\"}],\"name\":\"Delegated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"caller\",\"type\":\"address\"}],\"name\":\"Undelegated\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"caller\",\"type\":\"address\"}],\"name\":\"Unlocked\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"voter\",\"type\":\"address\"}],\"name\":\"VoteRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"voter\",\"type\":\"address\"}],\"name\":\"VoteRemovedForTrack\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"caller\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"}],\"name\":\"VoteRemovedOther\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"voter\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"aye\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nay\",\"type\":\"uint256\"}],\"name\":\"VoteSplit\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"voter\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"aye\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"nay\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"abstain\",\"type\":\"uint256\"}],\"name\":\"VoteSplitAbstained\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"voter\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bool\",\"name\":\"aye\",\"type\":\"bool\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"voteAmount\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint8\",\"name\":\"conviction\",\"type\":\"uint8\"}],\"name\":\"Voted\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"internalType\":\"address\",\"name\":\"representative\",\"type\":\"address\"},{\"internalType\":\"enum ConvictionVoting.Conviction\",\"name\":\"conviction\",\"type\":\"uint8\"},{\"internalType\":\"uint256\",\"name\":\"amount\",\"type\":\"uint256\"}],\"name\":\"delegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"},{\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"}],\"name\":\"removeOtherVote\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"}],\"name\":\"removeVote\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"}],\"name\":\"removeVoteForTrack\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"}],\"name\":\"undelegate\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint16\",\"name\":\"trackId\",\"type\":\"uint16\"},{\"internalType\":\"address\",\"name\":\"target\",\"type\":\"address\"}],\"name\":\"unlock\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"voteAmount\",\"type\":\"uint256\"},{\"internalType\":\"enum ConvictionVoting.Conviction\",\"name\":\"conviction\",\"type\":\"uint8\"}],\"name\":\"voteNo\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"aye\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nay\",\"type\":\"uint256\"}],\"name\":\"voteSplit\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"aye\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"nay\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"abstain\",\"type\":\"uint256\"}],\"name\":\"voteSplitAbstain\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"pollIndex\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"voteAmount\",\"type\":\"uint256\"},{\"internalType\":\"enum ConvictionVoting.Conviction\",\"name\":\"conviction\",\"type\":\"uint8\"}],\"name\":\"voteYes\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"author\":\"The Moonbeam Team\",\"custom:address\":\"0x0000000000000000000000000000000000000812\",\"events\":{\"Delegated(uint16,address,address,uint256,uint8)\":{\"custom:selector\":\"6cc151d547592e227b1e85a264ac3699c6f1014112b08bb3832de1f23b9c66db\",\"details\":\"An account delegated for the given trackId.\",\"params\":{\"conviction\":\"uint8 Conviction being delegated.\",\"delegatedAmount\":\"uint256 Amount being delegated.\",\"from\":\"address Address of the caller.\",\"to\":\"address Address of the representative.\",\"trackId\":\"uint16 The trackId.\"}},\"Undelegated(uint16,address)\":{\"custom:selector\":\"1053303328f6db14014ccced6297bcad2b3897157ce46070711ab995a05dfa14\",\"details\":\"An account undelegated for the given trackId.\",\"params\":{\"caller\":\"address Address of the caller.\",\"trackId\":\"uint16 The trackId.\"}},\"Unlocked(uint16,address)\":{\"custom:selector\":\"dcf72fa65ca7fb720b9ccc8ee28e0188edc3d943115124cdd4086c49f836a128\",\"details\":\"An account called to unlock tokens for the given trackId.\",\"params\":{\"caller\":\"address Address of the caller.\",\"trackId\":\"uint16 The trackId.\"}},\"VoteRemoved(uint32,address)\":{\"custom:selector\":\"49fc1dd929f126e1d88cbb9c135625e30c2deba291adeea4740e446098b9957b\",\"details\":\"An account removed its vote from an ongoing poll.\",\"params\":{\"pollIndex\":\"uint32 Index of the poll.\",\"voter\":\"address Address of the voter.\"}},\"VoteRemovedForTrack(uint32,uint16,address)\":{\"custom:selector\":\"49fc1dd929f126e1d88cbb9c135625e30c2deba291adeea4740e446098b9957b\",\"details\":\"An account removed its vote from an ongoing poll.\",\"params\":{\"pollIndex\":\"uint32 Index of the poll.\",\"trackId\":\"uint32 TrackId of the poll.\",\"voter\":\"address Address of the voter.\"}},\"VoteRemovedOther(uint32,address,address,uint16)\":{\"custom:selector\":\"c1d068675720ab00d0c8792a0cbc7e198c0d2202111f0280f039f2c09c50491b\",\"details\":\"An account removed a vote from a poll.\",\"params\":{\"caller\":\"address Address of the origin caller.\",\"pollIndex\":\"uint32 Index of the poll.\",\"target\":\"address Address of the address which's vote is being removed.\",\"trackId\":\"uint16 The trackId.\"}},\"VoteSplit(uint32,address,uint256,uint256)\":{\"custom:selector\":\"022787093a8aa26fe59d28969068711f73e0e78ae67d9359c71058b6a21f7ef0\",\"details\":\"An account made a split vote in a poll.\",\"params\":{\"aye\":\"uint256 Amount for aye vote.\",\"nay\":\"uint256 Amount for nay vote.\",\"pollIndex\":\"uint32 Index of the poll.\",\"voter\":\"address Address of the voter.\"}},\"VoteSplitAbstained(uint32,address,uint256,uint256,uint256)\":{\"custom:selector\":\"476e687ab5e38fc714552f3acc083d7d83ccaa12ea11dd5f3393478d158c6fd4\",\"details\":\"An account made a split abstain vote in a poll.\",\"params\":{\"abstain\":\"uint256 Amount for abstained.\",\"aye\":\"uint256 Amount for aye vote.\",\"nay\":\"uint256 Amount for nay vote.\",\"pollIndex\":\"uint32 Index of the poll.\",\"voter\":\"address Address of the voter.\"}},\"Voted(uint32,address,bool,uint256,uint8)\":{\"custom:selector\":\"3839f7832b2a6263aa1fd5040f37d10fd4f9e9c4a9ef07ec384cb1cef9fb4c0e\",\"details\":\"An account made a vote in a poll.\",\"params\":{\"aye\":\"bool Is it a vote for or against the poll.\",\"conviction\":\"uint8 Conviction of the vote.\",\"pollIndex\":\"uint32 Index of the poll.\",\"voteAmount\":\"uint256 Amount used to vote.\",\"voter\":\"address Address of the voter.\"}}},\"kind\":\"dev\",\"methods\":{\"delegate(uint16,address,uint8,uint256)\":{\"custom:selector\":\"681750e8\",\"details\":\"Delegate to a representative for the vote trackId\",\"params\":{\"amount\":\"delegated to representative for this vote trackId\",\"conviction\":\"The conviction multiplier\",\"representative\":\"The representative for the trackId\",\"trackId\":\"The trackId\"}},\"removeOtherVote(address,uint16,uint32)\":{\"params\":{\"pollIndex\":\"the poll index\",\"trackId\":\"The trackId\"}},\"removeVote(uint32)\":{\"custom:selector\":\"79cae220\",\"details\":\"Remove vote in poll\",\"params\":{\"pollIndex\":\"Index of the poll\"}},\"removeVoteForTrack(uint32,uint16)\":{\"custom:selector\":\"cc3aee1a\",\"details\":\"Remove vote in poll for track\",\"params\":{\"pollIndex\":\"Index of the poll\",\"trackId\":\"Id of the track\"}},\"undelegate(uint16)\":{\"custom:selector\":\"98be4094\",\"details\":\"Undelegate for the trackId\",\"params\":{\"trackId\":\"The trackId\"}},\"unlock(uint16,address)\":{\"custom:selector\":\"4259d98c\",\"details\":\"Unlock tokens locked for trackId\",\"params\":{\"target\":\"The target address\",\"trackId\":\"The trackId\"}},\"voteNo(uint32,uint256,uint8)\":{\"custom:selector\":\"cc600eba\",\"details\":\"Vote no in a poll.\",\"params\":{\"conviction\":\"Conviction multiplier for length of vote lock\",\"pollIndex\":\"Index of poll\",\"voteAmount\":\"Balance locked for vote\"}},\"voteSplit(uint32,uint256,uint256)\":{\"custom:selector\":\"dd6c52a4\",\"details\":\"Vote split in a poll.\",\"params\":{\"aye\":\"Balance locked for aye vote\",\"nay\":\"Balance locked for nay vote\",\"pollIndex\":\"Index of poll\"}},\"voteSplitAbstain(uint32,uint256,uint256,uint256)\":{\"custom:selector\":\"52004540\",\"details\":\"Vote split abstain in a poll.\",\"params\":{\"abstain\":\"Balance locked for abstain vote (support)\",\"aye\":\"Balance locked for aye vote\",\"nay\":\"Balance locked for nay vote\",\"pollIndex\":\"Index of poll\"}},\"voteYes(uint32,uint256,uint8)\":{\"custom:selector\":\"da9df518\",\"details\":\"Vote yes in a poll.\",\"params\":{\"conviction\":\"Conviction multiplier for length of vote lock\",\"pollIndex\":\"Index of poll\",\"voteAmount\":\"Balance locked for vote\"}}},\"title\":\"Pallet Conviction Voting InterfaceThe interface through which solidity contracts will interact with the Conviction Voting pallet\",\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"main.sol\":\"ConvictionVoting\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"main.sol\":{\"keccak256\":\"0x792ed63d767cc168bd810adbc54f89958d6cfed6ce92c7adcfea5567c31c8f89\",\"license\":\"GPL-3.0-only\",\"urls\":[\"bzz-raw://26c0a267d2e4516b9f21ea61cb70809a1518eac5e0e40452c16fa98d5779f905\",\"dweb:/ipfs/QmfWBRAAZxwzTSzVhpGxo3oG83tRaHkkqkv5tjGjMU7zk1\"]}},\"version\":1}",
     "storageLayout": { "storage": [], "types": null },
     "userdoc": { "kind": "user", "methods": {}, "version": 1 }
   },
-  "sourceCode": "// SPDX-License-Identifier: GPL-3.0-only\npragma solidity >=0.8.3;\n\n/// @dev The Conviction Voting contract's address.\naddress constant CONVICTION_VOTING_ADDRESS = 0x0000000000000000000000000000000000000812;\n\n/// @dev The Conviction Voting contract's instance.\nConvictionVoting constant CONVICTION_VOTING_CONTRACT = ConvictionVoting(\n    CONVICTION_VOTING_ADDRESS\n);\n\n/// @author The Moonbeam Team\n/// @title Pallet Conviction Voting Interface\n/// @title The interface through which solidity contracts will interact with the Conviction Voting pallet\n/// @custom:address 0x0000000000000000000000000000000000000812\ninterface ConvictionVoting {\n    /// @dev Defines the conviction multiplier type.\n    /// The values start at `0` and are represented as `uint8`.\n    /// None => 0.1x votes, unlocked.\n    /// Locked1x => 1x votes, locked for an enactment period following a successful vote.\n    /// Locked2x => 2x votes, locked for 2x enactment periods following a successful vote\n    /// Locked3x => 3x votes, locked for 4x...\n    /// Locked4x => 4x votes, locked for 8x...,\n    /// Locked5x => 5x votes, locked for 16x...\n    /// Locked6x => 6x votes, locked for 32x...\n    enum Conviction {\n        None,\n        Locked1x,\n        Locked2x,\n        Locked3x,\n        Locked4x,\n        Locked5x,\n        Locked6x\n    }\n\n    /// @dev Vote yes in a poll.\n    /// @custom:selector da9df518\n    /// @param pollIndex Index of poll\n    /// @param voteAmount Balance locked for vote\n    /// @param conviction Conviction multiplier for length of vote lock\n    function voteYes(\n        uint32 pollIndex,\n        uint256 voteAmount,\n        Conviction conviction\n    ) external;\n\n    /// @dev Vote no in a poll.\n    /// @custom:selector cc600eba\n    /// @param pollIndex Index of poll\n    /// @param voteAmount Balance locked for vote\n    /// @param conviction Conviction multiplier for length of vote lock\n    function voteNo(\n        uint32 pollIndex,\n        uint256 voteAmount,\n        Conviction conviction\n    ) external;\n\n    /// @dev Remove vote in poll\n    /// @custom:selector 79cae220\n    /// @param pollIndex Index of the poll\n    function removeVote(uint32 pollIndex) external;\n\n    /// @dev Remove vote in poll for other voter\n    /// @custom:selector cbcb9276\n    //// @param target The voter to have vote removed. The removed vote must already be expired.\n    /// @param trackId The trackId\n    /// @param pollIndex the poll index\n    function removeOtherVote(\n        address target,\n        uint16 trackId,\n        uint32 pollIndex\n    ) external;\n\n    /// @dev Delegate to a representative for the vote trackId\n    /// @custom:selector 681750e8\n    /// @param trackId The trackId\n    /// @param representative The representative for the trackId\n    /// @param conviction The conviction multiplier\n    /// @param amount delegated to representative for this vote trackId\n    function delegate(\n        uint16 trackId,\n        address representative,\n        Conviction conviction,\n        uint256 amount\n    ) external;\n\n    /// @dev Undelegate for the trackId\n    /// @custom:selector 98be4094\n    /// @param trackId The trackId\n    function undelegate(uint16 trackId) external;\n\n    /// @dev Unlock tokens locked for trackId\n    /// @custom:selector 4259d98c\n    /// @param trackId The trackId\n    /// @param target The target address\n    function unlock(uint16 trackId, address target) external;\n\n    /// @dev An account made a vote in a poll.\n    /// @custom:selector 3839f7832b2a6263aa1fd5040f37d10fd4f9e9c4a9ef07ec384cb1cef9fb4c0e\n    /// @param pollIndex uint32 Index of the poll.\n    /// @param voter address Address of the voter.\n    /// @param aye bool Is it a vote for or against the poll.\n    /// @param voteAmount uint256 Amount used to vote.\n    /// @param conviction uint8 Conviction of the vote.\n    event Voted(\n        uint32 indexed pollIndex,\n        address voter,\n        bool aye,\n        uint256 voteAmount,\n        uint8 conviction\n    );\n\n    /// @dev An account removed its vote from an ongoing poll.\n    /// @custom:selector 49fc1dd929f126e1d88cbb9c135625e30c2deba291adeea4740e446098b9957b\n    /// @param pollIndex uint32 Index of the poll.\n    /// @param voter address Address of the voter.\n    event VoteRemoved(uint32 indexed pollIndex, address voter);\n\n    /// @dev An account removed a vote from a poll.\n    /// @custom:selector c1d068675720ab00d0c8792a0cbc7e198c0d2202111f0280f039f2c09c50491b\n    /// @param pollIndex uint32 Index of the poll.\n    /// @param caller address Address of the origin caller.\n    /// @param target address Address of the address which's vote is being removed.\n    /// @param trackId uint16 The trackId.\n    event VoteRemovedOther(\n        uint32 indexed pollIndex,\n        address caller,\n        address target,\n        uint16 trackId\n    );\n\n    /// @dev An account delegated for the given trackId.\n    /// @custom:selector 6cc151d547592e227b1e85a264ac3699c6f1014112b08bb3832de1f23b9c66db\n    /// @param trackId uint16 The trackId.\n    /// @param from address Address of the caller.\n    /// @param to address Address of the representative.\n    /// @param delegatedAmount uint256 Amount being delegated.\n    /// @param conviction uint8 Conviction being delegated.\n    event Delegated(\n        uint16 indexed trackId,\n        address from,\n        address to,\n        uint256 delegatedAmount,\n        uint8 conviction\n    );\n\n    /// @dev An account undelegated for the given trackId.\n    /// @custom:selector 1053303328f6db14014ccced6297bcad2b3897157ce46070711ab995a05dfa14\n    /// @param trackId uint16 The trackId.\n    /// @param caller address Address of the caller.\n    event Undelegated(uint16 indexed trackId, address caller);\n\n    /// @dev An account called to unlock tokens for the given trackId.\n    /// @custom:selector dcf72fa65ca7fb720b9ccc8ee28e0188edc3d943115124cdd4086c49f836a128\n    /// @param trackId uint16 The trackId.\n    /// @param caller address Address of the caller.\n    event Unlocked(uint16 indexed trackId, address caller);\n}\n"
+  "sourceCode": "// SPDX-License-Identifier: GPL-3.0-only\npragma solidity >=0.8.3;\n\n/// @dev The Conviction Voting contract's address.\naddress constant CONVICTION_VOTING_ADDRESS = 0x0000000000000000000000000000000000000812;\n\n/// @dev The Conviction Voting contract's instance.\nConvictionVoting constant CONVICTION_VOTING_CONTRACT = ConvictionVoting(\n    CONVICTION_VOTING_ADDRESS\n);\n\n/// @author The Moonbeam Team\n/// @title Pallet Conviction Voting Interface\n/// @title The interface through which solidity contracts will interact with the Conviction Voting pallet\n/// @custom:address 0x0000000000000000000000000000000000000812\ninterface ConvictionVoting {\n    /// @dev Defines the conviction multiplier type.\n    /// The values start at `0` and are represented as `uint8`.\n    /// None => 0.1x votes, unlocked.\n    /// Locked1x => 1x votes, locked for an enactment period following a successful vote.\n    /// Locked2x => 2x votes, locked for 2x enactment periods following a successful vote\n    /// Locked3x => 3x votes, locked for 4x...\n    /// Locked4x => 4x votes, locked for 8x...,\n    /// Locked5x => 5x votes, locked for 16x...\n    /// Locked6x => 6x votes, locked for 32x...\n    enum Conviction {\n        None,\n        Locked1x,\n        Locked2x,\n        Locked3x,\n        Locked4x,\n        Locked5x,\n        Locked6x\n    }\n\n    /// @dev Vote yes in a poll.\n    /// @custom:selector da9df518\n    /// @param pollIndex Index of poll\n    /// @param voteAmount Balance locked for vote\n    /// @param conviction Conviction multiplier for length of vote lock\n    function voteYes(\n        uint32 pollIndex,\n        uint256 voteAmount,\n        Conviction conviction\n    ) external;\n\n    /// @dev Vote no in a poll.\n    /// @custom:selector cc600eba\n    /// @param pollIndex Index of poll\n    /// @param voteAmount Balance locked for vote\n    /// @param conviction Conviction multiplier for length of vote lock\n    function voteNo(\n        uint32 pollIndex,\n        uint256 voteAmount,\n        Conviction conviction\n    ) external;\n\n    /// @dev Vote split in a poll.\n    /// @custom:selector dd6c52a4\n    /// @param pollIndex Index of poll\n    /// @param aye Balance locked for aye vote\n    /// @param nay Balance locked for nay vote\n    function voteSplit(uint32 pollIndex, uint256 aye, uint256 nay) external;\n\n    /// @dev Vote split abstain in a poll.\n    /// @custom:selector 52004540\n    /// @param pollIndex Index of poll\n    /// @param aye Balance locked for aye vote\n    /// @param nay Balance locked for nay vote\n    /// @param abstain Balance locked for abstain vote (support)\n    function voteSplitAbstain(\n        uint32 pollIndex,\n        uint256 aye,\n        uint256 nay,\n        uint256 abstain\n    ) external;\n\n    /// @dev Remove vote in poll\n    /// @custom:selector 79cae220\n    /// @param pollIndex Index of the poll\n    function removeVote(uint32 pollIndex) external;\n\n    /// @dev Remove vote in poll for track\n    /// @custom:selector cc3aee1a\n    /// @param pollIndex Index of the poll\n    /// @param trackId Id of the track\n    function removeVoteForTrack(uint32 pollIndex, uint16 trackId) external;\n\n    /// @dev Remove vote in poll for other voter\n    /// @custom:selector cbcb9276\n    //// @param target The voter to have vote removed. The removed vote must already be expired.\n    /// @param trackId The trackId\n    /// @param pollIndex the poll index\n    function removeOtherVote(\n        address target,\n        uint16 trackId,\n        uint32 pollIndex\n    ) external;\n\n    /// @dev Delegate to a representative for the vote trackId\n    /// @custom:selector 681750e8\n    /// @param trackId The trackId\n    /// @param representative The representative for the trackId\n    /// @param conviction The conviction multiplier\n    /// @param amount delegated to representative for this vote trackId\n    function delegate(\n        uint16 trackId,\n        address representative,\n        Conviction conviction,\n        uint256 amount\n    ) external;\n\n    /// @dev Undelegate for the trackId\n    /// @custom:selector 98be4094\n    /// @param trackId The trackId\n    function undelegate(uint16 trackId) external;\n\n    /// @dev Unlock tokens locked for trackId\n    /// @custom:selector 4259d98c\n    /// @param trackId The trackId\n    /// @param target The target address\n    function unlock(uint16 trackId, address target) external;\n\n    /// @dev An account made a vote in a poll.\n    /// @custom:selector 3839f7832b2a6263aa1fd5040f37d10fd4f9e9c4a9ef07ec384cb1cef9fb4c0e\n    /// @param pollIndex uint32 Index of the poll.\n    /// @param voter address Address of the voter.\n    /// @param aye bool Is it a vote for or against the poll.\n    /// @param voteAmount uint256 Amount used to vote.\n    /// @param conviction uint8 Conviction of the vote.\n    event Voted(\n        uint32 indexed pollIndex,\n        address voter,\n        bool aye,\n        uint256 voteAmount,\n        uint8 conviction\n    );\n\n    /// @dev An account made a split vote in a poll.\n    /// @custom:selector 022787093a8aa26fe59d28969068711f73e0e78ae67d9359c71058b6a21f7ef0\n    /// @param pollIndex uint32 Index of the poll.\n    /// @param voter address Address of the voter.\n    /// @param aye uint256 Amount for aye vote.\n    /// @param nay uint256 Amount for nay vote.\n    event VoteSplit(\n        uint32 indexed pollIndex,\n        address voter,\n        uint256 aye,\n        uint256 nay\n    );\n\n    /// @dev An account made a split abstain vote in a poll.\n    /// @custom:selector 476e687ab5e38fc714552f3acc083d7d83ccaa12ea11dd5f3393478d158c6fd4\n    /// @param pollIndex uint32 Index of the poll.\n    /// @param voter address Address of the voter.\n    /// @param aye uint256 Amount for aye vote.\n    /// @param nay uint256 Amount for nay vote.\n    /// @param abstain uint256 Amount for abstained.\n    event VoteSplitAbstained(\n        uint32 indexed pollIndex,\n        address voter,\n        uint256 aye,\n        uint256 nay,\n        uint256 abstain\n    );\n\n    /// @dev An account removed its vote from an ongoing poll.\n    /// @custom:selector 49fc1dd929f126e1d88cbb9c135625e30c2deba291adeea4740e446098b9957b\n    /// @param pollIndex uint32 Index of the poll.\n    /// @param voter address Address of the voter.\n    event VoteRemoved(uint32 indexed pollIndex, address voter);\n\n    /// @dev An account removed its vote from an ongoing poll.\n    /// @custom:selector 49fc1dd929f126e1d88cbb9c135625e30c2deba291adeea4740e446098b9957b\n    /// @param pollIndex uint32 Index of the poll.\n    /// @param trackId uint32 TrackId of the poll.\n    /// @param voter address Address of the voter.\n    event VoteRemovedForTrack(\n        uint32 indexed pollIndex,\n        uint16 trackId,\n        address voter\n    );\n\n    /// @dev An account removed a vote from a poll.\n    /// @custom:selector c1d068675720ab00d0c8792a0cbc7e198c0d2202111f0280f039f2c09c50491b\n    /// @param pollIndex uint32 Index of the poll.\n    /// @param caller address Address of the origin caller.\n    /// @param target address Address of the address which's vote is being removed.\n    /// @param trackId uint16 The trackId.\n    event VoteRemovedOther(\n        uint32 indexed pollIndex,\n        address caller,\n        address target,\n        uint16 trackId\n    );\n\n    /// @dev An account delegated for the given trackId.\n    /// @custom:selector 6cc151d547592e227b1e85a264ac3699c6f1014112b08bb3832de1f23b9c66db\n    /// @param trackId uint16 The trackId.\n    /// @param from address Address of the caller.\n    /// @param to address Address of the representative.\n    /// @param delegatedAmount uint256 Amount being delegated.\n    /// @param conviction uint8 Conviction being delegated.\n    event Delegated(\n        uint16 indexed trackId,\n        address from,\n        address to,\n        uint256 delegatedAmount,\n        uint8 conviction\n    );\n\n    /// @dev An account undelegated for the given trackId.\n    /// @custom:selector 1053303328f6db14014ccced6297bcad2b3897157ce46070711ab995a05dfa14\n    /// @param trackId uint16 The trackId.\n    /// @param caller address Address of the caller.\n    event Undelegated(uint16 indexed trackId, address caller);\n\n    /// @dev An account called to unlock tokens for the given trackId.\n    /// @custom:selector dcf72fa65ca7fb720b9ccc8ee28e0188edc3d943115124cdd4086c49f836a128\n    /// @param trackId uint16 The trackId.\n    /// @param caller address Address of the caller.\n    event Unlocked(uint16 indexed trackId, address caller);\n}\n"
 }

--- a/tests/tests/test-precompile/test-precompile-conviction-voting.ts
+++ b/tests/tests/test-precompile/test-precompile-conviction-voting.ts
@@ -1,0 +1,324 @@
+import "@moonbeam-network/api-augment";
+import Debug from "debug";
+import Contract from "web3-eth-contract";
+import { expect } from "chai";
+import { ethers } from "ethers";
+import { BALTATHAR_PRIVATE_KEY, alith, baltathar } from "../../util/accounts";
+import { PRECOMPILE_CONVICTION_VOTING_ADDRESS } from "../../util/constants";
+
+import { getCompiled } from "../../util/contracts";
+
+import { expectSubstrateEvent } from "../../util/expect";
+
+import { DevTestContext, describeDevMoonbeam } from "../../util/setup-dev-tests";
+import { createContractExecution } from "../../util/transactions";
+import { expectEVMResult, extractRevertReason } from "../../util/eth-transactions";
+import { ApiPromise } from "@polkadot/api";
+const debug = Debug("test:precompile-conviction-voting");
+
+const CONVICTION_VOTING_CONTRACT = getCompiled("ConvictionVoting");
+const CONVICTION_VOTING_INTERFACE = new ethers.utils.Interface(
+  CONVICTION_VOTING_CONTRACT.contract.abi
+);
+
+const convictionVotingContract = new Contract(
+  CONVICTION_VOTING_CONTRACT.contract.abi,
+  PRECOMPILE_CONVICTION_VOTING_ADDRESS
+);
+
+async function createProposal(context: DevTestContext, track = "root") {
+  let nonce = (await context.polkadotApi.rpc.system.accountNextIndex(alith.address)).toNumber();
+  const call = context.polkadotApi.tx.identity.setIdentity({ display: { raw: "Me" } });
+  const block = await context.createBlock([
+    context.polkadotApi.tx.preimage.notePreimage(call.toHex()).signAsync(alith, { nonce: nonce++ }),
+    context.polkadotApi.tx.referenda
+      .submit(
+        track == "root" ? { system: "root" } : { Origins: track },
+        { Lookup: { Hash: call.hash.toHex(), len: call.length } },
+        { After: 1 }
+      )
+      .signAsync(alith, { nonce: nonce++ }),
+  ]);
+  return expectSubstrateEvent(block, "referenda", "Submitted").data[0].toNumber();
+}
+
+// Each test is instantiating a new proposal (Not ideal for isolation but easier to write)
+// Be careful to not reach the maximum number of proposals.
+describeDevMoonbeam("Precompiles - Conviction Voting precompile", (context) => {
+  let proposalIndex: number;
+  beforeEach("create a proposal", async function () {
+    proposalIndex = await createProposal(context);
+  });
+
+  it("should allow to vote yes for a proposal", async function () {
+    const block = await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.voteYes(proposalIndex, 1n * 10n ** 18n, 1),
+      })
+    );
+
+    // Verifies the EVM Side
+    expectEVMResult(block.result.events, "Succeed");
+    const { data } = await expectSubstrateEvent(block, "evm", "Log");
+    const evmLog = CONVICTION_VOTING_INTERFACE.parseLog({
+      topics: data[0].topics.map((t) => t.toHex()),
+      data: data[0].data.toHex(),
+    });
+    expect(evmLog.name, "Wrong event").to.equal("Voted");
+    expect(evmLog.args.voter).to.equal(alith.address);
+    expect(evmLog.args.pollIndex).to.equal(proposalIndex);
+    expect(evmLog.args.aye).to.equal(true);
+    expect(BigInt(evmLog.args.voteAmount)).to.equal(1n * 10n ** 18n);
+    expect(evmLog.args.conviction).to.equal(1);
+
+    // Verifies the Subsrtate side
+    const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+    expect(referendum.unwrap().asOngoing.tally.ayes.toBigInt()).to.equal(1n * 10n ** 18n);
+  });
+
+  it("should allow to vote no for a proposal", async function () {
+    const block = await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.voteNo(proposalIndex, 1n * 10n ** 18n, 1),
+      })
+    );
+    // Verifies the EVM Side
+    expectEVMResult(block.result.events, "Succeed");
+    const { data } = await expectSubstrateEvent(block, "evm", "Log");
+    const evmLog = CONVICTION_VOTING_INTERFACE.parseLog({
+      topics: data[0].topics.map((t) => t.toHex()),
+      data: data[0].data.toHex(),
+    });
+    expect(evmLog.name, "Wrong event").to.equal("Voted");
+    expect(evmLog.args.voter).to.equal(alith.address);
+    expect(evmLog.args.pollIndex).to.equal(proposalIndex);
+    expect(evmLog.args.aye).to.equal(false);
+    expect(BigInt(evmLog.args.voteAmount)).to.equal(1n * 10n ** 18n);
+    expect(evmLog.args.conviction).to.equal(1);
+
+    // Verifies the Subsrtate side
+    const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+    expect(referendum.unwrap().asOngoing.tally.nays.toBigInt()).to.equal(1n * 10n ** 18n);
+  });
+
+  it("should allow to replace yes by a no", async function () {
+    const block1 = await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.voteYes(proposalIndex, 1n * 10n ** 18n, 1),
+      })
+    );
+    expectEVMResult(block1.result.events, "Succeed");
+
+    const block2 = await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.voteNo(proposalIndex, 1n * 10n ** 18n, 1),
+      })
+    );
+    expectEVMResult(block2.result.events, "Succeed");
+    const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+    expect(referendum.unwrap().asOngoing.tally.ayes.toBigInt()).to.equal(0n);
+    expect(referendum.unwrap().asOngoing.tally.nays.toBigInt()).to.equal(1n * 10n ** 18n);
+  });
+
+  it("should fail to vote for the wrong proposal", async function () {
+    const block = await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.voteYes(999999, 1n * 10n ** 18n, 1),
+      })
+    );
+    expectEVMResult(block.result.events, "Revert", "Reverted");
+    const revertReason = await extractRevertReason(block.result.hash, context.ethers);
+    expect(revertReason).to.contain("NotOngoing");
+  });
+
+  it("should fail to vote with the wrong conviction", async function () {
+    const block = await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.voteYes(proposalIndex, 1n * 10n ** 18n, 7),
+      })
+    );
+    expectEVMResult(block.result.events, "Revert", "Reverted");
+    const revertReason = await extractRevertReason(block.result.hash, context.ethers);
+    expect(revertReason).to.contain("Must be an integer between 0 and 6 included");
+  });
+});
+
+const CONVICTION_VALUES = [0n, 1n, 2n, 3n, 4n, 5n, 6n];
+// Each test is instantiating a new proposal (Not ideal for isolation but easier to write)
+// Be careful to not reach the maximum number of proposals.
+describeDevMoonbeam("Precompiles - Conviction", (context) => {
+  let proposalIndex: number;
+  beforeEach("create a proposal", async function () {
+    proposalIndex = await createProposal(context);
+  });
+
+  for (const conviction of CONVICTION_VALUES) {
+    it(`should allow to vote with confiction x${conviction}`, async function () {
+      const block = await context.createBlock(
+        createContractExecution(context, {
+          contract: convictionVotingContract,
+          contractCall: convictionVotingContract.methods.voteYes(
+            proposalIndex,
+            1n * 10n ** 18n,
+            conviction
+          ),
+        })
+      );
+      expectEVMResult(block.result.events, "Succeed");
+
+      // Verifies the Subsrtate side
+      const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+      expect(referendum.unwrap().asOngoing.tally.ayes.toBigInt()).to.equal(
+        1n * 10n ** 17n * (conviction == 0n ? 1n : conviction * 10n)
+      );
+    });
+  }
+});
+
+// Each test is instantiating a new proposal and a vote
+// (Not ideal for isolation but easier to write)
+// Be careful to not reach the maximum number of proposals.
+describeDevMoonbeam("Precompiles - Conviction on Root Track", (context) => {
+  let proposalIndex: number;
+  beforeEach("create a proposal", async function () {
+    proposalIndex = await createProposal(context);
+    await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.voteYes(proposalIndex, 1n * 10n ** 18n, 1),
+      })
+    );
+    // Verifies the setup is correct
+    const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+    expect(referendum.unwrap().asOngoing.tally.ayes.toBigInt()).to.equal(1n * 10n ** 18n);
+  });
+
+  it(`should be removable`, async function () {
+    const block = await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.removeVote(proposalIndex),
+      })
+    );
+    expectEVMResult(block.result.events, "Succeed");
+
+    // Verifies the Subsrtate side
+    const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+    expect(referendum.unwrap().asOngoing.tally.ayes.toBigInt()).to.equal(0n);
+  });
+
+  it(`should be removable by specifying the track`, async function () {
+    const block = await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.removeVoteForTrack(proposalIndex, 0),
+      })
+    );
+    expectEVMResult(block.result.events, "Succeed");
+
+    // Verifies the Subsrtate side
+    const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+    expect(referendum.unwrap().asOngoing.tally.ayes.toBigInt()).to.equal(0n);
+  });
+});
+
+// Each test is instantiating a new proposal and a vote
+// (Not ideal for isolation but easier to write)
+// Be careful to not reach the maximum number of proposals.
+describeDevMoonbeam("Precompiles - Conviction on General Admin Track", (context) => {
+  let proposalIndex: number;
+  beforeEach("create a proposal", async function () {
+    proposalIndex = await createProposal(context, "generaladmin");
+    await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.voteYes(proposalIndex, 1n * 10n ** 18n, 1),
+      })
+    );
+    // Verifies the setup is correct
+    const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+    expect(referendum.unwrap().asOngoing.tally.ayes.toBigInt()).to.equal(1n * 10n ** 18n);
+  });
+
+  it(`should be removable`, async function () {
+    const block = await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.removeVote(proposalIndex),
+      })
+    );
+    expectEVMResult(block.result.events, "Succeed");
+    const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+    expect(referendum.unwrap().asOngoing.tally.ayes.toBigInt()).to.equal(0n);
+  });
+
+  it(`should be removable using self removeOtherVote`, async function () {
+    // general_admin is track 2
+    const block = await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.removeOtherVote(
+          alith.address,
+          2,
+          proposalIndex
+        ),
+      })
+    );
+    expectEVMResult(block.result.events, "Succeed");
+    const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+    expect(referendum.unwrap().asOngoing.tally.ayes.toBigInt()).to.equal(0n);
+  });
+
+  it(`should be removable by specifying the track general_admin`, async function () {
+    // general_admin is track 2
+    const block = await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.removeVoteForTrack(proposalIndex, 2),
+      })
+    );
+    expectEVMResult(block.result.events, "Succeed");
+    const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+    expect(referendum.unwrap().asOngoing.tally.ayes.toBigInt()).to.equal(0n);
+  });
+
+  it(`should not be removable by specifying the wrong track`, async function () {
+    // general_admin is track 2
+    const block = await context.createBlock(
+      createContractExecution(context, {
+        contract: convictionVotingContract,
+        contractCall: convictionVotingContract.methods.removeVoteForTrack(proposalIndex, 0),
+      })
+    );
+    expectEVMResult(block.result.events, "Revert");
+    const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+    expect(referendum.unwrap().asOngoing.tally.ayes.toBigInt()).to.equal(1n * 10n ** 18n);
+  });
+
+  it(`should not be removable by someone else during voting time`, async function () {
+    // general_admin is track 2
+    const block = await context.createBlock(
+      createContractExecution(
+        context,
+        {
+          contract: convictionVotingContract,
+          contractCall: convictionVotingContract.methods.removeOtherVote(
+            alith.address,
+            2,
+            proposalIndex
+          ),
+        },
+        { from: baltathar.address, privateKey: BALTATHAR_PRIVATE_KEY, gas: 1000000 }
+      )
+    );
+    expectEVMResult(block.result.events, "Revert");
+    const referendum = await context.polkadotApi.query.referenda.referendumInfoFor(proposalIndex);
+    expect(referendum.unwrap().asOngoing.tally.ayes.toBigInt()).to.equal(1n * 10n ** 18n);
+  });
+});


### PR DESCRIPTION
Allows users of the ConvictionVoting precompile to specify class: Some(trackId) for removeVote extrinsic. Previously, the removeVote precompile method assumed class: None, which led to unexpected errors. The new precompile method `removeVoteForTrack` allows users to specify trackId for substrate removeVote extrinsic.
