### PR TITLE
 Fix smoke test S21 for relay XCM fees

### DIFF
--- a/test/suites/smoke/test-relay-xcm-fees.ts
+++ b/test/suites/smoke/test-relay-xcm-fees.ts
@@ -23,7 +23,8 @@ describeSuite({
 
     it({
       id: "C100",
-      title: "should register relay asset as active with positive relativePrice in xcmWeightTrader.supportedAssets",
+      title:
+        "should register relay asset as active with positive relativePrice in xcmWeightTrader.supportedAssets",
       test: async function () {
         const relayRuntime = relayApi.runtimeVersion.specName.toString();
         const paraRuntime = paraApi.runtimeVersion.specName.toString();


### PR DESCRIPTION
## Summary

The `xcmTransactor.destinationAssetFeePerSecond` storage was removed in 85045c5c58 ([MOON-3323] Refactor XCM Transactor to Delegate Fee Pricing to XCM Weight Trader) and replaced by `xcmWeightTrader.supportedAssets`.

 This updates the smoke test to query the new pallet and verify that the relay asset (`{parents: 1, interior: "Here"}`) is:
 - Registered in `xcmWeightTrader.supportedAssets`
 - Active (enabled)
 - Has a non-zero `relativePrice`