### PR TITLE
detect taplo formatted multiline entries for check-reentrancy sccript

### DIFF
--- a/scripts/check-forbid-evm-reentrancy.sh
+++ b/scripts/check-forbid-evm-reentrancy.sh
@@ -3,13 +3,15 @@
 while IFS= read -r path
 do
     echo "$path"
-    # 
+
+    # Detect single or multiline declarations of pallet-evm and pallet-ethereum to
+    # contain the "forbid-evm-reentrancy" feature.
     matches=$(awk 'flag{
-      if (buf ~ /}/ && buf !~ /reentrancy/) { 
-        printf "(line %d) %s", line, buf; flag=0; buf=""        # single line declaration
+      if (buf ~ /}/ && buf !~ /forbid-evm-reentrancy/) { 
+        printf "(line %d) %s", line, buf; flag=0; buf=""              # single line declaration
       } else  {
           buf = buf $0 ORS;
-          if (flag && /}/ && buf !~ /reentrancy/) {             # multiline declaration
+          if (flag && /}/ && buf !~ /forbid-evm-reentrancy/) {        # multiline declaration
             printf "(line %d) %s", line, buf; flag=0; buf="" 
           }
       }

--- a/scripts/check-forbid-evm-reentrancy.sh
+++ b/scripts/check-forbid-evm-reentrancy.sh
@@ -3,13 +3,22 @@
 while IFS= read -r path
 do
     echo "$path"
-    while IFS= read -r line
-    do
-        matches=$(echo "$line" | awk '(/^pallet-evm = / || /^pallet-ethereum = /) && !/reentrancy/');
-        if [ ! -z "$matches" ]; then
-            echo "Check fails: $line"
-            echo "Please add 'forbid-evm-reentrancy' feature to 'pallet-evm' and 'pallet-ethereum'."
-            exit 1
-        fi
-    done < "$path"
+    # 
+    matches=$(awk 'flag{
+      if (buf ~ /}/ && buf !~ /reentrancy/) { 
+        printf "(line %d) %s", line, buf; flag=0; buf=""        # single line declaration
+      } else  {
+          buf = buf $0 ORS;
+          if (flag && /}/ && buf !~ /reentrancy/) {             # multiline declaration
+            printf "(line %d) %s", line, buf; flag=0; buf="" 
+          }
+      }
+    }
+    /pallet-(ethereum|evm) = /{buf = $0 ORS; flag=1;line=NR}' "${path}") 
+
+    if [[ -n "$matches" ]]; then
+      echo "Check failed. Please add 'forbid-evm-reentrancy' feature to 'pallet-evm' and 'pallet-ethereum'."
+      echo "${matches}"
+      exit 1
+    fi
 done < <(find . -name "Cargo.toml" -not -path "*/target/*" -not -path "*/build/*")


### PR DESCRIPTION
### What does it do?
adapts the `check-forbid-evm-reentrancy` script to also detect multiline declarations that are formatted via taplo when the feature list is too long.
