### PR TITLE
fix erc20-xcm on moonriver and moonbeam

### DIFF
--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -199,6 +199,7 @@ pub type AssetTransactors = (
 	LocalAssetTransactor,
 	ForeignFungiblesTransactor,
 	LocalFungiblesTransactor,
+	Erc20XcmBridge,
 );
 
 /// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
@@ -457,26 +458,37 @@ pub enum CurrencyId {
 	ForeignAsset(AssetId),
 	// Our local assets
 	LocalAssetReserve(AssetId),
+	// Erc20 token
+	Erc20 { contract_address: H160 },
 }
 
 impl AccountIdToCurrencyId<AccountId, CurrencyId> for Runtime {
 	fn account_to_currency_id(account: AccountId) -> Option<CurrencyId> {
-		match account {
+		Some(match account {
 			// the self-reserve currency is identified by the pallet-balances address
-			a if a == H160::from_low_u64_be(2050).into() => Some(CurrencyId::SelfReserve),
+			a if a == H160::from_low_u64_be(2050).into() => CurrencyId::SelfReserve,
 			// the rest of the currencies, by their corresponding erc20 address
-			_ => Runtime::account_to_asset_id(account).map(|(prefix, asset_id)| {
-				if prefix == FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX.to_vec() {
-					CurrencyId::ForeignAsset(asset_id)
-				} else {
-					CurrencyId::LocalAssetReserve(asset_id)
+			_ => match Runtime::account_to_asset_id(account) {
+				// We distinguish by prefix, and depending on it we create either
+				// Foreign or Local
+				Some((prefix, asset_id)) => {
+					if prefix == FOREIGN_ASSET_PRECOMPILE_ADDRESS_PREFIX.to_vec() {
+						CurrencyId::ForeignAsset(asset_id)
+					} else {
+						CurrencyId::LocalAssetReserve(asset_id)
+					}
 				}
-			}),
-		}
+				// If no known prefix is identified, we consider that it's a "real" erc20 token
+				// (i.e. managed by a real smart contract)
+				None => CurrencyId::Erc20 {
+					contract_address: account.into(),
+				},
+			},
+		})
 	}
 }
-// How to convert from CurrencyId to MultiLocation
 
+// How to convert from CurrencyId to MultiLocation
 pub struct CurrencyIdtoMultiLocation<AssetXConverter>(sp_std::marker::PhantomData<AssetXConverter>);
 impl<AssetXConverter> sp_runtime::traits::Convert<CurrencyId, Option<MultiLocation>>
 	for CurrencyIdtoMultiLocation<AssetXConverter>
@@ -498,6 +510,16 @@ where
 			CurrencyId::LocalAssetReserve(asset) => {
 				let mut location = LocalAssetsPalletLocation::get();
 				location.push_interior(Junction::GeneralIndex(asset)).ok();
+				Some(location)
+			}
+			CurrencyId::Erc20 { contract_address } => {
+				let mut location = Erc20XcmBridgePalletLocation::get();
+				location
+					.push_interior(Junction::AccountKey20 {
+						key: contract_address.0,
+						network: None,
+					})
+					.ok();
 				Some(location)
 			}
 		}

--- a/tests/tests/test-xcm/test-xcm-erc20-transfer.ts
+++ b/tests/tests/test-xcm/test-xcm-erc20-transfer.ts
@@ -9,7 +9,7 @@ import { ALITH_ADDRESS, BALTATHAR_ADDRESS, CHARLETH_ADDRESS } from "../../util/a
 import { PRECOMPILE_XTOKENS_ADDRESS } from "../../util/constants";
 import { web3EthCall } from "../../util/providers";
 import { getCompiled } from "../../util/contracts";
-import { describeDevMoonbeam } from "../../util/setup-dev-tests";
+import { describeDevMoonbeamAllRuntimes } from "../../util/setup-dev-tests";
 import {
   ALITH_TRANSACTION_TEMPLATE,
   createTransaction,
@@ -30,7 +30,7 @@ const ERC20_INTERFACE = new ethers.utils.Interface(ERC20_CONTRACT.contract.abi);
 const XTOKENS_CONTRACT = getCompiled("XtokensInstance");
 const XTOKENS_INTERFACE = new ethers.utils.Interface(XTOKENS_CONTRACT.contract.abi);
 
-describeDevMoonbeam("Mock XCM - Send local erc20", (context) => {
+describeDevMoonbeamAllRuntimes("Mock XCM - Send local erc20", (context) => {
   let erc20Contract: Contract;
   let erc20ContractAddress: string;
 
@@ -95,7 +95,7 @@ describeDevMoonbeam("Mock XCM - Send local erc20", (context) => {
   });
 });
 
-describeDevMoonbeam("Mock XCM - Receive back erc20", (context) => {
+describeDevMoonbeamAllRuntimes("Mock XCM - Receive back erc20", (context) => {
   let erc20Contract: Contract;
   let erc20ContractAddress: string;
 


### PR DESCRIPTION
### What does it do?

The XCM configuration for moonriver and moonbeam has not been sufficiently adapted to support erc20 transfers via XCM.

Apply theses changes on moonriver runtime and moonbeam runtime:

* Add `Erc20XcmBridge` in the `AssetTransactors` tuple
* Add `Erc20` variant in `CurencyId`
* Refactor `AccountIdToCurrencyId` converter to resolve to erc20 currency by default
* Handle `Erc20` variant in `CurrencyIdtoMultiLocation` converter 

### What important points reviewers should know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
