### PR TITLE
Allow retries when checking for transaction receipts

### DIFF
--- a/test/suites/dev/common/test-eip7702/test-eip7702-advanced.ts
+++ b/test/suites/dev/common/test-eip7702/test-eip7702-advanced.ts
@@ -3,6 +3,7 @@ import { beforeAll, describeSuite, expect, deployCreateCompiledContract } from "
 import { sendRawTransaction } from "@moonwall/util";
 import { encodeFunctionData, decodeFunctionResult, type Abi, parseEther } from "viem";
 import { createFundedAccount, createViemTransaction } from "./helpers";
+import { getTransactionReceiptWithRetry } from "../../../../helpers/eth-transactions";
 
 describeSuite({
   id: "D020802",
@@ -95,9 +96,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -128,9 +127,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
 
           // Verify transaction succeeded
           expect(receipt.status).toBe("success");
@@ -173,9 +170,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -243,9 +238,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -269,9 +262,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
 
           // Verify transaction succeeded
           expect(receipt.status).toBe("success");
@@ -306,9 +297,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -332,9 +321,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
 
           // Verify transaction succeeded
           expect(receipt.status).toBe("success");
@@ -360,9 +347,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
 
           // Verify transaction succeeded
           expect(receipt.status).toBe("success");
@@ -403,9 +388,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -464,9 +447,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -488,9 +469,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
 
           // Verify transaction succeeded
           expect(receipt.status).toBe("success");
@@ -517,9 +496,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
 
           expect(receipt.status).toBe("reverted");
         }
@@ -560,9 +537,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -605,9 +580,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -633,9 +606,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
 
           // Verify transaction succeeded
           expect(receipt.status).toBe("success");
@@ -674,9 +645,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
 
           // Verify transaction succeeded
           expect(receipt.status).toBe("success");

--- a/test/suites/dev/common/test-eip7702/test-eip7702-delegatecall.ts
+++ b/test/suites/dev/common/test-eip7702/test-eip7702-delegatecall.ts
@@ -4,6 +4,7 @@ import { encodeFunctionData, type Abi } from "viem";
 import { sendRawTransaction } from "@moonwall/util";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { createFundedAccount, createViemTransaction } from "./helpers";
+import { getTransactionReceiptWithRetry } from "../../../../helpers/eth-transactions";
 
 describeSuite({
   id: "D020803",
@@ -78,9 +79,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         // Verify transaction succeeded
         expect(receipt.status).toBe("success");
@@ -129,9 +128,7 @@ describeSuite({
         const hash = await sendRawTransaction(context, signedTx);
         await context.createBlock();
 
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
       },
     });
@@ -179,9 +176,7 @@ describeSuite({
         const hash = await sendRawTransaction(context, signedTx);
         await context.createBlock();
 
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
 
         // Storage should be in the delegating EOA's context (via caller contract delegation)
@@ -245,9 +240,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
 
         // Read the stored value
@@ -295,9 +288,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
 
         // Now call the delegated EOA from another contract
@@ -327,9 +318,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
           expect(receipt.status).toBe("success");
         }
 
@@ -372,9 +361,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -454,9 +441,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
       },
     });

--- a/test/suites/dev/common/test-eip7702/test-eip7702-happypath.ts
+++ b/test/suites/dev/common/test-eip7702/test-eip7702-happypath.ts
@@ -4,6 +4,7 @@ import { sendRawTransaction } from "@moonwall/util";
 import { keccak256, concat, encodeFunctionData, numberToHex, type Abi } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { createViemTransaction } from "./helpers";
+import { getTransactionReceiptWithRetry } from "../../../../helpers/eth-transactions";
 
 describeSuite({
   id: "D020512",
@@ -107,7 +108,7 @@ describeSuite({
         console.log(`Transaction hash: ${hash}`);
 
         // Check transaction receipt
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -223,9 +224,7 @@ describeSuite({
         const incrementHash = await sendRawTransaction(context, signedIncrement);
         await context.createBlock();
 
-        const incrementReceipt = await context
-          .viem()
-          .getTransactionReceipt({ hash: incrementHash });
+        const incrementReceipt = await getTransactionReceiptWithRetry(context, incrementHash);
         expect(incrementReceipt.status).toBe("success");
 
         // Check updated balance through the delegated address
@@ -282,7 +281,7 @@ describeSuite({
         const hash = await sendRawTransaction(context, signature);
         await context.createBlock();
 
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         // Check that delegation did not occur due to invalid nonce
         const codeAtDelegator = await context.viem().getCode({
@@ -351,7 +350,7 @@ describeSuite({
         const hash = await sendRawTransaction(context, signature);
         await context.createBlock();
 
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -394,7 +393,7 @@ describeSuite({
         const clearHash = await sendRawTransaction(context, clearSignature);
         await context.createBlock();
 
-        const clearReceipt = await context.viem().getTransactionReceipt({ hash: clearHash });
+        const clearReceipt = await getTransactionReceiptWithRetry(context, clearHash);
 
         expect(clearReceipt.status).toBe("success");
 
@@ -490,7 +489,7 @@ describeSuite({
         const hash = await sendRawTransaction(context, signature);
         await context.createBlock();
 
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         // Check that delegation did not occur due to chain ID mismatch
         const codeAtDelegator = await context.viem().getCode({

--- a/test/suites/dev/common/test-eip7702/test-eip7702-invalid.ts
+++ b/test/suites/dev/common/test-eip7702/test-eip7702-invalid.ts
@@ -5,6 +5,7 @@ import { type Abi, parseEther } from "viem";
 import { sendRawTransaction } from "@moonwall/util";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { createFundedAccount, createViemTransaction } from "./helpers";
+import { getTransactionReceiptWithRetry } from "../../../../helpers/eth-transactions";
 
 describeSuite({
   id: "D020805",
@@ -100,7 +101,7 @@ describeSuite({
         expect(code).toBeFalsy();
 
         // Verify transaction succeeded but authorization was invalid
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
       },
     });
@@ -148,7 +149,7 @@ describeSuite({
         expect(code).toBeFalsy();
 
         // Verify transaction succeeded but authorization was invalid
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
       },
     });
@@ -195,7 +196,7 @@ describeSuite({
         expect(code).toBeFalsy();
 
         // Verify transaction succeeded but authorization was invalid
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
       },
     });
@@ -241,7 +242,7 @@ describeSuite({
         expect(code).toBeFalsy();
 
         // Verify transaction result - may revert when calling zero address delegation
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         // Transaction may revert when calling zero address after delegation
         expect(["success", "reverted"]).toContain(receipt.status);
       },
@@ -275,7 +276,7 @@ describeSuite({
         await context.createBlock();
 
         // Verify transaction result - may revert when calling EOA after delegation
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         // Transaction may revert when calling EOA after delegation
         expect(["success", "reverted"]).toContain(receipt.status);
 
@@ -337,7 +338,7 @@ describeSuite({
         expect(code).toBeFalsy();
 
         // Verify transaction succeeded but authorization was invalid
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
       },
     });
@@ -376,7 +377,7 @@ describeSuite({
         await context.createBlock();
 
         // First authorization should succeed, second should be ignored
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         // Transaction may succeed but only one delegation should be set
         const code = await context.viem().getCode({
@@ -437,7 +438,7 @@ describeSuite({
         expect(code).toBeFalsy();
 
         // Verify transaction succeeded but authorization was invalid
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
       },
     });
@@ -489,7 +490,7 @@ describeSuite({
         expect(code).toBeFalsy();
 
         // Verify transaction succeeded but authorization was invalid
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
       },
     });

--- a/test/suites/dev/common/test-eip7702/test-eip7702-self-delegation.ts
+++ b/test/suites/dev/common/test-eip7702/test-eip7702-self-delegation.ts
@@ -4,6 +4,7 @@ import { encodeFunctionData, type Abi, parseEther } from "viem";
 import { sendRawTransaction } from "@moonwall/util";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { createViemTransaction } from "./helpers";
+import { getTransactionReceiptWithRetry } from "../../../../helpers/eth-transactions";
 
 describeSuite({
   id: "D020806",
@@ -87,9 +88,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 

--- a/test/suites/dev/common/test-eip7702/test-eip7702-setcode.ts
+++ b/test/suites/dev/common/test-eip7702/test-eip7702-setcode.ts
@@ -4,6 +4,7 @@ import { sendRawTransaction } from "@moonwall/util";
 import { encodeFunctionData, type Abi, parseEther, parseGwei, keccak256 } from "viem";
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { createFundedAccount, createViemTransaction } from "./helpers";
+import { getTransactionReceiptWithRetry } from "../../../../helpers/eth-transactions";
 
 describeSuite({
   id: "D020807",
@@ -99,9 +100,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         console.log("Transaction receipt:", receipt);
 
         expect(receipt.status).toBe("success");
@@ -165,7 +164,7 @@ describeSuite({
         const hash = await sendRawTransaction(context, signature);
         await context.createBlock();
 
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
 
         // Verify storage was written
@@ -206,7 +205,7 @@ describeSuite({
           const hash = await sendRawTransaction(context, signature);
           await context.createBlock();
 
-          const receipt = await context.viem().getTransactionReceipt({ hash });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
           expect(receipt.status).toBe("success");
         }
 
@@ -247,7 +246,7 @@ describeSuite({
         const hash = await sendRawTransaction(context, signature);
         await context.createBlock();
 
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -302,9 +301,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -326,9 +323,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
 
           expect(receipt.status).toBe("success");
         }
@@ -381,7 +376,7 @@ describeSuite({
         const hash = await sendRawTransaction(context, signature);
         await context.createBlock();
 
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
       },
     });
@@ -429,7 +424,7 @@ describeSuite({
         const hash = await sendRawTransaction(context, signature);
         await context.createBlock();
 
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
 
         // After EIP-6780, SELFDESTRUCT only transfers balance in same transaction
@@ -498,9 +493,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -532,9 +525,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
 
           expect(receipt.status).toBe("success");
 
@@ -584,7 +575,7 @@ describeSuite({
         await context.createBlock();
 
         // Check if transaction succeeded or failed due to stack depth
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         console.log(`Re-entry test status: ${receipt.status}`);
 
@@ -649,9 +640,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -681,9 +670,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
 
           expect(receipt.status).toBe("success");
         }
@@ -737,9 +724,7 @@ describeSuite({
         await context.createBlock();
 
         // Get transaction receipt to check for events and status
-        const receipt = await context.viem().getTransactionReceipt({
-          hash,
-        });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
 
         expect(receipt.status).toBe("success");
 
@@ -777,9 +762,7 @@ describeSuite({
           await context.createBlock();
 
           // Get transaction receipt to check for events and status
-          const receipt = await context.viem().getTransactionReceipt({
-            hash,
-          });
+          const receipt = await getTransactionReceiptWithRetry(context, hash);
 
           expect(receipt.status).toBe("success");
         }
@@ -870,7 +853,7 @@ describeSuite({
         const hash = await sendRawTransaction(context, signature);
         await context.createBlock();
 
-        const receipt = await context.viem().getTransactionReceipt({ hash });
+        const receipt = await getTransactionReceiptWithRetry(context, hash);
         expect(receipt.status).toBe("success");
 
         // Verify all delegations were set


### PR DESCRIPTION
### What does it do?

Introduces retries when checking for transaction receipts in tests.
