### PR TITLE
Add dummy weight benchmarks for XCM functions

### DIFF
--- a/pallets/moonbeam-xcm-benchmarks/src/generic/benchmarking.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/generic/benchmarking.rs
@@ -21,6 +21,8 @@ use pallet_xcm_benchmarks::{new_executor, XcmCallOf};
 use sp_std::vec;
 use sp_std::vec::Vec;
 use xcm::latest::prelude::*;
+use frame_benchmarking::BenchmarkResult;
+use frame_support::traits::Get;
 
 benchmarks! {
 	buy_execution {
@@ -41,8 +43,41 @@ benchmarks! {
 
 	} : {
 		executor.bench_process(xcm)?;
-	} verify {
+	}
 
+	exchange_asset {
+	} : {
+		BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+	}
+
+	export_message {
+	} : {
+		BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+	}
+
+	lock_asset {
+	} : {
+		BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+	}
+
+	note_unlockable {
+	} : {
+		BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+	}
+
+	request_unlock {
+	} : {
+		BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+	}
+
+	universal_origin {
+	} : {
+		BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+	}
+
+	unlock_asset {
+	} : {
+		BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
 	}
 
 	impl_benchmark_test_suite!(


### PR DESCRIPTION
### What does it do?
Add dummy weight benchmark for XCM functions to `max_block` to prevent `moonbeam_xcm_benchmarks_generic` from failing

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
