### PR TITLE
Refactored RateLimiter for CI

### DIFF
--- a/tests/smoke-tests/test-author-filter-consistency.ts
+++ b/tests/smoke-tests/test-author-filter-consistency.ts
@@ -1,6 +1,5 @@
 import "@moonbeam-network/api-augment";
 import { ApiDecoration } from "@polkadot/api/types";
-import type { FrameSystemAccountInfo } from "@polkadot/types/lookup";
 import { expect } from "chai";
 import { describeSmokeSuite } from "../util/setup-smoke-tests";
 const debug = require("debug")("smoke:author");

--- a/tests/smoke-tests/test-balances-consistency.ts
+++ b/tests/smoke-tests/test-balances-consistency.ts
@@ -10,15 +10,15 @@ import type {
 import { expect } from "chai";
 import { printTokens } from "../util/logging";
 import { describeSmokeSuite } from "../util/setup-smoke-tests";
-import Bottleneck from "bottleneck";
 import { Option } from "@polkadot/types-codec";
 import { StorageKey } from "@polkadot/types";
 import { extractPreimageDeposit } from "../util/block";
+import { rateLimiter } from "../util/common";
 const debug = require("debug")("smoke:balances");
 
 describeSmokeSuite("S300", `Verifying balances consistency`, (context, testIt) => {
   const accounts: { [account: string]: FrameSystemAccountInfo } = {};
-  const limiter = new Bottleneck({ maxConcurrent: 10, minTime: 150 });
+  const limiter = rateLimiter();
 
   let atBlockNumber: number = 0;
   let apiAt: ApiDecoration<"promise"> = null;

--- a/tests/smoke-tests/test-block-finalized.ts
+++ b/tests/smoke-tests/test-block-finalized.ts
@@ -2,8 +2,8 @@ import "@moonbeam-network/api-augment/moonbase";
 import { expect } from "chai";
 import { checkBlockFinalized, getBlockTime, fetchHistoricBlockNum } from "../util/block";
 import { describeSmokeSuite } from "../util/setup-smoke-tests";
-import Bottleneck from "bottleneck";
 import semverLt from "semver/functions/lt";
+import { rateLimiter } from "../util/common";
 const debug = require("debug")("smoke:block-finalized");
 const timePeriod = process.env.TIME_PERIOD ? Number(process.env.TIME_PERIOD) : 2 * 60 * 60 * 1000;
 const timeout = Math.floor(timePeriod / 12); // 2 hour -> 10 minute timeout
@@ -44,7 +44,7 @@ describeSmokeSuite("S400", `Parachain blocks should be finalized`, (context, tes
 
       const lastBlockNumber = signedBlock.block.header.number.toNumber();
       const lastBlockTime = getBlockTime(signedBlock);
-      const limiter = new Bottleneck({ maxConcurrent: 5 });
+      const limiter = rateLimiter();
 
       const firstBlockTime = lastBlockTime - timePeriod;
       debug(`Searching for the block at: ${new Date(firstBlockTime)}`);

--- a/tests/smoke-tests/test-block-weights.ts
+++ b/tests/smoke-tests/test-block-weights.ts
@@ -2,15 +2,15 @@ import "@moonbeam-network/api-augment";
 import { BN } from "@polkadot/util";
 import { expect } from "chai";
 import { describeSmokeSuite } from "../util/setup-smoke-tests";
-import Bottleneck from "bottleneck";
 import { extractWeight, getBlockArray } from "../util/block";
 import { WEIGHT_PER_GAS } from "../util/constants";
 import { FrameSystemEventRecord } from "@polkadot/types/lookup";
+import { rateLimiter } from "../util/common";
 
 const debug = require("debug")("smoke:weights");
 const timePeriod = process.env.TIME_PERIOD ? Number(process.env.TIME_PERIOD) : 2 * 60 * 60 * 1000;
 const timeout = Math.floor(timePeriod / 12); // 2 hour -> 10 minute timeout
-const limiter = new Bottleneck({ maxConcurrent: 10, minTime: 100 });
+const limiter = rateLimiter();
 
 interface BlockInfo {
   blockNum: number;
@@ -40,7 +40,7 @@ describeSmokeSuite(
 
     before("Retrieve all weight limits and usage", async function () {
       this.timeout(timeout);
-      const blockNumArray = await getBlockArray(context.polkadotApi, timePeriod, limiter);
+      const blockNumArray = await getBlockArray(context.polkadotApi, timePeriod);
       const limits = context.polkadotApi.consts.system.blockWeights;
 
       const getLimits = async (blockNum: number) => {

--- a/tests/smoke-tests/test-dynamic-fees.ts
+++ b/tests/smoke-tests/test-dynamic-fees.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import { checkTimeSliceForUpgrades, getBlockArray } from "../util/block";
 import { describeSmokeSuite } from "../util/setup-smoke-tests";
 import type { DispatchInfo } from "@polkadot/types/interfaces";
-import Bottleneck from "bottleneck";
+import { rateLimiter } from "../util/common";
 import { BigNumber, ethers } from "ethers";
 import { GenericExtrinsic, u256 } from "@polkadot/types";
 import {
@@ -27,7 +27,7 @@ import { BN_MILLION } from "@polkadot/util";
 const debug = require("debug")("smoke:dynamic-fees");
 const timePeriod = process.env.TIME_PERIOD ? Number(process.env.TIME_PERIOD) : 2 * 60 * 60 * 1000;
 const timeout = Math.max(Math.floor(timePeriod / 12), 5000);
-const limiter = new Bottleneck({ maxConcurrent: 10, minTime: 100 });
+const limiter = rateLimiter();
 const hours = (timePeriod / (1000 * 60 * 60)).toFixed(2);
 const atBlock = process.env.AT_BLOCK ? Number(process.env.AT_BLOCK) : -1;
 
@@ -125,7 +125,7 @@ describeSmokeSuite(
       }
 
       const blockNumArray =
-        atBlock > 0 ? [atBlock] : await getBlockArray(context.polkadotApi, timePeriod, limiter);
+        atBlock > 0 ? [atBlock] : await getBlockArray(context.polkadotApi, timePeriod);
 
       debug(`Collecting ${hours} hours worth of block data`);
 

--- a/tests/smoke-tests/test-ethereum-failures.ts
+++ b/tests/smoke-tests/test-ethereum-failures.ts
@@ -3,14 +3,14 @@ import { expect } from "chai";
 import { checkTimeSliceForUpgrades, getBlockArray } from "../util/block";
 import { describeSmokeSuite } from "../util/setup-smoke-tests";
 import type { DispatchInfo } from "@polkadot/types/interfaces";
-import Bottleneck from "bottleneck";
+import { rateLimiter } from "../util/common";
 import { FrameSystemEventRecord } from "@polkadot/types/lookup";
 import { GenericExtrinsic } from "@polkadot/types";
 import { AnyTuple } from "@polkadot/types/types";
 const debug = require("debug")("smoke:eth-failures");
 const timePeriod = process.env.TIME_PERIOD ? Number(process.env.TIME_PERIOD) : 2 * 60 * 60 * 1000;
 const timeout = Math.max(Math.floor(timePeriod / 12), 5000);
-const limiter = new Bottleneck({ maxConcurrent: 10, minTime: 100 });
+const limiter = rateLimiter();
 const hours = (timePeriod / (1000 * 60 * 60)).toFixed(2);
 
 type BlockFilteredRecord = {
@@ -30,7 +30,7 @@ describeSmokeSuite(
 
     before("Retrieve events for previous blocks", async function () {
       this.timeout(timeout);
-      const blockNumArray = await getBlockArray(context.polkadotApi, timePeriod, limiter);
+      const blockNumArray = await getBlockArray(context.polkadotApi, timePeriod);
 
       debug(`Collecting ${hours} hours worth of events`);
 

--- a/tests/smoke-tests/test-foreign-xcm-failures.ts
+++ b/tests/smoke-tests/test-foreign-xcm-failures.ts
@@ -2,14 +2,14 @@ import "@moonbeam-network/api-augment/moonbase";
 import { expect } from "chai";
 import { checkTimeSliceForUpgrades, getBlockArray } from "../util/block";
 import { describeSmokeSuite } from "../util/setup-smoke-tests";
-import Bottleneck from "bottleneck";
+import { rateLimiter } from "../util/common";
 import { FrameSystemEventRecord } from "@polkadot/types/lookup";
 import { ForeignChainsEndpoints, getEndpoints } from "../util/foreign-chains";
 import { ApiPromise, WsProvider } from "@polkadot/api";
 const debug = require("debug")("smoke:foreign-xcm-fails");
 const timePeriod = process.env.TIME_PERIOD ? Number(process.env.TIME_PERIOD) : 30 * 60 * 1000;
 const timeout = Math.max(Math.floor(timePeriod / 12), 60000);
-const limiter = new Bottleneck({ maxConcurrent: 20 });
+const limiter = rateLimiter();
 
 type BlockEventsRecord = {
   blockNum: number;
@@ -82,7 +82,7 @@ describeSmokeSuite(
             throw new Error("Cannot Connect");
           }
 
-          const blockNumArray = await getBlockArray(api, timePeriod, limiter);
+          const blockNumArray = await getBlockArray(api, timePeriod);
 
           // Determine if the block range intersects with an upgrade event
           const { result, specVersion: onChainRt } = await checkTimeSliceForUpgrades(

--- a/tests/smoke-tests/test-historic-compatibility.ts
+++ b/tests/smoke-tests/test-historic-compatibility.ts
@@ -3,11 +3,11 @@ import { expect } from "chai";
 import { numberToHex } from "@polkadot/util";
 import { describeSmokeSuite } from "../util/setup-smoke-tests";
 import { NetworkTestArtifact, tracingTxns } from "../util/tracing-txns";
-import Bottleneck from "bottleneck";
+import { rateLimiter } from "../util/common";
 import { BigNumber, providers } from "ethers";
 
 const debug = require("debug")("smoke:historic-compatibility");
-const limiter = new Bottleneck({ maxConcurrent: 10, minTime: 100 });
+const limiter = rateLimiter();
 const httpEndpoint = process.env.HTTP_URL;
 
 describeSmokeSuite("S1200", `Verifying historic compatibility`, async (context, testIt) => {

--- a/tests/smoke-tests/test-staking-rewards.ts
+++ b/tests/smoke-tests/test-staking-rewards.ts
@@ -13,11 +13,12 @@ import {
   PalletParachainStakingBond,
 } from "@polkadot/types/lookup";
 import { ApiDecoration } from "@polkadot/api/types";
-import Bottleneck from "bottleneck";
+import { rateLimiter } from "../util/common";
 import { AccountId20 } from "@polkadot/types/interfaces";
 import { FIVE_MINS, ONE_HOURS, TWO_HOURS } from "../util/constants";
 import { Perbill, Percent } from "../util/common";
 const debug = require("debug")("smoke:staking");
+const limiter = rateLimiter();
 
 describeSmokeSuite("S2000", `When verifying ParachainStaking rewards`, function (context, testIt) {
   let atStakeSnapshot: [StorageKey<[u32, AccountId20]>, PalletParachainStakingCollatorSnapshot][];
@@ -78,11 +79,6 @@ describeSmokeSuite("S2000", `When verifying ParachainStaking rewards`, function 
   testIt("C200", `should have accurate collator stats in snapshot`, async function () {
     this.timeout(FIVE_MINS);
 
-    const limiter = new Bottleneck({
-      maxConcurrent: 5,
-      minTime: 200,
-    });
-
     const results = await limiter.schedule(() => {
       const allTasks = atStakeSnapshot.map(async (coll, index) => {
         const [
@@ -132,10 +128,6 @@ describeSmokeSuite("S2000", `When verifying ParachainStaking rewards`, function 
 
     this.timeout(TWO_HOURS);
     this.slow(TWO_HOURS);
-    const limiter = new Bottleneck({
-      maxConcurrent: 10,
-      minTime: 100,
-    });
     // Function to check a single Delegator's delegation to a collator
     const checkDelegatorDelegation = async (
       accountId: AccountId20,
@@ -246,10 +238,6 @@ describeSmokeSuite("S2000", `When verifying ParachainStaking rewards`, function 
 
     this.timeout(ONE_HOURS);
     this.slow(ONE_HOURS);
-    const limiter = new Bottleneck({
-      maxConcurrent: 10,
-      minTime: 100,
-    });
 
     // Function to check a single Delegator's delegation to a collator
     const checkDelegatorAutocompound = async (

--- a/tests/smoke-tests/test-xcm-failures.ts
+++ b/tests/smoke-tests/test-xcm-failures.ts
@@ -2,7 +2,7 @@ import "@moonbeam-network/api-augment/moonbase";
 import { expect } from "chai";
 import { checkTimeSliceForUpgrades, getBlockArray } from "../util/block";
 import { describeSmokeSuite } from "../util/setup-smoke-tests";
-import Bottleneck from "bottleneck";
+import { rateLimiter } from "../util/common";
 import { FrameSystemEventRecord, XcmV3MultiLocation } from "@polkadot/types/lookup";
 import { FIVE_MINS } from "../util/constants";
 import { isMuted } from "../util/foreign-chains";
@@ -11,7 +11,7 @@ const debug = require("debug")("smoke:xcm-failures");
 const timePeriod = process.env.TIME_PERIOD ? Number(process.env.TIME_PERIOD) : 2 * 60 * 60 * 1000;
 const atBlock = process.env.AT_BLOCK ? Number(process.env.AT_BLOCK) : -1;
 const timeout = Math.max(Math.floor(timePeriod / 12), 5000);
-const limiter = new Bottleneck({ maxConcurrent: 10, minTime: 100 });
+const limiter = rateLimiter();
 
 type BlockEventsRecord = {
   blockNum: number;
@@ -46,7 +46,7 @@ describeSmokeSuite(
       this.timeout(timeout);
 
       const blockNumArray =
-        atBlock > 0 ? [atBlock] : await getBlockArray(context.polkadotApi, timePeriod, limiter);
+        atBlock > 0 ? [atBlock] : await getBlockArray(context.polkadotApi, timePeriod);
 
       // Determine if this block range intersects with an upgrade event
       const { result, specVersion: onChainRt } = await checkTimeSliceForUpgrades(
@@ -324,7 +324,7 @@ describeSmokeSuite(
       ).map((a) => a.toNumber());
       const channels = [...new Set([...inChannels, ...outChannels])];
 
-      const fiveMinutesOfBlocks = await getBlockArray(context.relayApi, FIVE_MINS, limiter);
+      const fiveMinutesOfBlocks = await getBlockArray(context.relayApi, FIVE_MINS);
 
       const getEvents = async (blockNum: number) => {
         const blockHash = await context.relayApi.rpc.chain.getBlockHash(blockNum);

--- a/tests/util/block.ts
+++ b/tests/util/block.ts
@@ -10,16 +10,14 @@ import {
 } from "@polkadot/types/interfaces";
 import { FrameSystemEventRecord, SpWeightsWeightV2Weight } from "@polkadot/types/lookup";
 import { u32, u64, u128, Option } from "@polkadot/types";
-
 import { expect } from "chai";
-
 import { WEIGHT_PER_GAS } from "./constants";
 import { DevTestContext } from "./setup-dev-tests";
-
+import { rateLimiter } from "./common";
 import type { Block, AccountId20 } from "@polkadot/types/interfaces/runtime/types";
 import type { TxWithEvent } from "@polkadot/api-derive/types";
 import type { ITuple } from "@polkadot/types-codec/types";
-import Bottleneck from "bottleneck";
+
 const debug = require("debug")("test:blocks");
 export async function createAndFinalizeBlock(
   api: ApiPromise,
@@ -412,7 +410,7 @@ export const fetchHistoricBlockNum = async (
   );
 };
 
-export const getBlockArray = async (api: ApiPromise, timePeriod: number, limiter?: Bottleneck) => {
+export const getBlockArray = async (api: ApiPromise, timePeriod: number) => {
   /**  
   @brief Returns an sequential array of block numbers from a given period of time in the past
   @param api Connected ApiPromise to perform queries on
@@ -420,9 +418,7 @@ export const getBlockArray = async (api: ApiPromise, timePeriod: number, limiter
   @param limiter Bottleneck rate limiter to throttle requests
   */
 
-  if (limiter == null) {
-    limiter = new Bottleneck({ maxConcurrent: 10, minTime: 100 });
-  }
+  const limiter = rateLimiter();
   const finalizedHead = await limiter.schedule(() => api.rpc.chain.getFinalizedHead());
   const signedBlock = await limiter.schedule(() => api.rpc.chain.getBlock(finalizedHead));
 

--- a/tests/util/common.ts
+++ b/tests/util/common.ts
@@ -2,7 +2,8 @@ import { BN } from "@polkadot/util";
 import Bottleneck from "bottleneck";
 
 export function rateLimiter() {
-  const settings = process.env.SKIP_RATE_LIMITER === "true" ? {} : { maxConcurrent: 10, minTime: 150 };
+  const settings =
+    process.env.SKIP_RATE_LIMITER === "true" ? {} : { maxConcurrent: 10, minTime: 150 };
   return new Bottleneck(settings);
 }
 

--- a/tests/util/common.ts
+++ b/tests/util/common.ts
@@ -1,4 +1,10 @@
 import { BN } from "@polkadot/util";
+import Bottleneck from "bottleneck";
+
+export function rateLimiter() {
+  const settings = process.env.CI === "true" ? {} : { maxConcurrent: 10, minTime: 150 };
+  return new Bottleneck(settings);
+}
 
 // Sort dict by key
 export function sortObjectByKeys(o) {

--- a/tests/util/common.ts
+++ b/tests/util/common.ts
@@ -2,7 +2,7 @@ import { BN } from "@polkadot/util";
 import Bottleneck from "bottleneck";
 
 export function rateLimiter() {
-  const settings = process.env.CI === "true" ? {} : { maxConcurrent: 10, minTime: 150 };
+  const settings = process.env.SKIP_RATE_LIMITER === "true" ? {} : { maxConcurrent: 10, minTime: 150 };
   return new Bottleneck(settings);
 }
 


### PR DESCRIPTION
### What does it do?
Refactors the Bottleneck RateLimiter so that we have a single config for the entire project, and adds a CI override. enabled by passing env var `SKIP_RATE_LIMITER` to `true`

### What important points reviewers should know?
No material change, tested without issue.

### What value does it bring to the blockchain users?
Faster CI runs which mean more responsive on-chain monitoring from the team.