### PR TITLE
Import extract_genesis_wasm function instead of duplicating it

### DIFF
--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -17,7 +17,7 @@
 //! This module constructs and executes the appropriate service components for the given subcommand
 
 use crate::cli::{Cli, RelayChainCli, RunCmd, Subcommand};
-use cumulus_client_cli::generate_genesis_block;
+use cumulus_client_cli::{extract_genesis_wasm, generate_genesis_block};
 use cumulus_primitives_core::ParaId;
 use frame_benchmarking_cli::BenchmarkCmd;
 use log::{info, warn};
@@ -193,16 +193,6 @@ impl SubstrateCli for RelayChainCli {
 	fn native_runtime_version(chain_spec: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
 		polkadot_cli::Cli::native_runtime_version(chain_spec)
 	}
-}
-
-#[allow(clippy::borrowed_box)]
-fn extract_genesis_wasm(chain_spec: &Box<dyn sc_service::ChainSpec>) -> Result<Vec<u8>> {
-	let mut storage = chain_spec.build_storage()?;
-
-	storage
-		.top
-		.remove(sp_core::storage::well_known_keys::CODE)
-		.ok_or_else(|| "Could not find wasm file in genesis state!".into())
 }
 
 fn validate_trace_environment(cli: &Cli) -> Result<()> {
@@ -462,7 +452,7 @@ pub fn run() -> Result<()> {
 			let _ = builder.init();
 
 			let raw_wasm_blob =
-				extract_genesis_wasm(&cli.load_spec(&params.chain.clone().unwrap_or_default())?)?;
+				extract_genesis_wasm(&*cli.load_spec(&params.chain.clone().unwrap_or_default())?)?;
 			let output_buf = if params.raw {
 				raw_wasm_blob
 			} else {

--- a/node/cli/src/command.rs
+++ b/node/cli/src/command.rs
@@ -299,9 +299,8 @@ pub fn run() -> Result<()> {
 				// Although the cumulus_client_cli::PurgeCommand will extract the relay chain id,
 				// we need to extract it here to determine whether we are running the dev service.
 				let extension = chain_spec::Extensions::try_get(&*config.chain_spec);
-				let relay_chain_id = extension.map(|e| e.relay_chain.clone());
-				let dev_service =
-					cli.run.dev_service || relay_chain_id == Some("dev-service".to_string());
+				let relay_chain_id = extension.map(|e| e.relay_chain.as_str());
+				let dev_service = cli.run.dev_service || relay_chain_id == Some("dev-service");
 
 				// Remove Frontier offchain db
 				let frontier_database_config = match config.database {
@@ -391,7 +390,7 @@ pub fn run() -> Result<()> {
 
 			// Cumulus approach here, we directly call the generic load_spec func
 			let chain_spec = load_spec(
-				&params.chain.clone().unwrap_or_default(),
+				params.chain.as_deref().unwrap_or_default(),
 				params.parachain_id.unwrap_or(1000).into(),
 				&cli.run,
 			)?;
@@ -451,8 +450,9 @@ pub fn run() -> Result<()> {
 			builder.with_profiling(sc_tracing::TracingReceiver::Log, "");
 			let _ = builder.init();
 
-			let raw_wasm_blob =
-				extract_genesis_wasm(&*cli.load_spec(&params.chain.clone().unwrap_or_default())?)?;
+			let raw_wasm_blob = extract_genesis_wasm(
+				&*cli.load_spec(params.chain.as_deref().unwrap_or_default())?,
+			)?;
 			let output_buf = if params.raw {
 				raw_wasm_blob
 			} else {
@@ -735,9 +735,9 @@ pub fn run() -> Result<()> {
 				// 1. by providing the --dev-service flag to the CLI
 				// 2. by specifying "dev-service" in the chain spec's "relay-chain" field.
 				// NOTE: the --dev flag triggers the dev service by way of number 2
-				let relay_chain_id = extension.map(|e| e.relay_chain.clone());
+				let relay_chain_id = extension.map(|e| e.relay_chain.as_str());
 				let dev_service =
-					config.chain_spec.is_dev() || relay_chain_id == Some("dev-service".to_string());
+					config.chain_spec.is_dev() || relay_chain_id == Some("dev-service");
 
 				if dev_service {
 					// When running the dev service, just use Alice's author inherent


### PR DESCRIPTION
A refactor because I noticed that this function already exists in cumulus_client_cli, and the code is exactly the same.

Also remove a few clones.