### PR TITLE
Add `try-runtime` feature to `moonbeam-cli` and Moonbeam node

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -29,3 +29,6 @@ metadata-hash = ["moonbeam-cli/metadata-hash"]
 runtime-benchmarks = [
 	"moonbeam-cli/runtime-benchmarks"
 ]
+try-runtime = [
+	"moonbeam-cli/try-runtime"
+]

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -65,3 +65,8 @@ runtime-benchmarks = [
 	"sc-service/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks"
 ]
+try-runtime = [
+	"moonbeam-service/try-runtime",
+	"polkadot-cli/try-runtime",
+	"sp-runtime/try-runtime",
+]


### PR DESCRIPTION
### Description

 The check-unused-dependencies CI job fails with:

 ```
   error[E0046]: not all trait items implemented, missing: `try_state`
     --> pallet-bags-list/src/lib.rs:455:1
       |
   455 | impl<T: Config<I>, I: 'static> SortedListProvider<T::AccountId> for Pallet<T, I> {
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `try_state` in implementation
 ```

 This is caused by a Cargo feature unification mismatch when running cargo +nightly udeps --workspace --features runtime-benchmarks,evm-tracing,try-runtime --all-targets.

 moonbeam-service/try-runtime enables polkadot-runtime-common/try-runtime, which activates frame-election-provider-support/try-runtime — making SortedListProvider::try_state() a required trait method. However,
 moonbeam-cli and moonbeam (node) had no try-runtime feature, so polkadot-cli/try-runtime → polkadot-service/try-runtime was never activated, and pallet-bags-list never got try-runtime enabled. The result: the
 trait requires try_state() but the implementation is gated out.

 ### Changes

 - node/cli/Cargo.toml: Add try-runtime feature propagating to moonbeam-service/try-runtime, polkadot-cli/try-runtime, and sp-runtime/try-runtime.
 - node/Cargo.toml: Add try-runtime feature propagating to moonbeam-cli/try-runtime.

 This ensures consistent try-runtime feature activation across the full dependency chain.