### PR TITLE
Skip required jobs when only markdown or txt files are changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,6 @@ jobs:
           files_ignore: |
             **.md
             **.txt
-            **/**.yml
 
   check-copyright:
     if: needs.set-tags.outputs.any_changed == 'true'


### PR DESCRIPTION
### What does it do?

Follow-up of https://github.com/moonbeam-foundation/moonbeam/pull/3518, adding `paths-ignore` was not enough.