### PR TITLE
Use `using_fake_author` at `initialize_pending_block()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-backing-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "sp-api",
  "sp-consensus-slots",
@@ -1198,7 +1198,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "hash-db",
  "log",
@@ -2572,7 +2572,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.24.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2642,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.24.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.24.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2739,7 +2739,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.18.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2760,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.24.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2831,7 +2831,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.21.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "array-bytes 6.2.3",
  "bytes",
@@ -2869,7 +2869,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -2949,7 +2949,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.19.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2966,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.19.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2980,7 +2980,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.13.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2990,7 +2990,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "12.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3052,7 +3052,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.24.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3149,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures 0.3.31",
@@ -3163,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4502,7 +4502,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4629,7 +4629,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "41.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4732,7 +4732,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -4743,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4760,7 +4760,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "41.0.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4832,7 +4832,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -4873,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4893,7 +4893,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.3.0",
@@ -4905,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4915,7 +4915,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "41.0.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4934,7 +4934,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4948,7 +4948,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4958,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.47.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5751,7 +5751,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -8788,7 +8788,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "async-backing-primitives",
  "async-trait",
@@ -8837,7 +8837,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -9259,7 +9259,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9325,7 +9325,7 @@ dependencies = [
 [[package]]
 name = "pallet-async-backing"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -9345,7 +9345,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9383,8 +9383,9 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
+ "environmental",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -9401,7 +9402,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9416,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9429,7 +9430,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9473,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "42.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9631,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9824,7 +9825,7 @@ dependencies = [
 [[package]]
 name = "pallet-emergency-para-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -10423,7 +10424,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "cumulus-primitives-core",
  "evm",
@@ -10622,7 +10623,7 @@ dependencies = [
 [[package]]
 name = "pallet-maintenance-mode"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10638,7 +10639,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10694,7 +10695,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10982,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -11053,7 +11054,7 @@ dependencies = [
 [[package]]
 name = "pallet-relay-storage-roots"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -11188,7 +11189,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -11242,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -11350,7 +11351,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11386,7 +11387,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11502,7 +11503,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "20.1.3"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -11646,8 +11647,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
- "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -12080,7 +12081,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "18.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12113,7 +12114,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "20.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -12500,7 +12501,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bs58",
  "futures 0.3.31",
@@ -12517,7 +12518,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -12542,7 +12543,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "20.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -12566,7 +12567,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -12575,7 +12576,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -12603,7 +12604,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "24.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "fatality",
  "futures 0.3.31",
@@ -12717,7 +12718,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -12737,7 +12738,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "17.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.20",
@@ -12753,7 +12754,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "19.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -12865,7 +12866,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "21.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -12877,7 +12878,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "20.0.3"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -12925,7 +12926,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.10.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -13088,7 +13089,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "20.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13649,7 +13650,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -13669,7 +13670,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -14730,7 +14731,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "32.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "log",
  "sp-core",
@@ -14741,7 +14742,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.51.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -14793,7 +14794,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.45.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -14808,7 +14809,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "array-bytes 6.2.3",
  "clap",
@@ -14835,7 +14836,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -14846,7 +14847,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.53.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -14891,7 +14892,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "fnv",
  "futures 0.3.31",
@@ -14917,7 +14918,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.47.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -14945,7 +14946,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -14968,7 +14969,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.51.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -14997,7 +14998,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.51.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -15109,7 +15110,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -15186,7 +15187,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.52.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -15221,7 +15222,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -15244,7 +15245,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15268,7 +15269,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.39.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "polkavm 0.24.0",
@@ -15282,7 +15283,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.36.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "log",
  "polkavm 0.24.0",
@@ -15293,7 +15294,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.39.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "anyhow",
  "log",
@@ -15310,7 +15311,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "console",
  "futures 0.3.31",
@@ -15326,7 +15327,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "36.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.3",
@@ -15340,7 +15341,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.21.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -15368,7 +15369,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.51.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15418,7 +15419,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.49.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -15447,7 +15448,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15489,7 +15490,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15524,7 +15525,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.31",
@@ -15543,7 +15544,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.17.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bs58",
  "bytes",
@@ -15607,7 +15608,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "46.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "futures 0.3.31",
  "jsonrpsee",
@@ -15639,7 +15640,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.50.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15659,7 +15660,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -15683,7 +15684,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.51.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.31",
@@ -15731,7 +15732,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.52.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "directories",
@@ -15795,7 +15796,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.39.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15858,7 +15859,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "43.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "derive_more 0.99.20",
  "futures 0.3.31",
@@ -15878,7 +15879,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "29.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "chrono",
  "futures 0.3.31",
@@ -15897,7 +15898,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "40.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "chrono",
  "console",
@@ -15927,7 +15928,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -15938,7 +15939,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -15969,7 +15970,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -15986,7 +15987,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "19.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.31",
@@ -16484,7 +16485,7 @@ dependencies = [
 [[package]]
 name = "session-keys-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -17029,7 +17030,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "docify",
  "hash-db",
@@ -17051,7 +17052,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -17065,7 +17066,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17077,7 +17078,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "27.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -17091,7 +17092,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17103,7 +17104,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -17113,7 +17114,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "futures 0.3.31",
  "parity-scale-codec",
@@ -17132,7 +17133,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "futures 0.3.31",
@@ -17146,7 +17147,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17162,7 +17163,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17200,7 +17201,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -17217,7 +17218,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17228,7 +17229,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -17290,7 +17291,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -17303,7 +17304,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506)",
@@ -17313,7 +17314,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -17322,7 +17323,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -17332,7 +17333,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -17342,7 +17343,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.18.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17354,7 +17355,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -17367,7 +17368,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "41.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bytes",
  "docify",
@@ -17393,7 +17394,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "42.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -17403,7 +17404,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -17414,7 +17415,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -17423,7 +17424,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.11.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-metadata 23.0.0",
  "parity-scale-codec",
@@ -17433,7 +17434,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17444,7 +17445,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -17461,7 +17462,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17474,7 +17475,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -17484,7 +17485,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "backtrace",
  "regex",
@@ -17493,7 +17494,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "35.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -17503,7 +17504,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "42.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -17532,7 +17533,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "30.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -17551,7 +17552,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "19.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "Inflector",
  "expander",
@@ -17564,7 +17565,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -17578,7 +17579,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -17591,7 +17592,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.46.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "hash-db",
  "log",
@@ -17611,7 +17612,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "21.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -17635,12 +17636,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -17652,7 +17653,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17664,7 +17665,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -17675,7 +17676,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -17684,7 +17685,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17698,7 +17699,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "ahash",
  "foldhash 0.1.5",
@@ -17723,7 +17724,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -17740,7 +17741,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -17752,7 +17753,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "22.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -17764,7 +17765,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "32.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -17979,7 +17980,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "17.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -18000,7 +18001,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "21.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "environmental",
  "frame-support",
@@ -18024,7 +18025,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "20.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -18150,7 +18151,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.12.2",
@@ -18211,7 +18212,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.6"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "http-body-util",
  "hyper 1.6.0",
@@ -19177,7 +19178,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "20.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -19188,7 +19189,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "expander",
  "proc-macro-crate 3.3.0",
@@ -19295,7 +19296,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -20716,7 +20717,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#0a23f9b88c513821b293d33338b0fda6b1cb387e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -20753,7 +20754,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -20764,7 +20765,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.8.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#373ff2c1dd3b3a647d4ae81c637168dca5c86f36"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2506#5f45e6f34ac1490f134d6b76e320ffc990307703"
 dependencies = [
  "frame-support",
  "parity-scale-codec",

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -653,7 +653,9 @@ macro_rules! impl_runtime_apis_plus_common {
 
 				fn initialize_pending_block(header: &<Block as BlockT>::Header) {
 					pallet_randomness::vrf::using_fake_vrf(|| {
-						let _ = Executive::initialize_block(header);
+						pallet_author_slot_filter::using_fake_author(|| {
+							let _ = Executive::initialize_block(header);
+						})
 					})
 				}
 			}


### PR DESCRIPTION
### What does it do?
This PR uses `pallet-author-slot-filter::using_fake_author()` at runtime `EthereumRuntimeRPCApi::initialize_pending_block()`.

This logic allows any `NimbuId` to author a block making the pending block workflow complete without any `storage transactions are left open by the runtime.` warnings.