### PR TITLE
[MOON-2433] enforce MaxCandidates limit for staking storage items

### DIFF
--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -120,6 +120,7 @@ parameter_types! {
 	pub const MinCandidateStk: u128 = 10;
 	pub const MinDelegatorStk: u128 = 5;
 	pub const MinDelegation: u128 = 3;
+	pub const MaxCandidates: u32 = 10;
 }
 impl Config for Test {
 	type RuntimeEvent = RuntimeEvent;
@@ -144,6 +145,7 @@ impl Config for Test {
 	type PayoutCollatorReward = ();
 	type OnNewRound = ();
 	type WeightInfo = ();
+	type MaxCandidates = MaxCandidates;
 }
 
 pub(crate) struct ExtBuilder {

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -15,7 +15,6 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 /* TODO: use orml_utilities::OrderedSet without leaking substrate v2.0 dependencies*/
-#![allow(dead_code)]
 
 use frame_support::traits::Get;
 use parity_scale_codec::{Decode, Encode};

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -15,11 +15,14 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 /* TODO: use orml_utilities::OrderedSet without leaking substrate v2.0 dependencies*/
+#![allow(dead_code)]
+
+use frame_support::traits::Get;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
-use sp_runtime::RuntimeDebug;
+use sp_runtime::{BoundedVec, RuntimeDebug};
 use sp_std::prelude::*;
 
 /// An ordered set backed by `Vec`
@@ -84,6 +87,81 @@ impl<T: Ord> OrderedSet<T> {
 
 impl<T: Ord> From<Vec<T>> for OrderedSet<T> {
 	fn from(v: Vec<T>) -> Self {
+		Self::from(v)
+	}
+}
+
+/// An ordered set backed by `BoundedVec`
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+#[derive(RuntimeDebug, PartialEq, Eq, Encode, Decode, Clone, TypeInfo)]
+#[scale_info(skip_type_params(S))]
+pub struct BoundedOrderedSet<T, S: Get<u32>>(pub BoundedVec<T, S>);
+
+impl<T, S: Get<u32>> sp_std::default::Default for BoundedOrderedSet<T, S> {
+	fn default() -> Self {
+		BoundedOrderedSet(BoundedVec::default())
+	}
+}
+
+impl<T: Ord, S: Get<u32>> BoundedOrderedSet<T, S> {
+	/// Create a new empty set
+	pub fn new() -> Self {
+		Self(BoundedVec::default())
+	}
+
+	/// Create a set from a `Vec`.
+	/// `v` will be sorted and dedup first.
+	pub fn from(mut v: BoundedVec<T, S>) -> Self {
+		v.sort();
+		let v = v.try_mutate(|inner| inner.dedup()).expect(
+			"input is a valid BoundedVec and deduping can only reduce the number of entires; qed",
+		);
+		Self::from_sorted_set(v)
+	}
+
+	/// Create a set from a `Vec`.
+	/// Assume `v` is sorted and contain unique elements.
+	pub fn from_sorted_set(v: BoundedVec<T, S>) -> Self {
+		Self(v)
+	}
+
+	/// Insert an element.
+	/// Return true if insertion happened.
+	pub fn try_insert(&mut self, value: T) -> Result<bool, ()> {
+		match self.0.binary_search(&value) {
+			Ok(_) => Ok(false),
+			Err(loc) => self.0.try_insert(loc, value).map(|_| true).map_err(|_| ()),
+		}
+	}
+
+	/// Remove an element.
+	/// Return true if removal happened.
+	pub fn remove(&mut self, value: &T) -> bool {
+		match self.0.binary_search(value) {
+			Ok(loc) => {
+				self.0.remove(loc);
+				true
+			}
+			Err(_) => false,
+		}
+	}
+
+	/// Return if the set contains `value`
+	pub fn contains(&self, value: &T) -> bool {
+		self.0.binary_search(value).is_ok()
+	}
+
+	/// Clear the set
+	pub fn clear(mut self) {
+		let v = self.0.try_mutate(|inner| inner.clear()).expect(
+			"input is a valid BoundedVec and clearing can only reduce the number of entires; qed",
+		);
+		self.0 = v;
+	}
+}
+
+impl<T: Ord, S: Get<u32>> From<BoundedVec<T, S>> for BoundedOrderedSet<T, S> {
+	fn from(v: BoundedVec<T, S>) -> Self {
 		Self::from(v)
 	}
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -860,6 +860,43 @@ fn sufficient_join_candidates_weight_hint_succeeds() {
 		});
 }
 
+#[test]
+fn join_candidates_fails_if_above_max_candidate_count() {
+	ExtBuilder::default()
+		.with_balances(vec![
+			(1, 20),
+			(2, 20),
+			(3, 20),
+			(4, 20),
+			(5, 20),
+			(6, 20),
+			(7, 20),
+			(8, 20),
+			(9, 20),
+			(10, 20),
+			(11, 20),
+		])
+		.with_candidates(vec![
+			(1, 20),
+			(2, 20),
+			(3, 20),
+			(4, 20),
+			(5, 20),
+			(6, 20),
+			(7, 20),
+			(8, 20),
+			(9, 20),
+			(10, 20),
+		])
+		.build()
+		.execute_with(|| {
+			assert_noop!(
+				ParachainStaking::join_candidates(RuntimeOrigin::signed(11), 20, 10),
+				Error::<Test>::CandidateLimitReached,
+			);
+		});
+}
+
 // SCHEDULE LEAVE CANDIDATES
 
 #[test]

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -93,6 +93,17 @@ fn set_total_selected_fails_if_above_blocks_per_round() {
 }
 
 #[test]
+fn set_total_selected_fails_if_above_max_candidates() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_eq!(<Test as crate::Config>::MaxCandidates::get(), 10); // test relies on this
+		assert_noop!(
+			ParachainStaking::set_total_selected(RuntimeOrigin::root(), 15u32),
+			Error::<Test>::CannotSetAboveMaxCandidates,
+		);
+	});
+}
+
+#[test]
 fn set_total_selected_fails_if_equal_to_blocks_per_round() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(ParachainStaking::set_blocks_per_round(
@@ -129,10 +140,10 @@ fn set_blocks_per_round_fails_if_below_total_selected() {
 		));
 		assert_ok!(ParachainStaking::set_total_selected(
 			RuntimeOrigin::root(),
-			15u32
+			10u32
 		));
 		assert_noop!(
-			ParachainStaking::set_blocks_per_round(RuntimeOrigin::root(), 14u32),
+			ParachainStaking::set_blocks_per_round(RuntimeOrigin::root(), 9u32),
 			Error::<Test>::RoundLengthMustBeGreaterThanTotalSelectedCollators,
 		);
 	});

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -172,7 +172,7 @@ parameter_types! {
 	pub const MinCandidateStk: u128 = 10;
 	pub const MinDelegatorStk: u128 = 5;
 	pub const MinDelegation: u128 = 3;
-	pub const MaxCandidates: u32 = 5;
+	pub const MaxCandidates: u32 = 10;
 	pub BlockAuthor: AccountId = Alice.into();
 }
 impl pallet_parachain_staking::Config for Runtime {

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -172,6 +172,7 @@ parameter_types! {
 	pub const MinCandidateStk: u128 = 10;
 	pub const MinDelegatorStk: u128 = 5;
 	pub const MinDelegation: u128 = 3;
+	pub const MaxCandidates: u32 = 5;
 	pub BlockAuthor: AccountId = Alice.into();
 }
 impl pallet_parachain_staking::Config for Runtime {
@@ -197,6 +198,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type OnCollatorPayout = ();
 	type OnNewRound = ();
 	type WeightInfo = ();
+	type MaxCandidates = MaxCandidates;
 }
 
 pub(crate) struct ExtBuilder {

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -741,6 +741,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type PayoutCollatorReward = PayoutCollatorOrOrbiterReward;
 	type OnNewRound = OnNewRound;
 	type WeightInfo = pallet_parachain_staking::weights::SubstrateWeight<Runtime>;
+	type MaxCandidates = ConstU32<200>;
 }
 
 impl pallet_author_inherent::Config for Runtime {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -730,6 +730,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type PayoutCollatorReward = PayoutCollatorOrOrbiterReward;
 	type OnNewRound = OnNewRound;
 	type WeightInfo = pallet_parachain_staking::weights::SubstrateWeight<Runtime>;
+	type MaxCandidates = ConstU32<200>;
 }
 
 impl pallet_author_inherent::Config for Runtime {

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -731,6 +731,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	type PayoutCollatorReward = PayoutCollatorOrOrbiterReward;
 	type OnNewRound = OnNewRound;
 	type WeightInfo = pallet_parachain_staking::weights::SubstrateWeight<Runtime>;
+	type MaxCandidates = ConstU32<200>;
 }
 
 impl pallet_author_inherent::Config for Runtime {


### PR DESCRIPTION
### What does it do?
enforces `MaxCandidates` limit for candidates.

### :warning: Breaking Changes :warning: 

#### Error
* :exclamation: `CandidateLimitReached` is thrown if the number of candidates exceeds `MaxCandidates`
* :exclamation:  `CannotSetAboveMaxCandidates` is thrown if setting selected total candidates via `set_total_selected` extrinsic. 

#### Extrinsics
* :exclamation: `join_candidates` may throw `CandidateLimitReached` error

#### Storage
* :exclamation: `CandidatePool` is now bound by  `MaxCandidates`
* :exclamation: `SelectedCandidates` is now bound by  `MaxCandidates`