### PR TITLE
Fix moonriver smoke test

### DIFF
--- a/test/helpers/foreign-chains.ts
+++ b/test/helpers/foreign-chains.ts
@@ -82,7 +82,9 @@ export const ForeignChainsEndpoints = [
       {
         name: "Bifrost",
         paraId: 2001,
-        // mutedUntil: new Date("2025-11-01").getTime(), // Remove this channel on November 1st
+        // Seems like there's an issue with Bifrost connectivity, so we mute it for now
+        // check again in a month
+        mutedUntil: new Date("2025-10-22").getTime(),
       },
       {
         name: "Shiden",

--- a/test/suites/smoke/test-foreign-xcm-failures.ts
+++ b/test/suites/smoke/test-foreign-xcm-failures.ts
@@ -59,13 +59,17 @@ describeSuite({
       chainsWithRpcs = chainsWithRpcs.map((chain) => {
         return {
           ...chain,
-          endpoints: chain.endpoints.filter(value => value.startsWith("ws://") || value.startsWith("wss://")),
+          endpoints: chain.endpoints.filter(
+            (value) => value.startsWith("ws://") || value.startsWith("wss://")
+          ),
         };
       });
 
       for (const chain of chainsWithRpcs) {
         if (chain.endpoints.length === 0) {
-          expect.fail(`No valid endpoints for ${chain.name} (paraId: ${chain.paraId}) on network ${networkName}`);
+          expect.fail(
+            `No valid endpoints for ${chain.name} (paraId: ${chain.paraId}) on network ${networkName}`
+          );
         }
       }
 


### PR DESCRIPTION
`provider.disconnect` would emit an error and it will cause an infinite callbacks loop to be triggered, so I unregister the event listener before we call `provider.disconnect`.