### PR TITLE
Configure coderabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+  commit_status: true
+  enable_prompt_for_ai_agents: true
+  high_level_summary: false
+  poem: false
+  profile: "chill"
+  review_status: true
+  review_details: false
+  request_changes_workflow: true
+chat:
+  auto_reply: true


### PR DESCRIPTION
### What does it do?

Configure CodeRabbit to approve PRs when it has no blocking comments, and never edit the PR description. Instead, ask for clarification if the description is not clear enough.