### PR TITLE
Depend on MBF's `ethereum` fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-backing-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "sp-api",
  "sp-consensus-slots",
@@ -3920,8 +3920,7 @@ dependencies = [
 [[package]]
 name = "ethereum"
 version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee371ebb7479ed3258617557ab0b3247e741075cb6b02b820d188f68da44441"
+source = "git+https://github.com/moonbeam-foundation/ethereum?branch=moonbeam-polkadot-stable2506#cf3076f07e61102eec686f6816da668f97d94f1f"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -4001,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "evm"
 version = "0.43.4"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2506#349849116745a3a1bbb52102ab2d6aad0fd3ce56"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2506#662508e1a60f9d7aaf300fed832d86c67ef4f1d1"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -4021,7 +4020,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2506#349849116745a3a1bbb52102ab2d6aad0fd3ce56"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2506#662508e1a60f9d7aaf300fed832d86c67ef4f1d1"
 dependencies = [
  "parity-scale-codec",
  "primitive-types 0.13.1",
@@ -4032,7 +4031,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2506#349849116745a3a1bbb52102ab2d6aad0fd3ce56"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2506#662508e1a60f9d7aaf300fed832d86c67ef4f1d1"
 dependencies = [
  "environmental",
  "evm-core",
@@ -4043,7 +4042,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2506#349849116745a3a1bbb52102ab2d6aad0fd3ce56"
+source = "git+https://github.com/moonbeam-foundation/evm?branch=moonbeam-polkadot-stable2506#662508e1a60f9d7aaf300fed832d86c67ef4f1d1"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -4164,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4176,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4192,7 +4191,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4222,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4245,7 +4244,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4299,7 +4298,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4315,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-v2-api"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "ethereum-types",
  "fc-rpc-v2-types",
@@ -4325,7 +4324,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-v2-types"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "const-hex",
  "ethereum-types",
@@ -4336,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4529,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4547,7 +4546,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4558,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4570,7 +4569,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "environmental",
  "evm",
@@ -4586,7 +4585,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4602,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4614,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8788,7 +8787,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "async-backing-primitives",
  "async-trait",
@@ -8837,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -9325,7 +9324,7 @@ dependencies = [
 [[package]]
 name = "pallet-async-backing"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -9345,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9364,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9383,7 +9382,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9825,7 +9824,7 @@ dependencies = [
 [[package]]
 name = "pallet-emergency-para-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -9867,7 +9866,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "environmental",
  "ethereum",
@@ -9922,7 +9921,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -9947,7 +9946,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10025,7 +10024,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "fp-evm",
 ]
@@ -10033,7 +10032,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bls12381"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "ark-bls12-381 0.4.0",
  "ark-ec 0.4.2",
@@ -10045,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -10201,7 +10200,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "fp-evm",
  "num",
@@ -10403,7 +10402,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -10414,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -10424,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "cumulus-primitives-core",
  "evm",
@@ -10623,7 +10622,7 @@ dependencies = [
 [[package]]
 name = "pallet-maintenance-mode"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10983,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -11054,7 +11053,7 @@ dependencies = [
 [[package]]
 name = "pallet-relay-storage-roots"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -13345,7 +13344,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -13374,7 +13373,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#fc04876e7a35a8a0cecf101906f5c1650c231107"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2506#22da39d0de6571c799d48512232e6b89fc6ee42d"
 dependencies = [
  "case",
  "num_enum 0.7.3",
@@ -16485,7 +16484,7 @@ dependencies = [
 [[package]]
 name = "session-keys-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -20717,7 +20716,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#23f88438df111684ab434750944cf32b9eb10a8e"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2506#13e40bbafd3d400265fd293c9b7d74f204949958"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,7 +234,7 @@ substrate-rpc-client = { git = "https://github.com/moonbeam-foundation/polkadot-
 
 # Frontier (wasm)
 
-ethereum = { version = "0.18.2", default-features = false, features = [
+ethereum = { git = "https://github.com/moonbeam-foundation/ethereum", branch = "moonbeam-polkadot-stable2506", default-features = false, features = [
     "with-scale",
 ] }
 ethereum-types = { version = "0.15.1", default-features = false }
@@ -359,7 +359,9 @@ nimbus-consensus = { git = "https://github.com/Moonsong-Labs/moonkit", branch = 
 async-trait = { version = "0.1.42" }
 derive_more = "0.99.17"
 environmental = { version = "1.1.4", default-features = false }
-frame-metadata = { version = "23.0.0", default-features = false, features = ["current"] }
+frame-metadata = { version = "23.0.0", default-features = false, features = [
+    "current",
+] }
 frame-metadata-hash-extension = { git = "https://github.com/moonbeam-foundation/polkadot-sdk", branch = "moonbeam-polkadot-stable2506", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 hex-literal = { version = "0.4.1", default-features = false }


### PR DESCRIPTION
### What does it do?

Switch the `ethereum` crate dependency from crates.io (`0.18.2`) to the Moonbeam Foundation fork (`moonbeam-polkadot-stable2506` branch).

### Details

- Replace the crates.io `ethereum` dependency with `git+https://github.com/moonbeam-foundation/ethereum?branch=moonbeam-polkadot-stable2506` in the workspace `Cargo.toml`.
- `Cargo.lock` updates reflect the new `ethereum` source and bumped commit hashes across `frontier`, `evm`, and `moonkit` forks (all on `moonbeam-polkadot-stable2506`).
- No code changes; only dependency source and lockfile updates.