### PR TITLE
CI: revert paths-ignore in Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,6 @@ name: Build
 
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
   push:
     branches:
       - master


### PR DESCRIPTION
### What does it do?

Follow-up of https://github.com/moonbeam-foundation/moonbeam/pull/3518, adding `paths-ignore` was incorrect.