### PR TITLE
fix: 🛠️ Resolve coverage CI flakiness

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Enable coverage gathering
         run: |
           # Enable coverage when running tests
-          echo "LLVM_PROFILE_FILE=$(pwd)/proffiles/default_%m_%p.profraw" >> $GITHUB_ENV
+          echo "LLVM_PROFILE_FILE=$(pwd)/proffiles/default_%m.profraw" >> $GITHUB_ENV
       - name: Unit tests
         run: |
           # curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash


### PR DESCRIPTION
### What does it do?
Currently the coverage job generates many thousand of individual profiling files. By removing the `%p` specifier we use LLVM's online merging reducing in far fewer files - and thus far less memory required to merge them. 

This will massively reduce the burden on the CI runners which reguarly fail this task when other CI jobs are running. The downside is that this will increase the time (somewhat) due to these pre-merges.

> [!NOTE]  
> This PR reduces profFiles size 98.5% (79 GB => 1.2 GB), without loss of coverage

### What value does it bring to the blockchain users?
Better error logging