### PR TITLE
Fix `xcm-transactor` migration values

### DIFF
--- a/pallets/xcm-transactor/src/migrations.rs
+++ b/pallets/xcm-transactor/src/migrations.rs
@@ -80,9 +80,16 @@ pub struct OldRemoteTransactInfoWithMaxWeight {
 
 impl From<OldRemoteTransactInfoWithMaxWeight> for RemoteTransactInfoWithMaxWeight {
 	fn from(old: OldRemoteTransactInfoWithMaxWeight) -> RemoteTransactInfoWithMaxWeight {
-		let transact_extra_weight: Weight =
-			Weight::from_parts(old.transact_extra_weight, DEFAULT_PROOF_SIZE);
-		let max_weight: Weight = Weight::from_parts(old.max_weight, DEFAULT_PROOF_SIZE);
+		// This only accounts for everything outside the Transact instruction
+		// A.K.A. outside require weight at most.
+		let transact_extra_weight: Weight = Weight::from_parts(
+			old.transact_extra_weight,
+			DEFAULT_PROOF_SIZE.saturating_div(2),
+		);
+		let max_weight: Weight = Weight::from_parts(
+			old.max_weight,
+			cumulus_primitives_core::relay_chain::MAX_POV_SIZE as u64,
+		);
 		let transact_extra_weight_signed: Option<Weight> =
 			if let Some(w) = old.transact_extra_weight_signed {
 				Some(Weight::from_parts(w, DEFAULT_PROOF_SIZE))


### PR DESCRIPTION
### What does it do?

Fixes `transact_extra_weight` and `max_weight` default proof size value. The previous values would prevent messages to go through as they would overflow the allowed `max_weight`.

`transact_extra_weight`: a value of 64Kb is now set as default.
`max_weight`: the max pov size currently set in kusama for the ump queue.

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
