### PR TITLE
[MOON-3375] Fix smoke test "S22C500 all delegators lessTotal matches revoke/decrease requests"

### DIFF
--- a/test/suites/smoke/test-staking-consistency.ts
+++ b/test/suites/smoke/test-staking-consistency.ts
@@ -209,7 +209,8 @@ describeSuite({
             ]: any
           ) => {
             for (const request of requests) {
-              const delegatorHex = specVersion < 4_100 ? request.delegator.toHex() : delegator.toHex();
+              const delegatorHex =
+                specVersion < 4_100 ? request.delegator.toHex() : delegator.toHex();
               p[delegatorHex] = p[delegatorHex] || [];
               p[delegatorHex].push(request);
             }


### PR DESCRIPTION
### What does it do?

This PR adds a local `delegatorHex` variable inside the `for` loop so we do not mutate `delegator` for `requests.length >= 2`.
