### PR TITLE
Update solidity interface with correct precompile address

### DIFF
--- a/precompiles/gmp/Gmp.sol
+++ b/precompiles/gmp/Gmp.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.3;
 
 /// @dev The Gmp contract's address.
-address constant GMP_ADDRESS = 0x0000000000000000000000000000000000000815;
+address constant GMP_ADDRESS = 0x0000000000000000000000000000000000000816;
 
 /// @dev The Gmp contract's instance.
 Gmp constant GMP_CONTRACT = Gmp(GMP_ADDRESS);


### PR DESCRIPTION
### What does it do?

During #2155 the precompile address changed from `0x815` to `0x816` but the constant in the `Gmp.sol` file did not get updated. This fixes that.