### PR TITLE
Add typescript tests for multisigs

### DIFF
--- a/tests/tests/test-multisigs/test-multisigs.ts
+++ b/tests/tests/test-multisigs/test-multisigs.ts
@@ -50,7 +50,7 @@ describeDevMoonbeam("Multisigs - perform multisigs operations", (context) => {
     expect(block.result.successful).to.be.true;
   });
 
-  it("Should be able to aprove multisig operation with approveAsMulti", async function () {
+  it("Should be able to approve multisig operation with approveAsMulti", async function () {
     // change signatories and put them sorted
     otherSignatories = [CHARLETH_ADDRESS, ALITH_ADDRESS];
     const block = await context.createBlock(

--- a/tests/tests/test-multisigs/test-multisigs.ts
+++ b/tests/tests/test-multisigs/test-multisigs.ts
@@ -1,0 +1,46 @@
+import "@polkadot/api-augment";
+import "@moonbeam-network/api-augment";
+import { blake2AsHex, createKeyMulti } from "@polkadot/util-crypto";
+import {u8aToHex} from "@polkadot/util"
+import { expect } from "chai";
+import { describeDevMoonbeam } from "../../util/setup-dev-tests";
+import { alith, ethan , ALITH_ADDRESS, DOROTHY_ADDRESS, CHARLETH_ADDRESS, BALTATHAR_ADDRESS} from "../../util/accounts";
+import { expectOk } from "../../util/expect";
+
+describeDevMoonbeam("Multisigs - perform multisigs operations", (context) => {
+    const threshold = 2;
+    const otherSignatories = [BALTATHAR_ADDRESS, CHARLETH_ADDRESS];
+    let call: any;
+    let encodedCall: any;
+    let encodedCallHash: any;
+
+    let encodedMultisigId = createKeyMulti([ALITH_ADDRESS, BALTATHAR_ADDRESS, CHARLETH_ADDRESS],2);
+    let multisigId = u8aToHex(encodedMultisigId.slice(0,20));
+
+    it("Should create a multisig operation with asMulti", async function () {
+
+        call = context.polkadotApi.tx.balances.transferKeepAlive(DOROTHY_ADDRESS, 20);
+        encodedCall = call.method.toHex();
+        encodedCallHash = blake2AsHex(encodedCall);
+        const block = await context.createBlock(
+            context.polkadotApi.tx.multisig.asMulti(threshold, otherSignatories, null, encodedCall, {})
+            .signAsync(alith)
+        );
+
+        expect(block.result.successful).to.be.true;
+    });
+
+    it("should be able to cancel the multisig operation", async () => {
+
+        console.log("CALL: ", encodedCall)
+        console.log("HASH: ", encodedCallHash)
+
+        const multisigInfo = await context.polkadotApi.query.multisig.multisigs(multisigId, encodedCallHash);
+        console.log(multisigInfo.toHuman())
+        
+        /* const records = (await context.polkadotApi.query.system.events()) as any;
+        const events = records.filter(
+            ({ event }) => console.log(event.method)
+        ); */
+    });
+});

--- a/tests/tests/test-multisigs/test-multisigs.ts
+++ b/tests/tests/test-multisigs/test-multisigs.ts
@@ -14,24 +14,29 @@ import {
 } from "../../util/accounts";
 
 describeDevMoonbeam("Multisigs - perform multisigs operations", (context) => {
-  const threshold = 2;
-  let otherSignatories = [BALTATHAR_ADDRESS, CHARLETH_ADDRESS];
-
+  let threshold: number;
   let call: any;
-  let encodedCall: any;
-  let encodedCallHash: any;
+  let encodedCall: string;
+  let encodedCallHash: string;
 
-  // create multisig accountId
-  let encodedMultisigId = createKeyMulti([ALITH_ADDRESS, BALTATHAR_ADDRESS, CHARLETH_ADDRESS], 2);
-  let multisigId = u8aToHex(encodedMultisigId.slice(0, 20));
+  // multisig accountId
+  let encodedMultisigId: Uint8Array;
+  let multisigId: string;
   let multisigInfo: any;
 
-  it("Should create a multisig operation with asMulti", async function () {
+  before("Should create a multisig operation with asMulti", async function () {
+    // set threshold and create multisig accountId
+    threshold = 2;
+    encodedMultisigId = createKeyMulti([ALITH_ADDRESS, BALTATHAR_ADDRESS, CHARLETH_ADDRESS], 2);
+    multisigId = u8aToHex(encodedMultisigId.slice(0, 20));
+
     // encode and hash the call we want to dispatch as a multisig operation
     call = context.polkadotApi.tx.balances.transferKeepAlive(DOROTHY_ADDRESS, 20);
     encodedCall = call.method.toHex();
     encodedCallHash = blake2AsHex(encodedCall);
 
+    // set signatories
+    const otherSignatories = [BALTATHAR_ADDRESS, CHARLETH_ADDRESS];
     const block = await context.createBlock(
       context.polkadotApi.tx.multisig
         .asMulti(threshold, otherSignatories, null, encodedCall, {})
@@ -51,8 +56,8 @@ describeDevMoonbeam("Multisigs - perform multisigs operations", (context) => {
   });
 
   it("Should be able to approve the multisig operation with approveAsMulti", async function () {
-    // change signatories and put them sorted
-    otherSignatories = [CHARLETH_ADDRESS, ALITH_ADDRESS];
+    // signatories (sorted)
+    const otherSignatories = [CHARLETH_ADDRESS, ALITH_ADDRESS];
     const block = await context.createBlock(
       context.polkadotApi.tx.multisig
         .approveAsMulti(
@@ -75,8 +80,8 @@ describeDevMoonbeam("Multisigs - perform multisigs operations", (context) => {
   });
 
   it("Should be able to cancel the multisig operation", async () => {
-    // change signatories and put them sorted
-    otherSignatories = [BALTATHAR_ADDRESS, CHARLETH_ADDRESS];
+    // signatories (sorted)
+    const otherSignatories = [BALTATHAR_ADDRESS, CHARLETH_ADDRESS];
     const block = await context.createBlock(
       context.polkadotApi.tx.multisig
         .cancelAsMulti(threshold, otherSignatories, multisigInfo.toHuman()["when"], encodedCallHash)
@@ -93,8 +98,8 @@ describeDevMoonbeam("Multisigs - perform multisigs operations", (context) => {
   });
 
   it("Should fail if signatories are out of order", async () => {
-    // change signatories (they are not sorted)
-    otherSignatories = [CHARLETH_ADDRESS, BALTATHAR_ADDRESS];
+    // signatories (they are not sorted)
+    const otherSignatories = [CHARLETH_ADDRESS, BALTATHAR_ADDRESS];
     const block = await context.createBlock(
       context.polkadotApi.tx.multisig
         .asMulti(threshold, otherSignatories, null, encodedCall, {})
@@ -105,8 +110,8 @@ describeDevMoonbeam("Multisigs - perform multisigs operations", (context) => {
   });
 
   it("Should fail if sender is present in signatories", async () => {
-    // change signatories
-    otherSignatories = [ALITH_ADDRESS, BALTATHAR_ADDRESS];
+    // signatories (with sender in signatories)
+    const otherSignatories = [ALITH_ADDRESS, BALTATHAR_ADDRESS];
     const block = await context.createBlock(
       context.polkadotApi.tx.multisig
         .asMulti(threshold, otherSignatories, null, encodedCall, {})

--- a/tests/tests/test-multisigs/test-multisigs.ts
+++ b/tests/tests/test-multisigs/test-multisigs.ts
@@ -50,7 +50,7 @@ describeDevMoonbeam("Multisigs - perform multisigs operations", (context) => {
     expect(block.result.successful).to.be.true;
   });
 
-  it("Should be able to approve multisig operation with approveAsMulti", async function () {
+  it("Should be able to approve the multisig operation with approveAsMulti", async function () {
     // change signatories and put them sorted
     otherSignatories = [CHARLETH_ADDRESS, ALITH_ADDRESS];
     const block = await context.createBlock(

--- a/tests/tests/test-multisigs/test-multisigs.ts
+++ b/tests/tests/test-multisigs/test-multisigs.ts
@@ -1,46 +1,118 @@
 import "@polkadot/api-augment";
 import "@moonbeam-network/api-augment";
 import { blake2AsHex, createKeyMulti } from "@polkadot/util-crypto";
-import {u8aToHex} from "@polkadot/util"
+import { u8aToHex } from "@polkadot/util";
 import { expect } from "chai";
 import { describeDevMoonbeam } from "../../util/setup-dev-tests";
-import { alith, ethan , ALITH_ADDRESS, DOROTHY_ADDRESS, CHARLETH_ADDRESS, BALTATHAR_ADDRESS} from "../../util/accounts";
-import { expectOk } from "../../util/expect";
+import {
+  alith,
+  ALITH_ADDRESS,
+  DOROTHY_ADDRESS,
+  CHARLETH_ADDRESS,
+  BALTATHAR_ADDRESS,
+  baltathar,
+} from "../../util/accounts";
 
 describeDevMoonbeam("Multisigs - perform multisigs operations", (context) => {
-    const threshold = 2;
-    const otherSignatories = [BALTATHAR_ADDRESS, CHARLETH_ADDRESS];
-    let call: any;
-    let encodedCall: any;
-    let encodedCallHash: any;
+  const threshold = 2;
+  let otherSignatories = [BALTATHAR_ADDRESS, CHARLETH_ADDRESS];
 
-    let encodedMultisigId = createKeyMulti([ALITH_ADDRESS, BALTATHAR_ADDRESS, CHARLETH_ADDRESS],2);
-    let multisigId = u8aToHex(encodedMultisigId.slice(0,20));
+  let call: any;
+  let encodedCall: any;
+  let encodedCallHash: any;
 
-    it("Should create a multisig operation with asMulti", async function () {
+  // create multisig accountId
+  let encodedMultisigId = createKeyMulti([ALITH_ADDRESS, BALTATHAR_ADDRESS, CHARLETH_ADDRESS], 2);
+  let multisigId = u8aToHex(encodedMultisigId.slice(0, 20));
+  let multisigInfo: any;
 
-        call = context.polkadotApi.tx.balances.transferKeepAlive(DOROTHY_ADDRESS, 20);
-        encodedCall = call.method.toHex();
-        encodedCallHash = blake2AsHex(encodedCall);
-        const block = await context.createBlock(
-            context.polkadotApi.tx.multisig.asMulti(threshold, otherSignatories, null, encodedCall, {})
-            .signAsync(alith)
-        );
+  it("Should create a multisig operation with asMulti", async function () {
+    // encode and hash the call we want to dispatch as a multisig operation
+    call = context.polkadotApi.tx.balances.transferKeepAlive(DOROTHY_ADDRESS, 20);
+    encodedCall = call.method.toHex();
+    encodedCallHash = blake2AsHex(encodedCall);
 
-        expect(block.result.successful).to.be.true;
-    });
+    const block = await context.createBlock(
+      context.polkadotApi.tx.multisig
+        .asMulti(threshold, otherSignatories, null, encodedCall, {})
+        .signAsync(alith)
+    );
 
-    it("should be able to cancel the multisig operation", async () => {
+    // take the info of the new multisig operation saved in storage
+    multisigInfo = await context.polkadotApi.query.multisig.multisigs(multisigId, encodedCallHash);
 
-        console.log("CALL: ", encodedCall)
-        console.log("HASH: ", encodedCallHash)
+    // check the event 'NewMultisig' was emitted
+    const records = (await context.polkadotApi.query.system.events()) as any;
+    const events = records.filter(
+      ({ event }) => event.section == "multisig" && event.method == "NewMultisig"
+    );
+    expect(events).to.have.lengthOf(1);
+    expect(block.result.successful).to.be.true;
+  });
 
-        const multisigInfo = await context.polkadotApi.query.multisig.multisigs(multisigId, encodedCallHash);
-        console.log(multisigInfo.toHuman())
-        
-        /* const records = (await context.polkadotApi.query.system.events()) as any;
-        const events = records.filter(
-            ({ event }) => console.log(event.method)
-        ); */
-    });
+  it("Should be able to aprove multisig operation with approveAsMulti", async function () {
+    // change signatories and put them sorted
+    otherSignatories = [CHARLETH_ADDRESS, ALITH_ADDRESS];
+    const block = await context.createBlock(
+      context.polkadotApi.tx.multisig
+        .approveAsMulti(
+          threshold,
+          otherSignatories,
+          multisigInfo.toHuman()["when"],
+          encodedCallHash,
+          {}
+        )
+        .signAsync(baltathar)
+    );
+
+    // check the event 'MultisigApproval' was emitted
+    const records = (await context.polkadotApi.query.system.events()) as any;
+    const events = records.filter(
+      ({ event }) => event.section == "multisig" && event.method == "MultisigApproval"
+    );
+    expect(events).to.have.lengthOf(1);
+    expect(block.result.successful).to.be.true;
+  });
+
+  it("Should be able to cancel the multisig operation", async () => {
+    // change signatories and put them sorted
+    otherSignatories = [BALTATHAR_ADDRESS, CHARLETH_ADDRESS];
+    const block = await context.createBlock(
+      context.polkadotApi.tx.multisig
+        .cancelAsMulti(threshold, otherSignatories, multisigInfo.toHuman()["when"], encodedCallHash)
+        .signAsync(alith)
+    );
+
+    // check the event 'MultisigCancelled' was emitted
+    const records = (await context.polkadotApi.query.system.events()) as any;
+    const events = records.filter(
+      ({ event }) => event.section == "multisig" && event.method == "MultisigCancelled"
+    );
+    expect(events).to.have.lengthOf(1);
+    expect(block.result.successful).to.be.true;
+  });
+
+  it("Should fail if signatories are out of order", async () => {
+    // change signatories (they are not sorted)
+    otherSignatories = [CHARLETH_ADDRESS, BALTATHAR_ADDRESS];
+    const block = await context.createBlock(
+      context.polkadotApi.tx.multisig
+        .asMulti(threshold, otherSignatories, null, encodedCall, {})
+        .signAsync(alith)
+    );
+    expect(block.result.error.name).to.equal("SignatoriesOutOfOrder");
+    expect(block.result.successful).to.be.false;
+  });
+
+  it("Should fail if sender is present in signatories", async () => {
+    // change signatories
+    otherSignatories = [ALITH_ADDRESS, BALTATHAR_ADDRESS];
+    const block = await context.createBlock(
+      context.polkadotApi.tx.multisig
+        .asMulti(threshold, otherSignatories, null, encodedCall, {})
+        .signAsync(alith)
+    );
+    expect(block.result.error.name).to.equal("SenderInSignatories");
+    expect(block.result.successful).to.be.false;
+  });
 });


### PR DESCRIPTION
### What does it do?

Adds the following typescript tests for multisigs:

- [x] Create a new multisig operation with `asMulti` extrinsic.
- [x] Approve an existing multisig operation with `approveAsMulti`.
- [x] Cancel an existing multisig operation with `cancelAsMulti`.
- [x] Ensure it fails if signatories are out of order.
- [x] Ensure it fails if sender is present in signatories.
