### PR TITLE
Update polkadot-sdk dependency pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "hash-db",
  "log",
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "bp-bridge-hub-cumulus"
 version = "0.21.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -1240,7 +1240,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.20.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1257,7 +1257,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.20.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1305,7 +1305,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1322,7 +1322,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.20.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1339,7 +1339,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.20.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.20.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1400,7 +1400,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.6.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.17.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1429,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.13.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1448,7 +1448,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.21.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.23.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.23.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.23.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2340,7 +2340,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.19.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2355,7 +2355,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.23.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2381,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.17.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.23.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2427,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.24.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2464,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2499,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -2529,7 +2529,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.19.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2544,7 +2544,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2569,7 +2569,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.18.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.18.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2599,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.12.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2609,7 +2609,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "11.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2626,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.19.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -2636,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2653,7 +2653,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.24.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.23.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2696,7 +2696,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.24.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -2730,7 +2730,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.23.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2770,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.19.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4011,7 +4011,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4139,7 +4139,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "40.2.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4163,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "48.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "40.1.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4264,7 +4264,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "40.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.8.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -4322,7 +4322,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4363,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "33.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.3.0",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4405,7 +4405,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "40.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4424,7 +4424,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "40.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4438,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "36.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4448,7 +4448,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.46.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6999,7 +6999,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "log",
@@ -7018,7 +7018,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "22.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8710,7 +8710,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "19.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8724,7 +8724,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8741,7 +8741,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "42.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8833,7 +8833,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8848,7 +8848,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8861,7 +8861,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "39.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "aquamarine",
  "docify",
@@ -8905,7 +8905,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "41.1.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8921,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "41.1.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8940,7 +8940,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -8965,7 +8965,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8982,7 +8982,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -9001,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.20.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9020,7 +9020,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9040,7 +9040,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.19.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9081,7 +9081,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9099,7 +9099,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "21.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9118,7 +9118,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9135,7 +9135,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9172,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "7.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9204,7 +9204,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "39.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9226,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9239,7 +9239,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "41.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9958,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9976,7 +9976,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9998,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10015,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "39.1.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10034,7 +10034,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10065,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10081,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "43.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10100,7 +10100,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10118,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "10.1.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10137,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10214,7 +10214,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10225,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "38.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10253,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10273,7 +10273,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "36.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -10283,7 +10283,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10298,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10343,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.11.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "docify",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10450,7 +10450,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10468,7 +10468,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10482,7 +10482,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10523,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "16.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10537,7 +10537,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "41.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10554,7 +10554,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "40.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10575,7 +10575,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10591,7 +10591,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10608,7 +10608,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "40.1.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -10639,7 +10639,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "26.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10665,7 +10665,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10680,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10699,7 +10699,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10717,7 +10717,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10733,7 +10733,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "43.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -10749,7 +10749,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -10761,7 +10761,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10780,7 +10780,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10795,7 +10795,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.3.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10811,7 +10811,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10825,7 +10825,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10835,7 +10835,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "19.2.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -10860,7 +10860,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "20.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10877,7 +10877,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.16.3"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -10944,7 +10944,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "21.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -11275,7 +11275,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -11293,7 +11293,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "23.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -11308,7 +11308,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -11331,7 +11331,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "fatality",
@@ -11364,7 +11364,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -11388,7 +11388,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11411,7 +11411,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "17.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11422,7 +11422,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -11444,7 +11444,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "19.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -11458,7 +11458,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "23.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -11479,7 +11479,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -11502,7 +11502,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -11520,7 +11520,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -11552,7 +11552,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.6.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11576,7 +11576,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bitvec",
  "futures 0.3.31",
@@ -11595,7 +11595,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11616,7 +11616,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-subsystem",
@@ -11631,7 +11631,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11653,7 +11653,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-metrics",
@@ -11667,7 +11667,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "futures-timer",
@@ -11683,7 +11683,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -11701,7 +11701,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11718,7 +11718,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "22.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -11732,7 +11732,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11749,7 +11749,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -11777,7 +11777,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-subsystem",
@@ -11790,7 +11790,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "19.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cpu-time",
  "futures 0.3.31",
@@ -11816,7 +11816,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "polkadot-node-metrics",
@@ -11831,7 +11831,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bs58",
  "futures 0.3.31",
@@ -11848,7 +11848,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "23.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -11873,7 +11873,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "19.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -11897,7 +11897,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -11906,7 +11906,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -11934,7 +11934,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -11966,7 +11966,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -11986,7 +11986,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "16.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.20",
@@ -12002,7 +12002,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "18.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -12030,7 +12030,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -12063,7 +12063,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "19.1.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12113,7 +12113,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "20.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -12125,7 +12125,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "19.2.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -12181,7 +12181,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.9.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12216,7 +12216,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -12324,7 +12324,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
@@ -12347,7 +12347,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "19.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13357,7 +13357,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -13455,7 +13455,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "20.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13764,7 +13764,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "31.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "log",
  "sp-core",
@@ -13775,7 +13775,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -13803,7 +13803,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.49.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "log",
@@ -13824,7 +13824,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.44.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -13839,7 +13839,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "43.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "docify",
@@ -13865,7 +13865,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -13876,7 +13876,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.52.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -13921,7 +13921,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "fnv",
  "futures 0.3.31",
@@ -13947,7 +13947,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.46.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -13973,7 +13973,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.49.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -13996,7 +13996,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -14025,7 +14025,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -14061,7 +14061,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -14083,7 +14083,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "29.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -14117,7 +14117,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "29.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -14137,7 +14137,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.49.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -14150,7 +14150,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.35.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -14194,7 +14194,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.35.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.31",
@@ -14214,7 +14214,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.51.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -14249,7 +14249,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.49.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -14272,7 +14272,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.42.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14296,7 +14296,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.38.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "polkavm",
@@ -14310,7 +14310,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.35.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "log",
  "polkavm",
@@ -14321,7 +14321,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.38.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "anyhow",
  "log",
@@ -14338,7 +14338,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.49.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "console",
  "futures 0.3.31",
@@ -14354,7 +14354,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "35.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -14368,7 +14368,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -14396,7 +14396,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.50.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -14446,7 +14446,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.48.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -14456,7 +14456,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "ahash",
  "futures 0.3.31",
@@ -14475,7 +14475,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.49.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -14496,7 +14496,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.49.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -14531,7 +14531,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.49.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "futures 0.3.31",
@@ -14550,7 +14550,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.16.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bs58",
  "bytes",
@@ -14569,7 +14569,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bytes",
  "fnv",
@@ -14603,7 +14603,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -14612,7 +14612,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -14644,7 +14644,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.49.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -14664,7 +14664,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "22.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -14688,7 +14688,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "futures 0.3.31",
@@ -14721,7 +14721,7 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
@@ -14736,7 +14736,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.51.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "directories",
@@ -14800,7 +14800,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.38.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14811,7 +14811,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.24.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "clap",
  "fs4",
@@ -14824,7 +14824,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -14843,7 +14843,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "42.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "derive_more 0.99.20",
  "futures 0.3.31",
@@ -14863,7 +14863,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "28.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "chrono",
  "futures 0.3.31",
@@ -14882,7 +14882,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "chrono",
  "console",
@@ -14911,7 +14911,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -14922,7 +14922,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -14954,7 +14954,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -14971,7 +14971,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "18.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.31",
@@ -15624,7 +15624,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "17.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -15887,7 +15887,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.13.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bp-relayers",
  "ethabi-decode",
@@ -15973,7 +15973,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "36.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "hash-db",
@@ -15995,7 +15995,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "22.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -16009,7 +16009,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16021,7 +16021,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -16035,7 +16035,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "36.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16047,7 +16047,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "36.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -16057,7 +16057,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -16076,7 +16076,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.42.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -16090,7 +16090,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.42.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16106,7 +16106,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.42.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16124,7 +16124,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "24.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16144,7 +16144,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "23.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -16161,7 +16161,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.42.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16172,7 +16172,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "36.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -16233,7 +16233,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -16246,7 +16246,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503)",
@@ -16256,7 +16256,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -16265,7 +16265,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16275,7 +16275,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -16285,7 +16285,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.17.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16297,7 +16297,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "36.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -16310,7 +16310,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "40.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bytes",
  "docify",
@@ -16336,7 +16336,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -16346,7 +16346,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.42.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -16357,7 +16357,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -16366,7 +16366,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.10.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-metadata 20.0.0",
  "parity-scale-codec",
@@ -16376,7 +16376,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16387,7 +16387,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "36.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16404,7 +16404,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "36.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16417,7 +16417,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "36.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -16427,7 +16427,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "backtrace",
  "regex",
@@ -16436,7 +16436,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -16446,7 +16446,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "41.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -16475,7 +16475,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "29.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -16494,7 +16494,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "Inflector",
  "expander",
@@ -16507,7 +16507,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "38.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16521,7 +16521,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "38.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -16534,7 +16534,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.45.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "hash-db",
  "log",
@@ -16554,7 +16554,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "20.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -16578,12 +16578,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -16595,7 +16595,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "36.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16607,7 +16607,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -16618,7 +16618,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "36.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -16627,7 +16627,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "36.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16641,7 +16641,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "39.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "ahash",
  "hash-db",
@@ -16663,7 +16663,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -16680,7 +16680,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -16692,7 +16692,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -16704,7 +16704,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -16893,7 +16893,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -16906,7 +16906,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "16.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -16927,7 +16927,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "20.1.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "environmental",
  "frame-support",
@@ -16951,7 +16951,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "19.1.3"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -17077,7 +17077,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.12.2",
@@ -17102,7 +17102,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 
 [[package]]
 name = "substrate-fixed"
@@ -17117,7 +17117,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -17137,7 +17137,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.3"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -17151,7 +17151,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.49.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -17164,7 +17164,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "43.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -17181,7 +17181,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -17206,7 +17206,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "frame-executive",
@@ -17250,7 +17250,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "futures 0.3.31",
  "sc-block-builder",
@@ -17278,7 +17278,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "26.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -18049,7 +18049,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "19.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -18060,7 +18060,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "expander",
  "proc-macro-crate 3.3.0",
@@ -18951,7 +18951,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -19060,7 +19060,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "20.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -19599,7 +19599,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -19610,7 +19610,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.7.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -19624,7 +19624,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "20.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#0f69fab280f4865fe0e674e2842b2801c34ff880"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2503#f1c87aa36c6cc49ae5e010bdaed36f39e10e6096"
 dependencies = [
  "frame-support",
  "frame-system",


### PR DESCRIPTION
### What does it do?

This includes 2 new polkadot-sdk commits: https://github.com/moonbeam-foundation/polkadot-sdk/compare/0f69fab280f4865fe0e674e2842b2801c34ff880...f1c87aa36c6cc49ae5e010bdaed36f39e10e6096

- [Stronger WASM compression ](https://github.com/paritytech/polkadot-sdk/pull/9875) Reduces the wasm runtime size
- [sync/fix: Clear gap sync on known imported blocks](https://github.com/paritytech/polkadot-sdk/pull/8445) This one should address the :fast_forward: `Block history` misleading logs we have seen in recent releases.