### PR TITLE
More reliable docker image check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
         id: check-docker-image
         run: |
           TAG=sha-${{ steps.get-sha.outputs.sha8 }}
-          echo "image_exists=$(docker image inspect purestake/moonbeam:$TAG > /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
+          echo "image_exists=$(docker buildx imagetools inspect --raw purestake/moonbeam:$TAG > /dev/null && echo "true" || echo "false")" >> $GITHUB_OUTPUT
       - name: Display variables
         run: |
           echo git_ref: ${{ steps.check-git-ref.outputs.git_ref }}
@@ -260,7 +260,7 @@ jobs:
           POLKADOT_COMMIT=${{ needs.set-tags.outputs.polkadot_commit }}
           DOCKER_TAG="purestake/moonbase-relay-testnet:sha-$POLKADOT_COMMIT"
 
-          POLKADOT_EXISTS=$(docker image inspect $DOCKER_TAG > /dev/null && \
+          POLKADOT_EXISTS=$(docker buildx imagetools inspect --raw $DOCKER_TAG > /dev/null && \
             echo "true" || echo "false")
           if [[ "$POLKADOT_EXISTS" == "false" ]]; then
             # $POLKADOT_COMMIT and $POLKADOT_REPO is used to build the relay image
@@ -273,7 +273,7 @@ jobs:
           POLKADOT_COMMIT=${{ needs.set-tags.outputs.polkadot_commit }}
           DOCKER_TAG="docker.io/purestake/polkadot-para-tests:sha-$POLKADOT_COMMIT"
 
-          POLKADOT_EXISTS=$(docker image inspect $DOCKER_TAG > /dev/null && \
+          POLKADOT_EXISTS=$(docker buildx imagetools inspect --raw $DOCKER_TAG > /dev/null && \
             echo "true" || echo "false")
           if [[ "$POLKADOT_EXISTS" == "false" ]]; then
             mkdir -p build


### PR DESCRIPTION
According to https://github.com/docker/buildx/issues/1509#issuecomment-1378538197, using `docker buildx imagetools inspect --raw` is recommanded over `docker manifest inspect`

cc @girazoki for visibility