### PR TITLE
Fix `check-unused-dependencies` CI by pinning nightly and wasm targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -524,7 +524,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: nightly-2026-04-01
           components: rust-src

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -527,7 +527,7 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
-          targets: wasm32-unknown-unknown
+          targets: wasm32v1-none
       - name: Install required dependencies
         run: |
           sudo apt-get install -y libprotobuf-dev protobuf-compiler libclang-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -532,12 +532,12 @@ jobs:
       - name: Install required dependencies
         run: |
           sudo apt-get install -y libprotobuf-dev protobuf-compiler libclang-dev
-          cargo +nightly install cargo-udeps
+          cargo +nightly-2026-04-01 install cargo-udeps
       - name: Check for unused dependencies
         run: |
           # There may be false negatives/positives
           # In case of false positives, check https://github.com/est31/cargo-udeps?tab=readme-ov-file#ignoring-some-of-the-dependencies
-          cargo +nightly udeps --workspace --features runtime-benchmarks,evm-tracing,try-runtime --all-targets
+          cargo +nightly-2026-04-01 udeps --workspace --features runtime-benchmarks,evm-tracing,try-runtime --all-targets
 
   rust-test:
     if: ${{ needs.set-tags.outputs.any_changed == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -524,8 +524,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2026-04-01
           components: rust-src
           targets: wasm32v1-none
       - name: Install required dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -528,7 +528,7 @@ jobs:
         with:
           toolchain: nightly-2026-04-01
           components: rust-src
-          targets: wasm32v1-none
+          targets: wasm32v1-none, wasm32-unknown-unknown
       - name: Install required dependencies
         run: |
           sudo apt-get install -y libprotobuf-dev protobuf-compiler libclang-dev


### PR DESCRIPTION
## Summary

`check-unused-dependencies` started failing because the job environment drifted from the toolchain/target expectations used by `cargo-udeps` and `substrate-wasm-builder`.

This PR makes that job deterministic again by pinning the nightly toolchain used by `cargo-udeps`, and by installing both wasm targets needed during dependency analysis.

## Changes

In `.github/workflows/build.yml` (`check-unused-dependencies` job):

- switch `dtolnay/rust-toolchain` usage to pinned nightly `nightly-2026-04-01`
- install both targets:
  - `wasm32v1-none`
  - `wasm32-unknown-unknown`
- run `cargo-udeps` install and execution with `+nightly-2026-04-01`

## Reviewer notes

- CI/workflow-only change (no runtime logic changes)
- no storage, RPC, or API impact

## Test plan

- [x] `check-unused-dependencies` is passing on this PR
