### PR TITLE
Fix 0 deposit smoketest

### DIFF
--- a/tests/smoke-tests/test-balances-consistency.ts
+++ b/tests/smoke-tests/test-balances-consistency.ts
@@ -277,10 +277,11 @@ describeSmokeSuite("S300", `Verifying balances consistency`, (context, testIt) =
               ? status[1].unwrap().asUnrequested
               : status[1].unwrap().asRequested
           );
+
           return {
             accountId: deposit.accountId,
             reserved: {
-              preimage: deposit.amount.toBigInt(),
+              preimage: deposit.amount !== 0n ? deposit.amount.toBigInt() : 0n,
             },
           };
         }),

--- a/tests/util/block.ts
+++ b/tests/util/block.ts
@@ -471,12 +471,17 @@ export function extractPreimageDeposit(
       }
 ) {
   const deposit = "deposit" in request ? request.deposit : request;
-  if ("isSome" in deposit) {
+  if ("isSome" in deposit && deposit.isSome) {
     return {
       accountId: deposit.unwrap()[0].toHex(),
       amount: deposit.unwrap()[1],
     };
   }
+
+  if (deposit.isEmpty) {
+    return { accountId: "", amount: 0n };
+  }
+
   return {
     accountId: deposit[0].toHex(),
     amount: deposit[1],


### PR DESCRIPTION
### What does it do?
This fixes smoke tests to account for situations where zero deposit preimages are requested, such as `parachainSystem.authorizeUpgrade`. Fixes situations like:

```
  Error: Option: unwrapping a None value
     at processTicksAndRejections (node:internal/process/task_queues:95:5)
       📁  #S300C100 should have matching deposit/reserved:
      at Type.unwrap (node_modules/@polkadot/types-codec/cjs/base/Option.js:214:19)
      at extractPreimageDeposit (util/block.ts:476:26)
```

### What important points reviewers should know?
Tested against all chains without issue

### What value does it bring to the blockchain users?
Reducing test noise so increasing availability for real problems

