### PR TITLE
Handle substrate tips

### DIFF
--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -317,6 +317,13 @@ where
 			// Balances pallet automatically burns dropped Negative Imbalances by decreasing
 			// total_supply accordingly
 			<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+
+			// handle tip if there is one
+			if let Some(tip) = fees_then_tips.next() {
+				// for now we use the same burn/treasury strategy used for regular fees
+				let (_, to_treasury) = tip.ration(80, 20);
+				<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+			}
 		}
 	}
 

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -305,6 +305,13 @@ where
 			// Balances pallet automatically burns dropped Negative Imbalances by decreasing
 			// total_supply accordingly
 			<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+
+			// handle tip if there is one
+			if let Some(tip) = fees_then_tips.next() {
+				// for now we use the same burn/treasury strategy used for regular fees
+				let (_, to_treasury) = tip.ration(80, 20);
+				<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+			}
 		}
 	}
 

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -2912,6 +2912,37 @@ fn removed_precompiles() {
 }
 
 #[test]
+fn deal_with_fees_handles_tip() {
+	use frame_support::traits::OnUnbalanced;
+	use moonbase_runtime::{DealWithFees, Treasury};
+
+	ExtBuilder::default()
+		.with_balances(vec![(AccountId::from(ALICE), 10_000)])
+		.build()
+		.execute_with(|| {
+			// Alice has 10_000, which makes inital supply 10_000.
+			// drop()ing the NegativeImbalance below will cause the total_supply to be decreased
+			// incorrectly (since there was never a withdraw to begin with), which in this case has
+			// the desired effect of showing that currency was burned.
+			let total_supply_before = Balances::total_issuance();
+			assert_eq!(total_supply_before, 10_000);
+
+			let fees_then_tips = vec![
+				NegativeImbalance::<moonbase_runtime::Runtime>::new(100),
+				NegativeImbalance::<moonbase_runtime::Runtime>::new(1_000),
+			];
+			DealWithFees::on_unbalanceds(fees_then_tips.into_iter());
+
+			// treasury should have received 20%
+			assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);
+
+			// verify 80% burned
+			let total_supply_after = Balances::total_issuance();
+			assert_eq!(total_supply_before - total_supply_after, 880);
+		});
+}
+
+#[test]
 fn evm_revert_substrate_events() {
 	ExtBuilder::default()
 		.with_balances(vec![(AccountId::from(ALICE), 100_000 * GLMR)])

--- a/runtime/moonbeam/tests/integration_test.rs
+++ b/runtime/moonbeam/tests/integration_test.rs
@@ -2914,7 +2914,8 @@ fn removed_precompiles() {
 #[test]
 fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
-	use moonbase_runtime::{DealWithFees, Treasury};
+	use moonbeam_runtime::{DealWithFees, Treasury};
+	use pallet_balances::NegativeImbalance;
 
 	ExtBuilder::default()
 		.with_balances(vec![(AccountId::from(ALICE), 10_000)])
@@ -2928,8 +2929,8 @@ fn deal_with_fees_handles_tip() {
 			assert_eq!(total_supply_before, 10_000);
 
 			let fees_then_tips = vec![
-				NegativeImbalance::<moonbase_runtime::Runtime>::new(100),
-				NegativeImbalance::<moonbase_runtime::Runtime>::new(1_000),
+				NegativeImbalance::<moonbeam_runtime::Runtime>::new(100),
+				NegativeImbalance::<moonbeam_runtime::Runtime>::new(1_000),
 			];
 			DealWithFees::on_unbalanceds(fees_then_tips.into_iter());
 

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -308,6 +308,13 @@ where
 			// Balances pallet automatically burns dropped Negative Imbalances by decreasing
 			// total_supply accordingly
 			<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+
+			// handle tip if there is one
+			if let Some(tip) = fees_then_tips.next() {
+				// for now we use the same burn/treasury strategy used for regular fees
+				let (_, to_treasury) = tip.ration(80, 20);
+				<pallet_treasury::Pallet<R> as OnUnbalanced<_>>::on_unbalanced(to_treasury);
+			}
 		}
 	}
 

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -2930,6 +2930,37 @@ fn removed_precompiles() {
 }
 
 #[test]
+fn deal_with_fees_handles_tip() {
+	use frame_support::traits::OnUnbalanced;
+	use moonbase_runtime::{DealWithFees, Treasury};
+
+	ExtBuilder::default()
+		.with_balances(vec![(AccountId::from(ALICE), 10_000)])
+		.build()
+		.execute_with(|| {
+			// Alice has 10_000, which makes inital supply 10_000.
+			// drop()ing the NegativeImbalance below will cause the total_supply to be decreased
+			// incorrectly (since there was never a withdraw to begin with), which in this case has
+			// the desired effect of showing that currency was burned.
+			let total_supply_before = Balances::total_issuance();
+			assert_eq!(total_supply_before, 10_000);
+
+			let fees_then_tips = vec![
+				NegativeImbalance::<moonbase_runtime::Runtime>::new(100),
+				NegativeImbalance::<moonbase_runtime::Runtime>::new(1_000),
+			];
+			DealWithFees::on_unbalanceds(fees_then_tips.into_iter());
+
+			// treasury should have received 20%
+			assert_eq!(Balances::free_balance(&Treasury::account_id()), 220);
+
+			// verify 80% burned
+			let total_supply_after = Balances::total_issuance();
+			assert_eq!(total_supply_before - total_supply_after, 880);
+		});
+}
+
+#[test]
 fn evm_revert_substrate_events() {
 	ExtBuilder::default()
 		.with_balances(vec![(AccountId::from(ALICE), 1_000 * MOVR)])

--- a/runtime/moonriver/tests/integration_test.rs
+++ b/runtime/moonriver/tests/integration_test.rs
@@ -2932,7 +2932,8 @@ fn removed_precompiles() {
 #[test]
 fn deal_with_fees_handles_tip() {
 	use frame_support::traits::OnUnbalanced;
-	use moonbase_runtime::{DealWithFees, Treasury};
+	use moonriver_runtime::{DealWithFees, Treasury};
+	use pallet_balances::NegativeImbalance;
 
 	ExtBuilder::default()
 		.with_balances(vec![(AccountId::from(ALICE), 10_000)])
@@ -2946,8 +2947,8 @@ fn deal_with_fees_handles_tip() {
 			assert_eq!(total_supply_before, 10_000);
 
 			let fees_then_tips = vec![
-				NegativeImbalance::<moonbase_runtime::Runtime>::new(100),
-				NegativeImbalance::<moonbase_runtime::Runtime>::new(1_000),
+				NegativeImbalance::<moonriver_runtime::Runtime>::new(100),
+				NegativeImbalance::<moonriver_runtime::Runtime>::new(1_000),
 			];
 			DealWithFees::on_unbalanceds(fees_then_tips.into_iter());
 


### PR DESCRIPTION
### What does it do?

Handles Substrate-based tips.

## :warning: Breaking Changes :warning: 

* Affects all runtimes
* Tips for Substrate-based transactions were not handled properly. The entire portion of the tip was burned because it was not handled in the runtime code.
* It has been fixed so that 20% is paid to treasury and 80% is burned, which is consistent with all other fee behavior 
