### PR TITLE
remove erroneous expression brackets in if-condition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -466,7 +466,7 @@ jobs:
   docker-moonbeam:
     runs-on: ubuntu-latest
     needs: ["set-tags", "build"]
-    if: ${{ needs.set-tags.outputs.image_exists }} == false && ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: needs.set-tags.outputs.image_exists == false && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### What does it do?
Removes redundant/erroneous `${{ }}` from build step.

As per github [docs](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution)
```
When you use expressions in an if conditional, you may omit the expression syntax (${{ }}) because GitHub automatically evaluates the if conditional as an expression. 
```

This was causing this build step to be run also on forked PRs on [tanssi](https://github.com/moondance-labs/tanssi/)