### PR TITLE
Fix hrmp-manage in XCM Transactor

### DIFF
--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -818,7 +818,8 @@ pub mod pallet {
 			);
 
 			// The appendix instruction will be a deposit back to a self location
-			let deposit_appendix = Self::deposit_instruction(T::SelfLocation::get(), &destination)?;
+			let deposit_appendix =
+				Self::deposit_instruction(T::SelfLocation::get(), &destination, 1u32)?;
 
 			Self::transact_in_dest_chain_asset_non_signed(
 				destination,
@@ -1018,13 +1019,14 @@ pub mod pallet {
 		fn deposit_instruction(
 			mut beneficiary: MultiLocation,
 			at: &MultiLocation,
+			asset_amount: u32,
 		) -> Result<Instruction<()>, DispatchError> {
 			let universal_location = T::UniversalLocation::get();
 			beneficiary
 				.reanchor(at, universal_location)
 				.map_err(|_| Error::<T>::CannotReanchor)?;
 			Ok(DepositAsset {
-				assets: Wild(All),
+				assets: Wild(AllCounted(asset_amount)),
 				beneficiary,
 			})
 		}

--- a/pallets/xcm-transactor/src/lib.rs
+++ b/pallets/xcm-transactor/src/lib.rs
@@ -1019,14 +1019,14 @@ pub mod pallet {
 		fn deposit_instruction(
 			mut beneficiary: MultiLocation,
 			at: &MultiLocation,
-			asset_amount: u32,
+			max_assets: u32,
 		) -> Result<Instruction<()>, DispatchError> {
 			let universal_location = T::UniversalLocation::get();
 			beneficiary
 				.reanchor(at, universal_location)
 				.map_err(|_| Error::<T>::CannotReanchor)?;
 			Ok(DepositAsset {
-				assets: Wild(AllCounted(asset_amount)),
+				assets: Wild(AllCounted(max_assets)),
 				beneficiary,
 			})
 		}

--- a/pallets/xcm-transactor/src/mock.rs
+++ b/pallets/xcm-transactor/src/mock.rs
@@ -33,9 +33,7 @@ use xcm::latest::{
 	Junctions, MultiAsset, MultiLocation, NetworkId, Result as XcmResult, SendError, SendResult,
 	SendXcm, Xcm, XcmContext, XcmHash,
 };
-use xcm::IntoVersion;
-use xcm::VersionedXcm;
-use xcm::WrapVersion;
+use xcm::{IntoVersion, VersionedXcm, WrapVersion};
 use xcm_primitives::{
 	HrmpAvailableCalls, HrmpEncodeCall, UtilityAvailableCalls, UtilityEncodeCall, XcmTransact,
 };

--- a/pallets/xcm-transactor/src/tests.rs
+++ b/pallets/xcm-transactor/src/tests.rs
@@ -1104,6 +1104,173 @@ fn test_hrmp_manipulator_init() {
 }
 
 #[test]
+fn test_hrmp_manipulator_init_v2_convert_works() {
+	ExtBuilder::default()
+		.with_balances(vec![])
+		.build()
+		.execute_with(|| {
+			// We are gonna use a total weight of 10_100, a tx weight of 100,
+			// and a total fee of 100
+			let total_weight: Weight = 10_100u64.into();
+			let tx_weight: Weight = 100_u64.into();
+			let total_fee = 100u128;
+
+			// Change xcm version
+			CustomVersionWrapper::set_version(2);
+
+			assert_ok!(XcmTransactor::hrmp_manage(
+				RuntimeOrigin::root(),
+				HrmpOperation::InitOpen(HrmpInitParams {
+					para_id: 1u32.into(),
+					proposed_max_capacity: 1,
+					proposed_max_message_size: 1
+				}),
+				CurrencyPayment {
+					currency: Currency::AsMultiLocation(Box::new(xcm::VersionedMultiLocation::V3(
+						MultiLocation::parent()
+					))),
+					fee_amount: Some(total_fee)
+				},
+				TransactWeights {
+					transact_required_weight_at_most: tx_weight,
+					overall_weight: Some(total_weight)
+				}
+			));
+
+			let sent_messages = mock::sent_xcm();
+			let (_, sent_message) = sent_messages.first().unwrap();
+			// Lets make sure the message is as expected
+			assert!(sent_message
+				.0
+				.contains(&WithdrawAsset((MultiLocation::here(), total_fee).into())));
+			assert!(sent_message.0.contains(&BuyExecution {
+				fees: (MultiLocation::here(), total_fee).into(),
+				weight_limit: Limited(total_weight),
+			}));
+			assert!(sent_message.0.contains(&Transact {
+				origin_kind: OriginKind::Native,
+				require_weight_at_most: tx_weight,
+				call: vec![1u8, 0u8].into(),
+			}));
+
+			// Check message contains the new appendix
+			assert!(sent_message.0.contains(&SetAppendix(Xcm(vec![
+				RefundSurplus,
+				DepositAsset {
+					assets: Wild(AllCounted(1)),
+					beneficiary: MultiLocation {
+						parents: 0,
+						interior: X1(Junction::Parachain(100))
+					}
+				}
+			]))));
+		})
+}
+
+#[test]
+fn test_hrmp_manipulator_init_v3_convert_works() {
+	ExtBuilder::default()
+		.with_balances(vec![])
+		.build()
+		.execute_with(|| {
+			// We are gonna use a total weight of 10_100, a tx weight of 100,
+			// and a total fee of 100
+			let total_weight: Weight = 10_100u64.into();
+			let tx_weight: Weight = 100_u64.into();
+			let total_fee = 100u128;
+
+			// Change xcm version
+			CustomVersionWrapper::set_version(3);
+
+			assert_ok!(XcmTransactor::hrmp_manage(
+				RuntimeOrigin::root(),
+				HrmpOperation::InitOpen(HrmpInitParams {
+					para_id: 1u32.into(),
+					proposed_max_capacity: 1,
+					proposed_max_message_size: 1
+				}),
+				CurrencyPayment {
+					currency: Currency::AsMultiLocation(Box::new(xcm::VersionedMultiLocation::V3(
+						MultiLocation::parent()
+					))),
+					fee_amount: Some(total_fee)
+				},
+				TransactWeights {
+					transact_required_weight_at_most: tx_weight,
+					overall_weight: Some(total_weight)
+				}
+			));
+
+			let sent_messages = mock::sent_xcm();
+			let (_, sent_message) = sent_messages.first().unwrap();
+			// Lets make sure the message is as expected
+			assert!(sent_message
+				.0
+				.contains(&WithdrawAsset((MultiLocation::here(), total_fee).into())));
+			assert!(sent_message.0.contains(&BuyExecution {
+				fees: (MultiLocation::here(), total_fee).into(),
+				weight_limit: Limited(total_weight),
+			}));
+			assert!(sent_message.0.contains(&Transact {
+				origin_kind: OriginKind::Native,
+				require_weight_at_most: tx_weight,
+				call: vec![1u8, 0u8].into(),
+			}));
+
+			// Check message contains the new appendix
+			assert!(sent_message.0.contains(&SetAppendix(Xcm(vec![
+				RefundSurplus,
+				DepositAsset {
+					assets: Wild(AllCounted(1)),
+					beneficiary: MultiLocation {
+						parents: 0,
+						interior: X1(Junction::Parachain(100))
+					}
+				}
+			]))));
+		})
+}
+
+#[test]
+fn test_hrmp_manipulator_init_v4_convert_fails() {
+	ExtBuilder::default()
+		.with_balances(vec![])
+		.build()
+		.execute_with(|| {
+			// We are gonna use a total weight of 10_100, a tx weight of 100,
+			// and a total fee of 100
+			let total_weight: Weight = 10_100u64.into();
+			let tx_weight: Weight = 100_u64.into();
+			let total_fee = 100u128;
+
+			// Change xcm version
+			CustomVersionWrapper::set_version(4);
+
+			assert_noop!(
+				XcmTransactor::hrmp_manage(
+					RuntimeOrigin::root(),
+					HrmpOperation::InitOpen(HrmpInitParams {
+						para_id: 1u32.into(),
+						proposed_max_capacity: 1,
+						proposed_max_message_size: 1
+					}),
+					CurrencyPayment {
+						currency: Currency::AsMultiLocation(Box::new(
+							xcm::VersionedMultiLocation::V3(MultiLocation::parent())
+						)),
+						fee_amount: Some(total_fee)
+					},
+					TransactWeights {
+						transact_required_weight_at_most: tx_weight,
+						overall_weight: Some(total_weight)
+					}
+				),
+				Error::<Test>::ErrorValidating
+			);
+		})
+}
+
+#[test]
 fn test_hrmp_max_fee_errors() {
 	ExtBuilder::default()
 		.with_balances(vec![])


### PR DESCRIPTION
### What does it do?

Currently, `hrmp-manage()` function in XCM Transactor, uses `deposit_instruction()` function which adds a `DepositAsset` instruction using `Wild(All)`. This breaks compatibility while converting the message to XCM V2. This PR fixes that issue by using `Wild(AllCounted)` instead of `Wild(All)`.
