### PR TITLE
Reduce Minimum Collator Candidate Stake from 500K to 100K GLMR

### DIFF
--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -848,7 +848,7 @@ impl pallet_parachain_staking::Config for Runtime {
 	/// Maximum delegations per delegator
 	type MaxDelegationsPerDelegator = ConstU32<100>;
 	/// Minimum stake required to be reserved to be a candidate
-	type MinCandidateStk = ConstU128<{ 1_000 * currency::GLMR * currency::SUPPLY_FACTOR }>;
+	type MinCandidateStk = ConstU128<{ 100_000 * currency::GLMR }>;
 	/// Minimum stake required to be reserved to be a delegator
 	type MinDelegation = ConstU128<{ 500 * currency::MILLIGLMR * currency::SUPPLY_FACTOR }>;
 	type BlockAuthor = AuthorInherent;


### PR DESCRIPTION
### What does it do?

This PR reduces the minimum self-bond requirement for collator candidates from `500,000` GLMR to `100,000` GLMR, making it more accessible to participate in network as a collator.

## Motivation

This change implements a community-driven proposal discussed in the [Moonbeam forum](https://forum.moonbeam.network/t/reducing-glmr-self-bond-and-active-set/2351). Lowering the barrier to entry will improve network accessibility for smaller operators