### PR TITLE
Use the selected backend worker (Libp2p vs Litep2p)

### DIFF
--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1253,17 +1253,30 @@ where
 		+ cumulus_primitives_core::RelayParentOffsetApi<Block>,
 	Customizations: ClientCustomizations + 'static,
 {
-	start_node_impl::<RuntimeApi, Customizations, sc_network::NetworkWorker<_, _>>(
-		parachain_config,
-		polkadot_config,
-		collator_options,
-		para_id,
-		rpc_config,
-		block_authoring_duration,
-		hwbench,
-		node_extra_args
-	)
-	.await
+	match parachain_config.network.network_backend {
+			sc_network::config::NetworkBackendType::Libp2p =>
+				start_node_impl::<RuntimeApi, Customizations, sc_network::NetworkWorker<_, _>>(
+					parachain_config,
+					polkadot_config,
+					collator_options,
+					para_id,
+					rpc_config,
+					block_authoring_duration,
+					hwbench,
+					node_extra_args
+				).await,
+			sc_network::config::NetworkBackendType::Litep2p =>
+				start_node_impl::<RuntimeApi, Customizations, sc_network::Litep2pNetworkBackend>(
+					parachain_config,
+					polkadot_config,
+					collator_options,
+					para_id,
+					rpc_config,
+					block_authoring_duration,
+					hwbench,
+					node_extra_args
+				).await
+		}
 }
 
 /// Builds a new development service. This service uses manual seal, and mocks


### PR DESCRIPTION
## What does it do?

Context: https://github.com/paritytech/polkadot-sdk/pull/8461

This PR updates Moonbeam’s node startup wiring so the selected P2P backend is actually used. Instead of always building the networking stack with the `libp2p` worker type, `start_node` now branches on `parachain_config.network.network_backend` and instantiates the appropriate backend (Libp2p vs Litep2p). The `Litep2p` is the default on recent polkadot-sdk versions.

### Context

When a node is configured to run with Litep2p, the service should construct the corresponding networking backend. This change ensures Moonbeam respects the configured backend selection and avoids mismatched network worker types.