### PR TITLE
Fix precompiled proxy call transfer with tx value

### DIFF
--- a/precompiles/proxy/Cargo.toml
+++ b/precompiles/proxy/Cargo.toml
@@ -16,6 +16,7 @@ precompile-utils = { workspace = true }
 # Substrate
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+pallet-balances = { workspace = true }
 pallet-proxy = { workspace = true }
 parity-scale-codec = { workspace = true, features = [ "derive" ] }
 sp-core = { workspace = true }
@@ -48,10 +49,12 @@ std = [
 	"fp-evm/std",
 	"frame-support/std",
 	"frame-system/std",
+	"pallet-balances/std",
 	"pallet-evm/std",
 	"pallet-proxy/std",
 	"parity-scale-codec/std",
 	"precompile-utils/std",
+	"sp-core/std",
 	"sp-runtime/std",
 	"sp-std/std",
 ]

--- a/precompiles/proxy/src/lib.rs
+++ b/precompiles/proxy/src/lib.rs
@@ -19,6 +19,7 @@
 use evm::ExitReason;
 use fp_evm::{Context, PrecompileFailure, PrecompileHandle, Transfer};
 use frame_support::dispatch::{Dispatchable, GetDispatchInfo, PostDispatchInfo};
+use pallet_balances::Call as BalancesCall;
 use pallet_evm::AddressMapping;
 use pallet_proxy::Call as ProxyCall;
 use pallet_proxy::Pallet as ProxyPallet;
@@ -41,7 +42,8 @@ pub struct OnlyIsProxy<Runtime>(PhantomData<Runtime>);
 
 impl<Runtime> SelectorFilter for OnlyIsProxy<Runtime>
 where
-	Runtime: pallet_proxy::Config + pallet_evm::Config + frame_system::Config,
+	Runtime:
+		pallet_proxy::Config + pallet_evm::Config + frame_system::Config + pallet_balances::Config,
 	<<Runtime as pallet_proxy::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
 		From<Option<Runtime::AccountId>>,
 	<Runtime as pallet_proxy::Config>::ProxyType: Decode + EvmProxyCallFilter,
@@ -49,7 +51,9 @@ where
 		Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
 	<<Runtime as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
 		From<Option<Runtime::AccountId>>,
-	<Runtime as frame_system::Config>::RuntimeCall: From<ProxyCall<Runtime>>,
+	<Runtime as frame_system::Config>::RuntimeCall:
+		From<ProxyCall<Runtime>> + From<BalancesCall<Runtime>>,
+	<Runtime as pallet_balances::Config<()>>::Balance: TryFrom<U256> + Into<U256>,
 {
 	fn is_allowed(_caller: H160, selector: Option<u32>) -> bool {
 		match selector {
@@ -70,7 +74,8 @@ pub struct OnlyIsProxyAndProxy<Runtime>(PhantomData<Runtime>);
 
 impl<Runtime> SelectorFilter for OnlyIsProxyAndProxy<Runtime>
 where
-	Runtime: pallet_proxy::Config + pallet_evm::Config + frame_system::Config,
+	Runtime:
+		pallet_proxy::Config + pallet_evm::Config + frame_system::Config + pallet_balances::Config,
 	<<Runtime as pallet_proxy::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
 		From<Option<Runtime::AccountId>>,
 	<Runtime as pallet_proxy::Config>::ProxyType: Decode + EvmProxyCallFilter,
@@ -78,7 +83,9 @@ where
 		Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
 	<<Runtime as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
 		From<Option<Runtime::AccountId>>,
-	<Runtime as frame_system::Config>::RuntimeCall: From<ProxyCall<Runtime>>,
+	<Runtime as frame_system::Config>::RuntimeCall:
+		From<ProxyCall<Runtime>> + From<BalancesCall<Runtime>>,
+	<Runtime as pallet_balances::Config<()>>::Balance: TryFrom<U256> + Into<U256>,
 {
 	fn is_allowed(_caller: H160, selector: Option<u32>) -> bool {
 		match selector {
@@ -128,7 +135,8 @@ pub struct ProxyPrecompile<Runtime>(PhantomData<Runtime>);
 #[precompile_utils::precompile]
 impl<Runtime> ProxyPrecompile<Runtime>
 where
-	Runtime: pallet_proxy::Config + pallet_evm::Config + frame_system::Config,
+	Runtime:
+		pallet_proxy::Config + pallet_evm::Config + frame_system::Config + pallet_balances::Config,
 	<<Runtime as pallet_proxy::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
 		From<Option<Runtime::AccountId>>,
 	<Runtime as pallet_proxy::Config>::ProxyType: Decode + EvmProxyCallFilter,
@@ -136,7 +144,9 @@ where
 		Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
 	<<Runtime as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
 		From<Option<Runtime::AccountId>>,
-	<Runtime as frame_system::Config>::RuntimeCall: From<ProxyCall<Runtime>>,
+	<Runtime as frame_system::Config>::RuntimeCall:
+		From<ProxyCall<Runtime>> + From<BalancesCall<Runtime>>,
+	<Runtime as pallet_balances::Config<()>>::Balance: TryFrom<U256> + Into<U256>,
 {
 	/// Register a proxy account for the sender that is able to make calls on its behalf.
 	/// The dispatch origin for this call must be Signed.
@@ -176,7 +186,7 @@ where
 
 		let delegate: <Runtime::Lookup as StaticLookup>::Source =
 			Runtime::Lookup::unlookup(delegate.clone());
-		let call = ProxyCall::<Runtime>::add_proxy {
+		let call: ProxyCall<Runtime> = ProxyCall::<Runtime>::add_proxy {
 			delegate,
 			proxy_type,
 			delay,
@@ -212,7 +222,7 @@ where
 		let delegate: <Runtime::Lookup as StaticLookup>::Source =
 			Runtime::Lookup::unlookup(delegate.clone());
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
-		let call = ProxyCall::<Runtime>::remove_proxy {
+		let call: ProxyCall<Runtime> = ProxyCall::<Runtime>::remove_proxy {
 			delegate,
 			proxy_type,
 			delay,
@@ -231,7 +241,7 @@ where
 	#[precompile::public("removeProxies()")]
 	fn remove_proxies(handle: &mut impl PrecompileHandle) -> EvmResult {
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
-		let call = ProxyCall::<Runtime>::remove_proxies {}.into();
+		let call: ProxyCall<Runtime> = ProxyCall::<Runtime>::remove_proxies {}.into();
 
 		<RuntimeHelper<Runtime>>::try_dispatch(handle, Some(origin).into(), call)?;
 
@@ -380,8 +390,28 @@ where
 		let transfer = if value.is_zero() {
 			None
 		} else {
+			let contract_address: Runtime::AccountId =
+				Runtime::AddressMapping::into_account_id(handle.context().address);
+
+			// Send back funds received by the precompile.
+			RuntimeHelper::<Runtime>::try_dispatch(
+				handle,
+				Some(contract_address).into(),
+				pallet_balances::Call::<Runtime>::transfer {
+					dest: Runtime::Lookup::unlookup(who),
+					value: {
+						let balance: <Runtime as pallet_balances::Config<()>>::Balance =
+							value.try_into().map_err(|_| PrecompileFailure::Revert {
+								exit_status: fp_evm::ExitRevert::Reverted,
+								output: sp_std::vec::Vec::new(),
+							})?;
+						balance
+					},
+				},
+			)?;
+
 			Some(Transfer {
-				source: handle.context().caller,
+				source: sub_context.caller,
 				target: address.clone(),
 				value,
 			})

--- a/tests/tests/test-precompile/test-precompile-proxy.ts
+++ b/tests/tests/test-precompile/test-precompile-proxy.ts
@@ -487,7 +487,7 @@ describeDevMoonbeam("Pallet proxy - should transfer using value", (context) => {
     const value = BigInt(context.web3.utils.toWei("10", "ether"));
 
     const {
-      result: { events: events2 },
+      result: { events: events2, hash: hash2 },
     } = await context.createBlock(
       createTransaction(context, {
         ...BALTATHAR_TRANSACTION_TEMPLATE,
@@ -499,15 +499,18 @@ describeDevMoonbeam("Pallet proxy - should transfer using value", (context) => {
 
     expectEVMResult(events2, "Succeed");
 
+    const { gasUsed } = await context.web3.eth.getTransactionReceipt(hash2);
+    expect(gasUsed).to.equal(40892);
+
     const afterAlithBalance = BigInt(await context.web3.eth.getBalance(ALITH_ADDRESS));
     const afterCharlethBalance = BigInt(await context.web3.eth.getBalance(CHARLETH_ADDRESS));
     const afterProxyPrecompileBalance = BigInt(
       await context.web3.eth.getBalance(PRECOMPILE_PROXY_ADDRESS)
     );
 
-    expect(afterAlithBalance - beforeAlithBalance).to.be.eq(-value);
-    expect(afterCharlethBalance - beforeCharlethBalance).to.be.eq(value);
-    expect(afterProxyPrecompileBalance).to.be.eq(0n);
+    expect(beforeAlithBalance - afterAlithBalance).to.equal(value);
+    expect(afterCharlethBalance - beforeCharlethBalance).to.equal(value);
+    expect(afterProxyPrecompileBalance).to.equal(0n);
   });
 });
 
@@ -536,7 +539,7 @@ describeDevMoonbeam("Pallet proxy - should transfer using balances precompile", 
     const value = BigInt(context.web3.utils.toWei("10", "ether"));
 
     const {
-      result: { events: events2 },
+      result: { events: events2, hash: hash2 },
     } = await context.createBlock(
       createTransaction(context, {
         ...BALTATHAR_TRANSACTION_TEMPLATE,
@@ -551,10 +554,13 @@ describeDevMoonbeam("Pallet proxy - should transfer using balances precompile", 
 
     expectEVMResult(events2, "Succeed");
 
+    const { gasUsed } = await context.web3.eth.getTransactionReceipt(hash2);
+    expect(gasUsed).to.equal(33997);
+
     const afterAlithBalance = BigInt(await context.web3.eth.getBalance(ALITH_ADDRESS));
     const afterCharlethBalance = BigInt(await context.web3.eth.getBalance(CHARLETH_ADDRESS));
 
-    expect(beforeAlithBalance - afterAlithBalance).to.be.eq(value);
-    expect(afterCharlethBalance - beforeCharlethBalance).to.be.eq(value);
+    expect(beforeAlithBalance - afterAlithBalance).to.equal(value);
+    expect(afterCharlethBalance - beforeCharlethBalance).to.equal(value);
   });
 });


### PR DESCRIPTION
Two fixes for `proxy` transfer calls using transaction's `value`:

- Refund proxy account (caller) on `proxy` transfer call using transaction's `value`
- Correct origin of funds

Added tests cases for each