### PR TITLE
Configure EVM transaction max gas limit to 35 million gas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -3926,7 +3926,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -3956,7 +3956,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "ethereum-types",
  "fc-db",
@@ -3980,7 +3980,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-v2-api"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "ethereum-types",
  "fc-rpc-v2-types",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-v2-types"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "const-hex",
  "ethereum-types",
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "hex",
  "impl-serde",
@@ -4283,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "environmental",
  "evm",
@@ -4322,7 +4322,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "ethereum",
  "ethereum-types",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4350,7 +4350,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9501,7 +9501,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "environmental",
  "ethereum",
@@ -9556,7 +9556,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "environmental",
@@ -9581,7 +9581,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9659,7 +9659,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "fp-evm",
 ]
@@ -9667,7 +9667,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bls12381"
 version = "1.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "ark-bls12-381 0.4.0",
  "ark-ec 0.4.2",
@@ -9679,7 +9679,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9835,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "fp-evm",
  "num",
@@ -10037,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -12929,7 +12929,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -12958,7 +12958,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#4e792270a0e6d5097d7998bf43b618bc975a1ee1"
+source = "git+https://github.com/moonbeam-foundation/frontier?branch=moonbeam-polkadot-stable2512#0d6d5b8fed14f70216ddd8dd7823c30510460f47"
 dependencies = [
  "case",
  "num_enum 0.7.5",

--- a/pallets/erc20-xcm-bridge/src/mock.rs
+++ b/pallets/erc20-xcm-bridge/src/mock.rs
@@ -149,6 +149,7 @@ impl pallet_evm::Config for Test {
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type ChainId = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type OnChargeTransaction = ();
 	type FindAuthor = ();
 	type BlockHashMapping = SubstrateBlockHashMapping<Self>;

--- a/pallets/ethereum-xcm/src/lib.rs
+++ b/pallets/ethereum-xcm/src/lib.rs
@@ -362,6 +362,7 @@ impl<T: Config> Pallet<T> {
 							T::ReservedXcmpWeight::get(),
 						),
 					),
+					transaction_gas_limit: <T as pallet_evm::Config>::TransactionGasLimit::get(),
 					base_fee: U256::zero(),
 					chain_id: 0u64,
 					is_transactional: true,

--- a/pallets/ethereum-xcm/src/mock.rs
+++ b/pallets/ethereum-xcm/src/mock.rs
@@ -190,6 +190,7 @@ impl pallet_evm::Config for Test {
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type ChainId = ChainId;
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type OnChargeTransaction = ();
 	type FindAuthor = FindAuthorTruncated;
 	type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;

--- a/pallets/moonbeam-foreign-assets/src/mock.rs
+++ b/pallets/moonbeam-foreign-assets/src/mock.rs
@@ -138,6 +138,7 @@ impl pallet_evm::Config for Test {
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type ChainId = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type OnChargeTransaction = ();
 	type FindAuthor = ();
 	type BlockHashMapping = SubstrateBlockHashMapping<Self>;

--- a/pallets/moonbeam-lazy-migrations/src/mock.rs
+++ b/pallets/moonbeam-lazy-migrations/src/mock.rs
@@ -139,6 +139,7 @@ impl pallet_evm::Config for Test {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/author-mapping/src/mock.rs
+++ b/precompiles/author-mapping/src/mock.rs
@@ -140,6 +140,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -141,6 +141,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/batch/src/mock.rs
+++ b/precompiles/batch/src/mock.rs
@@ -156,6 +156,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/call-permit/src/mock.rs
+++ b/precompiles/call-permit/src/mock.rs
@@ -135,6 +135,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = ();
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/collective/src/mock.rs
+++ b/precompiles/collective/src/mock.rs
@@ -156,6 +156,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/conviction-voting/src/mock.rs
+++ b/precompiles/conviction-voting/src/mock.rs
@@ -147,6 +147,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/crowdloan-rewards/src/mock.rs
+++ b/precompiles/crowdloan-rewards/src/mock.rs
@@ -195,6 +195,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/gmp/src/mock.rs
+++ b/precompiles/gmp/src/mock.rs
@@ -284,6 +284,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type GasLimitStorageGrowthRatio = GasLimitStorageGrowthRatio;
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();

--- a/precompiles/identity/src/mock.rs
+++ b/precompiles/identity/src/mock.rs
@@ -150,6 +150,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/parachain-staking/src/mock.rs
+++ b/precompiles/parachain-staking/src/mock.rs
@@ -151,6 +151,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/precompile-registry/src/mock.rs
+++ b/precompiles/precompile-registry/src/mock.rs
@@ -135,6 +135,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = ();
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/preimage/src/mock.rs
+++ b/precompiles/preimage/src/mock.rs
@@ -139,6 +139,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/proxy/src/mock.rs
+++ b/precompiles/proxy/src/mock.rs
@@ -183,6 +183,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/randomness/src/mock.rs
+++ b/precompiles/randomness/src/mock.rs
@@ -139,6 +139,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = ();
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/referenda/src/mock.rs
+++ b/precompiles/referenda/src/mock.rs
@@ -163,6 +163,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/relay-data-verifier/src/mock.rs
+++ b/precompiles/relay-data-verifier/src/mock.rs
@@ -202,6 +202,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/relay-encoder/src/mock.rs
+++ b/precompiles/relay-encoder/src/mock.rs
@@ -370,6 +370,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/xcm-transactor/src/mock.rs
+++ b/precompiles/xcm-transactor/src/mock.rs
@@ -218,6 +218,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/xcm-utils/src/mock.rs
+++ b/precompiles/xcm-utils/src/mock.rs
@@ -330,6 +330,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/precompiles/xtokens/src/mock.rs
+++ b/precompiles/xtokens/src/mock.rs
@@ -174,6 +174,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ();
 	type OnChargeTransaction = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -32,3 +32,8 @@ pub mod migrations;
 pub mod tests;
 pub mod types;
 pub mod xcm_origins;
+
+// The default transaction gas limit from EIP-7825 is 16,777,216, which is too low
+// for Moonbeam. Without this cap, Substrate enforces a maximum of 65% of the block
+// gas limit (39 million gas for Moonbeam), so we enforce a cap close to that value.
+pub const TX_MAX_GAS_LIMIT: u64 = 35_000_000;

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -84,6 +84,7 @@ use governance::councils::*;
 use moonbeam_rpc_primitives_txpool::TxPoolResponse;
 use moonbeam_runtime_common::{
 	impl_asset_conversion::AssetRateConverter, impl_multiasset_paymaster::MultiAssetPaymaster,
+	TX_MAX_GAS_LIMIT,
 };
 use nimbus_primitives::CanAuthor;
 use pallet_ethereum::Call::transact;
@@ -428,6 +429,7 @@ pub const BLOCK_STORAGE_LIMIT: u64 = 160 * 1024;
 parameter_types! {
 	pub BlockGasLimit: U256
 		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
+	pub TransactionGasLimit: Option<U256> = Some(U256::from(TX_MAX_GAS_LIMIT));
 	/// The portion of the `NORMAL_DISPATCH_RATIO` that we adjust the fees with. Blocks filled less
 	/// than this will decrease the weight and more will increase.
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(35);
@@ -537,6 +539,7 @@ impl pallet_evm::Config for Runtime {
 		DealWithEthereumPriorityFees<Runtime>,
 	>;
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = TransactionGasLimit;
 	type FindAuthor = FindAuthorAdapter<AccountId20, H160, AuthorInherent>;
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;

--- a/runtime/moonbase/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbase/tests/xcm_mock/parachain.rs
@@ -781,6 +781,7 @@ impl pallet_evm::Config for Runtime {
 	type PrecompilesValue = ();
 	type ChainId = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = moonbase_runtime::TransactionGasLimit;
 	type OnChargeTransaction = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -74,6 +74,7 @@ use moonbeam_runtime_common::{
 	},
 	impl_asset_conversion::AssetRateConverter,
 	impl_multiasset_paymaster::MultiAssetPaymaster,
+	TX_MAX_GAS_LIMIT,
 };
 pub use pallet_author_slot_filter::EligibilityValue;
 use pallet_ethereum::Call::transact;
@@ -424,6 +425,7 @@ pub const BLOCK_STORAGE_LIMIT: u64 = 160 * 1024;
 parameter_types! {
 	pub BlockGasLimit: U256
 		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
+	pub TransactionGasLimit: Option<U256> = Some(U256::from(TX_MAX_GAS_LIMIT));
 	/// The portion of the `NORMAL_DISPATCH_RATIO` that we adjust the fees with. Blocks filled less
 	/// than this will decrease the weight and more will increase.
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(35);
@@ -537,6 +539,7 @@ impl pallet_evm::Config for Runtime {
 		DealWithEthereumPriorityFees<Runtime>,
 	>;
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = TransactionGasLimit;
 	type FindAuthor = FindAuthorAdapter<AuthorInherent>;
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;

--- a/runtime/moonbeam/tests/xcm_mock/parachain.rs
+++ b/runtime/moonbeam/tests/xcm_mock/parachain.rs
@@ -774,6 +774,7 @@ impl pallet_evm::Config for Runtime {
 	type PrecompilesValue = ();
 	type ChainId = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = moonbeam_runtime::TransactionGasLimit;
 	type OnChargeTransaction = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -75,6 +75,7 @@ use moonbeam_runtime_common::{
 		ProofSizeToFee, RefTimeToFee, WeightToFee,
 	},
 	impl_multiasset_paymaster::MultiAssetPaymaster,
+	TX_MAX_GAS_LIMIT,
 };
 pub use pallet_author_slot_filter::EligibilityValue;
 use pallet_ethereum::Call::transact;
@@ -427,6 +428,7 @@ pub const BLOCK_STORAGE_LIMIT: u64 = 160 * 1024;
 parameter_types! {
 	pub BlockGasLimit: U256
 		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
+	pub TransactionGasLimit: Option<U256> = Some(U256::from(TX_MAX_GAS_LIMIT));
 	/// The portion of the `NORMAL_DISPATCH_RATIO` that we adjust the fees with. Blocks filled less
 	/// than this will decrease the weight and more will increase.
 	pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(35);
@@ -540,6 +542,7 @@ impl pallet_evm::Config for Runtime {
 		DealWithEthereumPriorityFees<Runtime>,
 	>;
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = TransactionGasLimit;
 	type FindAuthor = FindAuthorAdapter<AuthorInherent>;
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;

--- a/runtime/moonriver/tests/xcm_mock/parachain.rs
+++ b/runtime/moonriver/tests/xcm_mock/parachain.rs
@@ -771,6 +771,7 @@ impl pallet_evm::Config for Runtime {
 	type PrecompilesValue = ();
 	type ChainId = ();
 	type BlockGasLimit = BlockGasLimit;
+	type TransactionGasLimit = moonriver_runtime::TransactionGasLimit;
 	type OnChargeTransaction = ();
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();

--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -27,6 +27,9 @@ export const DEFAULT_MAX_TX_INPUT_BYTES = 4 * TX_SLOT_BYTE_SIZE;
 // EIP-7825: Maximum transaction gas limit cap (2^24)
 export const EIP_7825_MAX_TRANSACTION_GAS_LIMIT = 16_777_216n;
 
+// Moonbeam overrides the EIP-7825 default because it is too low for current block limits.
+export const TX_MAX_GAS_LIMIT = 35_000_000n;
+
 /**
  * Class allowing to store multiple value for a runtime constant based on the runtime version
  */

--- a/test/suites/dev/common/test-block/test-block-gas.ts
+++ b/test/suites/dev/common/test-block/test-block-gas.ts
@@ -6,7 +6,11 @@ import {
   deployCreateCompiledContract,
   beforeAll,
 } from "moonwall";
-import { ConstantStore, EIP_7825_MAX_TRANSACTION_GAS_LIMIT } from "../../../../helpers";
+import {
+  ConstantStore,
+  EIP_7825_MAX_TRANSACTION_GAS_LIMIT,
+  TX_MAX_GAS_LIMIT,
+} from "../../../../helpers";
 
 describeSuite({
   id: "D010103",
@@ -35,13 +39,13 @@ describeSuite({
 
       it({
         id: `T0${TransactionTypes.indexOf(txnType) * 2 + 1}`,
-        title: `${txnType} should fail exceeding EIP-7825 transaction gas limit cap`,
+        title: `${txnType} should fail exceeding transaction gas limit cap`,
         test: async function () {
           await expect(
             async () =>
               await deployCreateCompiledContract(context, "MultiplyBy7", {
                 type: txnType,
-                gas: EIP_7825_MAX_TRANSACTION_GAS_LIMIT + 1n,
+                gas: TX_MAX_GAS_LIMIT + 1n,
               }),
             "Transaction should be reverted but instead contract deployed"
           ).rejects.toThrowError("exceeds transaction gas limit cap");


### PR DESCRIPTION
### What does it do?


Update the Frontier pin and configure Moonbeam runtimes for Frontier's new EVM transaction gas cap support.

- Pinned Frontier dependencies in `Cargo.lock` to `0d6d5b8fed14f70216ddd8dd7823c30510460f47`.
- Added `TX_MAX_GAS_LIMIT = 35_000_000` in `runtime/common/src/lib.rs`.
- Wired `TransactionGasLimit` into Moonbeam, Moonriver, and Moonbase `pallet_evm::Config`.
- Passed the configured transaction gas limit into Ethereum XCM transaction validation.
- Documented why Moonbeam uses `35_000_000` instead of the EIP-7825 default `16_777_216`.