### PR TITLE
Remove Integritee and Phala from foreign chains smoke test

### DIFF
--- a/test/helpers/foreign-chains.ts
+++ b/test/helpers/foreign-chains.ts
@@ -143,10 +143,6 @@ export const ForeignChainsEndpoints = [
         paraId: 2034,
       },
       {
-        name: "Phala",
-        paraId: 2035,
-      },
-      {
         name: "Unique",
         paraId: 2037,
       },


### PR DESCRIPTION
Removes Integritee and Phala chain entries from foreign chains list.

Context: 
- https://x.com/integri_t_e_e/status/1983154906090377339
- https://forum.phala.network/t/phala-network-migration-execution-notice-migration-from-phala-parachain-to-ethereum-l2-network/4001
