### PR TITLE
Prune duplicate `hex` dependency

### DIFF
--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -12,7 +12,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 blake2-rfc = { workspace = true, optional = true }
-hex = { workspace = true }
 impl-serde = { workspace = true }
 libsecp256k1 = { workspace = true, features = ["hmac"] }
 log = { workspace = true }
@@ -27,6 +26,9 @@ sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-runtime-interface = { workspace = true }
 sp-std = { workspace = true }
+
+[dev-dependencies]
+hex = { workspace = true }
 
 [features]
 default = ["std"]

--- a/primitives/account/Cargo.toml
+++ b/primitives/account/Cargo.toml
@@ -8,15 +8,15 @@ repository = { workspace = true }
 version = "0.1.1"
 
 [package.metadata.docs.rs]
-targets = [ "x86_64-unknown-linux-gnu" ]
+targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 blake2-rfc = { workspace = true, optional = true }
 hex = { workspace = true }
 impl-serde = { workspace = true }
-libsecp256k1 = { workspace = true, features = [ "hmac" ] }
+libsecp256k1 = { workspace = true, features = ["hmac"] }
 log = { workspace = true }
-serde = { workspace = true, optional = true, features = [ "derive" ] }
+serde = { workspace = true, optional = true, features = ["derive"] }
 sha3 = { workspace = true }
 
 # Substrate
@@ -28,11 +28,8 @@ sp-runtime = { workspace = true }
 sp-runtime-interface = { workspace = true }
 sp-std = { workspace = true }
 
-[dev-dependencies]
-hex = { workspace = true }
-
 [features]
-default = [ "std" ]
+default = ["std"]
 std = [
 	"full_crypto",
 	"hex/std",


### PR DESCRIPTION
This PR cleans up the `account` crate's `Cargo.toml` file by removing the dependency on `hex`. The same create is only used as a dev-dependency and is already specified as such. Thus it is not necessary to also have it as a full dependency.