### PR TITLE
Fix delegation benchmarks

### DIFF
--- a/pallets/parachain-staking/src/benchmarks.rs
+++ b/pallets/parachain-staking/src/benchmarks.rs
@@ -1121,6 +1121,9 @@ benchmarks! {
 			+ T::MaxBottomDelegationsPerCandidate::get() - 1
 		);
 
+		let num_top = x.min(T::MaxTopDelegationsPerCandidate::get() - 1);
+		let num_bottom = x.saturating_sub(num_top).min(T::MaxBottomDelegationsPerCandidate::get());
+
 		let mut seed = Seed::new();
 		let collator = create_account::<T>(
 			"collator",
@@ -1134,7 +1137,7 @@ benchmarks! {
 			1u32.into(),
 		);
 		let mut col_del_count = 0u32;
-		for i in 0..T::MaxTopDelegationsPerCandidate::get() - 1 {
+		for i in 0..num_top {
 			let del = create_account::<T>(
 				"delegator",
 				seed.take(),
@@ -1176,7 +1179,7 @@ benchmarks! {
 			0,
 		);
 
-		for i in 0..T::MaxBottomDelegationsPerCandidate::get() {
+		for i in 0..num_bottom {
 			let del = create_account::<T>(
 				"delegator",
 				seed.take(),
@@ -1199,7 +1202,7 @@ benchmarks! {
 
 		assert_eq!(
 			<BottomDelegations<T>>::get(&collator).map(|bd| bd.delegations.len() as u32).unwrap_or_default(),
-			T::MaxBottomDelegationsPerCandidate::get(),
+			num_bottom,
 		);
 
 	}: {
@@ -1231,6 +1234,9 @@ benchmarks! {
 			+ T::MaxBottomDelegationsPerCandidate::get() - 1
 		);
 
+		let num_top = x.min(T::MaxTopDelegationsPerCandidate::get() - 1);
+		let num_bottom = x.saturating_sub(num_top).min(T::MaxBottomDelegationsPerCandidate::get());
+
 		let mut seed = Seed::new();
 		let collator = create_account::<T>(
 			"collator",
@@ -1244,7 +1250,7 @@ benchmarks! {
 			1u32.into(),
 		);
 		let mut col_del_count = 0u32;
-		for i in 0..T::MaxTopDelegationsPerCandidate::get() - 1 {
+		for i in 0..num_top {
 			let del = create_account::<T>(
 				"delegator",
 				seed.take(),
@@ -1286,7 +1292,7 @@ benchmarks! {
 			0,
 		);
 
-		for i in 0..T::MaxBottomDelegationsPerCandidate::get() {
+		for i in 0..num_bottom {
 			let del = create_account::<T>(
 				"delegator",
 				seed.take(),
@@ -1310,7 +1316,7 @@ benchmarks! {
 
 		assert_eq!(
 			<BottomDelegations<T>>::get(&collator).map(|bd| bd.delegations.len() as u32).unwrap_or_default(),
-			T::MaxBottomDelegationsPerCandidate::get(),
+			num_bottom,
 		);
 
 		let bond_more = 1_000u32.into();
@@ -1336,6 +1342,9 @@ benchmarks! {
 			+ T::MaxBottomDelegationsPerCandidate::get() - 1
 		);
 
+		let num_top = x.min(T::MaxTopDelegationsPerCandidate::get() - 1);
+		let num_bottom = x.saturating_sub(num_top).min(T::MaxBottomDelegationsPerCandidate::get());
+
 		let mut seed = Seed::new();
 		let collator = create_account::<T>(
 			"collator",
@@ -1349,7 +1358,7 @@ benchmarks! {
 			1u32.into(),
 		);
 		let mut col_del_count = 0u32;
-		for i in 0..T::MaxTopDelegationsPerCandidate::get() - 1 {
+		for i in 0..num_top {
 			let del = create_account::<T>(
 				"delegator",
 				seed.take(),
@@ -1390,7 +1399,7 @@ benchmarks! {
 			0,
 		);
 
-		for i in 0..T::MaxBottomDelegationsPerCandidate::get() {
+		for i in 0..num_bottom {
 			let del = create_account::<T>(
 				"delegator",
 				seed.take(),
@@ -1414,7 +1423,7 @@ benchmarks! {
 
 		assert_eq!(
 			<BottomDelegations<T>>::get(&collator).map(|bd| bd.delegations.len() as u32).unwrap_or_default(),
-			T::MaxBottomDelegationsPerCandidate::get(),
+			num_bottom,
 		);
 		let bond_less = 1_000u32.into();
 	}: {

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -498,31 +498,36 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// The range of component `x` is `[1, 100]`.
 	fn execute_leave_delegators_worst(x: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `4432 + x * (34704 ±0)`
-		//  Estimated: `51750 + x * (290063 ±3)`
-		// Minimum execution time: 164_783_000 picoseconds.
-		Weight::from_parts(16_062_092, 51750)
-			// Standard Error: 377_049
-			.saturating_add(Weight::from_parts(99_015_049, 0).saturating_mul(x.into()))
-			.saturating_add(T::DbWeight::get().reads(5_u64))
+		//  Measured:  `4433 + x * (34704 ±0)`
+		//  Estimated: `52310 + x * (290055 ±2)`
+		// Minimum execution time: 87_865_000 picoseconds.
+		Weight::from_parts(87_865_000, 0)
+			.saturating_add(Weight::from_parts(0, 52310))
+			// Standard Error: 404_296
+			.saturating_add(Weight::from_parts(63_821_602, 0).saturating_mul(x.into()))
+			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().reads((5_u64).saturating_mul(x.into())))
-			.saturating_add(T::DbWeight::get().writes(5_u64))
+			.saturating_add(T::DbWeight::get().writes(5))
 			.saturating_add(T::DbWeight::get().writes((5_u64).saturating_mul(x.into())))
-			.saturating_add(Weight::from_parts(0, 290063).saturating_mul(x.into()))
+			.saturating_add(Weight::from_parts(0, 290055).saturating_mul(x.into()))
 	}
 	/// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	/// Proof Skipped: ParachainStaking DelegatorState (max_values: None, max_size: None, mode: Measured)
 	/// Storage: ParachainStaking DelegationScheduledRequests (r:1 w:1)
 	/// Proof Skipped: ParachainStaking DelegationScheduledRequests (max_values: None, max_size: None, mode: Measured)
 	/// The range of component `x` is `[0, 349]`.
-	fn schedule_revoke_delegation(_x: u32, ) -> Weight {
+	fn schedule_revoke_delegation(x: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `15515`
-		//  Estimated: `37960`
-		// Minimum execution time: 55_538_000 picoseconds.
-		Weight::from_parts(58_365_791, 37960)
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().writes(2_u64))
+		//  Measured:  `574 + x * (42 ±0)`
+		//  Estimated: `7960 + x * (86 ±0)`
+		// Minimum execution time: 10_519_000 picoseconds.
+		Weight::from_parts(13_063_419, 0)
+			.saturating_add(Weight::from_parts(0, 7960))
+			// Standard Error: 2_915
+			.saturating_add(Weight::from_parts(48_921, 0).saturating_mul(x.into()))
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(2))
+			.saturating_add(Weight::from_parts(0, 86).saturating_mul(x.into()))
 	}
 	/// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	/// Proof Skipped: ParachainStaking DelegatorState (max_values: None, max_size: None, mode: Measured)
@@ -541,14 +546,18 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: ParachainStaking Total (r:1 w:1)
 	/// Proof Skipped: ParachainStaking Total (max_values: Some(1), max_size: None, mode: Measured)
 	/// The range of component `x` is `[0, 349]`.
-	fn delegator_bond_more(_x: u32, ) -> Weight {
+	fn delegator_bond_more(x: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `27979`
-		//  Estimated: `193037`
-		// Minimum execution time: 131_740_000 picoseconds.
-		Weight::from_parts(134_429_600, 193037)
-			.saturating_add(T::DbWeight::get().reads(8_u64))
-			.saturating_add(T::DbWeight::get().writes(7_u64))
+		//  Measured:  `1954 + x * (79 ±0)`
+		//  Estimated: `37061 + x * (468 ±1)`
+		// Minimum execution time: 34_946_000 picoseconds.
+		Weight::from_parts(38_839_287, 0)
+			.saturating_add(Weight::from_parts(0, 37061))
+			// Standard Error: 5_522
+			.saturating_add(Weight::from_parts(110_446, 0).saturating_mul(x.into()))
+			.saturating_add(T::DbWeight::get().reads(8))
+			.saturating_add(T::DbWeight::get().writes(7))
+			.saturating_add(Weight::from_parts(0, 468).saturating_mul(x.into()))
 	}
 	/// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	/// Proof Skipped: ParachainStaking DelegatorState (max_values: None, max_size: None, mode: Measured)
@@ -557,14 +566,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// The range of component `x` is `[0, 349]`.
 	fn schedule_delegator_bond_less(x: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `15515`
-		//  Estimated: `37960`
-		// Minimum execution time: 56_573_000 picoseconds.
-		Weight::from_parts(58_214_753, 37960)
-			// Standard Error: 10_063
-			.saturating_add(Weight::from_parts(7_073, 0).saturating_mul(x.into()))
-			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().writes(2_u64))
+		//  Measured:  `574 + x * (42 ±0)`
+		//  Estimated: `7960 + x * (86 ±0)`
+		// Minimum execution time: 12_233_000 picoseconds.
+		Weight::from_parts(13_630_744, 0)
+			.saturating_add(Weight::from_parts(0, 7960))
+			// Standard Error: 3_029
+			.saturating_add(Weight::from_parts(47_410, 0).saturating_mul(x.into()))
+			.saturating_add(T::DbWeight::get().reads(2))
+			.saturating_add(T::DbWeight::get().writes(2))
+			.saturating_add(Weight::from_parts(0, 86).saturating_mul(x.into()))
 	}
 	/// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	/// Proof Skipped: ParachainStaking DelegatorState (max_values: None, max_size: None, mode: Measured)

--- a/pallets/parachain-staking/src/weights.rs
+++ b/pallets/parachain-staking/src/weights.rs
@@ -498,18 +498,17 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// The range of component `x` is `[1, 100]`.
 	fn execute_leave_delegators_worst(x: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `4433 + x * (34704 ±0)`
-		//  Estimated: `52310 + x * (290055 ±2)`
-		// Minimum execution time: 87_865_000 picoseconds.
-		Weight::from_parts(87_865_000, 0)
-			.saturating_add(Weight::from_parts(0, 52310))
-			// Standard Error: 404_296
-			.saturating_add(Weight::from_parts(63_821_602, 0).saturating_mul(x.into()))
-			.saturating_add(T::DbWeight::get().reads(5))
+		//  Measured:  `4432 + x * (34704 ±0)`
+		//  Estimated: `51750 + x * (290063 ±3)`
+		// Minimum execution time: 164_783_000 picoseconds.
+		Weight::from_parts(16_062_092, 51750)
+			// Standard Error: 377_049
+			.saturating_add(Weight::from_parts(99_015_049, 0).saturating_mul(x.into()))
+			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().reads((5_u64).saturating_mul(x.into())))
-			.saturating_add(T::DbWeight::get().writes(5))
+			.saturating_add(T::DbWeight::get().writes(5_u64))
 			.saturating_add(T::DbWeight::get().writes((5_u64).saturating_mul(x.into())))
-			.saturating_add(Weight::from_parts(0, 290055).saturating_mul(x.into()))
+			.saturating_add(Weight::from_parts(0, 290063).saturating_mul(x.into()))
 	}
 	/// Storage: ParachainStaking DelegatorState (r:1 w:1)
 	/// Proof Skipped: ParachainStaking DelegatorState (max_values: None, max_size: None, mode: Measured)


### PR DESCRIPTION
### What does it do?

While reviewing #2317 I noticed some discrepancies in some of the benchmarks. Specifically, there were some that used a scaling parameter `x` which was supposed to represent the number of existing top/bottom delegations, but the benchmarks ignored this parameter accidentally.

This PR fixes that and updates the weights. These benchmarks were run on a local machine; they should be run on proper benchmarking hardware instead.

CC @nbaztec 