### PR TITLE
Remove MinCollatorStk from parachain-staking pallet

### DIFF
--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -30,7 +30,7 @@ use sp_std::vec::Vec;
 
 /// Minimum collator candidate stake
 fn min_candidate_stk<T: Config>() -> BalanceOf<T> {
-	<<T as Config>::MinCollatorStk as Get<BalanceOf<T>>>::get()
+	<<T as Config>::MinCandidateStk as Get<BalanceOf<T>>>::get()
 }
 
 /// Minimum delegator stake

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -151,9 +151,6 @@ pub mod pallet {
 		/// Maximum delegations per delegator
 		#[pallet::constant]
 		type MaxDelegationsPerDelegator: Get<u32>;
-		/// Minimum stake required for any candidate to be in `SelectedCandidates` for the round
-		#[pallet::constant]
-		type MinCollatorStk: Get<BalanceOf<Self>>;
 		/// Minimum stake required for any account to be a collator candidate
 		#[pallet::constant]
 		type MinCandidateStk: Get<BalanceOf<Self>>;
@@ -1744,7 +1741,6 @@ pub mod pallet {
 				let mut collators = candidates
 					.into_iter()
 					.take(top_n)
-					.filter(|x| x.amount >= T::MinCollatorStk::get())
 					.map(|x| x.owner)
 					.collect::<Vec<T::AccountId>>();
 
@@ -1757,7 +1753,6 @@ pub mod pallet {
 				// The candidates are already sorted by AccountId, so no need to sort again
 				candidates
 					.into_iter()
-					.filter(|x| x.amount >= T::MinCollatorStk::get())
 					.map(|x| x.owner)
 					.collect::<Vec<T::AccountId>>()
 			}

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -117,7 +117,7 @@ parameter_types! {
 	pub const MaxTopDelegationsPerCandidate: u32 = 4;
 	pub const MaxBottomDelegationsPerCandidate: u32 = 4;
 	pub const MaxDelegationsPerDelegator: u32 = 4;
-	pub const MinCollatorStk: u128 = 10;
+	pub const MinCandidateStk: u128 = 10;
 	pub const MinDelegatorStk: u128 = 5;
 	pub const MinDelegation: u128 = 3;
 }
@@ -136,8 +136,7 @@ impl Config for Test {
 	type MaxTopDelegationsPerCandidate = MaxTopDelegationsPerCandidate;
 	type MaxBottomDelegationsPerCandidate = MaxBottomDelegationsPerCandidate;
 	type MaxDelegationsPerDelegator = MaxDelegationsPerDelegator;
-	type MinCollatorStk = MinCollatorStk;
-	type MinCandidateStk = MinCollatorStk;
+	type MinCandidateStk = MinCandidateStk;
 	type MinDelegatorStk = MinDelegatorStk;
 	type MinDelegation = MinDelegation;
 	type BlockAuthor = BlockAuthor;

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -160,7 +160,7 @@ parameter_types! {
 	pub const MaxTopDelegationsPerCandidate: u32 = 2;
 	pub const MaxBottomDelegationsPerCandidate: u32 = 4;
 	pub const MaxDelegationsPerDelegator: u32 = 4;
-	pub const MinCollatorStk: u128 = 10;
+	pub const MinCandidateStk: u128 = 10;
 	pub const MinDelegatorStk: u128 = 5;
 	pub const MinDelegation: u128 = 3;
 	pub BlockAuthor: AccountId = Alice.into();
@@ -180,8 +180,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MaxTopDelegationsPerCandidate = MaxTopDelegationsPerCandidate;
 	type MaxBottomDelegationsPerCandidate = MaxBottomDelegationsPerCandidate;
 	type MaxDelegationsPerDelegator = MaxDelegationsPerDelegator;
-	type MinCollatorStk = MinCollatorStk;
-	type MinCandidateStk = MinCollatorStk;
+	type MinCandidateStk = MinCandidateStk;
 	type MinDelegatorStk = MinDelegatorStk;
 	type MinDelegation = MinDelegation;
 	type BlockAuthor = BlockAuthor;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -707,8 +707,6 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MaxBottomDelegationsPerCandidate = ConstU32<50>;
 	/// Maximum delegations per delegator
 	type MaxDelegationsPerDelegator = ConstU32<100>;
-	/// Minimum stake required to become a collator
-	type MinCollatorStk = ConstU128<{ 1000 * currency::UNIT * currency::SUPPLY_FACTOR }>;
 	/// Minimum stake required to be reserved to be a candidate
 	type MinCandidateStk = ConstU128<{ 500 * currency::UNIT * currency::SUPPLY_FACTOR }>;
 	/// Minimum stake required to be reserved to be a delegator
@@ -1568,10 +1566,6 @@ mod tests {
 		);
 
 		// staking minimums
-		assert_eq!(
-			get!(pallet_parachain_staking, MinCollatorStk, u128),
-			Balance::from(1 * KILOUNIT)
-		);
 		assert_eq!(
 			get!(pallet_parachain_staking, MinCandidateStk, u128),
 			Balance::from(500 * UNIT)

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -765,8 +765,6 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MaxBottomDelegationsPerCandidate = ConstU32<50>;
 	/// Maximum delegations per delegator
 	type MaxDelegationsPerDelegator = ConstU32<100>;
-	/// Minimum stake required to become a collator
-	type MinCollatorStk = ConstU128<{ 20_000 * currency::GLMR * currency::SUPPLY_FACTOR }>;
 	/// Minimum stake required to be reserved to be a candidate
 	type MinCandidateStk = ConstU128<{ 20_000 * currency::GLMR * currency::SUPPLY_FACTOR }>;
 	/// Minimum stake required to be reserved to be a delegator
@@ -1636,10 +1634,6 @@ mod tests {
 		);
 
 		// staking minimums
-		assert_eq!(
-			get!(pallet_parachain_staking, MinCollatorStk, u128),
-			Balance::from(2_000_000 * GLMR)
-		);
 		assert_eq!(
 			get!(pallet_parachain_staking, MinCandidateStk, u128),
 			Balance::from(2_000_000 * GLMR)

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -670,8 +670,6 @@ impl pallet_parachain_staking::Config for Runtime {
 	type MaxBottomDelegationsPerCandidate = ConstU32<50>;
 	/// Maximum delegations per delegator
 	type MaxDelegationsPerDelegator = ConstU32<100>;
-	/// Minimum stake required to become a collator
-	type MinCollatorStk = ConstU128<{ 10000 * currency::MOVR * currency::SUPPLY_FACTOR }>;
 	/// Minimum stake required to be reserved to be a candidate
 	type MinCandidateStk = ConstU128<{ 10000 * currency::MOVR * currency::SUPPLY_FACTOR }>;
 	/// Minimum stake required to be reserved to be a delegator
@@ -1564,10 +1562,6 @@ mod tests {
 		);
 
 		// staking minimums
-		assert_eq!(
-			get!(pallet_parachain_staking, MinCollatorStk, u128),
-			Balance::from(10 * KILOMOVR)
-		);
 		assert_eq!(
 			get!(pallet_parachain_staking, MinCandidateStk, u128),
 			Balance::from(10 * KILOMOVR)


### PR DESCRIPTION
### What does it do?

This PR removes `MinCollatorStk` constant present in `parachain-staking` pallet.

The reason for removing it is that now both amounts `MinCollatorStk` and `MinCandidateStk` are the same, so it doesn't make any sense to have them duplicated. In this case, we keep using `MinCandidateStk` (minimum stake required for any account to be a collator candidate). Another reason is that it's even dangerous to have this constant (`MinCollatorStk`) as if the candidate gets under that amount, it won’t get included in the collators set, even if there are free slots. This could stall the chain.
