### PR TITLE
fix publish-draft-release workflow

### DIFF
--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -54,10 +54,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
-      - name: Prepare moonbeam binary for release body generation
-        working-directory: build
-        run: |
-          mv moonbeam-x86-64 moonbeam
       - name: Generate release body
         id: generate-release-body
         env:


### PR DESCRIPTION
Removed dependency on the 'build-binary' job for the publish-draft-release job.

### What does it do?

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
