### PR TITLE
Remove migration specific to runtime 3800

### DIFF
--- a/runtime/moonbeam/src/migrations.rs
+++ b/runtime/moonbeam/src/migrations.rs
@@ -16,83 +16,13 @@
 
 //! # Moonbeam specific Migrations
 
-use crate::bridge_config::XcmOverKusamaInstance;
-use crate::{BridgeKusamaMessages, PolkadotXcm, Runtime, RuntimeOrigin};
-use bp_messages::MessagesOperatingMode;
-use frame_support::traits::{ConstBool, OnRuntimeUpgrade};
 use pallet_migrations::{GetMigrations, Migration};
 use sp_std::{prelude::*, vec};
-use sp_weights::Weight;
-
-use frame_support::parameter_types;
-
-use xcm::prelude::{InteriorLocation, Location, Parachain};
-
-parameter_types! {
-	pub Lane: bp_moonbeam::LaneId = Default::default();
-	pub RelativeLocation: Location = Location::new(
-		1,
-		[
-			Parachain(bp_moonbeam::PARACHAIN_ID)
-		],
-	);
-	pub BridgedUniversalLocation: InteriorLocation = bp_moonriver::GlobalConsensusLocation::get().interior;
-}
-
-pub struct SetupBridge;
-impl Migration for SetupBridge {
-	fn friendly_name(&self) -> &str {
-		"MM_SetupBridge"
-	}
-
-	fn migrate(&self, _available_weight: Weight) -> Weight {
-		let mut weight = <Runtime as frame_system::Config>::DbWeight::get().writes(1);
-		let _ = PolkadotXcm::force_xcm_version(
-			RuntimeOrigin::root(),
-			Box::new(bp_moonriver::GlobalConsensusLocation::get()),
-			xcm::v5::VERSION,
-		)
-		.map_err(|err| {
-			log::error!("Failed to set xcm version: {:?}", err);
-		});
-
-		weight =
-			weight.saturating_add(<Runtime as frame_system::Config>::DbWeight::get().writes(1));
-		let _ = BridgeKusamaMessages::set_operating_mode(
-			RuntimeOrigin::root(),
-			MessagesOperatingMode::RejectingOutboundMessages,
-		)
-		.map_err(|err| {
-			log::error!("Failed to set operating mode: {:?}", err);
-		});
-
-		weight = weight.saturating_add(pallet_xcm_bridge::migration::OpenBridgeForLane::<
-			Runtime,
-			XcmOverKusamaInstance,
-			Lane,
-			ConstBool<true>,
-			RelativeLocation,
-			BridgedUniversalLocation,
-		>::on_runtime_upgrade());
-
-		weight
-	}
-
-	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade(&self) -> Result<Vec<u8>, sp_runtime::DispatchError> {
-		Ok(Default::default())
-	}
-
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(&self, state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
-		Ok(())
-	}
-}
 
 pub struct MoonbeamMigrations;
 
 impl GetMigrations for MoonbeamMigrations {
 	fn get_migrations() -> Vec<Box<dyn Migration>> {
-		vec![Box::new(SetupBridge)]
+		vec![]
 	}
 }

--- a/runtime/moonriver/src/migrations.rs
+++ b/runtime/moonriver/src/migrations.rs
@@ -16,85 +16,13 @@
 
 //! # Moonriver specific Migrations
 
-use crate::bridge_config::XcmOverPolkadotInstance;
-use crate::{BridgePolkadotMessages, PolkadotXcm, Runtime, RuntimeOrigin};
-use bp_messages::MessagesOperatingMode;
-use frame_support::parameter_types;
-use frame_support::traits::{ConstBool, OnRuntimeUpgrade};
 use pallet_migrations::{GetMigrations, Migration};
 use sp_std::{prelude::*, vec};
-use sp_weights::Weight;
-use xcm::latest::{prelude::Parachain, InteriorLocation, Location};
-
-parameter_types! {
-	pub Lane: bp_moonriver::LaneId = Default::default();
-	pub RelativeLocation: Location = Location::new(
-		1,
-		[
-			Parachain(bp_moonriver::PARACHAIN_ID)
-		],
-	);
-	pub BridgedUniversalLocation: InteriorLocation = bp_moonbeam::GlobalConsensusLocation::get().interior;
-}
-
-pub struct SetupBridge;
-impl Migration for SetupBridge {
-	fn friendly_name(&self) -> &str {
-		"MM_SetupBridge"
-	}
-
-	fn migrate(&self, _available_weight: Weight) -> Weight {
-		let mut weight = <Runtime as frame_system::Config>::DbWeight::get().writes(1);
-		let _ = PolkadotXcm::force_xcm_version(
-			RuntimeOrigin::root(),
-			Box::new(bp_moonbeam::GlobalConsensusLocation::get()),
-			xcm::v5::VERSION,
-		)
-		.map_err(|err| {
-			log::error!("Failed to set xcm version: {:?}", err);
-		});
-
-		weight =
-			weight.saturating_add(<Runtime as frame_system::Config>::DbWeight::get().writes(1));
-		let _ = BridgePolkadotMessages::set_operating_mode(
-			RuntimeOrigin::root(),
-			MessagesOperatingMode::RejectingOutboundMessages,
-		)
-		.map_err(|err| {
-			log::error!("Failed to set operating mode: {:?}", err);
-		});
-
-		weight = weight.saturating_add(pallet_xcm_bridge::migration::OpenBridgeForLane::<
-			Runtime,
-			XcmOverPolkadotInstance,
-			Lane,
-			ConstBool<true>,
-			RelativeLocation,
-			BridgedUniversalLocation,
-		>::on_runtime_upgrade());
-
-		weight
-	}
-
-	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade(&self) -> Result<Vec<u8>, sp_runtime::DispatchError> {
-		Ok(Default::default())
-	}
-
-	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(&self, state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
-		Ok(())
-	}
-}
 
 pub struct MoonriverMigrations;
 
 impl GetMigrations for MoonriverMigrations {
 	fn get_migrations() -> Vec<Box<dyn Migration>> {
-		vec![
-			// Runtime 3000
-			// Box::new(PalletStakingMultiplyRoundLenBy2)
-			Box::new(SetupBridge),
-		]
+		vec![]
 	}
 }


### PR DESCRIPTION
### What does it do?

Removes migration specific to the bridge configuration included in runtime 3800.