### PR TITLE
Update Smoketests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -619,7 +619,7 @@ jobs:
           ## Generate old spec using latest published node, modify it, and generate raw spec
           chmod uog+x tmp/moonbeam_rt
           tmp/moonbeam_rt build-spec --chain ${{ matrix.chain }}-local > tmp/${{ matrix.chain }}-plain-spec.json
-          pnpm ts-node --esm --swc scripts/modify-plain-specs.ts process tmp/${{ matrix.chain }}-plain-spec.json tmp/${{ matrix.chain }}-modified-spec.json 
+          pnpm tsx scripts/modify-plain-specs.ts process tmp/${{ matrix.chain }}-plain-spec.json tmp/${{ matrix.chain }}-modified-spec.json 
           tmp/moonbeam_rt build-spec --chain tmp/${{ matrix.chain }}-modified-spec.json --raw > tmp/${{ matrix.chain }}-raw-spec.json
 
           ## Start zombie network and run tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -640,29 +640,30 @@ jobs:
           name: failed-node-logs
           path: ${{ env.NODE_LOGS_ZIP }}
 
-  dev-test:
-    runs-on:
-      labels: bare-metal
-    needs: ["set-tags", "build"]
-    strategy:
-      matrix:
-        chain: ["moonbase"]
-    env:
-      GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain }}
-      DEBUG_COLORS: 1
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ needs.set-tags.outputs.git_ref }}
-      - run: |
-          mkdir -p target/release
-      - name: "Download branch built node"
-        uses: actions/download-artifact@v3.0.2
-        with:
-          name: moonbeam
-          path: target/release
-      - name: "Run Moonwall Dev Tests"
-        uses: ./.github/workflow-templates/dev-tests
-        with:
-          moonwall_environment: dev_${{ matrix.chain }}
+  ## DISABLED UNTIL DEV-MIGRATE-2 COMPLETE
+  # dev-test:
+  #   runs-on:
+  #     labels: bare-metal
+  #   needs: ["set-tags", "build"]
+  #   strategy:
+  #     matrix:
+  #       chain: ["moonbase"]
+  #   env:
+  #     GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain }}
+  #     DEBUG_COLORS: 1
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ needs.set-tags.outputs.git_ref }}
+  #     - run: |
+  #         mkdir -p target/release
+  #     - name: "Download branch built node"
+  #       uses: actions/download-artifact@v3.0.2
+  #       with:
+  #         name: moonbeam
+  #         path: target/release
+  #     - name: "Run Moonwall Dev Tests"
+  #       uses: ./.github/workflow-templates/dev-tests
+  #       with:
+  #         moonwall_environment: dev_${{ matrix.chain }}

--- a/test/helpers/assets.ts
+++ b/test/helpers/assets.ts
@@ -45,7 +45,7 @@ export async function mockAssetBalance(
   account: string | AccountId20,
   is_sufficient = false
 ) {
-  const api = context.polkadotJs({ type: "moon" });
+  const api = context.polkadotJs();
   // Register the asset
   await context.createBlock(
     api.tx.sudo
@@ -126,7 +126,7 @@ export async function registerLocalAssetWithMeta(
     mints = [],
   }: RegisterLocalAssetOptions
 ): Promise<{ assetId: string; assetAddress: string }> {
-  const api = context.polkadotJs({ type: "moon" });
+  const api = context.polkadotJs();
   const { result } = await context.createBlock(
     api.tx.sudo
       .sudo(

--- a/test/helpers/block.ts
+++ b/test/helpers/block.ts
@@ -303,7 +303,7 @@ export const verifyLatestBlockFees = async (
   context: DevModeContext,
   expectedBalanceDiff: bigint = BigInt(0)
 ) => {
-  const signedBlock = await context.polkadotJs({ type: "moon" }).rpc.chain.getBlock();
+  const signedBlock = await context.polkadotJs().rpc.chain.getBlock();
   const blockNumber = Number(signedBlock.block.header.number);
   return verifyBlockFees(context, blockNumber, blockNumber, expectedBalanceDiff);
 };
@@ -312,7 +312,7 @@ export async function jumpToRound(context: DevModeContext, round: number): Promi
   let lastBlockHash = "";
   while (true) {
     const currentRound = (
-      await context.polkadotJs({ type: "moon" }).query.parachainStaking.round()
+      await context.polkadotJs().query.parachainStaking.round()
     ).current.toNumber();
     if (currentRound === round) {
       return lastBlockHash;
@@ -332,7 +332,7 @@ export async function jumpBlocks(context: DevModeContext, blockCount: number) {
 }
 
 export async function jumpRounds(context: DevModeContext, count: Number): Promise<string | null> {
-  const round = (await context.polkadotJs({ type: "moon" }).query.parachainStaking.round()).current
+  const round = (await context.polkadotJs().query.parachainStaking.round()).current
     .addn(count.valueOf())
     .toNumber();
 

--- a/test/helpers/common.ts
+++ b/test/helpers/common.ts
@@ -51,9 +51,7 @@ export async function getMappingInfo(
   context: DevModeContext,
   authorId: string
 ): Promise<{ account: string; deposit: BigInt } | null> {
-  const mapping = await context
-    .polkadotJs({ type: "moon" })
-    .query.authorMapping.mappingWithDeposit(authorId);
+  const mapping = await context.polkadotJs().query.authorMapping.mappingWithDeposit(authorId);
   if (mapping.isSome) {
     return {
       account: mapping.unwrap().account.toString(),

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -42,6 +42,7 @@
     {
       "name": "smoke_stagenet",
       "contracts": "contracts/",
+      "runScripts": ["compile-contracts.ts compile"],
       "testFileDir": ["/suites/smoke"],
       "reporters": ["basic", "html"],
       "foundation": {
@@ -55,7 +56,7 @@
         },
         {
           "name": "para",
-          "type": "moon",
+          "type": "polkadotJs",
           "endpoints": ["wss://wss.api.moondev.network"]
         },
         {
@@ -69,6 +70,7 @@
       "name": "smoke_moonriver",
       "testFileDir": ["/suites/smoke"],
       "contracts": "contracts/",
+      "runScripts": ["compile-contracts.ts compile"],
       "reporters": ["basic", "html"],
       "foundation": {
         "type": "read_only"
@@ -81,7 +83,7 @@
         },
         {
           "name": "para",
-          "type": "moon",
+          "type": "polkadotJs",
           "endpoints": ["wss://wss.moonriver.moonbeam.network"]
         },
         {
@@ -95,6 +97,7 @@
       "name": "smoke_moonbeam",
       "testFileDir": ["/suites/smoke"],
       "contracts": "contracts/",
+      "runScripts": ["compile-contracts.ts compile"],
       "reporters": ["basic", "html"],
       "foundation": {
         "type": "read_only"
@@ -107,7 +110,7 @@
         },
         {
           "name": "para",
-          "type": "moon",
+          "type": "polkadotJs",
           "endpoints": ["wss://wss.api.moonbeam.network"]
         },
         {
@@ -123,6 +126,7 @@
       "contracts": "contracts/",
       "reporters": ["basic", "html"],
       "envVars": ["DEBUG_COLORS=1"],
+      "runScripts": ["compile-contracts.ts compile"],
       "foundation": {
         "type": "read_only"
       },
@@ -134,7 +138,7 @@
         },
         {
           "name": "para",
-          "type": "moon",
+          "type": "polkadotJs",
           "endpoints": ["wss://wss.api.moonbase.moonbeam.network"]
         },
         {
@@ -162,7 +166,7 @@
       "connections": [
         {
           "name": "MB",
-          "type": "moon",
+          "type": "polkadotJs",
           "endpoints": ["ws://127.0.0.1:8000"]
         }
       ]
@@ -224,7 +228,7 @@
         },
         {
           "name": "mb",
-          "type": "moon",
+          "type": "polkadotJs",
           "endpoints": ["ws://127.0.0.1:9944"]
         }
       ]
@@ -246,7 +250,7 @@
       "connections": [
         {
           "name": "MB",
-          "type": "moon",
+          "type": "polkadotJs",
           "endpoints": ["ws://127.0.0.1:8000"]
         }
       ]
@@ -268,7 +272,7 @@
       "connections": [
         {
           "name": "MB",
-          "type": "moon",
+          "type": "polkadotJs",
           "endpoints": ["ws://127.0.0.1:8000"]
         }
       ]
@@ -290,7 +294,7 @@
       "connections": [
         {
           "name": "MB",
-          "type": "moon",
+          "type": "polkadotJs",
           "endpoints": ["ws://127.0.0.1:8000"]
         }
       ]
@@ -312,7 +316,7 @@
       "connections": [
         {
           "name": "MB",
-          "type": "moon",
+          "type": "polkadotJs",
           "endpoints": ["ws://127.0.0.1:8000"]
         }
       ]
@@ -334,7 +338,7 @@
       "connections": [
         {
           "name": "MB",
-          "type": "moon",
+          "type": "polkadotJs",
           "endpoints": ["ws://127.0.0.1:8000"]
         }
       ]
@@ -356,7 +360,7 @@
       "connections": [
         {
           "name": "MB",
-          "type": "moon",
+          "type": "polkadotJs",
           "endpoints": ["ws://127.0.0.1:8000"]
         }
       ]

--- a/test/package.json
+++ b/test/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "lint": "pnpm prettier --write --ignore-path .gitignore '**/*.(yml|js|ts)'",
     "start": "pnpm moonwall",
+    "compile-solidity": "pnpm tsx scripts/compile-contracts.ts compile",
     "typecheck": "pnpm exec tsc --noEmit"
   },
   "keywords": [],
@@ -14,8 +15,8 @@
   "license": "ISC",
   "devDependencies": {
     "@moonbeam-network/api-augment": "^0.2400.0",
-    "@moonwall/cli": "^3.0.7",
-    "@moonwall/util": "^3.0.7",
+    "@moonwall/cli": "^4.0.2",
+    "@moonwall/util": "^4.0.2",
     "@polkadot/api": "^10.9.1",
     "@polkadot/api-augment": "^10.9.1",
     "@polkadot/types": "^10.9.1",
@@ -25,10 +26,9 @@
     "@types/node": "^18.16.18",
     "bottleneck": "^2.19.5",
     "debug": "^4.3.4",
-    "ethers": "^6.6.0",
+    "ethers": "^6.6.3",
     "pnpm": "^8.6.3",
     "prettier": "^2.8.8",
-    "ts-node": "^10.9.1",
     "typescript": "^5.1.3",
     "web3": "4.0.1",
     "web3-eth": "4.0.1",
@@ -54,7 +54,8 @@
     "node-fetch": "^3.3.1",
     "semver": "^7.5.2",
     "solc": "0.8.19",
-    "viem": "^1.0.7",
+    "tsx": "^3.12.7",
+    "viem": "^1.2.15",
     "vitest": "^0.31.4"
   }
 }

--- a/test/pnpm-lock.yaml
+++ b/test/pnpm-lock.yaml
@@ -1,9 +1,13 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@acala-network/chopsticks':
     specifier: ^0.6.6
-    version: 0.6.6(debug@4.3.4)(ts-node@10.9.1)
+    version: 0.6.6(debug@4.3.4)
   '@openzeppelin/contracts':
     specifier: ^4.9.2
     version: 4.9.2
@@ -55,9 +59,12 @@ dependencies:
   solc:
     specifier: 0.8.19
     version: 0.8.19(debug@4.3.4)
+  tsx:
+    specifier: ^3.12.7
+    version: 3.12.7
   viem:
-    specifier: ^1.0.7
-    version: 1.0.7(typescript@5.1.3)
+    specifier: ^1.2.15
+    version: 1.2.15(typescript@5.1.3)
   vitest:
     specifier: ^0.31.4
     version: 0.31.4(@vitest/ui@0.31.4)
@@ -67,11 +74,11 @@ devDependencies:
     specifier: ^0.2400.0
     version: 0.2400.0
   '@moonwall/cli':
-    specifier: ^3.0.7
-    version: 3.0.7(@acala-network/chopsticks@0.6.6)(@moonbeam-network/api-augment@0.2400.0)(@moonwall/util@3.0.7)(@polkadot/api-augment@10.9.1)(@polkadot/api-derive@10.9.1)(@polkadot/api@10.9.1)(@polkadot/keyring@12.3.2)(@polkadot/types-codec@10.9.1)(@polkadot/types@10.9.1)(@polkadot/util@12.3.2)(@vitest/ui@0.31.4)(ethers@6.6.0)(typescript@5.1.3)(viem@1.0.7)(web3-providers-ws@4.0.1)(web3@4.0.1)
+    specifier: ^4.0.2
+    version: 4.0.2(@acala-network/chopsticks@0.6.6)(@moonbeam-network/api-augment@0.2400.0)(@moonwall/util@4.0.2)(@polkadot/api-augment@10.9.1)(@polkadot/api-derive@10.9.1)(@polkadot/api@10.9.1)(@polkadot/keyring@12.3.2)(@polkadot/types-codec@10.9.1)(@polkadot/types@10.9.1)(@polkadot/util@12.3.2)(@vitest/ui@0.31.4)(ethers@6.6.3)(typescript@5.1.3)(viem@1.2.15)(web3-providers-ws@4.0.1)(web3@4.0.1)
   '@moonwall/util':
-    specifier: ^3.0.7
-    version: 3.0.7(@moonbeam-network/api-augment@0.2400.0)(@polkadot/api-augment@10.9.1)(@polkadot/api-derive@10.9.1)(@polkadot/api@10.9.1)(@polkadot/keyring@12.3.2)(@polkadot/rpc-provider@10.9.1)(@polkadot/types-codec@10.9.1)(@polkadot/types@10.9.1)(@polkadot/util@12.3.2)(@vitest/ui@0.31.4)(ethers@6.6.0)(typescript@5.1.3)(web3@4.0.1)
+    specifier: ^4.0.2
+    version: 4.0.2(@moonbeam-network/api-augment@0.2400.0)(@polkadot/api-augment@10.9.1)(@polkadot/api-derive@10.9.1)(@polkadot/api@10.9.1)(@polkadot/keyring@12.3.2)(@polkadot/rpc-provider@10.9.1)(@polkadot/types-codec@10.9.1)(@polkadot/types@10.9.1)(@polkadot/util@12.3.2)(@vitest/ui@0.31.4)(ethers@6.6.3)(typescript@5.1.3)(web3@4.0.1)
   '@polkadot/api':
     specifier: ^10.9.1
     version: 10.9.1
@@ -100,17 +107,14 @@ devDependencies:
     specifier: ^4.3.4
     version: 4.3.4(supports-color@5.5.0)
   ethers:
-    specifier: ^6.6.0
-    version: 6.6.0
+    specifier: ^6.6.3
+    version: 6.6.3
   pnpm:
     specifier: ^8.6.3
     version: 8.6.3
   prettier:
     specifier: ^2.8.8
     version: 2.8.8
-  ts-node:
-    specifier: ^10.9.1
-    version: 10.9.1(@swc/core@1.3.65)(@types/node@18.16.18)(typescript@5.1.3)
   typescript:
     specifier: ^5.1.3
     version: 5.1.3
@@ -132,7 +136,7 @@ packages:
   /@acala-network/chopsticks-executor@0.6.6:
     resolution: {integrity: sha512-4darWv6AsuNMCPgGhvHfNYSB0KF5RXPks7rwmGcFIHIUAVp5H7ZegHl5lkDEeXLNSqAbduGE4wY913FHJ0uyog==}
 
-  /@acala-network/chopsticks@0.6.6(debug@4.3.4)(ts-node@10.9.1):
+  /@acala-network/chopsticks@0.6.6(debug@4.3.4):
     resolution: {integrity: sha512-PkWg/Y8TqaAkAsa+SFkmFrxnE3LtPdbAK+wvC0oJ6+rJSybEfqbqL9+LDhgvATPJ8q/mh5Mh+ydrR/+bEorrIA==}
     hasBin: true
     dependencies:
@@ -146,7 +150,7 @@ packages:
       pino-pretty: 10.0.0
       reflect-metadata: 0.1.13
       sqlite3: 5.1.6
-      typeorm: 0.3.16(sqlite3@5.1.6)(ts-node@10.9.1)
+      typeorm: 0.3.16(sqlite3@5.1.6)
       ws: 8.13.0
       yargs: 17.7.2
       zod: 3.21.4
@@ -391,6 +395,24 @@ packages:
   /@equilab/definitions@1.4.18:
     resolution: {integrity: sha512-rFEPaHmdn5I1QItbQun9H/x+o3hgjA6kLYLrNN6nl/ndtQMY2tqx/mQfcGIlKA1xVmyn9mUAqD8G0P/nBHD3yA==}
     dev: false
+
+  /@esbuild-kit/cjs-loader@2.4.2:
+    resolution: {integrity: sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==}
+    dependencies:
+      '@esbuild-kit/core-utils': 3.1.0
+      get-tsconfig: 4.6.2
+
+  /@esbuild-kit/core-utils@3.1.0:
+    resolution: {integrity: sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==}
+    dependencies:
+      esbuild: 0.17.19
+      source-map-support: 0.5.21
+
+  /@esbuild-kit/esm-loader@2.5.5:
+    resolution: {integrity: sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==}
+    dependencies:
+      '@esbuild-kit/core-utils': 3.1.0
+      get-tsconfig: 4.6.2
 
   /@esbuild/android-arm64@0.17.19:
     resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
@@ -765,6 +787,13 @@ packages:
     resolution: {integrity: sha512-ELJa2ftIbe8Ds2ejS7kO5HumN9EB5l2OBi3Qsy5iHJsHKq2HtXfFoKnW38HarM6hADrWG+e/yNGHSKJIJzEZuA==}
     dev: false
 
+  /@jest/schemas@29.6.0:
+    resolution: {integrity: sha512-rxLjXyJBTL4LQeJW3aKo0M/+GkCOXsO+8i9Iu7eDb6KwtP65ayoDsitrdPBtujxQ88k4wI2FNYfa6TOGwSn6cQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
@@ -858,14 +887,14 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /@moonwall/cli@3.0.7(@acala-network/chopsticks@0.6.6)(@moonbeam-network/api-augment@0.2400.0)(@moonwall/util@3.0.7)(@polkadot/api-augment@10.9.1)(@polkadot/api-derive@10.9.1)(@polkadot/api@10.9.1)(@polkadot/keyring@12.3.2)(@polkadot/types-codec@10.9.1)(@polkadot/types@10.9.1)(@polkadot/util@12.3.2)(@vitest/ui@0.31.4)(ethers@6.6.0)(typescript@5.1.3)(viem@1.0.7)(web3-providers-ws@4.0.1)(web3@4.0.1):
-    resolution: {integrity: sha512-MoIbkNcz2MWZSuxo+pwcIXiP5MeZfMDkDmzI69w+hv8Ruf2AfJo7jg/FSK165BVrIM5mKAvSvP8aKyVoCp2ZUw==}
+  /@moonwall/cli@4.0.2(@acala-network/chopsticks@0.6.6)(@moonbeam-network/api-augment@0.2400.0)(@moonwall/util@4.0.2)(@polkadot/api-augment@10.9.1)(@polkadot/api-derive@10.9.1)(@polkadot/api@10.9.1)(@polkadot/keyring@12.3.2)(@polkadot/types-codec@10.9.1)(@polkadot/types@10.9.1)(@polkadot/util@12.3.2)(@vitest/ui@0.31.4)(ethers@6.6.3)(typescript@5.1.3)(viem@1.2.15)(web3-providers-ws@4.0.1)(web3@4.0.1):
+    resolution: {integrity: sha512-2VvpzbRLId7Puj+W6nxp/TbbuLkUa1aq3GenjPr0dPCe276CbnfTzb68J6dAJgn7tjOYPXcZpke2PCn6fhbpdQ==}
     engines: {node: '>=14.16.0', pnpm: '>=7'}
     hasBin: true
     peerDependencies:
       '@acala-network/chopsticks': ^0.6.6
       '@moonbeam-network/api-augment': ^0.2400.0
-      '@moonwall/util': 3.0.7
+      '@moonwall/util': 4.0.2
       '@polkadot/api': ^10.9.1
       '@polkadot/api-augment': ^10.9.1
       '@polkadot/api-derive': ^10.9.1
@@ -873,15 +902,15 @@ packages:
       '@polkadot/types': ^10.9.1
       '@polkadot/types-codec': ^10.9.1
       '@polkadot/util': ^12.3.2
-      ethers: ^6.5.1
-      viem: ^1.0.7
+      ethers: ^6.6.2
+      viem: ^1.2.12
       web3: 4.0.1
       web3-providers-ws: 4.0.1
     dependencies:
-      '@acala-network/chopsticks': 0.6.6(debug@4.3.4)(ts-node@10.9.1)
+      '@acala-network/chopsticks': 0.6.6(debug@4.3.4)
       '@moonbeam-network/api-augment': 0.2400.0
-      '@moonwall/types': 3.0.7
-      '@moonwall/util': 3.0.7(@moonbeam-network/api-augment@0.2400.0)(@polkadot/api-augment@10.9.1)(@polkadot/api-derive@10.9.1)(@polkadot/api@10.9.1)(@polkadot/keyring@12.3.2)(@polkadot/rpc-provider@10.9.1)(@polkadot/types-codec@10.9.1)(@polkadot/types@10.9.1)(@polkadot/util@12.3.2)(@vitest/ui@0.31.4)(ethers@6.6.0)(typescript@5.1.3)(web3@4.0.1)
+      '@moonwall/types': 4.0.1
+      '@moonwall/util': 4.0.2(@moonbeam-network/api-augment@0.2400.0)(@polkadot/api-augment@10.9.1)(@polkadot/api-derive@10.9.1)(@polkadot/api@10.9.1)(@polkadot/keyring@12.3.2)(@polkadot/rpc-provider@10.9.1)(@polkadot/types-codec@10.9.1)(@polkadot/types@10.9.1)(@polkadot/util@12.3.2)(@vitest/ui@0.31.4)(ethers@6.6.3)(typescript@5.1.3)(web3@4.0.1)
       '@polkadot/api': 10.9.1
       '@polkadot/api-augment': 10.9.1
       '@polkadot/api-derive': 10.9.1
@@ -889,31 +918,28 @@ packages:
       '@polkadot/types': 10.9.1
       '@polkadot/types-codec': 10.9.1
       '@polkadot/util': 12.3.2
-      '@swc/core': 1.3.65
       '@types/cli-progress': 3.11.0
       '@types/debug': 4.1.8
-      '@types/node': 18.16.18
+      '@types/node': 18.16.19
       '@types/yargs': 17.0.24
-      '@zombienet/orchestrator': 0.0.47(@polkadot/util@12.3.2)(@swc/core@1.3.65)(@types/node@18.16.18)
+      '@zombienet/orchestrator': 0.0.49(@polkadot/util@12.3.2)(@types/node@18.16.19)
       bottleneck: 2.19.5
       chalk: 5.2.0
       clear: 0.1.0
       cli-progress: 3.12.0
       colors: 1.4.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       dotenv: 16.3.1
-      ethers: 6.6.0
+      ethers: 6.6.3
       inquirer: 8.2.5
       inquirer-press-to-continue: 1.2.0(inquirer@8.2.5)
-      moonbeam-types-bundle: 2.0.10
       node-fetch: 3.3.1
       prettier: 2.8.8
-      semver: 7.5.2
-      superagent: 8.0.9
-      ts-node: 10.9.1(@swc/core@1.3.65)(@types/node@18.16.18)(typescript@5.1.3)
-      tsup: 6.7.0(@swc/core@1.3.65)(ts-node@10.9.1)(typescript@5.1.3)
-      viem: 1.0.7(typescript@5.1.3)
-      vitest: 0.31.4(@vitest/ui@0.31.4)
+      semver: 7.5.4
+      tsup: 6.7.0(typescript@5.1.3)
+      tsx: 3.12.7
+      viem: 1.2.15(typescript@5.1.3)
+      vitest: 0.32.4(@vitest/ui@0.31.4)
       web3: 4.0.1
       web3-providers-ws: 4.0.1
       ws: 8.13.0
@@ -921,7 +947,7 @@ packages:
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@edge-runtime/vm'
-      - '@swc/helpers'
+      - '@swc/core'
       - '@swc/wasm'
       - '@vitest/browser'
       - '@vitest/ui'
@@ -940,18 +966,19 @@ packages:
       - sugarss
       - supports-color
       - terser
+      - ts-node
       - typescript
       - utf-8-validate
       - webdriverio
     dev: true
 
-  /@moonwall/types@3.0.7:
-    resolution: {integrity: sha512-bk3/Tp6WhjPYSHbu342gKJEK8Ll5eP2ZYAJU0YG3x7d24br+p3G9dkRXDz8cnY2Xp8i4YdmX0gXX9gaX5ixv8Q==}
+  /@moonwall/types@4.0.1:
+    resolution: {integrity: sha512-JPyKpb1yovK4/p7+VZ6eRp2SEQ2IvBQNDNpwwiLSflk2dz7FciyzelcTW80082Xx8Jbn9Fzm/BSi1+AV4hgy3w==}
     engines: {node: '>=14.16.0', pnpm: '>=7'}
     dependencies:
       '@polkadot/api': 10.9.1
-      debug: 4.3.4(supports-color@5.5.0)
-      ethers: 6.6.0
+      debug: 4.3.4
+      ethers: 6.6.3
       web3: 4.0.1
     transitivePeerDependencies:
       - bufferutil
@@ -960,8 +987,8 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@moonwall/util@3.0.7(@moonbeam-network/api-augment@0.2400.0)(@polkadot/api-augment@10.9.1)(@polkadot/api-derive@10.9.1)(@polkadot/api@10.9.1)(@polkadot/keyring@12.3.2)(@polkadot/rpc-provider@10.9.1)(@polkadot/types-codec@10.9.1)(@polkadot/types@10.9.1)(@polkadot/util@12.3.2)(@vitest/ui@0.31.4)(ethers@6.6.0)(typescript@5.1.3)(web3@4.0.1):
-    resolution: {integrity: sha512-ffUqqkVEz/oaeBWfjuqSASCncQlqosj/ZveWUSYsd8mpUF7/LufKSCp9RfG1WFxNFJvkey6T3ZOADHNMBM9N5A==}
+  /@moonwall/util@4.0.2(@moonbeam-network/api-augment@0.2400.0)(@polkadot/api-augment@10.9.1)(@polkadot/api-derive@10.9.1)(@polkadot/api@10.9.1)(@polkadot/keyring@12.3.2)(@polkadot/rpc-provider@10.9.1)(@polkadot/types-codec@10.9.1)(@polkadot/types@10.9.1)(@polkadot/util@12.3.2)(@vitest/ui@0.31.4)(ethers@6.6.3)(typescript@5.1.3)(web3@4.0.1):
+    resolution: {integrity: sha512-UuAMCUeNf++Dk6x6iNHqv+jq4nBH9jlRBPERWzrMQ1h9hYTvmByKVXi2898oNK6gQjRyxFrG4aZO2uoB/4uisw==}
     engines: {node: '>=14.16.0', pnpm: '>=7'}
     peerDependencies:
       '@moonbeam-network/api-augment': ^0.2400.0
@@ -973,11 +1000,11 @@ packages:
       '@polkadot/types': ^10.9.1
       '@polkadot/types-codec': ^10.9.1
       '@polkadot/util': ^12.3.2
-      ethers: ^6.5.1
+      ethers: ^6.6.2
       web3: 4.0.1
     dependencies:
       '@moonbeam-network/api-augment': 0.2400.0
-      '@moonwall/types': 3.0.7
+      '@moonwall/types': 4.0.1
       '@polkadot/api': 10.9.1
       '@polkadot/api-augment': 10.9.1
       '@polkadot/api-derive': 10.9.1
@@ -987,35 +1014,31 @@ packages:
       '@polkadot/types-codec': 10.9.1
       '@polkadot/util': 12.3.2
       '@types/debug': 4.1.8
-      '@types/node': 18.16.18
+      '@types/node': 18.16.19
       '@types/yargs': 17.0.24
       bottleneck: 2.19.5
       chalk: 5.2.0
       clear: 0.1.0
       cli-progress: 3.12.0
       colors: 1.4.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       dotenv: 16.3.1
-      ethers: 6.6.0
+      ethers: 6.6.3
       inquirer: 8.2.5
       inquirer-press-to-continue: 1.2.0(inquirer@8.2.5)
-      moonbeam-types-bundle: 2.0.10
       node-fetch: 3.3.1
       prettier: 2.8.8
       rlp: 3.0.0
-      semver: 7.5.2
-      ts-node: 10.9.1(@swc/core@1.3.65)(@types/node@18.16.18)(typescript@5.1.3)
-      viem: 1.0.7(typescript@5.1.3)
-      vite: 4.3.9(@types/node@18.16.18)
-      vitest: 0.31.4(@vitest/ui@0.31.4)
+      semver: 7.5.4
+      viem: 1.2.15(typescript@5.1.3)
+      vite: 4.3.9(@types/node@18.16.19)
+      vitest: 0.32.4(@vitest/ui@0.31.4)
       web3: 4.0.1
       ws: 8.13.0
       yaml: 2.3.1
       yargs: 17.7.2
     transitivePeerDependencies:
       - '@edge-runtime/vm'
-      - '@swc/core'
-      - '@swc/wasm'
       - '@vitest/browser'
       - '@vitest/ui'
       - bufferutil
@@ -1060,6 +1083,7 @@ packages:
 
   /@noble/hashes@1.2.0:
     resolution: {integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==}
+    dev: false
 
   /@noble/hashes@1.3.0:
     resolution: {integrity: sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==}
@@ -1201,6 +1225,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /@polkadot/api-base@10.9.1:
     resolution: {integrity: sha512-Q3m2KzlceMK2kX8bhnUZWk3RT6emmijeeFZZQgCePpEcrSeNjnqG4qjuTPgkveaOkUT8MAoDc5Avuzcc2jlW9g==}
@@ -1243,6 +1268,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /@polkadot/api-derive@10.9.1:
     resolution: {integrity: sha512-mRud1UZCFIc4Z63qAoGSIHh/foyUYADfy1RQYCmPpeFKfIdCIrHpd7xFdJXTOMYOS0BwlM6u4qli/ZT4XigezQ==}
@@ -1300,6 +1326,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /@polkadot/api@10.9.1:
     resolution: {integrity: sha512-ND/2UqZBWvtt4PfV03OStTKg0mxmPk4UpMAgJKutdgsz/wP9CYJ1KbjwFgPNekL9JnzbKQsWyQNPVrcw7kQk8A==}
@@ -1378,6 +1405,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /@polkadot/apps-config@0.132.1(@polkadot/keyring@12.3.2)(@polkadot/util-crypto@12.3.2):
     resolution: {integrity: sha512-AS5BAYnDPSuYU7EXmYpizHS/uFswwlGU+17yr0ng26kETy+mPft2koaBnRq5jUsqVIXN2sfI7619OgTK5XhuEg==}
@@ -1448,6 +1476,7 @@ packages:
       '@babel/runtime': 7.22.5
       '@polkadot/util': 10.4.2
       '@polkadot/util-crypto': 10.4.2(@polkadot/util@10.4.2)
+    dev: false
 
   /@polkadot/keyring@12.3.2(@polkadot/util-crypto@12.3.2)(@polkadot/util@12.3.2):
     resolution: {integrity: sha512-NTdtDeI0DP9l/45hXynNABeP5VB8piw5YR+CbUxK2e36xpJWVXwbcOepzslg5ghE9rs8UKJb30Z/HqTU4sBY0Q==}
@@ -1526,6 +1555,7 @@ packages:
       '@babel/runtime': 7.22.5
       '@polkadot/util': 10.4.2
       '@substrate/ss58-registry': 1.40.0
+    dev: false
 
   /@polkadot/networks@12.3.2:
     resolution: {integrity: sha512-uCkyybKoeEm1daKr0uT/9oNDHDDzCy2/ZdVl346hQqfdR1Ct3BaxMjxqvdmb5N8aCw0cBWSfgsxAYtw8ESmllQ==}
@@ -1617,6 +1647,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /@polkadot/rpc-core@10.9.1:
     resolution: {integrity: sha512-ZtA8B8SfXSAwVkBlCcKRHw0eSM7ec/sbiNOM5GasXPeRujUgT7lOwSH2GbUZSqe9RfRDMp6DvO9c2JoGc3LLWw==}
@@ -1662,6 +1693,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /@polkadot/rpc-provider@10.9.1:
     resolution: {integrity: sha512-4QzT2QzD+320+eT6b79sGAA85Tt3Bb8fQvse4r5Mom2iiBd2SO81vOhxSAOaIe4GUsw25VzFJmsbe7+OObItdg==}
@@ -1730,6 +1762,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /@polkadot/types-augment@10.9.1:
     resolution: {integrity: sha512-OY9/jTMFRFqYdkUnfcGwqMLC64A0Q25bjvCuVQCVjsPFKE3wl0Kt5rNT01eV2UmLXrR6fY0xWbR2w80bLA7CIQ==}
@@ -1758,6 +1791,7 @@ packages:
       '@polkadot/types': 9.14.2
       '@polkadot/types-codec': 9.14.2
       '@polkadot/util': 10.4.2
+    dev: false
 
   /@polkadot/types-codec@10.9.1:
     resolution: {integrity: sha512-mJ5OegKGraY1FLvEa8FopRCr3pQrhDkcn5RNOjmgJQozENVeRaxhk0NwxYz7IojFvSDnKnc6lNQfKaaSe5pLHg==}
@@ -1782,6 +1816,7 @@ packages:
       '@babel/runtime': 7.22.5
       '@polkadot/util': 10.4.2
       '@polkadot/x-bigint': 10.4.2
+    dev: false
 
   /@polkadot/types-create@10.9.1:
     resolution: {integrity: sha512-OVz50MGTTuiuVnRP/zAx4CTuLioc0hsiwNwqN2lNhmIJGtnQ4Vy/7mQRsIWehiYz6g0Vzzm5B3qWkTXO1NSN5w==}
@@ -1807,6 +1842,7 @@ packages:
       '@babel/runtime': 7.22.5
       '@polkadot/types-codec': 9.14.2
       '@polkadot/util': 10.4.2
+    dev: false
 
   /@polkadot/types-known@10.9.1:
     resolution: {integrity: sha512-zCMVWc4pJtkbMFPu72bD4IhvV/gkHXPX3C5uu92WdmCfnn0vEIEsMKWlVXVVvQQZKAqvs/awpqIfrUtEViOGEA==}
@@ -1861,6 +1897,7 @@ packages:
       '@polkadot/types-codec': 9.14.2
       '@polkadot/types-create': 9.14.2
       '@polkadot/util': 10.4.2
+    dev: false
 
   /@polkadot/types-support@10.9.1:
     resolution: {integrity: sha512-XsieuLDsszvMZQlleacQBfx07i/JkwQV/UxH9q8Hz7Okmaz9pEVEW1h3ka2/cPuC7a4l32JhaORBUYshBZNdJg==}
@@ -1883,6 +1920,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       '@polkadot/util': 10.4.2
+    dev: false
 
   /@polkadot/types@10.9.1:
     resolution: {integrity: sha512-AG33i2ZGGfq7u+5rkAdGrXAQHHl844/Yv+junH5ZzX69xiCoWO1bH/yzDUNBdpki2GlACWvF9nLYh3F2tVF93w==}
@@ -1945,6 +1983,7 @@ packages:
       '@polkadot/util': 10.4.2
       '@polkadot/util-crypto': 10.4.2(@polkadot/util@10.4.2)
       rxjs: 7.8.1
+    dev: false
 
   /@polkadot/ui-settings@3.5.1(@polkadot/networks@12.3.2)(@polkadot/util@12.3.2):
     resolution: {integrity: sha512-3Lhgr9bZZALUuJbpy2zlqRm1sA7YIYnVXGUo0p5YWqWsthGQRL8mR4WhxcAnR+fZumI5fW+nhjosm5SiGzvy/Q==}
@@ -1990,6 +2029,7 @@ packages:
       '@scure/base': 1.1.1
       ed2curve: 0.3.0
       tweetnacl: 1.0.3
+    dev: false
 
   /@polkadot/util-crypto@12.3.2(@polkadot/util@12.3.2):
     resolution: {integrity: sha512-pTpx+YxolY0BDT4RcGmgeKbHHD/dI6Ll9xRsqmVdIjpcVVY20uDNTyXs81ZNtfKgyod1y9JQkfNv2Dz9iEpTkQ==}
@@ -2062,6 +2102,7 @@ packages:
       '@polkadot/x-textencoder': 10.4.2
       '@types/bn.js': 5.1.1
       bn.js: 5.2.1
+    dev: false
 
   /@polkadot/util@12.3.2:
     resolution: {integrity: sha512-y/JShcGyOamCUiSIg++XZuLHt1ktSKBaSH2K5Nw5NXlgP0+7am+GZzqPB8fQ4qhYLruEOv+YRiz0GC1Zr9S+wg==}
@@ -2112,6 +2153,7 @@ packages:
       '@babel/runtime': 7.22.5
       '@polkadot/util': 10.4.2
       '@polkadot/x-randomvalues': 10.4.2
+    dev: false
 
   /@polkadot/wasm-bridge@7.2.1(@polkadot/util@12.3.2)(@polkadot/x-randomvalues@12.3.2):
     resolution: {integrity: sha512-uV/LHREDBGBbHrrv7HTki+Klw0PYZzFomagFWII4lp6Toj/VCvRh5WMzooVC+g/XsBGosAwrvBhoModabyHx+A==}
@@ -2153,6 +2195,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       '@polkadot/util': 10.4.2
+    dev: false
 
   /@polkadot/wasm-crypto-asmjs@7.2.1(@polkadot/util@12.3.2):
     resolution: {integrity: sha512-z/d21bmxyVfkzGsKef/FWswKX02x5lK97f4NPBZ9XBeiFkmzlXhdSnu58/+b1sKsRAGdW/Rn/rTNRDhW0GqCAg==}
@@ -2176,6 +2219,7 @@ packages:
       '@polkadot/wasm-crypto-asmjs': 6.4.1(@polkadot/util@10.4.2)
       '@polkadot/wasm-crypto-wasm': 6.4.1(@polkadot/util@10.4.2)
       '@polkadot/x-randomvalues': 10.4.2
+    dev: false
 
   /@polkadot/wasm-crypto-init@7.2.1(@polkadot/util@12.3.2)(@polkadot/x-randomvalues@12.3.2):
     resolution: {integrity: sha512-GcEXtwN9LcSf32V9zSaYjHImFw16hCyo2Xzg4GLLDPPeaAAfbFr2oQMgwyDbvBrBjLKHVHjsPZyGhXae831amw==}
@@ -2221,6 +2265,7 @@ packages:
       '@babel/runtime': 7.22.5
       '@polkadot/util': 10.4.2
       '@polkadot/wasm-util': 6.4.1(@polkadot/util@10.4.2)
+    dev: false
 
   /@polkadot/wasm-crypto-wasm@7.2.1(@polkadot/util@12.3.2):
     resolution: {integrity: sha512-DqyXE4rSD0CVlLIw88B58+HHNyrvm+JAnYyuEDYZwCvzUWOCNos/DDg9wi/K39VAIsCCKDmwKqkkfIofuOj/lA==}
@@ -2275,6 +2320,7 @@ packages:
       '@polkadot/wasm-crypto-wasm': 6.4.1(@polkadot/util@10.4.2)
       '@polkadot/wasm-util': 6.4.1(@polkadot/util@10.4.2)
       '@polkadot/x-randomvalues': 10.4.2
+    dev: false
 
   /@polkadot/wasm-crypto@7.2.1(@polkadot/util@12.3.2)(@polkadot/x-randomvalues@12.3.2):
     resolution: {integrity: sha512-SA2+33S9TAwGhniKgztVN6pxUKpGfN4Tre/eUZGUfpgRkT92wIUT2GpGWQE+fCCqGQgADrNiBcwt6XwdPqMQ4Q==}
@@ -2300,6 +2346,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       '@polkadot/util': 10.4.2
+    dev: false
 
   /@polkadot/wasm-util@7.2.1(@polkadot/util@12.3.2):
     resolution: {integrity: sha512-FBSn/3aYJzhN0sYAYhHB8y9JL8mVgxLy4M1kUXYbyo+8GLRQEN5rns8Vcb8TAlIzBWgVTOOptYBvxo0oj0h7Og==}
@@ -2316,6 +2363,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       '@polkadot/x-global': 10.4.2
+    dev: false
 
   /@polkadot/x-bigint@12.3.2:
     resolution: {integrity: sha512-JLqLgfGXe/x+hZJETd5ZqfpVsbwyMsH5Nn1Q20ineMMjXN/ig+kVR8Mc15LXBMuw4g7LldFW6UUrotWnuMI8Yw==}
@@ -2340,6 +2388,7 @@ packages:
       '@polkadot/x-global': 10.4.2
       '@types/node-fetch': 2.6.4
       node-fetch: 3.3.1
+    dev: false
 
   /@polkadot/x-fetch@12.3.2:
     resolution: {integrity: sha512-3IEuZ5S+RI/t33NsdPLIIa5COfDCfpUW2sbaByEczn75aD1jLqJZSEDwiBniJ2osyNd4uUxBf6e5jw7LAZeZJg==}
@@ -2366,6 +2415,7 @@ packages:
     engines: {node: '>=14.0.0'}
     dependencies:
       '@babel/runtime': 7.22.5
+    dev: false
 
   /@polkadot/x-global@12.3.2:
     resolution: {integrity: sha512-yVZq6oIegjlyh5rUZiTklgu+fL+W/DG1ypEa02683tUCB3avV5cA3PAHKptMSlb6FpweHu37lKKrqfAWrraDxg==}
@@ -2393,6 +2443,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       '@polkadot/x-global': 10.4.2
+    dev: false
 
   /@polkadot/x-randomvalues@12.3.2(@polkadot/util@12.3.2)(@polkadot/wasm-util@7.2.1):
     resolution: {integrity: sha512-ywjIs8CWpvOGmq+3cGCNPOHxAjPHdBUiXyDccftx5BRVdmtbt36gK/V84bKr6Xs73FGu0jprUAOSRRsLZX/3dg==}
@@ -2436,6 +2487,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       '@polkadot/x-global': 10.4.2
+    dev: false
 
   /@polkadot/x-textdecoder@12.3.2:
     resolution: {integrity: sha512-lY5bfA5xArJRWEJlYOlQQMJeTjWD8s0yMhchirVgf5xj8Id9vPGeUoneH+VFDEwgXxrqBvDFJ4smN4T/r6a/fg==}
@@ -2466,6 +2518,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.22.5
       '@polkadot/x-global': 10.4.2
+    dev: false
 
   /@polkadot/x-textencoder@12.3.2:
     resolution: {integrity: sha512-iP3qEBiHzBckQ9zeY7ZHRWuu7mCEg5SMpOugs6UODRk8sx6KHzGQYlghBbWLit0uppPDVE0ifEwZ2n73djJHWQ==}
@@ -2500,6 +2553,7 @@ packages:
       websocket: 1.0.34
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@polkadot/x-ws@12.3.2:
     resolution: {integrity: sha512-yM9Z64pLNlHpJE43+Xtr+iUXmYpFFY5u5hrke2PJt13O48H8f9Vb9cRaIh94appLyICoS0aekGhDkGH+MCspBA==}
@@ -2582,14 +2636,18 @@ packages:
     resolution: {integrity: sha512-bcKpo1oj54hGholplGLpqPHRbIsnbixFtc06nwuNM5/dwSXOq/AAYoIBRsBmnZJSdfeNW5rnff7NTAz3ZCqR9Q==}
     dependencies:
       '@noble/curves': 1.0.0
-      '@noble/hashes': 1.3.0
+      '@noble/hashes': 1.3.1
       '@scure/base': 1.1.1
 
   /@scure/bip39@1.2.0:
     resolution: {integrity: sha512-SX/uKq52cuxm4YFXWFaVByaSHJh2w3BnokVSeUJVCv6K7WulT9u2BuNRBhuFl8vAuYnzx9bEu9WgpcNYTrYieg==}
     dependencies:
-      '@noble/hashes': 1.3.0
+      '@noble/hashes': 1.3.1
       '@scure/base': 1.1.1
+
+  /@sinclair/typebox@0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
 
   /@snowfork/snowbridge-types@0.2.7(@polkadot/util-crypto@12.3.2)(@polkadot/util@12.3.2):
     resolution: {integrity: sha512-Dz3OM8xvYhzL7XU/QOjgyPWZI4IgPKGByaJo6eZe3UMS6F7TLaFaZW1oYhQVTTahGWWAE6ZwwCuMkVh2FC/9bw==}
@@ -2647,6 +2705,7 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: false
     optional: true
 
   /@substrate/connect@0.7.26:
@@ -2679,6 +2738,7 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: false
     optional: true
 
   /@substrate/ss58-registry@1.40.0:
@@ -2710,107 +2770,6 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@swc/core-darwin-arm64@1.3.65:
-    resolution: {integrity: sha512-fQIXZgr7CD/+1ADqrVbz/gHvSoIMmggHvPzguQjV8FggBuS9Efm1D1ZrdUSqptggKvuLLHMZf+49tENq8NWWcg==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
-  /@swc/core-darwin-x64@1.3.65:
-    resolution: {integrity: sha512-kGuWP7OP9mwOiIcJpEVa+ydC3Wxf0fPQ1MK0hUIPFcR6tAUEdOvdAuCzP6U20RX/JbbgwfI/Qq6ugT7VL6omgg==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
-  /@swc/core-linux-arm-gnueabihf@1.3.65:
-    resolution: {integrity: sha512-Bjbzldp8n4mWSdAvBt4VuLiHlfFM5pyftjJvJnmSY4H1IzbxkByyT60OHOedcIPRiZveD8NJzUJqutqrgTmtLg==}
-    engines: {node: '>=10'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@swc/core-linux-arm64-gnu@1.3.65:
-    resolution: {integrity: sha512-GmxtcCymeQqEqT9n5mo857koRsUbEwmuijrBA4OeD5KOPW9gqAmUxr+ZgwgYHwyJ3CiN+UbK8uEqPsL6UVQmLg==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@swc/core-linux-arm64-musl@1.3.65:
-    resolution: {integrity: sha512-yv9jP3gbfMsYrqswT2MwK5Q1+avSwRXAKo+LYUknTeoLQNNlukDfqSLHajNq23XrVDRP4B3Pjn7kaqjxRcihbg==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@swc/core-linux-x64-gnu@1.3.65:
-    resolution: {integrity: sha512-GQkwysEPTlAOQ3jiTiedObzh6pBaf9RLaQqpGdCp+iKze9+BR+STBP0IIKhZDMPG/nWWNhrYFD/VMQxRoYPjfw==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@swc/core-linux-x64-musl@1.3.65:
-    resolution: {integrity: sha512-ETzhOhtDluYFK4x73OTM9gVTMyzGd2WeWGlCu3WoT1EPPUwCqQpcAqI3TfEcP1ljFDG0pPkpYzVpwNf8yjQElg==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    optional: true
-
-  /@swc/core-win32-arm64-msvc@1.3.65:
-    resolution: {integrity: sha512-3weD0I6F8bggN0KOnbZkvYC1PBrT5wrvohpvtgijRsODxjoWwztozjawJxF3rqgVqlSI/+nA+JkrN48e2cxJjQ==}
-    engines: {node: '>=10'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
-  /@swc/core-win32-ia32-msvc@1.3.65:
-    resolution: {integrity: sha512-i6c3D7E9Ca41HteW3+hn1OKQfjIabc2P0p1mJRXBkn+igwb+Ba6gXJc7NqhrlF8uZsDhhcGZTsAqBBtfcfTuHQ==}
-    engines: {node: '>=10'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
-  /@swc/core-win32-x64-msvc@1.3.65:
-    resolution: {integrity: sha512-tQ9hEDtwPZxQ2sYb2n8ypfmdMjobKAf6VSnChteLMktofU7o562op5pLS6D6QCP2AtL3lcwe1piTCgIhk4vmjA==}
-    engines: {node: '>=10'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    optional: true
-
-  /@swc/core@1.3.65:
-    resolution: {integrity: sha512-d5iDiKWf12FBo6h9Fro2pcnLK6HSPbyZ7A1U5iFNpRRx8XEd4uGdKtf5NoXJ3GDLQDLXnNSLA82Cl6SfrJ1lyw==}
-    engines: {node: '>=10'}
-    requiresBuild: true
-    peerDependencies:
-      '@swc/helpers': ^0.5.0
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-    optionalDependencies:
-      '@swc/core-darwin-arm64': 1.3.65
-      '@swc/core-darwin-x64': 1.3.65
-      '@swc/core-linux-arm-gnueabihf': 1.3.65
-      '@swc/core-linux-arm64-gnu': 1.3.65
-      '@swc/core-linux-arm64-musl': 1.3.65
-      '@swc/core-linux-x64-gnu': 1.3.65
-      '@swc/core-linux-x64-musl': 1.3.65
-      '@swc/core-win32-arm64-msvc': 1.3.65
-      '@swc/core-win32-ia32-msvc': 1.3.65
-      '@swc/core-win32-x64-msvc': 1.3.65
-
   /@tootallnate/once@1.1.2:
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
     engines: {node: '>= 6'}
@@ -2836,13 +2795,13 @@ packages:
   /@types/bn.js@4.11.6:
     resolution: {integrity: sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==}
     dependencies:
-      '@types/node': 18.16.18
+      '@types/node': 18.16.19
     dev: false
 
   /@types/bn.js@5.1.1:
     resolution: {integrity: sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==}
     dependencies:
-      '@types/node': 18.16.18
+      '@types/node': 18.16.19
 
   /@types/chai-subset@1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
@@ -2855,7 +2814,7 @@ packages:
   /@types/cli-progress@3.11.0:
     resolution: {integrity: sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==}
     dependencies:
-      '@types/node': 18.16.18
+      '@types/node': 18.16.19
     dev: true
 
   /@types/debug@4.1.8:
@@ -2875,8 +2834,9 @@ packages:
   /@types/node-fetch@2.6.4:
     resolution: {integrity: sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==}
     dependencies:
-      '@types/node': 18.16.18
+      '@types/node': 18.16.19
       form-data: 3.0.1
+    dev: false
 
   /@types/node@18.15.13:
     resolution: {integrity: sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==}
@@ -2885,6 +2845,9 @@ packages:
   /@types/node@18.16.18:
     resolution: {integrity: sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==}
 
+  /@types/node@18.16.19:
+    resolution: {integrity: sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==}
+
   /@types/uuid@9.0.2:
     resolution: {integrity: sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==}
     dev: false
@@ -2892,7 +2855,8 @@ packages:
   /@types/websocket@1.0.5:
     resolution: {integrity: sha512-NbsqiNX9CnEfC1Z0Vf4mE1SgAJ07JnRYcNex7AJ9zAVzmiGHmjKFEk7O4TJIsgv2B1sLEb6owKFZrACwdYngsQ==}
     dependencies:
-      '@types/node': 18.16.18
+      '@types/node': 18.16.19
+    dev: false
 
   /@types/yargs-parser@21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -2949,6 +2913,14 @@ packages:
       '@vitest/utils': 0.31.4
       chai: 4.3.7
 
+  /@vitest/expect@0.32.4:
+    resolution: {integrity: sha512-m7EPUqmGIwIeoU763N+ivkFjTzbaBn0n9evsTOcde03ugy2avPs3kZbYmw3DkcH1j5mxhMhdamJkLQ6dM1bk/A==}
+    dependencies:
+      '@vitest/spy': 0.32.4
+      '@vitest/utils': 0.32.4
+      chai: 4.3.7
+    dev: true
+
   /@vitest/runner@0.31.4:
     resolution: {integrity: sha512-Wgm6UER+gwq6zkyrm5/wbpXGF+g+UBB78asJlFkIOwyse0pz8lZoiC6SW5i4gPnls/zUcPLWS7Zog0LVepXnpg==}
     dependencies:
@@ -2957,6 +2929,14 @@ packages:
       p-limit: 4.0.0
       pathe: 1.1.1
 
+  /@vitest/runner@0.32.4:
+    resolution: {integrity: sha512-cHOVCkiRazobgdKLnczmz2oaKK9GJOw6ZyRcaPdssO1ej+wzHVIkWiCiNacb3TTYPdzMddYkCgMjZ4r8C0JFCw==}
+    dependencies:
+      '@vitest/utils': 0.32.4
+      p-limit: 4.0.0
+      pathe: 1.1.1
+    dev: true
+
   /@vitest/snapshot@0.31.4:
     resolution: {integrity: sha512-LemvNumL3NdWSmfVAMpXILGyaXPkZbG5tyl6+RQSdcHnTj6hvA49UAI8jzez9oQyE/FWLKRSNqTGzsHuk89LRA==}
     dependencies:
@@ -2964,10 +2944,24 @@ packages:
       pathe: 1.1.1
       pretty-format: 27.5.1
 
+  /@vitest/snapshot@0.32.4:
+    resolution: {integrity: sha512-IRpyqn9t14uqsFlVI2d7DFMImGMs1Q9218of40bdQQgMePwVdmix33yMNnebXcTzDU5eiV3eUsoxxH5v0x/IQA==}
+    dependencies:
+      magic-string: 0.30.0
+      pathe: 1.1.1
+      pretty-format: 29.6.1
+    dev: true
+
   /@vitest/spy@0.31.4:
     resolution: {integrity: sha512-3ei5ZH1s3aqbEyftPAzSuunGICRuhE+IXOmpURFdkm5ybUADk+viyQfejNk6q8M5QGX8/EVKw+QWMEP3DTJDag==}
     dependencies:
       tinyspy: 2.1.1
+
+  /@vitest/spy@0.32.4:
+    resolution: {integrity: sha512-oA7rCOqVOOpE6rEoXuCOADX7Lla1LIa4hljI2MSccbpec54q+oifhziZIJXxlE/CvI2E+ElhBHzVu0VEvJGQKQ==}
+    dependencies:
+      tinyspy: 2.1.1
+    dev: true
 
   /@vitest/ui@0.31.4(vitest@0.31.4):
     resolution: {integrity: sha512-sKM16ITX6HrNFF+lNZ2AQAen4/6Bx2i6KlBfIvkUjcTgc5YII/j2ltcX14oCUv4EA0OTWGQuGhO3zDoAsTENGA==}
@@ -2990,8 +2984,16 @@ packages:
       loupe: 2.3.6
       pretty-format: 27.5.1
 
-  /@wagmi/chains@1.1.0(typescript@5.1.3):
-    resolution: {integrity: sha512-pWZlxBk0Ql8E7DV8DwqlbBpOyUdaG9UDlQPBxJNALuEK1I0tbQ3AVvSDnlsEIt06UPmPo5o27gzs3hwPQ/A+UA==}
+  /@vitest/utils@0.32.4:
+    resolution: {integrity: sha512-Gwnl8dhd1uJ+HXrYyV0eRqfmk9ek1ASE/LWfTCuWMw+d07ogHqp4hEAV28NiecimK6UY9DpSEPh+pXBA5gtTBg==}
+    dependencies:
+      diff-sequences: 29.4.3
+      loupe: 2.3.6
+      pretty-format: 29.6.1
+    dev: true
+
+  /@wagmi/chains@1.2.0(typescript@5.1.3):
+    resolution: {integrity: sha512-dmDRipsE54JfyudOBkuhEexqQWcrZqxn/qiujG8SBzMh/az/AH5xlJSA+j1CPWTx9+QofSMF3B7A4gb6XRmSaQ==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -3008,28 +3010,28 @@ packages:
     resolution: {integrity: sha512-OkqtOLPkR7oqWLrsgRKhzyLZVFLnNLfEF3DMXH+Rpn1fMNMDq/fOY9pXt55B+flBc62saN73CfOTy3hMSVZFTA==}
     dev: false
 
-  /@zombienet/orchestrator@0.0.47(@polkadot/util@12.3.2)(@swc/core@1.3.65)(@types/node@18.16.18):
-    resolution: {integrity: sha512-MSva5ghrULYNh9vBnkwibS+naoDu9Iz+FaZF9MmyqKp/nApg/nKZIvDKV36ufG4u0ZOgAgYD14w9MufbQWz2Cw==}
+  /@zombienet/orchestrator@0.0.49(@polkadot/util@12.3.2)(@types/node@18.16.19):
+    resolution: {integrity: sha512-gwxLIFaU34opdW6ZWDyVrGh3sncBzhDejGZMerrTJSTjTV7fuB+vaOpsRlGz7gVcAAbjZYdT86tpszJ/Al4o3A==}
     engines: {node: '>=18'}
     dependencies:
       '@polkadot/api': 10.9.1
       '@polkadot/keyring': 12.3.2(@polkadot/util-crypto@12.3.2)(@polkadot/util@12.3.2)
       '@polkadot/util-crypto': 12.3.2(@polkadot/util@12.3.2)
-      '@zombienet/utils': 0.0.21(@swc/core@1.3.65)(@types/node@18.16.18)(typescript@5.1.3)
+      '@zombienet/utils': 0.0.21(@types/node@18.16.19)(typescript@5.1.6)
       JSONStream: 1.3.5
       chai: 4.3.7
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       execa: 5.1.1
       fs-extra: 11.1.1
       jsdom: 22.1.0
       json-bigint: 1.0.0
       libp2p-crypto: 0.21.2
-      minimatch: 9.0.1
+      minimatch: 9.0.3
       mocha: 10.2.0
       napi-maybe-compressed-blob: 0.0.11
       peer-id: 0.16.0
       tmp-promise: 3.0.3
-      typescript: 5.1.3
+      typescript: 5.1.6
       yaml: 2.3.1
     transitivePeerDependencies:
       - '@polkadot/util'
@@ -3047,11 +3049,11 @@ packages:
     resolution: {integrity: sha512-dTU1orWPPMyGNi86nLLFEd3cK5n+DNbavAdiOOqu2rhem2m+AuycwYEGXKf+Y4j3Ofau2gnfdUllsfFjRWrj7A==}
     dependencies:
       cli-table3: 0.6.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       mocha: 10.2.0
       nunjucks: 3.2.4
       toml: 3.0.0
-      ts-node: 10.9.1(@swc/core@1.3.65)(@types/node@18.16.18)(typescript@5.1.3)
+      ts-node: 10.9.1(@types/node@18.16.18)(typescript@5.1.3)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -3061,15 +3063,15 @@ packages:
       - typescript
     dev: false
 
-  /@zombienet/utils@0.0.21(@swc/core@1.3.65)(@types/node@18.16.18)(typescript@5.1.3):
+  /@zombienet/utils@0.0.21(@types/node@18.16.19)(typescript@5.1.6):
     resolution: {integrity: sha512-31fMNlITzmj1gPha2CcihDE6nON94r8ixZTZbWa2g0nacS0nnoTKUNFukw9vg+aGF5QkwSevy+eobOQEb/jhjg==}
     dependencies:
       cli-table3: 0.6.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       mocha: 10.2.0
       nunjucks: 3.2.4
       toml: 3.0.0
-      ts-node: 10.9.1(@swc/core@1.3.65)(@types/node@18.16.18)(typescript@5.1.3)
+      ts-node: 10.9.1(@types/node@18.16.19)(typescript@5.1.6)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -3097,8 +3099,8 @@ packages:
   /abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
 
-  /abitype@0.8.7(typescript@5.1.3):
-    resolution: {integrity: sha512-wQ7hV8Yg/yKmGyFpqrNZufCxbszDe5es4AZGYPBitocfSqXtjrTG9JMWFcc4N30ukl2ve48aBTwt7NJxVQdU3w==}
+  /abitype@0.8.11(typescript@5.1.3):
+    resolution: {integrity: sha512-bM4v2dKvX08sZ9IU38IN5BKmN+ZkOSd2oI4a9f0ejHYZQYV6cDr7j+d95ga0z2XHG36Y4jzoG5Z7qDqxp7fi/A==}
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.19.1
@@ -3131,7 +3133,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -3139,7 +3141,7 @@ packages:
     resolution: {integrity: sha512-7Epl1Blf4Sy37j4v9f9FjICCh4+KAQOyXgHEwlyBiAQLbhKdq/i2QQU3amQalS/wPhdPzDXPL5DMR5bkn+YeWg==}
     engines: {node: '>= 8.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       depd: 2.0.0
       humanize-ms: 1.2.1
     transitivePeerDependencies:
@@ -3359,6 +3361,9 @@ packages:
   /browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
 
+  /buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   /buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
     dependencies:
@@ -3378,6 +3383,7 @@ packages:
     requiresBuild: true
     dependencies:
       node-gyp-build: 4.6.0
+    dev: false
 
   /bundle-require@4.0.1(esbuild@0.17.19):
     resolution: {integrity: sha512-9NQkRHlNdNpDBGmLpngF3EFDcwodhMUuLz9PaWYciVcQF9SE4LFjM2DB/xV1Li5JiuDMv7ZUWuC3rGbqR0MAXQ==}
@@ -3442,7 +3448,7 @@ packages:
   /canvas-renderer@2.2.1:
     resolution: {integrity: sha512-RrBgVL5qCEDIXpJ6NrzyRNoTnXxYarqm/cS/W6ERhUJts5UQtt/XPEosGN3rqUkZ4fjBArlnCbsISJ+KCFnIAg==}
     dependencies:
-      '@types/node': 18.16.18
+      '@types/node': 18.16.19
     dev: false
 
   /chai@4.3.7:
@@ -3649,10 +3655,6 @@ packages:
     engines: {node: '>= 12'}
     dev: false
 
-  /component-emitter@1.3.0:
-    resolution: {integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==}
-    dev: true
-
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -3671,10 +3673,6 @@ packages:
 
   /console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
-
-  /cookiejar@2.1.4:
-    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
-    dev: true
 
   /copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
@@ -3747,6 +3745,7 @@ packages:
     dependencies:
       es5-ext: 0.10.62
       type: 1.2.0
+    dev: false
 
   /data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -3785,6 +3784,18 @@ packages:
         optional: true
     dependencies:
       ms: 2.0.0
+    dev: false
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
 
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -3877,15 +3888,13 @@ packages:
     resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
     engines: {node: '>=8'}
 
-  /dezalgo@1.0.4:
-    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
-    dependencies:
-      asap: 2.0.6
-      wrappy: 1.0.2
-    dev: true
-
   /diff-match-patch@1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
+
+  /diff-sequences@29.4.3:
+    resolution: {integrity: sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
 
   /diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -3917,6 +3926,7 @@ packages:
     resolution: {integrity: sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==}
     dependencies:
       tweetnacl: 1.0.3
+    dev: false
 
   /elliptic@6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
@@ -3984,6 +3994,7 @@ packages:
       es6-iterator: 2.0.3
       es6-symbol: 3.1.3
       next-tick: 1.1.0
+    dev: false
 
   /es6-iterator@2.0.3:
     resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
@@ -3991,12 +4002,14 @@ packages:
       d: 1.0.1
       es5-ext: 0.10.62
       es6-symbol: 3.1.3
+    dev: false
 
   /es6-symbol@3.1.3:
     resolution: {integrity: sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==}
     dependencies:
       d: 1.0.1
       ext: 1.7.0
+    dev: false
 
   /es6-weak-map@2.0.3:
     resolution: {integrity: sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==}
@@ -4067,8 +4080,8 @@ packages:
       '@scure/bip39': 1.2.0
     dev: true
 
-  /ethers@6.6.0:
-    resolution: {integrity: sha512-7D2U+n8eZYmh592VZqap9vBu50jN7YUDHqAmwBYTMntmUKC9RVgcqcFbd+3DTCOQ1jMyK6QHv1usbcfgiGaHOA==}
+  /ethers@6.6.3:
+    resolution: {integrity: sha512-g8wLXeRWSGDD0T+wsL3pvyc3aYnmxEEAwH8LSoDTDRhRsmJeNs9YMXlNU7ax2caO+zHkeI9MkHiz6rwxEjN4Mw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@adraffy/ens-normalize': 1.9.2
@@ -4123,6 +4136,7 @@ packages:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
     dependencies:
       type: 2.7.2
+    dev: false
 
   /external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
@@ -4211,7 +4225,7 @@ packages:
       debug:
         optional: true
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -4226,6 +4240,7 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+    dev: false
 
   /form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
@@ -4240,15 +4255,6 @@ packages:
     engines: {node: '>=12.20.0'}
     dependencies:
       fetch-blob: 3.2.0
-
-  /formidable@2.1.2:
-    resolution: {integrity: sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==}
-    dependencies:
-      dezalgo: 1.0.4
-      hexoid: 1.0.0
-      once: 1.4.0
-      qs: 6.11.2
-    dev: true
 
   /fs-extra@11.1.1:
     resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
@@ -4343,6 +4349,11 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
     dev: true
+
+  /get-tsconfig@4.6.2:
+    resolution: {integrity: sha512-E5XrT4CbbXcXWy+1jChlZmrmCwd5KGx502kDCXJJ7y898TtWW9FwoG5HfOLVRKmlmDGkWN2HM9Ho+/Y8F0sJDg==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -4487,11 +4498,6 @@ packages:
       glob: 8.1.0
       readable-stream: 3.6.2
 
-  /hexoid@1.0.0:
-    resolution: {integrity: sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==}
-    engines: {node: '>=8'}
-    dev: true
-
   /highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
@@ -4525,7 +4531,7 @@ packages:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -4536,7 +4542,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4546,7 +4552,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -4832,6 +4838,7 @@ packages:
 
   /is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+    dev: false
 
   /is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
@@ -5180,11 +5187,6 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  /methods@1.1.2:
-    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
-    engines: {node: '>= 0.6'}
-    dev: true
-
   /micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
@@ -5201,12 +5203,6 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
-
-  /mime@2.6.0:
-    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
-    engines: {node: '>=4.0.0'}
-    hasBin: true
-    dev: true
 
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -5236,8 +5232,8 @@ packages:
     dependencies:
       brace-expansion: 2.0.1
 
-  /minimatch@9.0.1:
-    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
@@ -5320,6 +5316,15 @@ packages:
       pkg-types: 1.0.3
       ufo: 1.1.2
 
+  /mlly@1.4.0:
+    resolution: {integrity: sha512-ua8PAThnTwpprIaU47EPeZ/bPUVp2QYBbWMphUQpVdBI3Lgqzm5KZQ45Agm3YJedHXaIHl6pBGabaLSUPPSptg==}
+    dependencies:
+      acorn: 8.9.0
+      pathe: 1.1.1
+      pkg-types: 1.0.3
+      ufo: 1.1.2
+    dev: true
+
   /mocha@10.2.0:
     resolution: {integrity: sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==}
     engines: {node: '>= 14.0.0'}
@@ -5360,6 +5365,7 @@ packages:
       - bufferutil
       - supports-color
       - utf-8-validate
+    dev: false
 
   /mrmime@1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
@@ -5367,6 +5373,7 @@ packages:
 
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+    dev: false
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -5452,12 +5459,13 @@ packages:
 
   /next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+    dev: false
 
   /nock@13.3.1:
     resolution: {integrity: sha512-vHnopocZuI93p2ccivFyGuUfzjq2fxNyNurp7816mlT5V5HF4SzXu8lvLrVzBbNqzs+ODooZ6OksuSUNM7Njkw==}
     engines: {node: '>= 10.13'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       json-stringify-safe: 5.0.1
       lodash: 4.17.21
       propagate: 2.0.1
@@ -5498,6 +5506,7 @@ packages:
   /node-gyp-build@4.6.0:
     resolution: {integrity: sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==}
     hasBin: true
+    dev: false
 
   /node-gyp@8.4.1:
     resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
@@ -5818,7 +5827,7 @@ packages:
       - '@polkadot/util-crypto'
     dev: false
 
-  /postcss-load-config@3.1.4(ts-node@10.9.1):
+  /postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -5831,7 +5840,6 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
-      ts-node: 10.9.1(@swc/core@1.3.65)(@types/node@18.16.18)(typescript@5.1.3)
       yaml: 1.10.2
     dev: true
 
@@ -5860,6 +5868,15 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  /pretty-format@29.6.1:
+    resolution: {integrity: sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.0
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
+    dev: true
 
   /process-warning@2.2.0:
     resolution: {integrity: sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==}
@@ -5913,7 +5930,7 @@ packages:
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
       '@types/long': 4.0.2
-      '@types/node': 18.16.18
+      '@types/node': 18.16.19
       long: 4.0.0
     dev: true
 
@@ -5933,13 +5950,6 @@ packages:
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
-    dev: true
-
-  /qs@6.11.2:
-    resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
-    engines: {node: '>=0.6'}
-    dependencies:
-      side-channel: 1.0.4
     dev: true
 
   /querystringify@2.2.0:
@@ -5972,6 +5982,10 @@ packages:
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  /react-is@18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
+    dev: true
 
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -6027,6 +6041,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
     dev: true
+
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   /restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
@@ -6144,6 +6161,14 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
   /serialize-javascript@6.0.0:
     resolution: {integrity: sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==}
     dependencies:
@@ -6226,7 +6251,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       socks: 2.7.1
     transitivePeerDependencies:
       - supports-color
@@ -6263,6 +6288,16 @@ packages:
 
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
+    engines: {node: '>=0.10.0'}
+
+  /source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  /source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   /source-map@0.8.0-beta.0:
@@ -6396,24 +6431,6 @@ packages:
       mz: 2.7.0
       pirates: 4.0.5
       ts-interface-checker: 0.1.13
-    dev: true
-
-  /superagent@8.0.9:
-    resolution: {integrity: sha512-4C7Bh5pyHTvU33KpZgwrNKh/VQnvgtCSqPRfJAUdmrtSYePVzVg4E4OzsrbkhJj9O7SO6Bnv75K/F8XVZT8YHA==}
-    engines: {node: '>=6.4.0 <13 || >=14'}
-    dependencies:
-      component-emitter: 1.3.0
-      cookiejar: 2.1.4
-      debug: 4.3.4(supports-color@5.5.0)
-      fast-safe-stringify: 2.1.1
-      form-data: 4.0.0
-      formidable: 2.1.2
-      methods: 1.1.2
-      mime: 2.6.0
-      qs: 6.11.2
-      semver: 7.5.2
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /supports-color@5.5.0:
@@ -6567,7 +6584,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-node@10.9.1(@swc/core@1.3.65)(@types/node@18.16.18)(typescript@5.1.3):
+  /ts-node@10.9.1(@types/node@18.16.18)(typescript@5.1.3):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -6582,7 +6599,6 @@ packages:
         optional: true
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.3.65
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
@@ -6597,6 +6613,38 @@ packages:
       typescript: 5.1.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    dev: false
+
+  /ts-node@10.9.1(@types/node@18.16.19)(typescript@5.1.6):
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 18.16.19
+      acorn: 8.9.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.1.6
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
 
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -6609,7 +6657,7 @@ packages:
   /tslib@2.5.3:
     resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
 
-  /tsup@6.7.0(@swc/core@1.3.65)(ts-node@10.9.1)(typescript@5.1.3):
+  /tsup@6.7.0(typescript@5.1.3):
     resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -6625,16 +6673,15 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@swc/core': 1.3.65
       bundle-require: 4.0.1(esbuild@0.17.19)
       cac: 6.7.14
       chokidar: 3.5.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       esbuild: 0.17.19
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 3.1.4(ts-node@10.9.1)
+      postcss-load-config: 3.1.4
       resolve-from: 5.0.0
       rollup: 3.25.1
       source-map: 0.8.0-beta.0
@@ -6646,8 +6693,19 @@ packages:
       - ts-node
     dev: true
 
+  /tsx@3.12.7:
+    resolution: {integrity: sha512-C2Ip+jPmqKd1GWVQDvz/Eyc6QJbGfE7NrR3fx5BpEHMZsEHoIxHL1j+lKdGobr8ovEyqeNkPLSKp6SCSOt7gmw==}
+    hasBin: true
+    dependencies:
+      '@esbuild-kit/cjs-loader': 2.4.2
+      '@esbuild-kit/core-utils': 3.1.0
+      '@esbuild-kit/esm-loader': 2.5.5
+    optionalDependencies:
+      fsevents: 2.3.2
+
   /tweetnacl@1.0.3:
     resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+    dev: false
 
   /type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
@@ -6660,16 +6718,19 @@ packages:
 
   /type@1.2.0:
     resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==}
+    dev: false
 
   /type@2.7.2:
     resolution: {integrity: sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==}
+    dev: false
 
   /typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
       is-typedarray: 1.0.0
+    dev: false
 
-  /typeorm@0.3.16(sqlite3@5.1.6)(ts-node@10.9.1):
+  /typeorm@0.3.16(sqlite3@5.1.6):
     resolution: {integrity: sha512-wJ4Qy1oqRKNDdZiBTTaVMqwo/XxC52Q7uNPTjltPgLhvIW173bL6Iad0lhptMOsFlpixFPaUu3PNziaRBwX2Zw==}
     engines: {node: '>= 12.9.0'}
     hasBin: true
@@ -6733,14 +6794,13 @@ packages:
       chalk: 4.1.2
       cli-highlight: 2.1.11
       date-fns: 2.30.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       dotenv: 16.3.1
       glob: 8.1.0
       mkdirp: 2.1.6
       reflect-metadata: 0.1.13
       sha.js: 2.4.11
       sqlite3: 5.1.6
-      ts-node: 10.9.1(@swc/core@1.3.65)(@types/node@18.16.18)(typescript@5.1.3)
       tslib: 2.5.3
       uuid: 9.0.0
       yargs: 17.7.2
@@ -6751,11 +6811,18 @@ packages:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: false
 
   /typescript@5.1.3:
     resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
 
   /ufo@1.1.2:
     resolution: {integrity: sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==}
@@ -6801,6 +6868,7 @@ packages:
     requiresBuild: true
     dependencies:
       node-gyp-build: 4.6.0
+    dev: false
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -6822,18 +6890,21 @@ packages:
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
-  /viem@1.0.7(typescript@5.1.3):
-    resolution: {integrity: sha512-P/T2Zn8+V74kxO2e2NdhNR/MBtldovssigvc36+7g3DgTeETKnSS1fMQdBl0jE+Atlal+M6cuJ2HcFY7U45o0Q==}
+  /viem@1.2.15(typescript@5.1.3):
+    resolution: {integrity: sha512-M67YS3WQC/3vx12TvYxt9dlxqHjgXIwblyUdy7E6cZ2MNtyoSvq9HgkacfY0+SDZAbisVsUX8mi9Lb1bB5pUAQ==}
     peerDependencies:
       typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       '@adraffy/ens-normalize': 1.9.0
       '@noble/curves': 1.0.0
       '@noble/hashes': 1.3.0
       '@scure/bip32': 1.3.0
       '@scure/bip39': 1.2.0
-      '@wagmi/chains': 1.1.0(typescript@5.1.3)
-      abitype: 0.8.7(typescript@5.1.3)
+      '@wagmi/chains': 1.2.0(typescript@5.1.3)
+      abitype: 0.8.11(typescript@5.1.3)
       isomorphic-ws: 5.0.0(ws@8.12.0)
       typescript: 5.1.3
       ws: 8.12.0
@@ -6848,7 +6919,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       mlly: 1.3.0
       pathe: 1.1.1
       picocolors: 1.0.0
@@ -6861,6 +6932,27 @@ packages:
       - sugarss
       - supports-color
       - terser
+
+  /vite-node@0.32.4(@types/node@18.16.19):
+    resolution: {integrity: sha512-L2gIw+dCxO0LK14QnUMoqSYpa9XRGnTTTDjW2h19Mr+GR0EFj4vx52W41gFXfMLqpA00eK4ZjOVYo1Xk//LFEw==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      mlly: 1.4.0
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 4.3.9(@types/node@18.16.19)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
 
   /vite@4.3.9(@types/node@18.16.18):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
@@ -6893,6 +6985,39 @@ packages:
       rollup: 3.25.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  /vite@4.3.9(@types/node@18.16.19):
+    resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.16.19
+      esbuild: 0.17.19
+      postcss: 8.4.24
+      rollup: 3.25.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
 
   /vitest@0.31.4(@vitest/ui@0.31.4):
     resolution: {integrity: sha512-GoV0VQPmWrUFOZSg3RpQAPN+LPmHg2/gxlMNJlyxJihkz6qReHDV6b0pPDcqFLNEPya4tWJ1pgwUNP9MLmUfvQ==}
@@ -6939,7 +7064,7 @@ packages:
       cac: 6.7.14
       chai: 4.3.7
       concordance: 5.0.4
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       local-pkg: 0.4.3
       magic-string: 0.30.0
       pathe: 1.1.1
@@ -6958,6 +7083,71 @@ packages:
       - sugarss
       - supports-color
       - terser
+
+  /vitest@0.32.4(@vitest/ui@0.31.4):
+    resolution: {integrity: sha512-3czFm8RnrsWwIzVDu/Ca48Y/M+qh3vOnF16czJm98Q/AN1y3B6PBsyV8Re91Ty5s7txKNjEhpgtGPcfdbh2MZg==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.5
+      '@types/chai-subset': 1.3.3
+      '@types/node': 18.16.19
+      '@vitest/expect': 0.32.4
+      '@vitest/runner': 0.32.4
+      '@vitest/snapshot': 0.32.4
+      '@vitest/spy': 0.32.4
+      '@vitest/ui': 0.31.4(vitest@0.31.4)
+      '@vitest/utils': 0.32.4
+      acorn: 8.9.0
+      acorn-walk: 8.2.0
+      cac: 6.7.14
+      chai: 4.3.7
+      debug: 4.3.4
+      local-pkg: 0.4.3
+      magic-string: 0.30.0
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.3.3
+      strip-literal: 1.0.1
+      tinybench: 2.5.0
+      tinypool: 0.5.0
+      vite: 4.3.9(@types/node@18.16.19)
+      vite-node: 0.32.4(@types/node@18.16.19)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
 
   /w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
@@ -7249,6 +7439,7 @@ packages:
       yaeti: 0.0.6
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /well-known-symbols@2.0.0:
     resolution: {integrity: sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==}
@@ -7417,6 +7608,7 @@ packages:
   /yaeti@0.0.6:
     resolution: {integrity: sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==}
     engines: {node: '>=0.10.32'}
+    dev: false
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}

--- a/test/suites/dev/test-assets/test-assets-destroy.ts
+++ b/test/suites/dev/test-assets/test-assets-destroy.ts
@@ -18,7 +18,7 @@ describeSuite({
     let assetId: u128;
     let api: ApiPromise;
     beforeAll(async () => {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
       assetId = api.createType("u128", ARBITRARY_ASSET_ID);
       // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
       // And we need relay tokens for issuing a transaction to be executed in the relay

--- a/test/suites/dev/test-assets/test-assets-drain-asset.ts
+++ b/test/suites/dev/test-assets/test-assets-drain-asset.ts
@@ -20,7 +20,7 @@ describeSuite({
     let api: ApiPromise;
 
     beforeAll(async () => {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
       assetId = api.createType("u128", ARBITRARY_ASSET_ID);
       // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
       // And we need relay tokens for issuing a transaction to be executed in the relay

--- a/test/suites/dev/test-assets/test-assets-drain-both.ts
+++ b/test/suites/dev/test-assets/test-assets-drain-both.ts
@@ -20,7 +20,7 @@ describeSuite({
     let api: ApiPromise;
 
     beforeAll(async () => {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
       assetId = api.createType("u128", ARBITRARY_ASSET_ID);
       // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
       // And we need relay tokens for issuing a transaction to be executed in the relay

--- a/test/suites/dev/test-assets/test-assets-insufficients.ts
+++ b/test/suites/dev/test-assets/test-assets-insufficients.ts
@@ -20,7 +20,7 @@ describeSuite({
     const freshAccount = generateKeyringPair();
 
     beforeAll(async () => {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
       assetId = api.createType("u128", ARBITRARY_ASSET_ID);
       // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
       // And we need relay tokens for issuing a transaction to be executed in the relay

--- a/test/suites/dev/test-assets/test-assets-transfer.ts
+++ b/test/suites/dev/test-assets/test-assets-transfer.ts
@@ -17,7 +17,7 @@ describeSuite({
     let assetId: u128;
     let api: ApiPromise;
     beforeAll(async () => {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
       assetId = api.createType("u128", ARBITRARY_ASSET_ID);
       // We need to mint units with sudo.setStorage, as we dont have xcm mocker yet
       // And we need relay tokens for issuing a transaction to be executed in the relay

--- a/test/suites/dev/test-author/test-author-double-registration.ts
+++ b/test/suites/dev/test-author/test-author-double-registration.ts
@@ -19,7 +19,7 @@ describeSuite({
     let api: ApiPromise;
 
     beforeAll(async () => {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
     });
 
     it({

--- a/test/suites/dev/test-author/test-author-failed-association.ts
+++ b/test/suites/dev/test-author/test-author-failed-association.ts
@@ -18,7 +18,7 @@ describeSuite({
     let api: ApiPromise;
 
     beforeAll(async () => {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
     });
 
     it({

--- a/test/suites/dev/test-author/test-author-first-time-keys.ts
+++ b/test/suites/dev/test-author/test-author-first-time-keys.ts
@@ -19,7 +19,7 @@ describeSuite({
     let api: ApiPromise;
 
     beforeAll(async function () {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
       log(`Setting account ${charleth.address} keys: ${concatOriginalKeys}`);
       // TODO: fix all setKeys with api 1600.1
       await api.tx.authorMapping.setKeys(concatOriginalKeys).signAndSend(charleth);

--- a/test/suites/dev/test-author/test-author-missing-deposit-fail.ts
+++ b/test/suites/dev/test-author/test-author-missing-deposit-fail.ts
@@ -12,7 +12,7 @@ describeSuite({
     let api: ApiPromise;
 
     beforeAll(async function () {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
       const rando = generateKeyringPair();
       expect((await api.query.system.account(rando.address as string)).data.free.toBigInt()).to.eq(
         0n

--- a/test/suites/dev/test-author/test-author-non-author-clearing.ts
+++ b/test/suites/dev/test-author/test-author-non-author-clearing.ts
@@ -12,7 +12,7 @@ describeSuite({
       id: "T01",
       title: "should not succeed in clearing an association for a non-author",
       test: async function () {
-        const api = context.polkadotJs({ type: "moon" });
+        const api = context.polkadotJs();
         await context.createBlock(api.tx.authorMapping.addAssociation(BALTATHAR_SESSION_ADDRESS));
         expect((await getMappingInfo(context, BALTATHAR_SESSION_ADDRESS))!.account).to.eq(
           alith.address

--- a/test/suites/dev/test-author/test-author-non-author-rotate.ts
+++ b/test/suites/dev/test-author/test-author-non-author-rotate.ts
@@ -17,7 +17,7 @@ describeSuite({
     let api: ApiPromise;
 
     beforeAll(async () => {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
     });
 
     it({

--- a/test/suites/dev/test-author/test-author-registered-clear.ts
+++ b/test/suites/dev/test-author/test-author-registered-clear.ts
@@ -12,7 +12,7 @@ describeSuite({
       id: "T01",
       title: "should succeed in clearing an association",
       test: async function () {
-        const api = context.polkadotJs({ type: "moon" });
+        const api = context.polkadotJs();
         await context.createBlock(
           api.tx.authorMapping.addAssociation(BALTATHAR_SESSION_ADDRESS).signAsync(alith)
         );

--- a/test/suites/dev/test-author/test-author-registered-rotation.ts
+++ b/test/suites/dev/test-author/test-author-registered-rotation.ts
@@ -13,9 +13,7 @@ describeSuite({
       title: "should succeed in rotating account ids for an author",
       test: async function () {
         await context.createBlock(
-          context
-            .polkadotJs({ type: "moon" })
-            .tx.authorMapping.addAssociation(BALTATHAR_SESSION_ADDRESS)
+          context.polkadotJs().tx.authorMapping.addAssociation(BALTATHAR_SESSION_ADDRESS)
         );
         expect((await getMappingInfo(context, BALTATHAR_SESSION_ADDRESS))?.account).to.eq(
           alith.address
@@ -23,7 +21,7 @@ describeSuite({
 
         await context.createBlock(
           context
-            .polkadotJs({ type: "moon" })
+            .polkadotJs()
             .tx.authorMapping.updateAssociation(BALTATHAR_SESSION_ADDRESS, CHARLETH_SESSION_ADDRESS)
         );
         expect(await getMappingInfo(context, BALTATHAR_SESSION_ADDRESS)).to.eq(null);

--- a/test/suites/dev/test-author/test-author-removing-author.ts
+++ b/test/suites/dev/test-author/test-author-removing-author.ts
@@ -20,7 +20,7 @@ describeSuite({
 
     beforeAll(async function () {
       // Remove the keys
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
       await api.tx.authorMapping.removeKeys().signAndSend(dorothy);
       await context.createBlock();
     });

--- a/test/suites/dev/test-author/test-author-removing-keys.ts
+++ b/test/suites/dev/test-author/test-author-removing-keys.ts
@@ -19,7 +19,7 @@ describeSuite({
     let api: ApiPromise;
 
     beforeAll(async function () {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
       await (api.tx.authorMapping.setKeys as any)(concatOriginalKeys).signAndSend(charleth);
       await context.createBlock();
 

--- a/test/suites/dev/test-author/test-author-same-key-rotation.ts
+++ b/test/suites/dev/test-author/test-author-same-key-rotation.ts
@@ -19,7 +19,7 @@ describeSuite({
     let api: ApiPromise;
 
     beforeAll(async function () {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
       await (api.tx.authorMapping.setKeys as any)(concatOriginalKeys).signAndSend(charleth);
       await context.createBlock();
 

--- a/test/suites/dev/test-author/test-author-simple-association.ts
+++ b/test/suites/dev/test-author/test-author-simple-association.ts
@@ -22,7 +22,7 @@ describeSuite({
       id: "T01",
       title: "should match genesis state",
       test: async function () {
-        api = context.polkadotJs({ type: "moon" });
+        api = context.polkadotJs();
         expect((await getMappingInfo(context, ALITH_SESSION_ADDRESS))?.account).to.eq(
           ALITH_ADDRESS
         );

--- a/test/suites/dev/test-author/test-author-unregistered-clear.ts
+++ b/test/suites/dev/test-author/test-author-unregistered-clear.ts
@@ -13,7 +13,7 @@ describeSuite({
       title: "should not succeed in clearing an association for an unregistered author",
       test: async function () {
         expect(await getMappingInfo(context, BALTATHAR_SESSION_ADDRESS)).to.eq(null);
-        const api = context.polkadotJs({ type: "moon" });
+        const api = context.polkadotJs();
         const { result } = await context.createBlock(
           api.tx.authorMapping.clearAssociation(BALTATHAR_SESSION_ADDRESS),
           { allowFailures: true }

--- a/test/suites/dev/test-author/test-author-unregistered-rotation.ts
+++ b/test/suites/dev/test-author/test-author-unregistered-rotation.ts
@@ -14,7 +14,7 @@ describeSuite({
       test: async function () {
         await context.createBlock(
           context
-            .polkadotJs({ type: "moon" })
+            .polkadotJs()
             .tx.authorMapping.updateAssociation(
               BALTATHAR_SESSION_ADDRESS,
               CHARLETH_SESSION_ADDRESS

--- a/test/suites/dev/test-author/test-author-update-diff-keys.ts
+++ b/test/suites/dev/test-author/test-author-update-diff-keys.ts
@@ -24,7 +24,7 @@ describeSuite({
     let api: ApiPromise;
 
     beforeAll(async function () {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
       await api.tx.authorMapping.setKeys(concatOriginalKeys).signAndSend(charleth);
       await context.createBlock();
 

--- a/test/suites/dev/test-author/test-author-update-nimbus-key.ts
+++ b/test/suites/dev/test-author/test-author-update-nimbus-key.ts
@@ -25,7 +25,7 @@ describeSuite({
     let api: ApiPromise;
 
     beforeAll(async function () {
-      api = context.polkadotJs({ type: "moon" });
+      api = context.polkadotJs();
       await api.tx.authorMapping.setKeys(concatOriginalKeys).signAndSend(charleth);
       await context.createBlock();
 

--- a/test/suites/dev/test-balance/test-balance-genesis.ts
+++ b/test/suites/dev/test-balance/test-balance-genesis.ts
@@ -29,7 +29,7 @@ describeSuite({
       test: async function () {
         const genesisHash = await context.polkadotJs().rpc.chain.getBlockHash(0);
         const account = await (
-          await context.polkadotJs({ type: "moon" }).at(genesisHash)
+          await context.polkadotJs().at(genesisHash)
         ).query.system.account(ALITH_ADDRESS);
         expect(account.data.free.toBigInt()).toBe(ALITH_GENESIS_FREE_BALANCE);
         expect(account.data.reserved.toBigInt()).toBe(ALITH_GENESIS_RESERVE_BALANCE);

--- a/test/suites/para/test_moonbase.ts
+++ b/test/suites/para/test_moonbase.ts
@@ -15,8 +15,8 @@ describeSuite({
     let ethersSigner: Signer;
 
     beforeAll(async () => {
-      paraApi = context.polkadotJs({ type: "moon", apiName: "parachain" });
-      relayApi = context.polkadotJs({ type: "polkadotJs", apiName: "relaychain" });
+      paraApi = context.polkadotJs("parachain");
+      relayApi = context.polkadotJs("relaychain");
       ethersSigner = context.ethers();
 
       const relayNetwork = relayApi.consts.system.version.specName.toString();
@@ -46,10 +46,10 @@ describeSuite({
         const blockNumberBefore = (
           await paraApi.rpc.chain.getBlock()
         ).block.header.number.toNumber();
-        const currentCode = await paraApi.rpc.state.getStorage(":code");
+        const currentCode = (await paraApi.rpc.state.getStorage(":code")) as `0x${string}`;
         const codeString = currentCode.toString();
 
-        const wasm = fs.readFileSync(MoonwallContext.getContext().rtUpgradePath);
+        const wasm = fs.readFileSync(MoonwallContext.getContext().rtUpgradePath!);
         const rtHex = `0x${wasm.toString("hex")}`;
 
         if (rtHex === codeString) {
@@ -106,15 +106,15 @@ describeSuite({
       title: "Tags are present on emulated Ethereum blocks",
       test: async function () {
         expect(
-          (await ethersSigner.provider.getBlock("safe")).number,
+          (await ethersSigner.provider!.getBlock("safe"))!.number,
           "Safe tag is not present"
         ).to.be.greaterThan(0);
         expect(
-          (await ethersSigner.provider.getBlock("finalized")).number,
+          (await ethersSigner.provider!.getBlock("finalized"))!.number,
           "Finalized tag is not present"
         ).to.be.greaterThan(0);
         expect(
-          (await ethersSigner.provider.getBlock("latest")).number,
+          (await ethersSigner.provider!.getBlock("latest"))!.number,
           "Latest tag is not present"
         ).to.be.greaterThan(0);
         // log(await ethersSigner.provider.getTransactionCount(ALITH_ADDRESS, "latest"));

--- a/test/suites/para/test_moonbeam.ts
+++ b/test/suites/para/test_moonbeam.ts
@@ -15,8 +15,8 @@ describeSuite({
     let ethersSigner: Signer;
 
     beforeAll(async () => {
-      paraApi = context.polkadotJs({ type: "moon", apiName: "parachain" });
-      relayApi = context.polkadotJs({ type: "polkadotJs", apiName: "relaychain" });
+      paraApi = context.polkadotJs("parachain");
+      relayApi = context.polkadotJs("relaychain");
       ethersSigner = context.ethers()!;
 
       const relayNetwork = relayApi.consts.system.version.specName.toString();
@@ -45,10 +45,10 @@ describeSuite({
         const blockNumberBefore = (
           await paraApi.rpc.chain.getBlock()
         ).block.header.number.toNumber();
-        const currentCode = await paraApi.rpc.state.getStorage(":code");
+        const currentCode = (await paraApi.rpc.state.getStorage(":code")) as `0x${string}`;
         const codeString = currentCode.toString();
 
-        const wasm = fs.readFileSync(MoonwallContext.getContext().rtUpgradePath);
+        const wasm = fs.readFileSync(MoonwallContext.getContext().rtUpgradePath!);
         const rtHex = `0x${wasm.toString("hex")}`;
 
         if (rtHex === codeString) {
@@ -108,15 +108,15 @@ describeSuite({
       title: "Tags are present on emulated Ethereum blocks",
       test: async function () {
         expect(
-          (await ethersSigner.provider.getBlock("safe")).number,
+          (await ethersSigner.provider!.getBlock("safe"))!.number,
           "Safe tag is not present"
         ).to.be.greaterThan(0);
         expect(
-          (await ethersSigner.provider.getBlock("finalized")).number,
+          (await ethersSigner.provider!.getBlock("finalized"))!.number,
           "Finalized tag is not present"
         ).to.be.greaterThan(0);
         expect(
-          (await ethersSigner.provider.getBlock("latest")).number,
+          (await ethersSigner.provider!.getBlock("latest"))!.number,
           "Latest tag is not present"
         ).to.be.greaterThan(0);
         // log(await ethersSigner.provider.getTransactionCount(ALITH_ADDRESS, "latest"));

--- a/test/suites/smoke/test-author-filter-consistency.ts
+++ b/test/suites/smoke/test-author-filter-consistency.ts
@@ -14,7 +14,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       atBlockNumber = (await paraApi.rpc.chain.getHeader()).number.toNumber();
       apiAt = await paraApi.at(await paraApi.rpc.chain.getBlockHash(atBlockNumber));
       specVersion = (await apiAt.query.system.lastRuntimeUpgrade()).unwrap().specVersion.toNumber();

--- a/test/suites/smoke/test-author-mapping-consistency.ts
+++ b/test/suites/smoke/test-author-mapping-consistency.ts
@@ -16,7 +16,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       const limit = 1000;
       let last_key = "";
       let count = 0;

--- a/test/suites/smoke/test-balances-consistency.ts
+++ b/test/suites/smoke/test-balances-consistency.ts
@@ -142,7 +142,7 @@ describeSuite({
     };
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       const blockHash = process.env.BLOCK_NUMBER
         ? (await paraApi.rpc.chain.getBlockHash(parseInt(process.env.BLOCK_NUMBER))).toHex()
         : (await paraApi.rpc.chain.getFinalizedHead()).toHex();

--- a/test/suites/smoke/test-block-finalized.ts
+++ b/test/suites/smoke/test-block-finalized.ts
@@ -24,7 +24,7 @@ describeSuite({
     let ethers: Signer;
 
     beforeAll(() => {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       ethers = context.ethers();
     });
 

--- a/test/suites/smoke/test-block-weights.ts
+++ b/test/suites/smoke/test-block-weights.ts
@@ -41,7 +41,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para" }) as any as ApiPromise;
+      paraApi = context.polkadotJs("para") as any as ApiPromise;
       const blockNumArray = await getBlockArray(paraApi, timePeriod);
       const limits = paraApi.consts.system.blockWeights;
 

--- a/test/suites/smoke/test-dynamic-fees.ts
+++ b/test/suites/smoke/test-dynamic-fees.ts
@@ -98,7 +98,7 @@ describeSuite({
     };
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       const { specVersion, specName } = paraApi.consts.system.version;
       runtime = specName.toUpperCase() as any;
 

--- a/test/suites/smoke/test-ethereum-contract-code.ts
+++ b/test/suites/smoke/test-ethereum-contract-code.ts
@@ -20,7 +20,7 @@ describeSuite({
     const failedContractCodes: { accountId: string; codesize: number }[] = [];
 
     beforeAll(async function () {
-      const paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      const paraApi = context.polkadotJs("para");
       const blockHash = process.env.BLOCK_NUMBER
         ? (await paraApi.rpc.chain.getBlockHash(parseInt(process.env.BLOCK_NUMBER))).toHex()
         : (await paraApi.rpc.chain.getFinalizedHead()).toHex();

--- a/test/suites/smoke/test-ethereum-current-consistency.ts
+++ b/test/suites/smoke/test-ethereum-current-consistency.ts
@@ -40,7 +40,7 @@ describeSuite({
       title: "should have non default field values",
       timeout: THIRTY_MINS,
       test: async function () {
-        const paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+        const paraApi = context.polkadotJs("para");
 
         const lastBlockNumber = (await paraApi.rpc.chain.getHeader()).number.toNumber();
         const roundLength = (await paraApi.query.parachainStaking.round()).length.toNumber();

--- a/test/suites/smoke/test-ethereum-failures.ts
+++ b/test/suites/smoke/test-ethereum-failures.ts
@@ -29,7 +29,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       const blockNumArray = await getBlockArray(paraApi, timePeriod);
       log(`Collecting ${hours} hours worth of events`);
 

--- a/test/suites/smoke/test-foreign-asset-consistency.ts
+++ b/test/suites/smoke/test-foreign-asset-consistency.ts
@@ -20,7 +20,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       // Configure the api at a specific block
       // (to avoid inconsistency querying over multiple block when the test takes a long time to
       // query data and blocks are being produced)

--- a/test/suites/smoke/test-foreign-xcm-failures.ts
+++ b/test/suites/smoke/test-foreign-xcm-failures.ts
@@ -34,7 +34,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       const networkName = paraApi.runtimeChain.toString();
       const foreignChainInfos = ForeignChainsEndpoints.find(
         (a) => a.moonbeamNetworkName === networkName

--- a/test/suites/smoke/test-historic-compatibility.ts
+++ b/test/suites/smoke/test-historic-compatibility.ts
@@ -20,7 +20,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       const chainId = (await paraApi.query.ethereumChainId.chainId()).toString();
       log(`Loading test data for chainId ${chainId}.`);
       traceStatic = tracingTxns.find((a) => a.chainId.toString() === chainId);

--- a/test/suites/smoke/test-local-asset-consistency.ts
+++ b/test/suites/smoke/test-local-asset-consistency.ts
@@ -21,10 +21,10 @@ describeSuite({
       // query data and blocks are being produced)
       atBlockNumber = process.env.BLOCK_NUMBER
         ? parseInt(process.env.BLOCK_NUMBER)
-        : (await context.polkadotJs({ apiName: "para" }).rpc.chain.getHeader()).number.toNumber();
+        : (await context.polkadotJs("para").rpc.chain.getHeader()).number.toNumber();
       apiAt = await context
-        .polkadotJs({ apiName: "para" })
-        .at(await context.polkadotJs({ apiName: "para" }).rpc.chain.getBlockHash(atBlockNumber));
+        .polkadotJs("para")
+        .at(await context.polkadotJs("para").rpc.chain.getBlockHash(atBlockNumber));
       localAssetDeposits = await apiAt.query.assetManager.localAssetDeposit.keys();
       localAssetCounter = await (await apiAt.query.assetManager.localAssetCounter()).toNumber();
       localAssetInfo = await apiAt.query.assetManager.localAssetDeposit.keys();

--- a/test/suites/smoke/test-orbiter-consistency.ts
+++ b/test/suites/smoke/test-orbiter-consistency.ts
@@ -31,7 +31,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       const runtimeVersion = paraApi.runtimeVersion.specVersion.toNumber();
       atBlockNumber = process.env.BLOCK_NUMBER
         ? parseInt(process.env.BLOCK_NUMBER)

--- a/test/suites/smoke/test-polkadot-decoding.ts
+++ b/test/suites/smoke/test-polkadot-decoding.ts
@@ -17,7 +17,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       atBlockNumber = (await paraApi.rpc.chain.getHeader()).number.toNumber();
       apiAt = await paraApi.at(await paraApi.rpc.chain.getBlockHash(atBlockNumber));
       specVersion = apiAt.consts.system.version.specVersion.toNumber();

--- a/test/suites/smoke/test-proxy-consistency.ts
+++ b/test/suites/smoke/test-proxy-consistency.ts
@@ -19,7 +19,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       const limit = 1000;
       let last_key = "";
       let count = 0;

--- a/test/suites/smoke/test-randomness-consistency.ts
+++ b/test/suites/smoke/test-randomness-consistency.ts
@@ -19,7 +19,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       const runtimeVersion = paraApi.runtimeVersion.specVersion.toNumber();
       const runtimeName = paraApi.runtimeVersion.specName.toString();
       isRandomnessAvailable =

--- a/test/suites/smoke/test-relay-xcm-fees.ts
+++ b/test/suites/smoke/test-relay-xcm-fees.ts
@@ -18,8 +18,8 @@ describeSuite({
     let relayApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
-      relayApi = context.polkadotJs({ apiName: "relay" });
+      paraApi = context.polkadotJs("para");
+      relayApi = context.polkadotJs("relay");
 
       atBlockNumber = (await paraApi.rpc.chain.getHeader()).number.toNumber();
       apiAt = await paraApi.at(await paraApi.rpc.chain.getBlockHash(atBlockNumber));

--- a/test/suites/smoke/test-staking-consistency.ts
+++ b/test/suites/smoke/test-staking-consistency.ts
@@ -41,7 +41,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       atBlockNumber = (await paraApi.rpc.chain.getHeader()).number.toNumber();
       apiAt = await paraApi.at(await paraApi.rpc.chain.getBlockHash(atBlockNumber));
       specVersion = (await apiAt.query.system.lastRuntimeUpgrade()).unwrap().specVersion.toNumber();

--- a/test/suites/smoke/test-staking-rewards.ts
+++ b/test/suites/smoke/test-staking-rewards.ts
@@ -28,7 +28,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
 
       const atBlockNumber = process.env.BLOCK_NUMBER
         ? parseInt(process.env.BLOCK_NUMBER)

--- a/test/suites/smoke/test-staking-round-cleanup.ts
+++ b/test/suites/smoke/test-staking-round-cleanup.ts
@@ -51,7 +51,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
     });
 
     it({

--- a/test/suites/smoke/test-treasury-consistency.ts
+++ b/test/suites/smoke/test-treasury-consistency.ts
@@ -13,7 +13,7 @@ describeSuite({
     let paraApi: ApiPromise;
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
+      paraApi = context.polkadotJs("para");
       atBlockNumber = (await paraApi.rpc.chain.getHeader()).number.toNumber();
       apiAt = await paraApi.at(await paraApi.rpc.chain.getBlockHash(atBlockNumber));
     });

--- a/test/suites/smoke/test-xcm-failures.ts
+++ b/test/suites/smoke/test-xcm-failures.ts
@@ -41,8 +41,8 @@ describeSuite({
     };
 
     beforeAll(async function () {
-      paraApi = context.polkadotJs({ apiName: "para", type: "moon" });
-      relayApi = context.polkadotJs({ apiName: "relay" });
+      paraApi = context.polkadotJs("para");
+      relayApi = context.polkadotJs("relay");
 
       const blockNumArray = atBlock > 0 ? [atBlock] : await getBlockArray(paraApi, timePeriod);
 


### PR DESCRIPTION
### What does it do?
- Updates to latest moonwall
- Updated moonwall smoke tests compile contract before running
- Muted two relay-indices smoke tests until the updated RelayEncoder precompile is live
- Disabled moonwall `dev-tests` (until the migration#2 pr is complete)
- Replaced usage of `ts-node` with `tsx` (faster and better)

### What value does it bring to the blockchain users?
Better monitoring and live networks