### PR TITLE
Missing XCM benchmark overrides

### DIFF
--- a/pallets/moonbeam-xcm-benchmarks/src/generic/benchmarking.rs
+++ b/pallets/moonbeam-xcm-benchmarks/src/generic/benchmarking.rs
@@ -15,8 +15,8 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use frame_benchmarking::benchmarks;
-use frame_support::dispatch::Weight;
+use frame_benchmarking::{benchmarks, BenchmarkError, BenchmarkResult};
+use frame_support::{dispatch::Weight, traits::Get};
 use pallet_xcm_benchmarks::{new_executor, XcmCallOf};
 use sp_std::vec;
 use sp_std::vec::Vec;
@@ -41,8 +41,55 @@ benchmarks! {
 
 	} : {
 		executor.bench_process(xcm)?;
-	} verify {
+	}
 
+	exchange_asset {
+	} : {
+		Err(BenchmarkError::Override(
+			BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+		))?;
+	}
+
+	export_message {
+	} : {
+		Err(BenchmarkError::Override(
+			BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+		))?;
+	}
+
+	lock_asset {
+	} : {
+		Err(BenchmarkError::Override(
+			BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+		))?;
+	}
+
+	unlock_asset {
+	} : {
+		Err(BenchmarkError::Override(
+			BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+		))?;
+	}
+
+	note_unlockable {
+	} : {
+		Err(BenchmarkError::Override(
+			BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+		))?;
+	}
+
+	request_unlock {
+	} : {
+		Err(BenchmarkError::Override(
+			BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+		))?;
+	}
+
+	universal_origin {
+	} : {
+		Err(BenchmarkError::Override(
+			BenchmarkResult::from_weight(T::BlockWeights::get().max_block)
+		))?;
 	}
 
 	impl_benchmark_test_suite!(


### PR DESCRIPTION
### What does it do?
Adds missing XCM functions weight benchmarks