### PR TITLE
Align Vitest with Moonwall to restore smoke HTML artifacts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: 7.5.3
         version: 7.5.3(@polkadot/util-crypto@14.0.2(@polkadot/util@14.0.2))(@polkadot/util@14.0.2)(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@vitest/ui':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4)
+        specifier: 4.0.18
+        version: 4.0.18(vitest@4.0.18)
       '@zombienet/orchestrator':
         specifier: 0.0.110
         version: 0.0.110(@polkadot/util@14.0.2)(@types/node@24.7.0)(bufferutil@4.0.9)(chokidar@3.6.0)(utf-8-validate@5.0.10)
@@ -120,8 +120,8 @@ importers:
         specifier: 2.41.2
         version: 2.41.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.7.0)(@vitest/ui@3.2.4)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(tsx@4.20.6)(yaml@2.8.1)
+        specifier: 4.0.18
+        version: 4.0.18(@types/node@24.7.0)(@vitest/ui@4.0.18)(jsdom@23.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(tsx@4.20.6)(yaml@2.8.2)
       web3:
         specifier: 4.16.0
         version: 4.16.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)

--- a/test/package.json
+++ b/test/package.json
@@ -41,7 +41,7 @@
     "@polkadot/util-crypto": "14.0.2",
     "@substrate/txwrapper-core": "7.5.3",
     "@substrate/txwrapper-substrate": "7.5.3",
-    "@vitest/ui": "3.2.4",
+    "@vitest/ui": "4.0.18",
     "@zombienet/orchestrator": "0.0.110",
     "@zombienet/utils": "0.0.29",
     "chalk": "5.6.2",
@@ -58,7 +58,7 @@
     "solc": "0.8.31",
     "tsx": "^4.20.6",
     "viem": "2.41.2",
-    "vitest": "3.2.4",
+    "vitest": "4.0.18",
     "web3": "4.16.0",
     "yaml": "2.8.1"
   },


### PR DESCRIPTION
## Summary
- update test workspace Vitest deps to match Moonwall's Vitest major version
- bump `vitest` from `3.2.4` to `4.0.18`
- bump `@vitest/ui` from `3.2.4` to `4.0.18`
- update lockfile entries accordingly

## Why
After the Moonwall refactor, smoke jobs could complete but fail artifact upload because `html/html.meta.json.gz` was not produced. The root cause is a Vitest major-version mismatch between Moonwall (`4.0.18`) and the test workspace (`3.2.4`).

## Verification
- ran: `cd test && rm -rf html && pnpm moonwall test smoke_alphanet S21C100`
- observed: `HTML Report is generated`
- verified file exists: `test/html/html.meta.json.gz`