### PR TITLE
Pin `pnpm` version via packageManager field

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,8 +189,6 @@ jobs:
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -716,8 +714,6 @@ jobs:
           path: build
       - name: Use pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
@@ -772,8 +768,6 @@ jobs:
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
@@ -828,8 +822,6 @@ jobs:
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9.1.4
       - uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
@@ -880,8 +872,6 @@ jobs:
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"

--- a/.github/workflows/client-release-issue.yml
+++ b/.github/workflows/client-release-issue.yml
@@ -49,8 +49,6 @@ jobs:
           path: original-tools
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Generate client release issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-binary.yml
+++ b/.github/workflows/publish-binary.yml
@@ -80,8 +80,6 @@ jobs:
           node-version-file: "test/.nvmrc"
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Download Original Tools
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -147,8 +147,6 @@ jobs:
           path: original-tools
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Generate release body
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-types-bundle.yml
+++ b/.github/workflows/publish-types-bundle.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/publish-typescript-api.yml
+++ b/.github/workflows/publish-typescript-api.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/runtime-release-issue.yml
+++ b/.github/workflows/runtime-release-issue.yml
@@ -52,8 +52,6 @@ jobs:
           path: original-tools
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Generate runtime release issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-typescript-api.yml
+++ b/.github/workflows/update-typescript-api.yml
@@ -46,7 +46,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -31,8 +31,6 @@ jobs:
           node-version-file: "test/.nvmrc"
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - name: Generate version bump issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -21,5 +21,6 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"
 }


### PR DESCRIPTION
### What does it do?

Add packageManager field to `package.json` to pin `pnpm@9.15.9`, ensuring the same version is used locally (via Corepack) and in CI. Remove hardcoded version from all `pnpm/action-setup` steps since the action reads `packageManager` automatically.

### What important points should reviewers know?

### Is there something left for follow-up PRs?

### What alternative implementations were considered?

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

### What value does it bring to the blockchain users?
