### PR TITLE
XCM: Limit the max number of assets weighable

### DIFF
--- a/pallets/moonbeam-xcm-benchmarks/src/weights/mod.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/weights/mod.rs
@@ -27,8 +27,7 @@ use xcm::{
 	latest::{prelude::*, Weight as XCMWeight},
 	DoubleEncoded,
 };
-
-const MAX_ASSETS: u64 = 10;
+use xcm_primitives::MAX_ASSETS;
 
 trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;
@@ -45,9 +44,9 @@ impl WeighMultiAssetsFilter for MultiAssetFilter {
 				weight.saturating_mul(assets.inner().into_iter().count() as u64)
 			}
 			Self::Wild(AllCounted(count) | AllOfCounted { count, .. }) => {
-				weight.saturating_mul(min(MAX_ASSETS, *count as u64))
+				weight.saturating_mul(min(MAX_ASSETS, *count) as u64)
 			}
-			Self::Wild(All | AllOf { .. }) => weight.saturating_mul(MAX_ASSETS),
+			Self::Wild(All | AllOf { .. }) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }

--- a/pallets/moonbeam-xcm-benchmarks/src/weights/mod.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/weights/mod.rs
@@ -28,7 +28,7 @@ use xcm::{
 	DoubleEncoded,
 };
 
-const MAX_ASSETS: u64 = 100;
+const MAX_ASSETS: u64 = 10;
 
 trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;

--- a/primitives/xcm/src/constants.rs
+++ b/primitives/xcm/src/constants.rs
@@ -14,38 +14,4 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-//! The XCM primitive trait implementations
-
-#![cfg_attr(not(feature = "std"), no_std)]
-
-mod asset_id_conversions;
-pub use asset_id_conversions::*;
-
-mod barriers;
-pub use barriers::*;
-
-mod constants;
-pub use constants::*;
-
-mod fee_handlers;
-pub use fee_handlers::*;
-
-mod location_conversion;
-pub use location_conversion::*;
-
-mod origin_conversion;
-pub use origin_conversion::*;
-
-mod transactor_traits;
-pub use transactor_traits::*;
-
-mod ethereum_xcm;
-pub use ethereum_xcm::*;
-
-mod filter_asset_max_fee;
-pub use filter_asset_max_fee::*;
-
-mod xcm_execution_traits;
-pub use xcm_execution_traits::*;
-
-pub type XcmV2Weight = xcm::v2::Weight;
+pub const MAX_ASSETS: u32 = 64;

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -290,7 +290,7 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 }
 
 parameter_types! {
-	pub const MaxAssetsIntoHolding: u32 = 64;
+	pub const MaxAssetsIntoHolding: u32 = xcm_primitives::MAX_ASSETS;
 }
 
 pub struct XcmExecutorConfig;

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -250,7 +250,7 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 }
 
 parameter_types! {
-	pub const MaxAssetsIntoHolding: u32 = 64;
+	pub const MaxAssetsIntoHolding: u32 = xcm_primitives::MAX_ASSETS;
 }
 
 pub struct XcmExecutorConfig;

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -260,7 +260,7 @@ impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
 }
 
 parameter_types! {
-	pub const MaxAssetsIntoHolding: u32 = 64;
+	pub const MaxAssetsIntoHolding: u32 = xcm_primitives::MAX_ASSETS;
 }
 
 pub struct XcmExecutorConfig;


### PR DESCRIPTION
### What does it do?

To prevent unreasonably high count values from overweighing related XCM instructions, we should have an upper limit on how many assets we would weight during the weight calculation of XCM and we should apply this limit to all *Counted variants.

This PR also apply the same limit for `MAX_ASSETS` and `MaxAssetsIntoHolding`.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
