### PR TITLE
CI: Enable debug-assertions and overflow-checks in rust tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,7 +401,7 @@ jobs:
       # Checks are run after uploading artifacts since they are modified by the tests
       - name: Unit tests
         run: |
-          cargo test --release --all --features=evm-tracing
+          cargo test --profile testnet --all --features=evm-tracing
       - name: Run sccache stat for check pre test
         shell: bash
         run: ${SCCACHE_PATH} --show-stats

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -424,6 +424,12 @@ incremental = false
 inherits = "release"
 lto = true
 
+[profile.testnet]
+inherits = "release"
+debug = 1 # debug symbols are useful for profilers
+debug-assertions = true
+overflow-checks = true
+
 [profile.release]
 # Moonbeam runtime requires unwinding.
 opt-level = 3

--- a/primitives/xcm/src/fee_handlers.rs
+++ b/primitives/xcm/src/fee_handlers.rs
@@ -169,10 +169,8 @@ impl<
 	fn take_revenue(revenue: MultiAsset) {
 		match Matcher::matches_fungibles(&revenue) {
 			Ok((asset_id, amount)) => {
-				if !amount.is_zero() {
 					let ok = Assets::mint_into(asset_id, &ReceiverAccount::get(), amount).is_ok();
 					debug_assert!(ok, "`mint_into` cannot generally fail; qed");
-				}
 			}
 			Err(_) => log::debug!(
 				target: "xcm",

--- a/primitives/xcm/src/fee_handlers.rs
+++ b/primitives/xcm/src/fee_handlers.rs
@@ -146,7 +146,9 @@ impl<
 {
 	fn drop(&mut self) {
 		if let Some((id, amount, _)) = self.1.clone() {
-			R::take_revenue((id, amount).into());
+			if amount > 0 {
+				R::take_revenue((id, amount).into());
+			}
 		}
 	}
 }

--- a/primitives/xcm/src/fee_handlers.rs
+++ b/primitives/xcm/src/fee_handlers.rs
@@ -169,8 +169,8 @@ impl<
 	fn take_revenue(revenue: MultiAsset) {
 		match Matcher::matches_fungibles(&revenue) {
 			Ok((asset_id, amount)) => {
-					let ok = Assets::mint_into(asset_id, &ReceiverAccount::get(), amount).is_ok();
-					debug_assert!(ok, "`mint_into` cannot generally fail; qed");
+				let ok = Assets::mint_into(asset_id, &ReceiverAccount::get(), amount).is_ok();
+				debug_assert!(ok, "`mint_into` cannot generally fail; qed");
 			}
 			Err(_) => log::debug!(
 				target: "xcm",


### PR DESCRIPTION
### What does it do?

* Enable debug-assertions and overflow-checks in rust tests with a new dedicated rust profile, like polkadot does: https://github.com/paritytech/polkadot/blob/master/Cargo.toml#L198-L202

* Adapt our XCM fee handler implementation to comply with the assumption that a MultiAsset can't have a zeroed amount (fix #2268)

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
