### PR TITLE
MOdify proof size for XCM

### DIFF
--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -523,7 +523,7 @@ where
 
 parameter_types! {
 	pub const BaseXcmWeight: Weight
-		= Weight::from_parts(200_000_000u64, xcm_primitives::DEFAULT_PROOF_SIZE);
+		= Weight::from_parts(200_000_000u64, 0);
 	pub const MaxAssetsForTransfer: usize = 2;
 	// This is how we are going to detect whether the asset is a Reserve asset
 	// This however is the chain part only

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -50,7 +50,7 @@ use xcm_executor::traits::JustTry;
 use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToMultiLocation, AsAssetType,
-	FirstAssetTrader, SignedToAccountId20, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact
+	FirstAssetTrader, SignedToAccountId20, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact,
 };
 
 use parity_scale_codec::{Decode, Encode};

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -50,8 +50,7 @@ use xcm_executor::traits::JustTry;
 use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToMultiLocation, AsAssetType,
-	FirstAssetTrader, SignedToAccountId20, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact,
-	DEFAULT_PROOF_SIZE,
+	FirstAssetTrader, SignedToAccountId20, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact
 };
 
 use parity_scale_codec::{Decode, Encode};

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -199,7 +199,7 @@ pub type XcmOriginToTransactDispatchOrigin = (
 
 parameter_types! {
 	/// The amount of weight an XCM operation takes. This is safe overestimate.
-	pub UnitWeightCost: Weight = Weight::from_parts(200_000_000u64, DEFAULT_PROOF_SIZE);
+	pub UnitWeightCost: Weight = Weight::from_parts(200_000_000u64, 0);
 	/// Maximum number of instructions in a single XCM fragment. A sanity check against
 	/// weight caculations getting too crazy.
 	pub MaxInstructions: u32 = 100;
@@ -456,7 +456,7 @@ where
 }
 
 parameter_types! {
-	pub const BaseXcmWeight: Weight = Weight::from_parts(200_000_000u64, DEFAULT_PROOF_SIZE);
+	pub const BaseXcmWeight: Weight = Weight::from_parts(200_000_000u64, 0);
 	pub const MaxAssetsForTransfer: usize = 2;
 
 	// This is how we are going to detect whether the asset is a Reserve asset

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -50,7 +50,7 @@ use xcm_executor::traits::JustTry;
 use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToMultiLocation, AsAssetType,
-	FirstAssetTrader, SignedToAccountId20, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact
+	FirstAssetTrader, SignedToAccountId20, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact,
 };
 
 use parity_scale_codec::{Decode, Encode};

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -209,7 +209,7 @@ pub type XcmOriginToTransactDispatchOrigin = (
 
 parameter_types! {
 	/// The amount of weight an XCM operation takes. This is safe overestimate.
-	pub UnitWeightCost: Weight = Weight::from_parts(200_000_000u64, DEFAULT_PROOF_SIZE);
+	pub UnitWeightCost: Weight = Weight::from_parts(200_000_000u64, 0);
 	/// Maximum number of instructions in a single XCM fragment. A sanity check against
 	/// weight caculations getting too crazy.
 	pub MaxInstructions: u32 = 100;
@@ -472,7 +472,7 @@ where
 }
 
 parameter_types! {
-	pub const BaseXcmWeight: Weight = Weight::from_parts(200_000_000u64, DEFAULT_PROOF_SIZE);
+	pub const BaseXcmWeight: Weight = Weight::from_parts(200_000_000u64, 0);
 	pub const MaxAssetsForTransfer: usize = 2;
 
 	// This is how we are going to detect whether the asset is a Reserve asset

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -50,8 +50,7 @@ use xcm_executor::traits::JustTry;
 use orml_xcm_support::MultiNativeAsset;
 use xcm_primitives::{
 	AbsoluteAndRelativeReserve, AccountIdToCurrencyId, AccountIdToMultiLocation, AsAssetType,
-	FirstAssetTrader, SignedToAccountId20, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact,
-	DEFAULT_PROOF_SIZE,
+	FirstAssetTrader, SignedToAccountId20, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact
 };
 
 use parity_scale_codec::{Decode, Encode};

--- a/tests/tests/test-xcm/test-xcm-ver-conversion.ts
+++ b/tests/tests/test-xcm/test-xcm-ver-conversion.ts
@@ -1,0 +1,189 @@
+import "@moonbeam-network/api-augment";
+import { KeyringPair } from "@polkadot/keyring/types";
+import { ParaId } from "@polkadot/types/interfaces";
+import { BN, u8aToHex } from "@polkadot/util";
+import { expect } from "chai";
+import { generateKeyringPair } from "../../util/accounts";
+import {
+  injectHrmpMessageAndSeal,
+  RawXcmMessage,
+  weightMessage,
+  XcmFragment,
+} from "../../util/xcm";
+import { describeDevMoonbeam } from "../../util/setup-dev-tests";
+import { expectOk } from "../../util/expect";
+
+const foreign_para_id = 2000;
+
+// TODO: Add more test case permutations
+describeDevMoonbeam(
+  "XCM Moonbase: version compatibility",
+  (context) => {
+    let random: KeyringPair;
+    let paraId: ParaId;
+    let transferredBalance: bigint;
+    let sovereignAddress: string;
+
+    before("Should send DEV to the parachain sovereign", async function () {
+      random = generateKeyringPair();
+      paraId = context.polkadotApi.createType("ParaId", 2000) as any;
+      sovereignAddress = u8aToHex(
+        new Uint8Array([...new TextEncoder().encode("sibl"), ...paraId.toU8a()])
+      ).padEnd(42, "0");
+
+      transferredBalance = 100000000000000n;
+      await expectOk(
+        context.createBlock(
+          context.polkadotApi.tx.balances.transfer(sovereignAddress, transferredBalance)
+        )
+      );
+      const balance = (
+        (await context.polkadotApi.query.system.account(sovereignAddress)) as any
+      ).data.free.toBigInt();
+      expect(balance).to.eq(transferredBalance);
+    });
+
+    it("Should execute v2 message", async function () {
+      const metadata = await context.polkadotApi.rpc.state.getMetadata();
+      const balancesPalletIndex = (metadata.asLatest.toHuman().pallets as Array<any>).find(
+        (pallet) => pallet.name === "Balances"
+      ).index;
+
+      const xcmMessage = new XcmFragment({
+        assets: [
+          {
+            multilocation: {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
+              },
+            },
+            fungible: transferredBalance,
+          },
+        ],
+        weight_limit: new BN(8000000000),
+        beneficiary: random.address,
+      })
+        .withdraw_asset()
+        .clear_origin()
+        .buy_execution()
+        .deposit_asset()
+        .as_v2();
+
+      const chargedWeight = await weightMessage(
+        context,
+        context.polkadotApi.createType("XcmVersionedXcm", xcmMessage) as any
+      );
+
+      const chargedFee = chargedWeight * 50000n;
+
+      await injectHrmpMessageAndSeal(context, foreign_para_id, {
+        type: "XcmVersionedXcm",
+        payload: xcmMessage,
+      } as RawXcmMessage);
+
+      const balance = (
+        (await context.polkadotApi.query.system.account(sovereignAddress)) as any
+      ).data.free.toBigInt();
+      expect(balance.toString(), "Sovereign account not empty, transfer has failed").to.eq(
+        0n.toString()
+      );
+
+      const randomBalance = (
+        (await context.polkadotApi.query.system.account(random.address)) as any
+      ).data.free.toBigInt();
+      const expectedRandomBalance = transferredBalance - chargedFee;
+      expect(randomBalance, "Balance not increased, transfer has failed").to.eq(
+        expectedRandomBalance
+      );
+    });
+  },
+  "Legacy",
+  "moonbase"
+);
+
+describeDevMoonbeam(
+  "XCM Moonriver: version compatibility",
+  (context) => {
+    let random: KeyringPair;
+    let paraId: ParaId;
+    let transferredBalance: bigint;
+    let sovereignAddress: string;
+
+    before("Should send DEV to the parachain sovereign", async function () {
+      random = generateKeyringPair();
+      paraId = context.polkadotApi.createType("ParaId", 2000) as any;
+      sovereignAddress = u8aToHex(
+        new Uint8Array([...new TextEncoder().encode("sibl"), ...paraId.toU8a()])
+      ).padEnd(42, "0");
+
+      transferredBalance = 100000000000000n;
+      await expectOk(
+        context.createBlock(
+          context.polkadotApi.tx.balances.transfer(sovereignAddress, transferredBalance)
+        )
+      );
+      const balance = (
+        (await context.polkadotApi.query.system.account(sovereignAddress)) as any
+      ).data.free.toBigInt();
+      expect(balance).to.eq(transferredBalance);
+    });
+
+    it("Should execute v2 message", async function () {
+      const metadata = await context.polkadotApi.rpc.state.getMetadata();
+      const balancesPalletIndex = (metadata.asLatest.toHuman().pallets as Array<any>).find(
+        (pallet) => pallet.name === "Balances"
+      ).index;
+
+      const xcmMessage = new XcmFragment({
+        assets: [
+          {
+            multilocation: {
+              parents: 0,
+              interior: {
+                X1: { PalletInstance: balancesPalletIndex },
+              },
+            },
+            fungible: transferredBalance,
+          },
+        ],
+        weight_limit: new BN(8000000000),
+        beneficiary: random.address,
+      })
+        .withdraw_asset()
+        .clear_origin()
+        .buy_execution()
+        .deposit_asset()
+        .as_v2();
+
+      const chargedWeight = await weightMessage(
+        context,
+        context.polkadotApi.createType("XcmVersionedXcm", xcmMessage) as any
+      );
+
+      const chargedFee = chargedWeight * 50000n;
+
+      await injectHrmpMessageAndSeal(context, foreign_para_id, {
+        type: "XcmVersionedXcm",
+        payload: xcmMessage,
+      } as RawXcmMessage);
+
+      const balance = (
+        (await context.polkadotApi.query.system.account(sovereignAddress)) as any
+      ).data.free.toBigInt();
+      expect(balance.toString(), "Sovereign account not empty, transfer has failed").to.eq(
+        0n.toString()
+      );
+
+      const randomBalance = (
+        (await context.polkadotApi.query.system.account(random.address)) as any
+      ).data.free.toBigInt();
+      const expectedRandomBalance = transferredBalance - chargedFee;
+      expect(randomBalance, "Balance not increased, transfer has failed").to.eq(
+        expectedRandomBalance
+      );
+    });
+  },
+  "Legacy",
+  "moonriver"
+);


### PR DESCRIPTION
### What does it do?
Modifies proof sizes on moonriver and moonbeam runtimes to be compliant with V2->V3 BuyExecution transalations
### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
