### PR TITLE
CI: improve coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -141,10 +141,7 @@ jobs:
         run: |
           # curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-          # echo $PATH
-          # TODO: remove the --exclude once the following issue is solved (possibly in rustc 1.86)
-          # - https://github.com/rust-lang/rust/issues/125353
-          cargo nextest run --release --workspace --features=evm-tracing --exclude moonbeam-service
+          cargo nextest run --release --workspace --features=evm-tracing
       - name: "Run Moonwall Dev Tests"
         uses: ./.github/workflow-templates/dev-tests
         with:


### PR DESCRIPTION
### What does it do?

Removes a TODO in the coverage workflow, which was added in old versions of rustc.
