### PR TITLE
Switch to stable rust and make rust debug build usable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,10 +299,7 @@ jobs:
           echo "Checking $MB_VERSION contains $GIT_COMMIT"
           echo "$MB_VERSION" | grep $GIT_COMMIT
       - name: Unit tests
-        # TODO: remove the `--force` flag when cargo-expand has been
-        # correctly rebuild on all our CI servers
         run: |
-          cargo install --force cargo-expand
           cargo test --release --all
 
       # We determine whether there are unmodified Cargo.lock files by:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,8 +299,10 @@ jobs:
           echo "Checking $MB_VERSION contains $GIT_COMMIT"
           echo "$MB_VERSION" | grep $GIT_COMMIT
       - name: Unit tests
+        # TODO: remove the `--force` flag when cargo-expand has been
+        # correctly rebuild on all our CI servers
         run: |
-          cargo install cargo-expand
+          cargo install --force cargo-expand
           cargo test --release --all
 
       # We determine whether there are unmodified Cargo.lock files by:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "array-bytes 4.1.0",
  "async-trait",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "beefy-gadget",
  "futures 0.3.25",
@@ -570,7 +570,7 @@ dependencies = [
 [[package]]
 name = "beefy-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "sp-api",
  "sp-beefy",
@@ -2910,7 +2910,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3010,7 +3010,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "Inflector",
  "array-bytes 4.1.0",
@@ -3082,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3093,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3110,7 +3110,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3139,7 +3139,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "futures 0.3.25",
  "log",
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3202,7 +3202,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "log",
@@ -3242,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3257,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5208,7 +5208,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "futures 0.3.25",
  "log",
@@ -5227,7 +5227,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -6859,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6931,7 +6931,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6947,7 +6947,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6961,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6985,7 +6985,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7005,7 +7005,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7034,7 +7034,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7050,7 +7050,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "array-bytes 4.1.0",
  "beefy-merkle-tree",
@@ -7073,7 +7073,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7091,7 +7091,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7110,7 +7110,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7127,7 +7127,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7166,7 +7166,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7184,7 +7184,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7207,7 +7207,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7220,7 +7220,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7957,7 +7957,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7975,7 +7975,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7998,7 +7998,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8014,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8034,7 +8034,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8068,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8108,7 +8108,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8143,7 +8143,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8159,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8175,7 +8175,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8212,7 +8212,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8222,7 +8222,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8239,7 +8239,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8284,7 +8284,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8301,7 +8301,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8358,7 +8358,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8376,7 +8376,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8391,7 +8391,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8410,7 +8410,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "1.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8425,7 +8425,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8442,7 +8442,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8463,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8479,7 +8479,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8493,7 +8493,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8516,7 +8516,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -8527,7 +8527,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -8536,7 +8536,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8553,7 +8553,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8567,7 +8567,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8585,7 +8585,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8604,7 +8604,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8620,7 +8620,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -8636,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -8648,7 +8648,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8665,7 +8665,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8681,7 +8681,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8696,7 +8696,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11246,7 +11246,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "log",
  "sp-core",
@@ -11257,7 +11257,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -11284,7 +11284,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "futures 0.3.25",
  "futures-timer",
@@ -11307,7 +11307,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -11323,7 +11323,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -11338,7 +11338,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11349,7 +11349,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "array-bytes 4.1.0",
  "chrono",
@@ -11389,7 +11389,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "fnv",
  "futures 0.3.25",
@@ -11415,7 +11415,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -11441,7 +11441,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -11466,7 +11466,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -11495,7 +11495,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -11533,7 +11533,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "futures 0.3.25",
  "jsonrpsee",
@@ -11555,7 +11555,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -11568,7 +11568,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -11602,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -11625,7 +11625,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -11649,7 +11649,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -11662,7 +11662,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "log",
  "sc-allocator",
@@ -11675,7 +11675,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "cfg-if",
  "libc",
@@ -11692,7 +11692,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "ahash 0.8.3",
  "array-bytes 4.1.0",
@@ -11732,7 +11732,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.25",
@@ -11752,7 +11752,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "ansi_term",
  "futures 0.3.25",
@@ -11767,7 +11767,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "array-bytes 4.1.0",
  "async-trait",
@@ -11782,7 +11782,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "array-bytes 4.1.0",
  "async-trait",
@@ -11824,7 +11824,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "cid",
  "futures 0.3.25",
@@ -11843,7 +11843,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -11869,7 +11869,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "ahash 0.8.3",
  "futures 0.3.25",
@@ -11887,7 +11887,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "array-bytes 4.1.0",
  "futures 0.3.25",
@@ -11908,7 +11908,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "array-bytes 4.1.0",
  "async-trait",
@@ -11940,7 +11940,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "array-bytes 4.1.0",
  "futures 0.3.25",
@@ -11959,7 +11959,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "array-bytes 4.1.0",
  "bytes",
@@ -11989,7 +11989,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "futures 0.3.25",
  "libp2p",
@@ -12002,7 +12002,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -12011,7 +12011,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "futures 0.3.25",
  "jsonrpsee",
@@ -12041,7 +12041,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -12060,7 +12060,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -12075,7 +12075,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "array-bytes 4.1.0",
  "futures 0.3.25",
@@ -12101,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "directories",
@@ -12167,7 +12167,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -12178,7 +12178,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "clap",
  "futures 0.3.25",
@@ -12194,7 +12194,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -12213,7 +12213,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "futures 0.3.25",
  "libc",
@@ -12232,7 +12232,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "chrono",
  "futures 0.3.25",
@@ -12251,7 +12251,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "ansi_term",
  "atty",
@@ -12282,7 +12282,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -12293,7 +12293,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -12320,7 +12320,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -12334,7 +12334,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "backtrace",
  "futures 0.3.25",
@@ -12836,7 +12836,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "hash-db",
  "log",
@@ -12854,7 +12854,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -12866,7 +12866,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12879,7 +12879,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -12893,7 +12893,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12906,7 +12906,7 @@ dependencies = [
 [[package]]
 name = "sp-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12923,7 +12923,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12935,7 +12935,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "futures 0.3.25",
  "log",
@@ -12953,7 +12953,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -12971,7 +12971,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12989,7 +12989,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "merlin",
@@ -13012,7 +13012,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13024,7 +13024,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13037,7 +13037,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "array-bytes 4.1.0",
  "base58",
@@ -13079,7 +13079,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "blake2",
  "byteorder",
@@ -13093,7 +13093,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13104,7 +13104,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -13113,7 +13113,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13123,7 +13123,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -13134,7 +13134,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -13152,7 +13152,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -13166,7 +13166,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "bytes",
  "ed25519",
@@ -13175,6 +13175,7 @@ dependencies = [
  "libsecp256k1",
  "log",
  "parity-scale-codec",
+ "rustversion",
  "secp256k1",
  "sp-core",
  "sp-externalities",
@@ -13191,7 +13192,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -13202,7 +13203,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "futures 0.3.25",
@@ -13219,7 +13220,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "thiserror",
  "zstd",
@@ -13228,7 +13229,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -13246,7 +13247,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13260,7 +13261,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -13270,7 +13271,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -13280,7 +13281,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -13290,7 +13291,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -13312,7 +13313,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -13330,7 +13331,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -13342,7 +13343,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13356,7 +13357,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13368,7 +13369,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "hash-db",
  "log",
@@ -13388,12 +13389,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "impl-serde 0.4.0",
  "parity-scale-codec",
@@ -13406,7 +13407,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -13421,7 +13422,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -13433,7 +13434,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -13442,7 +13443,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "log",
@@ -13458,7 +13459,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "ahash 0.8.3",
  "hash-db",
@@ -13481,7 +13482,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "impl-serde 0.4.0",
  "parity-scale-codec",
@@ -13498,7 +13499,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -13509,7 +13510,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -13522,7 +13523,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13728,7 +13729,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "platforms",
 ]
@@ -13746,7 +13747,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.25",
@@ -13765,7 +13766,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "hyper",
  "log",
@@ -13777,7 +13778,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -13790,7 +13791,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -13809,7 +13810,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "array-bytes 4.1.0",
  "async-trait",
@@ -13835,7 +13836,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "beefy-merkle-tree",
  "cfg-if",
@@ -13878,7 +13879,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "futures 0.3.25",
  "parity-scale-codec",
@@ -13897,7 +13898,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -14565,7 +14566,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#525ccce2a32a6b640daff0d451c1060e867dde76"
+source = "git+https://github.com/purestake/substrate?branch=moonbeam-polkadot-v0.9.38#60f6004e4f553e5357df6d850358f9e76a71abb9"
 dependencies = [
  "clap",
  "frame-remote-externalities",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -349,6 +349,66 @@ evm-core = { git = "https://github.com/rust-blockchain/evm", rev = "842e03d068dd
 evm-gasometer = { git = "https://github.com/rust-blockchain/evm", rev = "842e03d068ddb6a3195a2dedc4a9b63caadb3355" }
 evm-runtime = { git = "https://github.com/rust-blockchain/evm", rev = "842e03d068ddb6a3195a2dedc4a9b63caadb3355" }
 
+# The list of dependencies below (which can be both direct and indirect dependencies) are crates
+# that are suspected to be CPU-intensive, and that are unlikely to require debugging (as some of
+# their debug info might be missing) or to require to be frequently recompiled. We compile these
+# dependencies with `opt-level=3` even in "dev" mode in order to make "dev" mode more usable.
+# The majority of these crates are cryptographic libraries.
+#
+# Note that this does **not** affect crates that depend on Moonbeam. In other words, if you add
+# a dependency on Moonbeam, you have to copy-paste this list in your own `Cargo.toml` (assuming
+# that you want the same list). This list is only relevant when running `cargo build` from within
+# the Moonbeam workspace.
+#
+# If you see an error mentioning "profile package spec ... did not match any packages", it
+# probably concerns this list.
+#
+# This list is ordered alphabetically.
+[profile.dev.package]
+blake2 = { opt-level = 3 }
+blake2b_simd = { opt-level = 3 }
+chacha20poly1305 = { opt-level = 3 }
+cranelift-codegen = { opt-level = 3 }
+cranelift-wasm = { opt-level = 3 }
+crc32fast = { opt-level = 3 }
+crossbeam-deque = { opt-level = 3 }
+crypto-mac = { opt-level = 3 }
+curve25519-dalek = { opt-level = 3 }
+ed25519-zebra = { opt-level = 3 }
+flate2 = { opt-level = 3 }
+futures-channel = { opt-level = 3 }
+hashbrown = { opt-level = 3 }
+hash-db = { opt-level = 3 }
+hmac = { opt-level = 3 }
+httparse = { opt-level = 3 }
+integer-sqrt = { opt-level = 3 }
+k256 = { opt-level = 3 }
+keccak = { opt-level = 3 }
+libm = { opt-level = 3 }
+librocksdb-sys = { opt-level = 3 }
+libsecp256k1 = { opt-level = 3 }
+libz-sys = { opt-level = 3 }
+mio = { opt-level = 3 }
+nalgebra = { opt-level = 3 }
+num-bigint = { opt-level = 3 }
+parking_lot = { opt-level = 3 }
+parking_lot_core = { opt-level = 3 }
+percent-encoding = { opt-level = 3 }
+primitive-types = { opt-level = 3 }
+ring = { opt-level = 3 }
+rustls = { opt-level = 3 }
+secp256k1 = { opt-level = 3 }
+sha2 = { opt-level = 3 }
+sha3 = { opt-level = 3 }
+smallvec = { opt-level = 3 }
+snow = { opt-level = 3 }
+twox-hash = { opt-level = 3 }
+uint = { opt-level = 3 }
+wasmi = { opt-level = 3 }
+x25519-dalek = { opt-level = 3 }
+yamux = { opt-level = 3 }
+zeroize = { opt-level = 3 }
+
 # make sure dev builds with backtrace do
 # not slow us down
 [profile.dev.package.backtrace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,8 +377,8 @@ curve25519-dalek = { opt-level = 3 }
 ed25519-zebra = { opt-level = 3 }
 flate2 = { opt-level = 3 }
 futures-channel = { opt-level = 3 }
-hashbrown = { opt-level = 3 }
 hash-db = { opt-level = 3 }
+hashbrown = { opt-level = 3 }
 hmac = { opt-level = 3 }
 httparse = { opt-level = 3 }
 integer-sqrt = { opt-level = 3 }

--- a/pallets/moonbeam-orbiters/src/lib.rs
+++ b/pallets/moonbeam-orbiters/src/lib.rs
@@ -27,7 +27,6 @@
 //! currently selected orbiter.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(step_trait)]
 
 pub mod types;
 pub mod weights;
@@ -108,8 +107,7 @@ pub mod pallet {
 			+ Default
 			+ sp_runtime::traits::MaybeDisplay
 			+ sp_runtime::traits::AtLeast32Bit
-			+ Copy
-			+ core::iter::Step;
+			+ Copy;
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
@@ -490,14 +488,18 @@ pub mod pallet {
 							Some(collator.clone()),
 						);
 						writes += 1;
-						for i in Zero::zero()..T::RotatePeriod::get() {
+
+						let mut i = Zero::zero();
+						while i < T::RotatePeriod::get() {
 							OrbiterPerRound::<T>::insert(
 								round_index.saturating_add(i),
 								collator.clone(),
 								next_orbiter.clone(),
 							);
+							i += One::one();
 							writes += 1;
 						}
+
 						Self::deposit_event(Event::OrbiterRotation {
 							collator,
 							old_orbiter: maybe_old_orbiter.map(|orbiter| orbiter.account_id),

--- a/precompiles/assets-erc20/src/lib.rs
+++ b/precompiles/assets-erc20/src/lib.rs
@@ -15,7 +15,6 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(test, feature(assert_matches))]
 
 use core::fmt::Display;
 use fp_evm::PrecompileHandle;

--- a/precompiles/author-mapping/src/lib.rs
+++ b/precompiles/author-mapping/src/lib.rs
@@ -17,7 +17,6 @@
 //! Precompile to interact with pallet author mapping through an evm precompile.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 use fp_evm::PrecompileHandle;
 use frame_support::{

--- a/precompiles/balances-erc20/src/lib.rs
+++ b/precompiles/balances-erc20/src/lib.rs
@@ -17,7 +17,6 @@
 //! Precompile to interact with pallet_balances instances using the ERC20 interface standard.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(test, feature(assert_matches))]
 
 use fp_evm::PrecompileHandle;
 use frame_support::{

--- a/precompiles/conviction-voting/src/lib.rs
+++ b/precompiles/conviction-voting/src/lib.rs
@@ -15,7 +15,6 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 use fp_evm::PrecompileHandle;
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};

--- a/precompiles/crowdloan-rewards/src/lib.rs
+++ b/precompiles/crowdloan-rewards/src/lib.rs
@@ -17,7 +17,6 @@
 //! Precompile to call pallet-crowdloan-rewards runtime methods via the EVM
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 use fp_evm::PrecompileHandle;
 use frame_support::{

--- a/precompiles/pallet-democracy/src/lib.rs
+++ b/precompiles/pallet-democracy/src/lib.rs
@@ -17,7 +17,6 @@
 //! Precompile to interact with pallet democracy through an evm precompile.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 use fp_evm::PrecompileHandle;
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -17,7 +17,6 @@
 //! Precompile to call parachain-staking runtime methods via the EVM
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(test, feature(assert_matches))]
 
 #[cfg(test)]
 mod mock;

--- a/precompiles/preimage/src/lib.rs
+++ b/precompiles/preimage/src/lib.rs
@@ -15,7 +15,6 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 use fp_evm::PrecompileHandle;
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};

--- a/precompiles/proxy/src/lib.rs
+++ b/precompiles/proxy/src/lib.rs
@@ -15,7 +15,6 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 use evm::ExitReason;
 use fp_evm::{Context, PrecompileFailure, PrecompileHandle, Transfer};

--- a/precompiles/randomness/src/lib.rs
+++ b/precompiles/randomness/src/lib.rs
@@ -17,7 +17,6 @@
 //! Precompile to interact with randomness through an evm precompile.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 extern crate alloc;
 

--- a/precompiles/referenda/src/lib.rs
+++ b/precompiles/referenda/src/lib.rs
@@ -15,7 +15,6 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 use fp_evm::PrecompileHandle;
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};

--- a/precompiles/relay-encoder/src/lib.rs
+++ b/precompiles/relay-encoder/src/lib.rs
@@ -17,7 +17,6 @@
 //! Precompile to encode relay staking calls via the EVM
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(test, feature(assert_matches))]
 
 use cumulus_primitives_core::relay_chain;
 

--- a/precompiles/utils/macro/tests/compile-fail/precompile/discriminant/missing-param.stderr
+++ b/precompiles/utils/macro/tests/compile-fail/precompile/discriminant/missing-param.stderr
@@ -2,4 +2,4 @@ error: The discriminant function must only take the code address (H160) as param
   --> tests/compile-fail/precompile/discriminant/missing-param.rs:25:2
    |
 25 |     fn discriminant() -> Option<u64> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^

--- a/precompiles/utils/macro/tests/compile-fail/precompile/discriminant/too-many-arguments.stderr
+++ b/precompiles/utils/macro/tests/compile-fail/precompile/discriminant/too-many-arguments.stderr
@@ -2,4 +2,4 @@ error: The discriminant function must only take the code address (H160) as param
   --> tests/compile-fail/precompile/discriminant/too-many-arguments.rs:25:2
    |
 25 |     fn discriminant(address: H160, other: u32) -> Option<u32> {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^

--- a/precompiles/utils/macro/tests/compile-fail/precompile/evm-data/no-output.stderr
+++ b/precompiles/utils/macro/tests/compile-fail/precompile/evm-data/no-output.stderr
@@ -2,4 +2,4 @@ error: A precompile method must have a return type of `EvmResult<_>` (exposed by
   --> tests/compile-fail/precompile/evm-data/no-output.rs:24:2
    |
 24 |     fn foo(test: &mut impl PrecompileHandle) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^

--- a/precompiles/utils/macro/tests/compile-fail/precompile/evm-data/output-dont-impl-evmdata.stderr
+++ b/precompiles/utils/macro/tests/compile-fail/precompile/evm-data/output-dont-impl-evmdata.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `String: EvmData` is not satisfied
   --> tests/compile-fail/precompile/evm-data/output-dont-impl-evmdata.rs:26:46
    |
 26 |     fn foo(test: &mut impl PrecompileHandle) -> EvmResult<String> {
-   |                                                 ^^^^^^^^^^^^^^^^^ the trait `EvmData` is not implemented for `String`
+   |                                                 ^^^^^^^^^ the trait `EvmData` is not implemented for `String`
    |
    = help: the following other types implement trait `EvmData`:
              ()

--- a/precompiles/utils/macro/tests/compile-fail/precompile/evm-data/output-wrong-error-result.stderr
+++ b/precompiles/utils/macro/tests/compile-fail/precompile/evm-data/output-wrong-error-result.stderr
@@ -1,8 +1,8 @@
 error[E0277]: `?` couldn't convert the error to `PrecompileFailure`
-  --> tests/compile-fail/precompile/evm-data/output-wrong-error-result.rs:25:63
+  --> tests/compile-fail/precompile/evm-data/output-wrong-error-result.rs:25:51
    |
 25 |     fn foo(test: &mut impl PrecompileHandle) -> Result<(), String> {
-   |                                                                  ^ the trait `From<String>` is not implemented for `PrecompileFailure`
+   |                                                      ^ the trait `From<String>` is not implemented for `PrecompileFailure`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
    = help: the following other types implement trait `From<T>`:

--- a/precompiles/utils/macro/tests/compile-fail/precompile/handle/missing.stderr
+++ b/precompiles/utils/macro/tests/compile-fail/precompile/handle/missing.stderr
@@ -2,4 +2,4 @@ error: Precompile methods must have at least 1 parameter (the PrecompileHandle)
   --> tests/compile-fail/precompile/handle/missing.rs:24:2
    |
 24 |     fn foo() {
-   |     ^^^^^^^^
+   |     ^^

--- a/precompiles/utils/macro/tests/compile-fail/precompile/handle/set-missing.stderr
+++ b/precompiles/utils/macro/tests/compile-fail/precompile/handle/set-missing.stderr
@@ -2,4 +2,4 @@ error: PrecompileSet methods must have at least 2 parameters (the precompile ins
   --> tests/compile-fail/precompile/handle/set-missing.rs:25:2
    |
 25 |     fn foo(_: u32) {
-   |     ^^^^^^^^^^^^^^
+   |     ^^

--- a/precompiles/utils/macro/tests/compile-fail/precompile/pre-check/no-parameter.stderr
+++ b/precompiles/utils/macro/tests/compile-fail/precompile/pre-check/no-parameter.stderr
@@ -2,4 +2,4 @@ error: Precompile methods must have at least 1 parameter (the PrecompileHandle)
   --> tests/compile-fail/precompile/pre-check/no-parameter.rs:24:2
    |
 24 |     fn pre_check() {
-   |     ^^^^^^^^^^^^^^
+   |     ^^

--- a/precompiles/utils/macro/tests/compile-fail/precompile/pre-check/too-many-parameters.stderr
+++ b/precompiles/utils/macro/tests/compile-fail/precompile/pre-check/too-many-parameters.stderr
@@ -2,4 +2,4 @@ error: Precompile pre_check method must have exactly 1 parameter (the Precompile
   --> tests/compile-fail/precompile/pre-check/too-many-parameters.rs:24:2
    |
 24 |     fn pre_check(_: &mut impl PrecompileHandle, _: u32) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^

--- a/precompiles/utils/macro/tests/expand/precompile.expanded.rs
+++ b/precompiles/utils/macro/tests/expand/precompile.expanded.rs
@@ -12,14 +12,7 @@ where
 {
     fn pre_check(handle: &mut impl PrecompileHandle) -> EvmResult {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["pre_check"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("pre_check")),
         )
     }
     fn batch_some(
@@ -30,14 +23,7 @@ where
         gas_limit: BoundedVec<u64, GetArrayLimit>,
     ) -> EvmResult {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["batch_some"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("batch_some")),
         )
     }
     fn batch_some_until_failure(
@@ -48,16 +34,8 @@ where
         gas_limit: BoundedVec<u64, GetArrayLimit>,
     ) -> EvmResult {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(
-                            &["batch_some_until_failure"],
-                            &[],
-                        ),
-                    ),
-                ],
+            format_args!(
+                "not yet implemented: {0}", format_args!("batch_some_until_failure")
             ),
         )
     }
@@ -69,26 +47,12 @@ where
         gas_limit: BoundedVec<u64, GetArrayLimit>,
     ) -> EvmResult {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["batch_all"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("batch_all")),
         )
     }
     fn fallback(handle: &mut impl PrecompileHandle) -> EvmResult {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["fallback"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("fallback")),
         )
     }
 }
@@ -234,10 +198,7 @@ where
             }
             Self::__phantom(_, _) => {
                 ::core::panicking::panic_fmt(
-                    ::core::fmt::Arguments::new_v1(
-                        &["__phantom variant should not be used"],
-                        &[],
-                    ),
+                    format_args!("__phantom variant should not be used"),
                 )
             }
         };
@@ -299,10 +260,7 @@ where
             Self::fallback {} => Default::default(),
             Self::__phantom(_, _) => {
                 ::core::panicking::panic_fmt(
-                    ::core::fmt::Arguments::new_v1(
-                        &["__phantom variant should not be used"],
-                        &[],
-                    ),
+                    format_args!("__phantom variant should not be used"),
                 )
             }
         }
@@ -347,12 +305,9 @@ pub(crate) fn __BatchPrecompile_test_solidity_signatures_inner() {
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"batch_all")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "batch_all"
                         ),
                     ),
                 );
@@ -376,12 +331,9 @@ pub(crate) fn __BatchPrecompile_test_solidity_signatures_inner() {
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"batch_some")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "batch_some"
                         ),
                     ),
                 );
@@ -405,16 +357,9 @@ pub(crate) fn __BatchPrecompile_test_solidity_signatures_inner() {
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[
-                                ::core::fmt::ArgumentV1::new_display(
-                                    &"batch_some_until_failure",
-                                ),
-                            ],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "batch_some_until_failure"
                         ),
                     ),
                 );
@@ -430,12 +375,9 @@ pub(crate) fn __BatchPrecompile_test_solidity_signatures_inner() {
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"fallback")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "fallback"
                         ),
                     ),
                 );

--- a/precompiles/utils/macro/tests/expand/precompileset.expanded.rs
+++ b/precompiles/utils/macro/tests/expand/precompileset.expanded.rs
@@ -15,14 +15,7 @@ where
     /// and if this is the case which one.
     fn discriminant(address: H160) -> Option<Discriminant> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["discriminant"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("discriminant")),
         )
     }
     fn total_supply(
@@ -30,14 +23,7 @@ where
         handle: &mut impl PrecompileHandle,
     ) -> EvmResult<U256> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["total_supply"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("total_supply")),
         )
     }
     fn balance_of(
@@ -46,14 +32,7 @@ where
         who: Address,
     ) -> EvmResult<U256> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["balance_of"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("balance_of")),
         )
     }
     fn allowance(
@@ -63,14 +42,7 @@ where
         spender: Address,
     ) -> EvmResult<U256> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["allowance"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("allowance")),
         )
     }
     fn approve(
@@ -80,14 +52,7 @@ where
         value: U256,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["approve"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("approve")),
         )
     }
     fn approve_inner(
@@ -98,14 +63,7 @@ where
         value: U256,
     ) -> EvmResult {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["approve_inner"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("approve_inner")),
         )
     }
     fn transfer(
@@ -115,14 +73,7 @@ where
         value: U256,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["transfer"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("transfer")),
         )
     }
     fn transfer_from(
@@ -133,14 +84,7 @@ where
         value: U256,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["transfer_from"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("transfer_from")),
         )
     }
     fn name(
@@ -148,14 +92,7 @@ where
         handle: &mut impl PrecompileHandle,
     ) -> EvmResult<UnboundedBytes> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["name"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("name")),
         )
     }
     fn symbol(
@@ -163,14 +100,7 @@ where
         handle: &mut impl PrecompileHandle,
     ) -> EvmResult<UnboundedBytes> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["symbol"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("symbol")),
         )
     }
     fn decimals(
@@ -178,14 +108,7 @@ where
         handle: &mut impl PrecompileHandle,
     ) -> EvmResult<u8> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["decimals"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("decimals")),
         )
     }
     fn mint(
@@ -195,14 +118,7 @@ where
         value: U256,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["mint"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("mint")),
         )
     }
     fn burn(
@@ -212,14 +128,7 @@ where
         value: U256,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["burn"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("burn")),
         )
     }
     fn freeze(
@@ -228,14 +137,7 @@ where
         account: Address,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["freeze"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("freeze")),
         )
     }
     fn thaw(
@@ -244,14 +146,7 @@ where
         account: Address,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["thaw"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("thaw")),
         )
     }
     fn freeze_asset(
@@ -259,14 +154,7 @@ where
         handle: &mut impl PrecompileHandle,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["freeze_asset"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("freeze_asset")),
         )
     }
     fn thaw_asset(
@@ -274,14 +162,7 @@ where
         handle: &mut impl PrecompileHandle,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["thaw_asset"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("thaw_asset")),
         )
     }
     fn transfer_ownership(
@@ -290,14 +171,7 @@ where
         owner: Address,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["transfer_ownership"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("transfer_ownership")),
         )
     }
     fn set_team(
@@ -308,14 +182,7 @@ where
         freezer: Address,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["set_team"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("set_team")),
         )
     }
     fn set_metadata(
@@ -326,14 +193,7 @@ where
         decimals: u8,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["set_metadata"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("set_metadata")),
         )
     }
     fn clear_metadata(
@@ -341,14 +201,7 @@ where
         handle: &mut impl PrecompileHandle,
     ) -> EvmResult<bool> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["clear_metadata"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("clear_metadata")),
         )
     }
     fn eip2612_permit(
@@ -363,14 +216,7 @@ where
         s: H256,
     ) -> EvmResult {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["eip2612_permit"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("eip2612_permit")),
         )
     }
     fn eip2612_nonces(
@@ -379,14 +225,7 @@ where
         owner: Address,
     ) -> EvmResult<U256> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["eip2612_nonces"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("eip2612_nonces")),
         )
     }
     fn eip2612_domain_separator(
@@ -394,16 +233,8 @@ where
         handle: &mut impl PrecompileHandle,
     ) -> EvmResult<H256> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(
-                            &["eip2612_domain_separator"],
-                            &[],
-                        ),
-                    ),
-                ],
+            format_args!(
+                "not yet implemented: {0}", format_args!("eip2612_domain_separator")
             ),
         )
     }
@@ -936,10 +767,7 @@ where
             }
             Self::__phantom(_, _) => {
                 ::core::panicking::panic_fmt(
-                    ::core::fmt::Arguments::new_v1(
-                        &["__phantom variant should not be used"],
-                        &[],
-                    ),
+                    format_args!("__phantom variant should not be used"),
                 )
             }
         };
@@ -1179,10 +1007,7 @@ where
             }
             Self::__phantom(_, _) => {
                 ::core::panicking::panic_fmt(
-                    ::core::fmt::Arguments::new_v1(
-                        &["__phantom variant should not be used"],
-                        &[],
-                    ),
+                    format_args!("__phantom variant should not be used"),
                 )
             }
         }
@@ -1234,12 +1059,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"allowance")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "allowance"
                         ),
                     ),
                 );
@@ -1255,12 +1077,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"approve")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "approve"
                         ),
                     ),
                 );
@@ -1276,12 +1095,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"balance_of")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "balance_of"
                         ),
                     ),
                 );
@@ -1297,12 +1113,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"burn")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "burn"
                         ),
                     ),
                 );
@@ -1318,12 +1131,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"clear_metadata")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "clear_metadata"
                         ),
                     ),
                 );
@@ -1339,12 +1149,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"decimals")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "decimals"
                         ),
                     ),
                 );
@@ -1360,16 +1167,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[
-                                ::core::fmt::ArgumentV1::new_display(
-                                    &"eip2612_domain_separator",
-                                ),
-                            ],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "eip2612_domain_separator"
                         ),
                     ),
                 );
@@ -1385,12 +1185,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"eip2612_nonces")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "eip2612_nonces"
                         ),
                     ),
                 );
@@ -1409,12 +1206,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"eip2612_permit")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "eip2612_permit"
                         ),
                     ),
                 );
@@ -1430,12 +1224,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"freeze")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "freeze"
                         ),
                     ),
                 );
@@ -1451,12 +1242,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"freeze_asset")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "freeze_asset"
                         ),
                     ),
                 );
@@ -1472,12 +1260,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"mint")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "mint"
                         ),
                     ),
                 );
@@ -1493,12 +1278,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"name")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "name"
                         ),
                     ),
                 );
@@ -1521,12 +1303,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"set_metadata")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "set_metadata"
                         ),
                     ),
                 );
@@ -1545,12 +1324,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"set_team")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "set_team"
                         ),
                     ),
                 );
@@ -1566,12 +1342,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"symbol")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "symbol"
                         ),
                     ),
                 );
@@ -1587,12 +1360,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"thaw")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "thaw"
                         ),
                     ),
                 );
@@ -1608,12 +1378,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"thaw_asset")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "thaw_asset"
                         ),
                     ),
                 );
@@ -1629,12 +1396,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"total_supply")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "total_supply"
                         ),
                     ),
                 );
@@ -1650,12 +1414,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"transfer")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "transfer"
                         ),
                     ),
                 );
@@ -1674,12 +1435,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"transfer_from")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "transfer_from"
                         ),
                     ),
                 );
@@ -1695,14 +1453,9 @@ where
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[
-                                ::core::fmt::ArgumentV1::new_display(&"transfer_ownership"),
-                            ],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "transfer_ownership"
                         ),
                     ),
                 );

--- a/precompiles/utils/macro/tests/expand/returns_tuple.expanded.rs
+++ b/precompiles/utils/macro/tests/expand/returns_tuple.expanded.rs
@@ -8,14 +8,7 @@ impl ExamplePrecompile {
         handle: &mut impl PrecompileHandle,
     ) -> EvmResult<(Address, U256, UnboundedBytes)> {
         ::core::panicking::panic_fmt(
-            ::core::fmt::Arguments::new_v1(
-                &["not yet implemented: "],
-                &[
-                    ::core::fmt::ArgumentV1::new_display(
-                        &::core::fmt::Arguments::new_v1(&["example"], &[]),
-                    ),
-                ],
-            ),
+            format_args!("not yet implemented: {0}", format_args!("example")),
         )
     }
 }
@@ -67,10 +60,7 @@ impl ExamplePrecompileCall {
             }
             Self::__phantom(_, _) => {
                 ::core::panicking::panic_fmt(
-                    ::core::fmt::Arguments::new_v1(
-                        &["__phantom variant should not be used"],
-                        &[],
-                    ),
+                    format_args!("__phantom variant should not be used"),
                 )
             }
         };
@@ -97,10 +87,7 @@ impl ExamplePrecompileCall {
             Self::example {} => EvmDataWriter::new_with_selector(1412775727u32).build(),
             Self::__phantom(_, _) => {
                 ::core::panicking::panic_fmt(
-                    ::core::fmt::Arguments::new_v1(
-                        &["__phantom variant should not be used"],
-                        &[],
-                    ),
+                    format_args!("__phantom variant should not be used"),
                 )
             }
         }
@@ -130,12 +117,9 @@ pub(crate) fn __ExamplePrecompile_test_solidity_signatures_inner() {
                     &*left_val,
                     &*right_val,
                     ::core::option::Option::Some(
-                        ::core::fmt::Arguments::new_v1(
-                            &[
-                                "",
-                                " function signature doesn\'t match (left: attribute, right: computed from Rust types)",
-                            ],
-                            &[::core::fmt::ArgumentV1::new_display(&"example")],
+                        format_args!(
+                            "{0} function signature doesn\'t match (left: attribute, right: computed from Rust types)",
+                            "example"
                         ),
                     ),
                 );

--- a/precompiles/utils/macro/tests/tests.rs
+++ b/precompiles/utils/macro/tests/tests.rs
@@ -58,7 +58,9 @@ fn ui() {
 	t.pass("tests/pass/**/*.rs");
 }
 
+// Cargo expand is not supported on stable rust
 #[test]
+#[ignore]
 fn expand() {
 	// Use `expand` to update the expansions
 	// Replace it with `expand_without_refresh` afterward so that

--- a/precompiles/utils/src/lib.rs
+++ b/precompiles/utils/src/lib.rs
@@ -15,7 +15,6 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 extern crate alloc;
 

--- a/precompiles/xcm-transactor/src/lib.rs
+++ b/precompiles/xcm-transactor/src/lib.rs
@@ -17,7 +17,6 @@
 //! Precompile to xcm transactor runtime methods via the EVM
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 #[cfg(test)]
 mod mock;

--- a/precompiles/xcm-utils/src/lib.rs
+++ b/precompiles/xcm-utils/src/lib.rs
@@ -17,7 +17,6 @@
 //! Precompile to xcm utils runtime methods via the EVM
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 use fp_evm::PrecompileHandle;
 use frame_support::codec::Decode;

--- a/precompiles/xtokens/src/lib.rs
+++ b/precompiles/xtokens/src/lib.rs
@@ -17,7 +17,6 @@
 //! Precompile to xtokens runtime methods via the EVM
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(assert_matches)]
 
 use fp_evm::PrecompileHandle;
 use frame_support::{

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2022-11-14"
+channel = "stable"
 components = [ "rustfmt", "clippy" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
### What does it do?

This pull request brings support for compiling moonbeam with stable Rust,  this required to cherry-pick https://github.com/paritytech/substrate/pull/13580 on our substrate branch `moonbeam-polkadot-v0.9.38`.

This PR also allows to use the moonbeam binary in debug build (much faster compilation), to achieve this we use the same trick as parity on these substrate and polkadot repos: force the optimized compilation only for the few low-level crates that need it.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
