### PR TITLE
fix GA workflow check features

### DIFF
--- a/.github/workflows/check-features.yml
+++ b/.github/workflows/check-features.yml
@@ -11,10 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install tooling
-        run: |
-          sudo apt-get install -y protobuf-compiler
-          protoc --version
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Setup Rust toolchain
@@ -22,9 +18,11 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.cargo/registry
-            ~/.cargo/git
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
             target
           key: ${{ runner.os }}-cargo-check-features-${{ hashFiles('**/Cargo.lock') }}
       - name: cargo check
-        run: cargo check --features try-runtime,runtime-benchmarks
+        run: cargo check --release --features try-runtime,runtime-benchmarks


### PR DESCRIPTION
### What does it do?

The GA workflow check-features fail randomly with "No space left on device" error. This is due to the fact that the available space on github runner is variable, and github only guarantee 14 GB: https://github.com/actions/runner-images/issues/2840#issuecomment-791177163

Unfortunatly, 14GB is not enough for rust debug builds, this PR propose to use release mode to consume much less disk space, but the compilation would then be longer.

If we want to still on debug build mode, we will need to use our how runner.

Also, this PR refactor the cache strategy to use what the documentation suggest: https://github.com/actions/cache/blob/main/examples.md#rust---cargo

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
