### PR TITLE
[MOON-2356] Disallow clippy todo in master and perm-* branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -305,13 +305,13 @@ jobs:
         uses: arduino/setup-protoc@v1
       - name: Setup Rust toolchain
         run: rustup show
-      # Basic clippy check
-      - name: Clippy (branch)
+      # Development branch clippy check
+      - name: Clippy (dev)
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'perm-')
         run: SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --features try-runtime,runtime-benchmarks
-      # Production code clippy check
+      # Main branch (master, perm-*) clippy check
       # Disallows: todo
-      - name: Clippy (prod)
+      - name: Clippy (main)
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'perm-')
         run: SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --features try-runtime,runtime-benchmarks -- -Dclippy::todo
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -305,8 +305,15 @@ jobs:
         uses: arduino/setup-protoc@v1
       - name: Setup Rust toolchain
         run: rustup show
-      - name: Clippy
+      # Basic clippy check
+      - name: Clippy (branch)
+        if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'perm-')
         run: SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --features try-runtime,runtime-benchmarks
+      # Production code clippy check
+      # Disallows: todo
+      - name: Clippy (prod)
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'perm-')
+        run: SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --features try-runtime,runtime-benchmarks -- -Dclippy::todo
 
   build:
     runs-on:

--- a/node/service/src/chain_spec/fake_spec.rs
+++ b/node/service/src/chain_spec/fake_spec.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(clippy::todo)]
+
 /// Fake specifications, only a workaround to compile with runtime optional features.
 /// It's a zero variant enum to ensure at compile time that we never instantiate this type.
 pub enum FakeSpec {}


### PR DESCRIPTION
### What does it do?
Disallows clippy todo in master and perm-* branches