### PR TITLE
add typescript test for erc20 xcm reception + refactor xcm utils (ts)

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@metamask/eth-sig-util": "^4.0.1",
-        "@openzeppelin/contracts": "^4.8.2",
         "@moonbeam-network/api-augment": "^0.2201.0",
+        "@openzeppelin/contracts": "^4.8.2",
         "@polkadot/api": "^10.1.4",
         "@polkadot/api-augment": "^10.1.4",
         "@polkadot/apps-config": "^0.122.2",

--- a/tests/package.json
+++ b/tests/package.json
@@ -52,7 +52,7 @@
     "watch": "npm-watch",
     "build": "npx tsc && cp -r contracts build/",
     "build-clean": "rm -r node_modules && npm i && npm run build",
-    "test-single": "mocha -r ts-node/register 'tests/test-xcm/test-xcm-erc20-transfer.ts'",
+    "test-single": "mocha -r ts-node/register 'tests/test-xcm/test-mock-hrmp-transact-ethereum.ts'",
     "current-test": "mocha -r ts-node/register",
     "lint": "npx prettier --write --ignore-path .gitignore '**/*.(yml|js|ts|json)'",
     "clean": "rimraf *.log binaries/* runtimes/* specs/*"

--- a/tests/tests/test-fees/test-fee-multiplier.ts
+++ b/tests/tests/test-fees/test-fee-multiplier.ts
@@ -288,17 +288,17 @@ describeDevMoonbeam("Fee Multiplier - XCM Executions", (context) => {
       .sudo(context.polkadotApi.tx.rootTesting.fillBlock(TARGET_FILL_AMOUNT))
       .signAndSend(alith, { nonce: -1 });
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: transferredBalance / 3n,
-      },
+          fungible: transferredBalance / 3n,
+        },
+      ],
       weight_limit: new BN(4000000000),
       descend_origin: sendingAddress,
     })
@@ -381,17 +381,17 @@ describeDevMoonbeam("Fee Multiplier - XCM Executions", (context) => {
       .sudo(context.polkadotApi.tx.rootTesting.fillBlock(TARGET_FILL_AMOUNT))
       .signAndSend(alith, { nonce: -1 });
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: transferredBalance / 3n,
-      },
+          fungible: transferredBalance / 3n,
+        },
+      ],
       weight_limit: new BN(4000000000),
       descend_origin: sendingAddress,
     })

--- a/tests/tests/test-xcm/test-mock-dmp-error-and-appendix.ts
+++ b/tests/tests/test-xcm/test-mock-dmp-error-and-appendix.ts
@@ -33,17 +33,17 @@ describeDevMoonbeam("Mock XCM - downward transfer with non-triggered error handl
 
   it("Should make sure that Alith does not receive 10 dot without error", async function () {
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 1,
             interior: {
               Here: null,
             },
           },
-        ],
-        fungible: 10n * RELAY_TOKEN,
-      },
+          fungible: 10n * RELAY_TOKEN,
+        },
+      ],
       weight_limit: new BN(500000000),
       beneficiary: alith.address,
     })
@@ -97,17 +97,17 @@ describeDevMoonbeam("Mock XCM - downward transfer with triggered error handler",
 
   it("Should make sure that Alith does receive 10 dot because there is error", async function () {
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 1,
             interior: {
               Here: null,
             },
           },
-        ],
-        fungible: 10n * RELAY_TOKEN,
-      },
+          fungible: 10n * RELAY_TOKEN,
+        },
+      ],
       weight_limit: new BN(1000000000),
       beneficiary: alith.address,
     })
@@ -162,17 +162,17 @@ describeDevMoonbeam("Mock XCM - downward transfer with always triggered appendix
 
   it("Should make sure Alith receives 10 dot with appendix and without error", async function () {
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 1,
             interior: {
               Here: null,
             },
           },
-        ],
-        fungible: 10n * RELAY_TOKEN,
-      },
+          fungible: 10n * RELAY_TOKEN,
+        },
+      ],
       weight_limit: new BN(800000000),
       beneficiary: alith.address,
     })
@@ -224,17 +224,17 @@ describeDevMoonbeam("Mock XCM - downward transfer with always triggered appendix
 
   it("Should make sure Alith receives 10 dot with appendix and without error", async function () {
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 1,
             interior: {
               Here: null,
             },
           },
-        ],
-        fungible: 10n * RELAY_TOKEN,
-      },
+          fungible: 10n * RELAY_TOKEN,
+        },
+      ],
       weight_limit: new BN(1000000000),
       beneficiary: alith.address,
     })
@@ -293,17 +293,17 @@ describeDevMoonbeam("Mock XCM - downward transfer claim trapped assets", (contex
     // Since we only BuyExecution, but we do not do anything with the assets after that,
     // they are trapped
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 1,
             interior: {
               Here: null,
             },
           },
-        ],
-        fungible: 10n * RELAY_TOKEN,
-      },
+          fungible: 10n * RELAY_TOKEN,
+        },
+      ],
     })
       .reserve_asset_deposited()
       .buy_execution()
@@ -333,17 +333,17 @@ describeDevMoonbeam("Mock XCM - downward transfer claim trapped assets", (contex
 
   it("Should make sure that Alith receives claimed assets", async function () {
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 1,
             interior: {
               Here: null,
             },
           },
-        ],
-        fungible: 10n * RELAY_TOKEN,
-      },
+          fungible: 10n * RELAY_TOKEN,
+        },
+      ],
       weight_limit: new BN(1000000000),
       beneficiary: alith.address,
     })

--- a/tests/tests/test-xcm/test-mock-dmp-queue.ts
+++ b/tests/tests/test-xcm/test-mock-dmp-queue.ts
@@ -39,17 +39,17 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
     // go on idle
 
     const config = {
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: 1_000_000_000_000_000n,
-      },
+          fungible: 1_000_000_000_000_000n,
+        },
+      ],
     };
 
     // How much does the withdraw weight?

--- a/tests/tests/test-xcm/test-mock-hrmp-asset-transfer.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp-asset-transfer.ts
@@ -118,15 +118,15 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     // Parachain(Statemint parachain)
     // GeneralIndex(assetId being transferred)
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 1,
             interior: { X2: [{ Parachain: statemint_para_id }, { GeneralIndex: 0 }] },
           },
-        ],
-        fungible: 10000000000000n,
-      },
+          fungible: 10000000000000n,
+        },
+      ],
       weight_limit: new BN(4000000000),
       beneficiary: alith.address,
     })
@@ -179,9 +179,9 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     // PalletInstance(Statemint assets pallet instance)
     // GeneralIndex(assetId being transferred)
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 1,
             interior: {
               X3: [
@@ -191,9 +191,9 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
               ],
             },
           },
-        ],
-        fungible: 10000000000000n,
-      },
+          fungible: 10000000000000n,
+        },
+      ],
       weight_limit: new BN(4000000000),
       beneficiary: alith.address,
     })
@@ -257,17 +257,17 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer of DEV", (context) =
     // We are charging 20 micro DEV for this operation
     // The rest should be going to the deposit account
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 1,
             interior: {
               X2: [{ Parachain: ownParaId }, { PalletInstance: balancesPalletIndex }],
             },
           },
-        ],
-        fungible: transferredBalance,
-      },
+          fungible: transferredBalance,
+        },
+      ],
       weight_limit: new BN(4000000000),
       beneficiary: random.address,
     })
@@ -336,17 +336,17 @@ describeDevMoonbeam(
 
       // The rest should be going to the deposit account
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [
-            {
+        assets: [
+          {
+            multilocation: {
               parents: 0,
               interior: {
                 X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          ],
-          fungible: transferredBalance,
-        },
+            fungible: transferredBalance,
+          },
+        ],
         weight_limit: new BN(8000000000),
         beneficiary: random.address,
       })
@@ -462,23 +462,26 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     // We are charging 20 micro DEV for this operation
     // The rest should be going to the deposit account
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-          {
+          fungible: transferredBalance,
+        },
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X2: [{ PalletInstance: localAssetsPalletIndex }, { GeneralIndex: assetId }],
             },
           },
-        ],
-        fungible: transferredBalance,
-      },
+          fungible: transferredBalance,
+        },
+      ],
       weight_limit: new BN(4000000000),
       beneficiary: alith.address,
     })
@@ -535,9 +538,9 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     // We are going to test that, using one of them as fee payment (assetOne),
     // we can receive the other
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 1,
             interior: {
               X3: [
@@ -547,7 +550,10 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
               ],
             },
           },
-          {
+          fungible: 10000000000000n,
+        },
+        {
+          multilocation: {
             parents: 1,
             interior: {
               X3: [
@@ -557,9 +563,9 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
               ],
             },
           },
-        ],
-        fungible: 10000000000000n,
-      },
+          fungible: 10000000000000n,
+        },
+      ],
       weight_limit: new BN(4000000000),
       beneficiary: alith.address,
     })
@@ -663,27 +669,26 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     // We are charging 20 micro DEV for this operation
     // The rest should be going to the deposit account
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 1,
             interior: {
               X2: [{ Parachain: ownParaId }, { PalletInstance: balancesPalletIndex }],
             },
           },
-          {
+          fungible: transferredBalance,
+        },
+        {
+          multilocation: {
             parents: 1,
             interior: {
-              X3: [
-                { Parachain: ownParaId },
-                { PalletInstance: localAssetsPalletIndex },
-                { GeneralIndex: assetId },
-              ],
+              X2: [{ Parachain: ownParaId }, { PalletInstance: balancesPalletIndex }],
             },
           },
-        ],
-        fungible: transferredBalance,
-      },
+          fungible: transferredBalance,
+        },
+      ],
       weight_limit: new BN(4000000000),
       beneficiary: baltathar.address,
     })
@@ -727,15 +732,15 @@ describeDevMoonbeam("Mock XCM - receive horizontal transfer", (context) => {
     // We are going to test that, using one of them as fee payment (assetOne),
     // we can receive the other
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 1,
             interior: { X2: [{ Parachain: statemint_para_id }, { GeneralIndex: 0 }] },
           },
-        ],
-        fungible: 10000000000000n,
-      },
+          fungible: 10000000000000n,
+        },
+      ],
       weight_limit: new BN(4000000000),
       beneficiary: alith.address,
     })

--- a/tests/tests/test-xcm/test-mock-hrmp-queue.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp-queue.ts
@@ -124,17 +124,17 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
     const weightPerMessage = (totalXcmpWeight * BigInt(2)) / BigInt(numParaMsgs);
 
     const config = {
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: 1_000_000_000_000_000n,
-      },
+          fungible: 1_000_000_000_000_000n,
+        },
+      ],
     };
 
     // How much does the withdraw weight?
@@ -255,17 +255,17 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
     const weightPerMessage = (totalXcmpWeight * BigInt(2)) / BigInt(numParaMsgs);
 
     const config = {
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: 1_000_000_000_000_000n,
-      },
+          fungible: 1_000_000_000_000_000n,
+        },
+      ],
     };
 
     // How much does the withdraw weight?
@@ -422,17 +422,17 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
     ).index;
 
     const xcmMessageNotExecuted = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: 1n,
-      },
+          fungible: 1n,
+        },
+      ],
       weight_limit: new BN(20000000000),
     })
       .withdraw_asset()
@@ -440,17 +440,17 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
       .as_v2();
 
     const xcmMessageExecuted = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: 2n,
-      },
+          fungible: 2n,
+        },
+      ],
       weight_limit: new BN(20000000000),
     })
       .withdraw_asset()
@@ -495,17 +495,17 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
     ).index;
 
     const xcmMessageNotExecuted = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: 1n,
-      },
+          fungible: 1n,
+        },
+      ],
       weight_limit: new BN(20000000000),
     })
       .withdraw_asset()
@@ -640,17 +640,17 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
 
     // we will prove we get two different events with xcmp.queue
     const xcmFirstFragment = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: 1_000_000_000_000_000n,
-      },
+          fungible: 1_000_000_000_000_000n,
+        },
+      ],
       weight_limit: new BN(1_000_000_000),
     })
       .withdraw_asset()
@@ -658,17 +658,17 @@ describeDevMoonbeam("Mock XCMP - test XCMP execution", (context) => {
       .as_v2();
 
     const xcmSecondFragment = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: 2_000_000_000_000_000n,
-      },
+          fungible: 2_000_000_000_000_000n,
+        },
+      ],
       weight_limit: new BN(2_000_000_000),
     })
       .withdraw_asset()

--- a/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp-transact-ethereum.ts
@@ -104,17 +104,17 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (transfer)"
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [
-            {
+        assets: [
+          {
+            multilocation: {
               parents: 0,
               interior: {
                 X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          ],
-          fungible: targetXcmFee,
-        },
+            fungible: targetXcmFee,
+          },
+        ],
         weight_limit: new BN(targetXcmWeight.toString()),
         descend_origin: sendingAddress,
       })
@@ -234,17 +234,17 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (call)", (c
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [
-            {
+        assets: [
+          {
+            multilocation: {
               parents: 0,
               interior: {
                 X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          ],
-          fungible: transferredBalance / 2n,
-        },
+            fungible: transferredBalance / 2n,
+          },
+        ],
         weight_limit: new BN(4000000000),
         descend_origin: sendingAddress,
       })
@@ -332,10 +332,12 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (asset fee)
     expect(registeredAsset.owner.toHex()).to.eq(palletId.toLowerCase());
 
     let config = {
-      fees: {
-        multilocation: [ASSET_MULTILOCATION],
-        fungible: 0n,
-      },
+      assets: [
+        {
+          multilocation: ASSET_MULTILOCATION,
+          fungible: 0n,
+        },
+      ],
       beneficiary: descendOriginAddress,
     };
 
@@ -355,7 +357,7 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (asset fee)
 
     // we modify the config now:
     // we send assetsToTransfer plus whatever we will be charged in weight
-    config.fees.fungible = assetsToTransfer + chargedWeight;
+    config.assets[0].fungible = assetsToTransfer + chargedWeight;
 
     // Construct the real message
     const xcmMessage = new XcmFragment(config)
@@ -422,10 +424,12 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (asset fee)
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [ASSET_MULTILOCATION],
-          fungible: assetsToTransfer / 2n,
-        },
+        assets: [
+          {
+            multilocation: ASSET_MULTILOCATION,
+            fungible: assetsToTransfer / 2n,
+          },
+        ],
         weight_limit: new BN((assetsToTransfer / 2n).toString()),
         descend_origin: sendingAddress,
       })
@@ -550,17 +554,17 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [
-            {
+        assets: [
+          {
+            multilocation: {
               parents: 0,
               interior: {
                 X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          ],
-          fungible: targetXcmFee,
-        },
+            fungible: targetXcmFee,
+          },
+        ],
         weight_limit: new BN(targetXcmWeight.toString()),
         descend_origin: sendingAddress,
       })
@@ -690,17 +694,17 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [
-            {
+        assets: [
+          {
+            multilocation: {
               parents: 0,
               interior: {
                 X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          ],
-          fungible: targetXcmFee,
-        },
+            fungible: targetXcmFee,
+          },
+        ],
         weight_limit: new BN(targetXcmWeight.toString()),
         descend_origin: sendingAddress,
       })
@@ -846,17 +850,17 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (proxy)", (
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [
-            {
+        assets: [
+          {
+            multilocation: {
               parents: 0,
               interior: {
                 X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          ],
-          fungible: targetXcmFee,
-        },
+            fungible: targetXcmFee,
+          },
+        ],
         weight_limit: new BN(targetXcmWeight.toString()),
         descend_origin: sendingAddress,
       })
@@ -1024,17 +1028,17 @@ describeDevMoonbeam("Mock XCM - transact ETHEREUM (proxy) disabled switch", (con
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [
-            {
+        assets: [
+          {
+            multilocation: {
               parents: 0,
               interior: {
                 X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          ],
-          fungible: targetXcmFee,
-        },
+            fungible: targetXcmFee,
+          },
+        ],
         weight_limit: new BN(targetXcmWeight.toString()),
         descend_origin: sendingAddress,
       })
@@ -1174,17 +1178,17 @@ describeDevMoonbeam("Mock XCM - transact ETHEREUM (non-proxy) disabled switch", 
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [
-            {
+        assets: [
+          {
+            multilocation: {
               parents: 0,
               interior: {
                 X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          ],
-          fungible: targetXcmFee,
-        },
+            fungible: targetXcmFee,
+          },
+        ],
         weight_limit: new BN(targetXcmWeight.toString()),
         descend_origin: sendingAddress,
       })
@@ -1333,17 +1337,17 @@ describeDevMoonbeam("Mock XCM - transact ETHEREUM input size check succeeds", (c
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [
-            {
+        assets: [
+          {
+            multilocation: {
               parents: 0,
               interior: {
                 X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          ],
-          fungible: transferredBalance / 2n,
-        },
+            fungible: transferredBalance / 2n,
+          },
+        ],
         weight_limit: new BN(40000000000),
         descend_origin: sendingAddress,
       })
@@ -1457,17 +1461,17 @@ describeDevMoonbeam("Mock XCM - transact ETHEREUM input size check fails", (cont
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [
-            {
+        assets: [
+          {
+            multilocation: {
               parents: 0,
               interior: {
                 X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          ],
-          fungible: transferredBalance / 2n,
-        },
+            fungible: transferredBalance / 2n,
+          },
+        ],
         weight_limit: new BN(40000000000),
         descend_origin: sendingAddress,
       })
@@ -1572,17 +1576,17 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact ETHEREUM (transfer)"
       // We are going to test that we can receive a transact operation from parachain 1
       // using descendOrigin first
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [
-            {
+        assets: [
+          {
+            multilocation: {
               parents: 0,
               interior: {
                 X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          ],
-          fungible: targetXcmFee,
-        },
+            fungible: targetXcmFee,
+          },
+        ],
         weight_limit: new BN(targetXcmWeight.toString()),
         descend_origin: sendingAddress,
       })

--- a/tests/tests/test-xcm/test-mock-hrmp-transact.ts
+++ b/tests/tests/test-xcm/test-mock-hrmp-transact.ts
@@ -56,17 +56,17 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact", (context) => {
     // We are going to test that we can receive a transact operation from parachain 1
     // using descendOrigin first
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: transferredBalance / 2n,
-      },
+          fungible: transferredBalance / 2n,
+        },
+      ],
       weight_limit: new BN(4000000000),
       descend_origin: sendingAddress,
     })
@@ -139,17 +139,17 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact with two Descends", 
     // We are going to test that we can receive a transact operation from parachain 1
     // using 2 descendOrigin first
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: transferredBalance / 2n,
-      },
+          fungible: transferredBalance / 2n,
+        },
+      ],
       weight_limit: new BN(4000000000),
       descend_origin: sendingAddress,
     })
@@ -223,17 +223,17 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact without withdraw", (
     // We are going to test that we can receive a transact operation from parachain 1
     // using descendOrigin first but without withdraw
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: transferredBalance / 2n,
-      },
+          fungible: transferredBalance / 2n,
+        },
+      ],
       weight_limit: new BN(4000000000),
       descend_origin: sendingAddress,
     })
@@ -305,17 +305,17 @@ describeDevMoonbeam("Mock XCM - receive horizontal transact without buy executio
     // We are going to test that we can receive a transact operation from parachain 1
     // using descendOrigin first but without buy execution
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: transferredBalance / 2n,
-      },
+          fungible: transferredBalance / 2n,
+        },
+      ],
       weight_limit: new BN(4000000000),
       descend_origin: sendingAddress,
     })

--- a/tests/tests/test-xcm/test-xcm-erc20-transfer.ts
+++ b/tests/tests/test-xcm/test-xcm-erc20-transfer.ts
@@ -124,7 +124,7 @@ describeDevMoonbeam("Mock XCM - Receice back erc20", (context) => {
     erc20ContractAddress = contractAddress;
   });
 
-  it.only("Should be able to transfer ERC20 token throught incoming XCM message", async function () {
+  it("Should be able to transfer ERC20 token throught incoming XCM message", async function () {
     this.timeout(20_000);
     const paraId = 888;
     const paraSovereign = "0x7369626c78030000000000000000000000000000";

--- a/tests/tests/test-xcm/test-xcm-erc20-transfer.ts
+++ b/tests/tests/test-xcm/test-xcm-erc20-transfer.ts
@@ -16,11 +16,7 @@ import {
   createTransaction,
 } from "../../util/transactions";
 import { expectEVMResult } from "../../util/eth-transactions";
-import {
-  injectHrmpMessage,
-  RawXcmMessage,
-  XcmFragment,
-} from "../../util/xcm";
+import { injectHrmpMessage, RawXcmMessage, XcmFragment } from "../../util/xcm";
 
 const ERC20_CONTRACT = getCompiled("ERC20WithInitialSupply");
 const ERC20_INTERFACE = new ethers.utils.Interface(ERC20_CONTRACT.contract.abi);
@@ -154,10 +150,7 @@ describeDevMoonbeam("Mock XCM - Receice back erc20", (context) => {
       createTransaction(context, {
         ...ALITH_TRANSACTION_TEMPLATE,
         to: erc20ContractAddress,
-        data: ERC20_INTERFACE.encodeFunctionData("transfer", [
-          paraSovereign,
-          amountTransferred,
-        ]),
+        data: ERC20_INTERFACE.encodeFunctionData("transfer", [paraSovereign, amountTransferred]),
       })
     );
     expectEVMResult(result2.events, "Succeed");

--- a/tests/tracing-tests/test-trace-ethereum-xcm.ts
+++ b/tests/tracing-tests/test-trace-ethereum-xcm.ts
@@ -80,17 +80,17 @@ describeDevMoonbeam("Trace ethereum xcm #1", (context) => {
       const transferCall = context.polkadotApi.tx.ethereumXcm.transact(xcmTransaction as any);
       const transferCallEncoded = transferCall?.method.toHex();
       const xcmMessage = new XcmFragment({
-        fees: {
-          multilocation: [
-            {
+        assets: [
+          {
+            multilocation: {
               parents: 0,
               interior: {
                 X1: { PalletInstance: balancesPalletIndex },
               },
             },
-          ],
-          fungible: transferredBalance / 2n,
-        },
+            fungible: transferredBalance / 2n,
+          },
+        ],
         weight_limit: new BN(4000000000),
         descend_origin: sendingAddress,
       })
@@ -181,17 +181,17 @@ describeDevMoonbeam("Trace ethereum xcm #2", (context) => {
     const transferCall = context.polkadotApi.tx.ethereumXcm.transact(xcmTransaction as any);
     const transferCallEncoded = transferCall?.method.toHex();
     const xcmMessage = new XcmFragment({
-      fees: {
-        multilocation: [
-          {
+      assets: [
+        {
+          multilocation: {
             parents: 0,
             interior: {
               X1: { PalletInstance: balancesPalletIndex },
             },
           },
-        ],
-        fungible: transferredBalance / 2n,
-      },
+          fungible: transferredBalance / 2n,
+        },
+      ],
       weight_limit: new BN(4000000000),
       descend_origin: sendingAddress,
     })

--- a/tests/util/xcm.ts
+++ b/tests/util/xcm.ts
@@ -253,6 +253,39 @@ export class XcmFragment {
     return this;
   }
 
+  // Add a `WithdrawAsset` instruction
+  withdraw_erc20_asset(erc20XcmPalletIndex: number, contractAddress: string, amount: BigInt): this {
+    this.instructions.push({
+      WithdrawAsset: [
+        {
+          id: {
+            Concrete: this.config.fees.multilocation[0],
+          },
+          fun: { Fungible: this.config.fees.fungible  },
+        },
+        {
+          id: {
+            Concrete: {
+              parents: 0,
+              interior: {
+                X2: [{
+                  PalletInstance: erc20XcmPalletIndex,
+                },{
+                  AccountKey20: {
+                    network: "Any",
+                    key: contractAddress,
+                  },
+                }],
+              },
+            },
+          },
+          fun: { Fungible: amount },
+        },
+      ],
+    });
+    return this;
+  }
+
   // Add one or more `BuyExecution` instruction
   // if weight_limit is not set in config, then we put unlimited
   buy_execution(multilocation_index: number = 0, repeat: bigint = 1n): this {

--- a/tests/util/xcm.ts
+++ b/tests/util/xcm.ts
@@ -261,21 +261,24 @@ export class XcmFragment {
           id: {
             Concrete: this.config.fees.multilocation[0],
           },
-          fun: { Fungible: this.config.fees.fungible  },
+          fun: { Fungible: this.config.fees.fungible },
         },
         {
           id: {
             Concrete: {
               parents: 0,
               interior: {
-                X2: [{
-                  PalletInstance: erc20XcmPalletIndex,
-                },{
-                  AccountKey20: {
-                    network: "Any",
-                    key: contractAddress,
+                X2: [
+                  {
+                    PalletInstance: erc20XcmPalletIndex,
                   },
-                }],
+                  {
+                    AccountKey20: {
+                      network: "Any",
+                      key: contractAddress,
+                    },
+                  },
+                ],
               },
             },
           },


### PR DESCRIPTION
### What does it do?

Add a typescript test that simulate an incoming XCM message to send back an ERC20 asset.

This PR take the opportunity to refactor xcm utils, especially xcm fragment configuration to make it more logical.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
