### PR TITLE
fix old erc20-xcm implementation: recreate XcmExecutorWrapper

### DIFF
--- a/pallets/erc20-xcm-bridge/src/lib.rs
+++ b/pallets/erc20-xcm-bridge/src/lib.rs
@@ -27,6 +27,7 @@ use frame_support::pallet;
 
 pub use erc20_trap::AssetTrapWrapper;
 pub use pallet::*;
+pub use xcm_holding_ext::XcmExecutorWrapper;
 
 #[pallet]
 pub mod pallet {

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -350,6 +350,11 @@ pub type XcmRouter = (
 	XcmpQueue,
 );
 
+type XcmExecutor = pallet_erc20_xcm_bridge::XcmExecutorWrapper<
+	RuntimeCall,
+	xcm_executor::XcmExecutor<XcmExecutorConfig>,
+>;
+
 #[cfg(feature = "runtime-benchmarks")]
 parameter_types! {
 	pub ReachableDest: Option<MultiLocation> = Some(Parent.into());
@@ -361,7 +366,7 @@ impl pallet_xcm::Config for Runtime {
 	type XcmRouter = XcmRouter;
 	type ExecuteXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
 	type XcmExecuteFilter = Everything;
-	type XcmExecutor = xcm_executor::XcmExecutor<XcmExecutorConfig>;
+	type XcmExecutor = XcmExecutor;
 	type XcmTeleportFilter = Nothing;
 	type XcmReserveTransferFilter = Everything;
 	type Weigher = XcmWeigher;
@@ -383,12 +388,12 @@ impl pallet_xcm::Config for Runtime {
 
 impl cumulus_pallet_xcm::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type XcmExecutor = xcm_executor::XcmExecutor<XcmExecutorConfig>;
+	type XcmExecutor = XcmExecutor;
 }
 
 impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type XcmExecutor = xcm_executor::XcmExecutor<XcmExecutorConfig>;
+	type XcmExecutor = XcmExecutor;
 	type ChannelInfo = ParachainSystem;
 	type VersionWrapper = PolkadotXcm;
 	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
@@ -400,7 +405,7 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 
 impl cumulus_pallet_dmp_queue::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type XcmExecutor = xcm_executor::XcmExecutor<XcmExecutorConfig>;
+	type XcmExecutor = XcmExecutor;
 	type ExecuteOverweightOrigin = EnsureRoot<AccountId>;
 }
 
@@ -547,7 +552,7 @@ impl orml_xtokens::Config for Runtime {
 	type AccountIdToMultiLocation = AccountIdToMultiLocation<AccountId>;
 	type CurrencyIdConvert =
 		CurrencyIdtoMultiLocation<AsAssetType<AssetId, AssetType, AssetManager>>;
-	type XcmExecutor = xcm_executor::XcmExecutor<XcmExecutorConfig>;
+	type XcmExecutor = XcmExecutor;
 	type SelfLocation = SelfLocation;
 	type Weigher = XcmWeigher;
 	type BaseXcmWeight = BaseXcmWeight;


### PR DESCRIPTION
### What does it do?

Recreate the executor wrapper to inject global context for the holding extension. This wrapper was removed by https://github.com/PureStake/moonbeam/pull/2145.

In the medium term the complete erc20 xcm implementation will be redesigned, but in the meantime we need to maintain the functioning of the old implementation on moonbase.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
