### PR TITLE
fix: 🛠️ Fix lazy-loading test case

### DIFF
--- a/node/service/src/lazy_loading/helpers.rs
+++ b/node/service/src/lazy_loading/helpers.rs
@@ -55,7 +55,11 @@ pub fn produce_first_block<Block: BlockT + sp_runtime::DeserializeOwned>(
 
 	// Update System::Number so that frame_system::initialize() doesn't panic
 	// with "Block number must be strictly increasing" on the next block.
-	let number_key = [twox_128(b"System").as_slice(), twox_128(b"Number").as_slice()].concat();
+	let number_key = [
+		twox_128(b"System").as_slice(),
+		twox_128(b"Number").as_slice(),
+	]
+	.concat();
 	state_overrides.push((number_key, next_block_number.encode()));
 
 	let _ = op.reset_storage(


### PR DESCRIPTION
### What does it do?
Fixes the perpetually failing lazy loading test case failure with error `RpcError: 20000: no nimbus keys available to manual seal`

When we forked from mainet we were at height N, when we should have been at N+1

### What important points should reviewers know?

This issue has always been around but old polkadot-SDK didn't enforce the block num in this way strictly. Rebasing to `stable2506` has an addition `assert_eq!()` which now trips the short circuit.

### What value does it bring to the blockchain users?
Improve monitoring and reliability
