### PR TITLE
CI: Increase threshold of the WASM size warning comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -425,7 +425,7 @@ jobs:
           get_status_emoji() {
             local size=$1
             local diff=$2
-            if [ $size -gt 3200 ]; then
+            if [ $size -gt 3000 ]; then
               echo "🚨"
             elif [ $diff -gt 0 ]; then
               echo "⚠️"


### PR DESCRIPTION
### What does it do?

Update the WASM size check CI step to half of the new 7.5 MB PoV limit.
