### PR TITLE
Deny teleport and withdrawal from remote origins

### DIFF
--- a/primitives/xcm/src/barriers.rs
+++ b/primitives/xcm/src/barriers.rs
@@ -67,7 +67,7 @@ impl ShouldExecute for DenyTeleportAndWithdrawFromNonLocalOrigin {
 				}
 				// Allow InitiateReserveWithdraw only from a local account
 				InitiateReserveWithdraw { .. }
-					if matches!(
+					if !matches!(
 						origin,
 						MultiLocation {
 							parents: 0,

--- a/primitives/xcm/src/barriers.rs
+++ b/primitives/xcm/src/barriers.rs
@@ -50,7 +50,7 @@ where
 	}
 }
 
-/// Deny initiation of any teleport or withdrawal from non local account
+/// Deny initiation of any teleport and withdrawal from non local account
 pub struct DenyTeleportAndWithdrawFromNonLocalOrigin;
 impl ShouldExecute for DenyTeleportAndWithdrawFromNonLocalOrigin {
 	fn should_execute<RuntimeCall>(

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -50,8 +50,8 @@ use xcm_executor::traits::JustTry;
 use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToMultiLocation, AsAssetType,
-	FirstAssetTrader, SignedToAccountId20, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact,
-	DEFAULT_PROOF_SIZE,
+	DenyTeleportAndWithdrawFromNonLocalOrigin, DenyThenTry, FirstAssetTrader, SignedToAccountId20,
+	UtilityAvailableCalls, UtilityEncodeCall, XcmTransact, DEFAULT_PROOF_SIZE,
 };
 
 use parity_scale_codec::{Decode, Encode};
@@ -208,15 +208,19 @@ parameter_types! {
 /// Xcm Weigher shared between multiple Xcm-related configs.
 pub type XcmWeigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
 
-// Allow paid executions
-pub type XcmBarrier = (
-	TakeWeightCredit,
-	AllowTopLevelPaidExecutionFrom<Everything>,
-	// Expected responses are OK.
-	AllowKnownQueryResponses<PolkadotXcm>,
-	// Subscriptions for version tracking are OK.
-	AllowSubscriptionsFrom<Everything>,
-);
+pub type XcmBarrier = DenyThenTry<
+	DenyTeleportAndWithdrawFromNonLocalOrigin,
+	(
+		// Allow local execution
+		TakeWeightCredit,
+		// Allow paid executions
+		AllowTopLevelPaidExecutionFrom<Everything>,
+		// Expected responses are OK.
+		AllowKnownQueryResponses<PolkadotXcm>,
+		// Subscriptions for version tracking are OK.
+		AllowSubscriptionsFrom<Everything>,
+	),
+>;
 
 parameter_types! {
 	/// Xcm fees will go to the treasury account

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -50,8 +50,8 @@ use xcm_executor::traits::JustTry;
 use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToMultiLocation, AsAssetType,
-	FirstAssetTrader, SignedToAccountId20, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact,
-	DEFAULT_PROOF_SIZE,
+	DenyTeleportAndWithdrawFromNonLocalOrigin, DenyThenTry, FirstAssetTrader, SignedToAccountId20,
+	UtilityAvailableCalls, UtilityEncodeCall, XcmTransact, DEFAULT_PROOF_SIZE,
 };
 
 use parity_scale_codec::{Decode, Encode};
@@ -218,15 +218,19 @@ parameter_types! {
 /// Xcm Weigher shared between multiple Xcm-related configs.
 pub type XcmWeigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
 
-// Allow paid executions
-pub type XcmBarrier = (
-	TakeWeightCredit,
-	AllowTopLevelPaidExecutionFrom<Everything>,
-	// Expected responses are OK.
-	AllowKnownQueryResponses<PolkadotXcm>,
-	// Subscriptions for version tracking are OK.
-	AllowSubscriptionsFrom<Everything>,
-);
+pub type XcmBarrier = DenyThenTry<
+	DenyTeleportAndWithdrawFromNonLocalOrigin,
+	(
+		// Allow local execution
+		TakeWeightCredit,
+		// Allow paid executions
+		AllowTopLevelPaidExecutionFrom<Everything>,
+		// Expected responses are OK.
+		AllowKnownQueryResponses<PolkadotXcm>,
+		// Subscriptions for version tracking are OK.
+		AllowSubscriptionsFrom<Everything>,
+	),
+>;
 
 parameter_types! {
 	/// Xcm fees will go to the treasury account


### PR DESCRIPTION
### What does it do?

Make sure that incoming XCM messages (so coming from remote chains) can't execute `InitiateReserveWithdraw`.
Also deny any usage of `InitiateTeleport` instruction.

### What important points reviewers should know?

This PR introduce a new helper struct `DenyThenTry` that allow to use blacklist kind of barrier (by default barrier are more like whitelist). This helper struct is a copy/paste from cumulus crate `parachains-common`, moonbeam not depend of this crate so we can't use it directly (there is a TODO to move it a in common xcm crate).

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
