### PR TITLE
Add GMP precompile killswitch

### DIFF
--- a/precompiles/gmp/src/lib.rs
+++ b/precompiles/gmp/src/lib.rs
@@ -19,7 +19,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use evm::ExitReason;
-use fp_evm::{Context, PrecompileFailure, PrecompileHandle};
+use fp_evm::{Context, ExitRevert, PrecompileFailure, PrecompileHandle};
 use frame_support::{
 	codec::Decode,
 	dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo},
@@ -78,11 +78,13 @@ where
 		log::debug!(target: "gmp-precompile", "wormhole_vaa: {:?}", wormhole_vaa.clone());
 
 		// tally up gas cost:
+		// 1 read for enabled flag
 		// 2 reads for contract addresses
 		// 2500 as fudge for computation, esp. payload decoding (TODO: benchmark?)
-		let initial_gas = 2500 + 2 * RuntimeHelper::<Runtime>::db_read_gas_cost();
-		log::warn!("initial_gas: {:?}", initial_gas);
+		let initial_gas = 2500 + 3 * RuntimeHelper::<Runtime>::db_read_gas_cost();
 		handle.record_cost(initial_gas)?;
+
+		ensure_enabled()?;
 
 		let wormhole = storage::CoreAddress::get()
 			.ok_or(RevertReason::custom("invalid wormhole core address"))?;
@@ -242,11 +244,30 @@ fn ensure_exit_reason_success(reason: ExitReason, output: &[u8]) -> EvmResult<()
 	}
 }
 
+pub fn is_enabled() -> bool {
+	match storage::PrecompileEnabled::get() {
+		Some(enabled) => enabled,
+		_ => false,
+	}
+}
+
+fn ensure_enabled() -> EvmResult<()> {
+	if is_enabled() {
+		Ok(())
+	} else {
+		Err(PrecompileFailure::Revert {
+			exit_status: ExitRevert::Reverted,
+			output: b"GMP Precompile is not enabled".to_vec(),
+		})
+	}
+}
+
 /// We use pallet storage in our precompile by implementing a StorageInstance for each item we need
 /// to store.
 /// twox_128("gmp") => 0xb7f047395bba5df0367b45771c00de50
 /// twox_128("CoreAddress") => 0x59ff23ff65cc809711800d9d04e4b14c
 /// twox_128("BridgeAddress") => 0xc1586bde54b249fb7f521faf831ade45
+/// twox_128("PrecompileEnabled") => 0x2551bba17abb82ef3498bab688e470b8
 mod storage {
 	use super::*;
 	use frame_support::{
@@ -273,4 +294,15 @@ mod storage {
 		}
 	}
 	pub type BridgeAddress = StorageValue<BridgeAddressStorageInstance, H160, OptionQuery>;
+
+	// storage for precompile enabled
+	// None or Some(false) both mean that the precompile is disabled; only Some(true) means enabled.
+	pub struct PrecompileEnabledStorageInstance;
+	impl StorageInstance for PrecompileEnabledStorageInstance {
+		const STORAGE_PREFIX: &'static str = "PrecompileEnabled";
+		fn pallet_prefix() -> &'static str {
+			"gmp"
+		}
+	}
+	pub type PrecompileEnabled = StorageValue<PrecompileEnabledStorageInstance, bool, OptionQuery>;
 }

--- a/precompiles/gmp/src/lib.rs
+++ b/precompiles/gmp/src/lib.rs
@@ -27,7 +27,7 @@ use frame_support::{
 };
 use pallet_evm::AddressMapping;
 use parity_scale_codec::DecodeLimit;
-use precompile_utils::prelude::*;
+use precompile_utils::{prelude::*, solidity::revert::revert_as_bytes};
 use sp_core::{H160, U256};
 use sp_std::boxed::Box;
 use sp_std::{marker::PhantomData, vec::Vec};
@@ -257,7 +257,7 @@ fn ensure_enabled() -> EvmResult<()> {
 	} else {
 		Err(PrecompileFailure::Revert {
 			exit_status: ExitRevert::Reverted,
-			output: b"GMP Precompile is not enabled".to_vec(),
+			output: revert_as_bytes("GMP Precompile is not enabled"),
 		})
 	}
 }

--- a/precompiles/gmp/src/mock.rs
+++ b/precompiles/gmp/src/mock.rs
@@ -385,3 +385,41 @@ impl orml_xtokens::Config for Runtime {
 	type ReserveProvider = AbsoluteReserveProvider;
 	type UniversalLocation = UniversalLocation;
 }
+
+pub(crate) struct ExtBuilder {
+	/// Endowed accounts with balances
+	balances: Vec<(AccountId, Balance)>,
+}
+
+impl Default for ExtBuilder {
+	fn default() -> ExtBuilder {
+		ExtBuilder { balances: vec![] }
+	}
+}
+
+impl ExtBuilder {
+	/// Fund some accounts before starting the test
+	pub(crate) fn with_balances(mut self, balances: Vec<(AccountId, Balance)>) -> Self {
+		self.balances = balances;
+		self
+	}
+
+	/// Build the test externalities for use in tests
+	pub(crate) fn build(self) -> sp_io::TestExternalities {
+		let mut t = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.expect("Frame system builds valid default genesis config");
+
+		pallet_balances::GenesisConfig::<Runtime> {
+			balances: self.balances.clone(),
+		}
+		.assimilate_storage(&mut t)
+		.expect("Pallet balances storage can be assimilated");
+
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| {
+			System::set_block_number(1);
+		});
+		ext
+	}
+}

--- a/precompiles/gmp/src/tests.rs
+++ b/precompiles/gmp/src/tests.rs
@@ -14,8 +14,60 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::mock::PCall;
+use crate::mock::{ExtBuilder, PCall};
+use fp_evm::{ExitRevert, PrecompileFailure};
 use precompile_utils::testing::*;
+
+#[test]
+fn contract_disabling_default_value_is_false() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 100_000)])
+		.build()
+		.execute_with(|| {
+			// default should be false
+			assert_eq!(crate::storage::PrecompileEnabled::get(), None);
+			assert_eq!(crate::is_enabled(), false);
+			assert_eq!(
+				crate::ensure_enabled(),
+				Err(PrecompileFailure::Revert {
+					exit_status: ExitRevert::Reverted,
+					output: b"GMP Precompile is not enabled".to_vec(),
+				})
+			);
+		})
+}
+
+#[test]
+fn contract_enabling_works() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 100_000)])
+		.build()
+		.execute_with(|| {
+			crate::storage::PrecompileEnabled::set(Some(true));
+			assert_eq!(crate::storage::PrecompileEnabled::get(), Some(true));
+			assert_eq!(crate::is_enabled(), true);
+			assert_eq!(crate::ensure_enabled(), Ok(()));
+		})
+}
+
+#[test]
+fn contract_disabling_works() {
+	ExtBuilder::default()
+		.with_balances(vec![(Alice.into(), 100_000)])
+		.build()
+		.execute_with(|| {
+			crate::storage::PrecompileEnabled::set(Some(false));
+			assert_eq!(crate::storage::PrecompileEnabled::get(), Some(false));
+			assert_eq!(crate::is_enabled(), false);
+			assert_eq!(
+				crate::ensure_enabled(),
+				Err(PrecompileFailure::Revert {
+					exit_status: ExitRevert::Reverted,
+					output: b"GMP Precompile is not enabled".to_vec(),
+				})
+			);
+		})
+}
 
 #[test]
 fn test_solidity_interface_has_all_function_selectors_documented_and_implemented() {

--- a/precompiles/gmp/src/tests.rs
+++ b/precompiles/gmp/src/tests.rs
@@ -14,9 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::mock::{ExtBuilder, PCall};
+use crate::mock::*;
 use fp_evm::{ExitRevert, PrecompileFailure};
 use precompile_utils::testing::*;
+
+fn precompiles() -> Precompiles<Runtime> {
+	PrecompilesValue::get()
+}
 
 #[test]
 fn contract_disabling_default_value_is_false() {
@@ -34,6 +38,16 @@ fn contract_disabling_default_value_is_false() {
 					output: b"GMP Precompile is not enabled".to_vec(),
 				})
 			);
+
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::wormhole_transfer_erc20 {
+						wormhole_vaa: Vec::new().into(),
+					},
+				)
+				.execute_reverts(|output| output == b"GMP Precompile is not enabled");
 		})
 }
 
@@ -47,6 +61,17 @@ fn contract_enabling_works() {
 			assert_eq!(crate::storage::PrecompileEnabled::get(), Some(true));
 			assert_eq!(crate::is_enabled(), true);
 			assert_eq!(crate::ensure_enabled(), Ok(()));
+
+			// should fail at a later point since contract addresses are not set
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::wormhole_transfer_erc20 {
+						wormhole_vaa: Vec::new().into(),
+					},
+				)
+				.execute_reverts(|output| output == b"invalid wormhole core address");
 		})
 }
 
@@ -66,6 +91,16 @@ fn contract_disabling_works() {
 					output: b"GMP Precompile is not enabled".to_vec(),
 				})
 			);
+
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					Precompile1,
+					PCall::wormhole_transfer_erc20 {
+						wormhole_vaa: Vec::new().into(),
+					},
+				)
+				.execute_reverts(|output| output == b"GMP Precompile is not enabled");
 		})
 }
 

--- a/precompiles/gmp/src/tests.rs
+++ b/precompiles/gmp/src/tests.rs
@@ -16,7 +16,7 @@
 
 use crate::mock::*;
 use fp_evm::{ExitRevert, PrecompileFailure};
-use precompile_utils::testing::*;
+use precompile_utils::{solidity::revert::revert_as_bytes, testing::*};
 
 fn precompiles() -> Precompiles<Runtime> {
 	PrecompilesValue::get()
@@ -35,7 +35,7 @@ fn contract_disabling_default_value_is_false() {
 				crate::ensure_enabled(),
 				Err(PrecompileFailure::Revert {
 					exit_status: ExitRevert::Reverted,
-					output: b"GMP Precompile is not enabled".to_vec(),
+					output: revert_as_bytes("GMP Precompile is not enabled"),
 				})
 			);
 
@@ -88,7 +88,7 @@ fn contract_disabling_works() {
 				crate::ensure_enabled(),
 				Err(PrecompileFailure::Revert {
 					exit_status: ExitRevert::Reverted,
-					output: b"GMP Precompile is not enabled".to_vec(),
+					output: revert_as_bytes("GMP Precompile is not enabled"),
 				})
 			);
 

--- a/precompiles/gmp/src/tests.rs
+++ b/precompiles/gmp/src/tests.rs
@@ -47,7 +47,7 @@ fn contract_disabling_default_value_is_false() {
 						wormhole_vaa: Vec::new().into(),
 					},
 				)
-				.execute_reverts(|output| output == b"GMP Precompile is not enabled");
+				.execute_reverts_no_decode(|output| output == b"GMP Precompile is not enabled");
 		})
 }
 
@@ -100,7 +100,7 @@ fn contract_disabling_works() {
 						wormhole_vaa: Vec::new().into(),
 					},
 				)
-				.execute_reverts(|output| output == b"GMP Precompile is not enabled");
+				.execute_reverts_no_decode(|output| output == b"GMP Precompile is not enabled");
 		})
 }
 

--- a/precompiles/gmp/src/tests.rs
+++ b/precompiles/gmp/src/tests.rs
@@ -47,7 +47,7 @@ fn contract_disabling_default_value_is_false() {
 						wormhole_vaa: Vec::new().into(),
 					},
 				)
-				.execute_reverts_no_decode(|output| output == b"GMP Precompile is not enabled");
+				.execute_reverts(|output| output == b"GMP Precompile is not enabled");
 		})
 }
 
@@ -100,7 +100,7 @@ fn contract_disabling_works() {
 						wormhole_vaa: Vec::new().into(),
 					},
 				)
-				.execute_reverts_no_decode(|output| output == b"GMP Precompile is not enabled");
+				.execute_reverts(|output| output == b"GMP Precompile is not enabled");
 		})
 }
 

--- a/precompiles/utils/src/testing/execution.rs
+++ b/precompiles/utils/src/testing/execution.rs
@@ -222,32 +222,6 @@ impl<'p, P: PrecompileSet> PrecompilesTester<'p, P> {
 		self.assert_optionals();
 	}
 
-	/// Execute the precompile set and check if it reverts.
-	/// Take a closure allowing to perform custom matching on the output.
-	/// Output is not automatically decoded.
-	pub fn execute_reverts_no_decode(mut self, check: impl Fn(&[u8]) -> bool) {
-		let res = self.execute();
-
-		match res {
-			Some(Err(PrecompileFailure::Revert { output, .. })) => {
-				if !check(&output) {
-					eprintln!(
-						"Revert message (bytes): {:?}",
-						sp_core::hexdisplay::HexDisplay::from(&output)
-					);
-					eprintln!(
-						"Revert message (string): {:?}",
-						core::str::from_utf8(&output).ok()
-					);
-					panic!("Revert reason doesn't match !");
-				}
-			}
-			other => panic!("Didn't revert, instead returned {:?}", other),
-		}
-
-		self.assert_optionals();
-	}
-
 	/// Execute the precompile set and check it returns provided output.
 	pub fn execute_error(mut self, error: ExitError) {
 		let res = self.execute();

--- a/tests/tests/test-precompile/test-precompile-wormhole.ts
+++ b/tests/tests/test-precompile/test-precompile-wormhole.ts
@@ -253,4 +253,21 @@ describeDevMoonbeam(`Test local Wormhole`, (context) => {
     expectEVMResult(result.result.events, "Succeed", "Returned");
     expectSubstrateEvents(result, "xTokens", "TransferredMultiAssets");
   });
+
+  it("should fail with killswitch enabled by default", async function () {
+    // payload should be irrelevant since the precompile will fail before attempting to decode
+    const transferVAA = "deadbeef";
+
+    const data = GMP_INTERFACE.encodeFunctionData("wormholeTransferERC20", [`0x${transferVAA}`]);
+
+    const result = await context.createBlock(
+      createTransaction(context, {
+        to: PRECOMPILE_GMP_ADDRESS,
+        gas: 500_000,
+        data,
+      })
+    );
+
+    expectEVMResult(result.result.events, "Revert", "Reverted");
+  });
 });

--- a/tests/tests/test-precompile/test-precompile-wormhole.ts
+++ b/tests/tests/test-precompile/test-precompile-wormhole.ts
@@ -254,7 +254,9 @@ describeDevMoonbeam(`Test local Wormhole`, (context) => {
     expectEVMResult(result.result.events, "Succeed", "Returned");
     expectSubstrateEvents(result, "xTokens", "TransferredMultiAssets");
   });
+});
 
+describeDevMoonbeam(`Test GMP Killswitch`, (context) => {
   it("should fail with killswitch enabled by default", async function () {
     // payload should be irrelevant since the precompile will fail before attempting to decode
     const transferVAA = "deadbeef";

--- a/tests/tests/test-precompile/test-precompile-wormhole.ts
+++ b/tests/tests/test-precompile/test-precompile-wormhole.ts
@@ -15,6 +15,8 @@ import { ethers } from "ethers";
 import { alith, ALITH_ADDRESS, ALITH_PRIVATE_KEY, BALTATHAR_ADDRESS } from "../../util/accounts";
 import { PRECOMPILE_GMP_ADDRESS } from "../../util/constants";
 import { expectSubstrateEvent, expectSubstrateEvents } from "../../util/expect";
+import { u8aConcat, u8aToHex } from "@polkadot/util";
+import { xxhashAsU8a } from "@polkadot/util-crypto";
 
 import { expectEVMResult, extractRevertReason } from "../../util/eth-transactions";
 import { expect } from "chai";
@@ -188,8 +190,13 @@ describeDevMoonbeam(`Test local Wormhole`, (context) => {
 
     // before interacting with the precompile, we need to set some contract addresses from our
     // our deployments above
-    const CORE_CONTRACT_STORAGE_ADDRESS =
-      "0xb7f047395bba5df0367b45771c00de5059ff23ff65cc809711800d9d04e4b14c";
+    const CORE_CONTRACT_STORAGE_ADDRESS = u8aToHex(
+      u8aConcat(xxhashAsU8a("gmp", 128), xxhashAsU8a("CoreAddress", 128))
+    );
+    expect(CORE_CONTRACT_STORAGE_ADDRESS).to.eq(
+      "0xb7f047395bba5df0367b45771c00de5059ff23ff65cc809711800d9d04e4b14c"
+    );
+
     await context.polkadotApi.tx.sudo
       .sudo(
         context.polkadotApi.tx.system.setStorage([
@@ -199,8 +206,13 @@ describeDevMoonbeam(`Test local Wormhole`, (context) => {
       .signAndSend(alith);
     await context.createBlock();
 
-    const BRIDGE_CONTRACT_STORAGE_ADDRESS =
-      "0xb7f047395bba5df0367b45771c00de50c1586bde54b249fb7f521faf831ade45";
+    const BRIDGE_CONTRACT_STORAGE_ADDRESS = u8aToHex(
+      u8aConcat(xxhashAsU8a("gmp", 128), xxhashAsU8a("BridgeAddress", 128))
+    );
+    expect(BRIDGE_CONTRACT_STORAGE_ADDRESS).to.eq(
+      "0xb7f047395bba5df0367b45771c00de50c1586bde54b249fb7f521faf831ade45"
+    );
+
     await context.polkadotApi.tx.sudo
       .sudo(
         context.polkadotApi.tx.system.setStorage([
@@ -211,8 +223,13 @@ describeDevMoonbeam(`Test local Wormhole`, (context) => {
     await context.createBlock();
 
     // we also need to disable the killswitch by setting the 'enabled' flag to Some(true)
-    const ENABLED_FLAG_STORAGE_ADDRESS =
-      "0xb7f047395bba5df0367b45771c00de502551bba17abb82ef3498bab688e470b8";
+    const ENABLED_FLAG_STORAGE_ADDRESS = u8aToHex(
+      u8aConcat(xxhashAsU8a("gmp", 128), xxhashAsU8a("PrecompileEnabled", 128))
+    );
+    expect(ENABLED_FLAG_STORAGE_ADDRESS).to.eq(
+      "0xb7f047395bba5df0367b45771c00de502551bba17abb82ef3498bab688e470b8"
+    );
+
     await context.polkadotApi.tx.sudo
       .sudo(
         context.polkadotApi.tx.system.setStorage([

--- a/tests/tests/test-precompile/test-precompile-wormhole.ts
+++ b/tests/tests/test-precompile/test-precompile-wormhole.ts
@@ -16,7 +16,8 @@ import { alith, ALITH_ADDRESS, ALITH_PRIVATE_KEY, BALTATHAR_ADDRESS } from "../.
 import { PRECOMPILE_GMP_ADDRESS } from "../../util/constants";
 import { expectSubstrateEvent, expectSubstrateEvents } from "../../util/expect";
 
-import { expectEVMResult } from "../../util/eth-transactions";
+import { expectEVMResult, extractRevertReason } from "../../util/eth-transactions";
+import { expect } from "chai";
 const debug = require("debug")("test:wormhole");
 
 const GUARDIAN_SET_INDEX = 0;
@@ -269,5 +270,7 @@ describeDevMoonbeam(`Test local Wormhole`, (context) => {
     );
 
     expectEVMResult(result.result.events, "Revert", "Reverted");
+    const revertReason = await extractRevertReason(result.result.hash, context.ethers);
+    expect(revertReason).to.contain("GMP Precompile is not enabled");
   });
 });

--- a/tests/tests/test-precompile/test-precompile-wormhole.ts
+++ b/tests/tests/test-precompile/test-precompile-wormhole.ts
@@ -217,8 +217,8 @@ describeDevMoonbeam(`Test local Wormhole`, (context) => {
         context.polkadotApi.tx.system.setStorage([
           [
             ENABLED_FLAG_STORAGE_ADDRESS,
-            context.polkadotApi.registry.createType("Option<bool>", true).toHex()
-          ]
+            context.polkadotApi.registry.createType("Option<bool>", true).toHex(),
+          ],
         ])
       )
       .signAndSend(alith);

--- a/tests/tests/test-precompile/test-precompile-wormhole.ts
+++ b/tests/tests/test-precompile/test-precompile-wormhole.ts
@@ -209,6 +209,21 @@ describeDevMoonbeam(`Test local Wormhole`, (context) => {
       .signAndSend(alith);
     await context.createBlock();
 
+    // we also need to disable the killswitch by setting the 'enabled' flag to Some(true)
+    const ENABLED_FLAG_STORAGE_ADDRESS =
+      "0xb7f047395bba5df0367b45771c00de502551bba17abb82ef3498bab688e470b8";
+    await context.polkadotApi.tx.sudo
+      .sudo(
+        context.polkadotApi.tx.system.setStorage([
+          [
+            ENABLED_FLAG_STORAGE_ADDRESS,
+            context.polkadotApi.registry.createType("Option<bool>", true).toHex()
+          ]
+        ])
+      )
+      .signAndSend(alith);
+    await context.createBlock();
+
     const transferVAA = await genTransferWithPayloadVAA(
       signerPKs,
       GUARDIAN_SET_INDEX,


### PR DESCRIPTION
### What does it do?

Adds an explicit killswitch to the GMP precompile. This defaults to enabled, so the precompile will not work without it being disabled first.

### TODO:

 - [x] Add call to `wormhole_transfer_erc20` in tests to make sure it properly fails
 - [x] Clean up `execute_reverts_no_decode()` mess
 - [x] Add TS test which calls `set_storage` to show that this technique works to manage the killswitch