### PR TITLE
enforce slot based and make offset dynamic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,7 +648,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "async-backing-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "sp-api",
  "sp-consensus-slots",
@@ -8430,7 +8430,7 @@ dependencies = [
 [[package]]
 name = "nimbus-consensus"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "async-backing-primitives",
  "async-trait",
@@ -8480,7 +8480,7 @@ dependencies = [
 [[package]]
 name = "nimbus-primitives"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "pallet-async-backing"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -8979,7 +8979,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-inherent"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8998,7 +8998,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-mapping"
 version = "2.0.5"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9017,7 +9017,7 @@ dependencies = [
 [[package]]
 name = "pallet-author-slot-filter"
 version = "0.9.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9459,7 +9459,7 @@ dependencies = [
 [[package]]
 name = "pallet-emergency-para-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xcm"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "cumulus-primitives-core",
  "evm",
@@ -10257,7 +10257,7 @@ dependencies = [
 [[package]]
 name = "pallet-maintenance-mode"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -10634,7 +10634,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10705,7 +10705,7 @@ dependencies = [
 [[package]]
 name = "pallet-relay-storage-roots"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -15952,7 +15952,7 @@ dependencies = [
 [[package]]
 name = "session-keys-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "async-trait",
  "frame-support",
@@ -20212,7 +20212,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.1.0"
-source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#1d7d4ad69b7c4494259f4f04066e4db4148abf0b"
+source = "git+https://github.com/Moonsong-Labs/moonkit?branch=moonbeam-polkadot-stable2512#8fae4417637f8e55ea04b3548809d7f1c22daf64"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",

--- a/node/service/src/lazy_loading/mod.rs
+++ b/node/service/src/lazy_loading/mod.rs
@@ -657,10 +657,8 @@ where
 							}
 						};
 
-						let relay_parent_offset = client_for_xcm
-							.runtime_api()
-							.relay_parent_offset(block)
-							.unwrap_or_default();
+						let relay_parent_offset =
+							client_for_xcm.runtime_api().relay_parent_offset(block)?;
 
 						let mocked_parachain = MockValidationDataInherentDataProvider {
 							current_para_block,

--- a/node/service/src/lazy_loading/mod.rs
+++ b/node/service/src/lazy_loading/mod.rs
@@ -23,7 +23,9 @@ use crate::{
 };
 use cumulus_client_parachain_inherent::{MockValidationDataInherentDataProvider, MockXcmConfig};
 use cumulus_client_service::ParachainTracingExecuteBlock;
-use cumulus_primitives_core::{relay_chain, BlockT, CollectCollationInfo, ParaId};
+use cumulus_primitives_core::{
+	relay_chain, BlockT, CollectCollationInfo, ParaId, RelayParentOffsetApi,
+};
 use fc_rpc::StorageOverrideHandler;
 use fc_rpc_core::types::{FeeHistoryCache, FilterPool};
 use frontier_backend::LazyLoadingFrontierBackend;
@@ -358,7 +360,8 @@ pub async fn new_lazy_loading_service<RuntimeApi, Customizations, Net>(
 ) -> Result<TaskManager, ServiceError>
 where
 	RuntimeApi: ConstructRuntimeApi<Block, LazyLoadingClient<RuntimeApi>> + Send + Sync + 'static,
-	RuntimeApi::RuntimeApi: RuntimeApiCollection,
+	RuntimeApi::RuntimeApi:
+		RuntimeApiCollection + cumulus_primitives_core::RelayParentOffsetApi<Block>,
 	Customizations: ClientCustomizations + 'static,
 	Net: NetworkBackend<Block, Hash>,
 {
@@ -654,6 +657,11 @@ where
 							}
 						};
 
+						let relay_parent_offset = client_for_xcm
+							.runtime_api()
+							.relay_parent_offset(block)
+							.unwrap_or_default();
+
 						let mocked_parachain = MockValidationDataInherentDataProvider {
 							current_para_block,
 							para_id: parachain_id,
@@ -664,7 +672,8 @@ where
 								UpgradeGoAhead::GoAhead
 							}),
 							current_para_block_head,
-							relay_offset: additional_relay_offset.load(Ordering::SeqCst),
+							relay_offset: relay_parent_offset
+								.saturating_add(additional_relay_offset.load(Ordering::SeqCst)),
 							relay_blocks_per_para_block: 1,
 							para_blocks_per_relay_epoch: 10,
 							relay_randomness_config: (),

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -34,7 +34,7 @@ use cumulus_client_service::{
 };
 use cumulus_primitives_core::{
 	relay_chain::{self, well_known_keys, CollatorPair},
-	CollectCollationInfo, ParaId,
+	CollectCollationInfo, ParaId, RelayParentOffsetApi,
 };
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{OverseerHandle, RelayChainInterface, RelayChainResult};
@@ -1297,7 +1297,8 @@ pub async fn new_dev<RuntimeApi, Customizations, Net>(
 ) -> Result<TaskManager, ServiceError>
 where
 	RuntimeApi: ConstructRuntimeApi<Block, FullClient<RuntimeApi>> + Send + Sync + 'static,
-	RuntimeApi::RuntimeApi: RuntimeApiCollection,
+	RuntimeApi::RuntimeApi:
+		RuntimeApiCollection + cumulus_primitives_core::RelayParentOffsetApi<Block>,
 	Customizations: ClientCustomizations + 'static,
 	Net: NetworkBackend<Block, Hash>,
 {
@@ -1548,6 +1549,11 @@ where
 							}
 						};
 
+						let relay_parent_offset = client_for_xcm
+							.runtime_api()
+							.relay_parent_offset(block)
+							.unwrap_or_default();
+
 						let mocked_parachain = MockValidationDataInherentDataProvider {
 							current_para_block,
 							para_id: parachain_id,
@@ -1559,7 +1565,8 @@ where
 								UpgradeGoAhead::GoAhead
 							}),
 							current_para_block_head,
-							relay_offset: additional_relay_offset.load(Ordering::SeqCst),
+							relay_offset: relay_parent_offset
+								.saturating_add(additional_relay_offset.load(Ordering::SeqCst)),
 							relay_blocks_per_para_block: 1,
 							para_blocks_per_relay_epoch: 10,
 							relay_randomness_config: (),

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -1549,10 +1549,8 @@ where
 							}
 						};
 
-						let relay_parent_offset = client_for_xcm
-							.runtime_api()
-							.relay_parent_offset(block)
-							.unwrap_or_default();
+						let relay_parent_offset =
+							client_for_xcm.runtime_api().relay_parent_offset(block)?;
 
 						let mocked_parachain = MockValidationDataInherentDataProvider {
 							current_para_block,

--- a/node/service/src/rpc.rs
+++ b/node/service/src/rpc.rs
@@ -241,14 +241,12 @@ where
 		);
 
 		let maybe_current_para_head = client_for_cidp.expect_header(block);
-		let relay_parent_offset = client_for_cidp
-			.runtime_api()
-			.relay_parent_offset(block)
-			.unwrap_or_default();
+		let maybe_relay_parent_offset = client_for_cidp.runtime_api().relay_parent_offset(block);
 		async move {
 			let current_para_block_head = Some(polkadot_primitives::HeadData(
 				maybe_current_para_head?.encode(),
 			));
+			let relay_parent_offset = maybe_relay_parent_offset?;
 
 			let builder = RelayStateSproofBuilder {
 				para_id,

--- a/node/service/src/rpc.rs
+++ b/node/service/src/rpc.rs
@@ -25,7 +25,7 @@ use sp_block_builder::BlockBuilder;
 
 use crate::client::RuntimeApiCollection;
 use crate::RELAY_CHAIN_SLOT_DURATION_MILLIS;
-use cumulus_primitives_core::{ParaId, PersistedValidationData};
+use cumulus_primitives_core::{ParaId, PersistedValidationData, RelayParentOffsetApi};
 use cumulus_primitives_parachain_inherent::ParachainInherentData;
 use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 use fc_mapping_sync::{kv::MappingSyncWorker, SyncStrategy};
@@ -175,7 +175,7 @@ where
 	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError> + 'static,
 	C: CallApiAt<Block>,
 	C: Send + Sync + 'static,
-	C::Api: RuntimeApiCollection,
+	C::Api: RuntimeApiCollection + RelayParentOffsetApi<Block>,
 	P: TransactionPool<Block = Block, Hash = <Block as BlockT>::Hash> + 'static,
 {
 	use fc_rpc::{
@@ -241,6 +241,10 @@ where
 		);
 
 		let maybe_current_para_head = client_for_cidp.expect_header(block);
+		let relay_parent_offset = client_for_cidp
+			.runtime_api()
+			.relay_parent_offset(block)
+			.unwrap_or_default();
 		async move {
 			let current_para_block_head = Some(polkadot_primitives::HeadData(
 				maybe_current_para_head?.encode(),
@@ -262,8 +266,8 @@ where
 			// Create a dummy parachain inherent data provider which is required to pass
 			// the checks by the para chain system. We use dummy values because in the 'pending context'
 			// neither do we have access to the real values nor do we need them.
-			let (relay_parent_storage_root, relay_chain_state) =
-				builder.into_state_root_and_proof();
+			let (relay_parent_storage_root, relay_chain_state, relay_parent_descendants) =
+				builder.into_state_root_proof_and_descendants(u64::from(relay_parent_offset));
 
 			let vfp = PersistedValidationData {
 				// This is a hack to make `cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases`
@@ -277,7 +281,7 @@ where
 				relay_chain_state,
 				downward_messages: Default::default(),
 				horizontal_messages: Default::default(),
-				relay_parent_descendants: Default::default(),
+				relay_parent_descendants,
 				collator_peer_id: None,
 			};
 

--- a/runtime/common/src/apis.rs
+++ b/runtime/common/src/apis.rs
@@ -90,7 +90,7 @@ macro_rules! impl_runtime_apis_plus_common {
 
 			impl cumulus_primitives_core::RelayParentOffsetApi<Block> for Runtime {
 				fn relay_parent_offset() -> u32 {
-					crate::RELAY_PARENT_OFFSET
+					crate::AsyncBacking::relay_parent_offset()
 				}
 			}
 

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -746,8 +746,6 @@ const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
 /// Maximum number of blocks simultaneously accepted by the Runtime, not yet included
 /// into the relay chain.
 const UNINCLUDED_SEGMENT_CAPACITY: u32 = 3;
-/// Build with an offset of 1 behind the relay chain.
-const RELAY_PARENT_OFFSET: u32 = 1;
 /// How many parachain blocks are processed by the relay chain per parent. Limits the
 /// number of blocks authored per slot.
 const BLOCK_PROCESSING_VELOCITY: u32 = 1;
@@ -771,7 +769,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ConsensusHook = ConsensusHook;
 	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
 	type WeightInfo = moonbase_weights::cumulus_pallet_parachain_system::WeightInfo<Runtime>;
-	type RelayParentOffset = ConstU32<0>;
+	type RelayParentOffset = AsyncBacking;
 }
 
 impl parachain_info::Config for Runtime {}

--- a/runtime/moonbase/tests/common/mod.rs
+++ b/runtime/moonbase/tests/common/mod.rs
@@ -428,7 +428,8 @@ pub fn set_parachain_inherent_data() {
 
 	relay_sproof.additional_key_values = additional_key_values;
 
-	let (relay_parent_storage_root, relay_chain_state) = relay_sproof.into_state_root_and_proof();
+	let (relay_parent_storage_root, relay_chain_state, relay_parent_descendants) = relay_sproof
+		.into_state_root_proof_and_descendants(u64::from(AsyncBacking::relay_parent_offset()));
 
 	let vfp = PersistedValidationData {
 		relay_parent_number: 1u32,
@@ -440,7 +441,7 @@ pub fn set_parachain_inherent_data() {
 		validation_data: vfp,
 		relay_chain_state,
 		collator_peer_id: Default::default(),
-		relay_parent_descendants: Default::default(),
+		relay_parent_descendants,
 	};
 
 	let inbound_messages_data = InboundMessagesData {

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -709,8 +709,6 @@ const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
 /// Maximum number of blocks simultaneously accepted by the Runtime, not yet included
 /// into the relay chain.
 const UNINCLUDED_SEGMENT_CAPACITY: u32 = 3;
-/// Build with an offset of 1 behind the relay chain.
-const RELAY_PARENT_OFFSET: u32 = 1;
 /// How many parachain blocks are processed by the relay chain per parent. Limits the
 /// number of blocks authored per slot.
 const BLOCK_PROCESSING_VELOCITY: u32 = 1;
@@ -734,7 +732,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ConsensusHook = ConsensusHook;
 	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
 	type WeightInfo = moonbeam_weights::cumulus_pallet_parachain_system::WeightInfo<Runtime>;
-	type RelayParentOffset = ConstU32<0>;
+	type RelayParentOffset = AsyncBacking;
 }
 
 pub struct EthereumXcmEnsureProxy;

--- a/runtime/moonbeam/tests/common/mod.rs
+++ b/runtime/moonbeam/tests/common/mod.rs
@@ -444,7 +444,8 @@ pub fn set_parachain_inherent_data() {
 
 	relay_sproof.additional_key_values = additional_key_values;
 
-	let (relay_parent_storage_root, relay_chain_state) = relay_sproof.into_state_root_and_proof();
+	let (relay_parent_storage_root, relay_chain_state, relay_parent_descendants) = relay_sproof
+		.into_state_root_proof_and_descendants(u64::from(AsyncBacking::relay_parent_offset()));
 
 	let vfp = PersistedValidationData {
 		relay_parent_number: 1u32,
@@ -455,7 +456,7 @@ pub fn set_parachain_inherent_data() {
 		validation_data: vfp,
 		relay_chain_state,
 		collator_peer_id: Default::default(),
-		relay_parent_descendants: Default::default(),
+		relay_parent_descendants,
 	};
 
 	let inbound_messages_data = InboundMessagesData {

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -747,8 +747,6 @@ const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
 /// Maximum number of blocks simultaneously accepted by the Runtime, not yet included
 /// into the relay chain.
 const UNINCLUDED_SEGMENT_CAPACITY: u32 = 3;
-/// Build with an offset of 1 behind the relay chain.
-const RELAY_PARENT_OFFSET: u32 = 1;
 /// How many parachain blocks are processed by the relay chain per parent. Limits the
 /// number of blocks authored per slot.
 const BLOCK_PROCESSING_VELOCITY: u32 = 1;
@@ -772,7 +770,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 	type ConsensusHook = ConsensusHook;
 	type DmpQueue = frame_support::traits::EnqueueWithOrigin<MessageQueue, RelayOrigin>;
 	type WeightInfo = moonriver_weights::cumulus_pallet_parachain_system::WeightInfo<Runtime>;
-	type RelayParentOffset = ConstU32<0>;
+	type RelayParentOffset = AsyncBacking;
 }
 
 impl parachain_info::Config for Runtime {}

--- a/runtime/moonriver/tests/common/mod.rs
+++ b/runtime/moonriver/tests/common/mod.rs
@@ -444,7 +444,8 @@ pub fn set_parachain_inherent_data() {
 
 	relay_sproof.additional_key_values = additional_key_values;
 
-	let (relay_parent_storage_root, relay_chain_state) = relay_sproof.into_state_root_and_proof();
+	let (relay_parent_storage_root, relay_chain_state, relay_parent_descendants) = relay_sproof
+		.into_state_root_proof_and_descendants(u64::from(AsyncBacking::relay_parent_offset()));
 
 	let vfp = PersistedValidationData {
 		relay_parent_number: 1u32,
@@ -455,7 +456,7 @@ pub fn set_parachain_inherent_data() {
 		validation_data: vfp,
 		relay_chain_state,
 		collator_peer_id: Default::default(),
-		relay_parent_descendants: Default::default(),
+		relay_parent_descendants,
 	};
 
 	let inbound_messages_data = InboundMessagesData {

--- a/test/configs/zombieAlphanet.json
+++ b/test/configs/zombieAlphanet.json
@@ -53,6 +53,7 @@
           "args": [
             "--no-hardware-benchmarks",
             "--force-authoring",
+            "--authoring=slot-based",
             "-lparachain=debug",
             "--database=paritydb",
             "--pool-type=fork-aware"

--- a/test/configs/zombieMoonbeam.json
+++ b/test/configs/zombieMoonbeam.json
@@ -53,6 +53,7 @@
           "args": [
             "--no-hardware-benchmarks",
             "--force-authoring",
+            "--authoring=slot-based",
             "-lparachain=debug",
             "--database=paritydb",
             "--pool-type=fork-aware"

--- a/test/configs/zombieMoonriver.json
+++ b/test/configs/zombieMoonriver.json
@@ -53,6 +53,7 @@
           "args": [
             "--no-hardware-benchmarks",
             "--force-authoring",
+            "--authoring=slot-based",
             "-lparachain=debug",
             "--database=paritydb",
             "--pool-type=fork-aware"

--- a/test/suites/dev/common/test-block/test-block-mocked-relay.ts
+++ b/test/suites/dev/common/test-block/test-block-mocked-relay.ts
@@ -25,7 +25,7 @@ describeSuite({
             blockData.block.extrinsics[index].method
               .args[0] as CumulusPrimitivesParachainInherentParachainInherentData
           ).validationData.relayParentNumber.toString()
-        ).to.eq("0");
+        ).to.eq("1");
         const blockResult2 = await context.createBlock();
         const blockData2 = await context.polkadotJs().rpc.chain.getBlock(blockResult2.block.hash);
         expect(
@@ -33,7 +33,7 @@ describeSuite({
             blockData2.block.extrinsics[index].method
               .args[0] as CumulusPrimitivesParachainInherentParachainInherentData
           ).validationData.relayParentNumber.toString()
-        ).to.eq("1");
+        ).to.eq("2");
       },
     });
   },

--- a/test/suites/dev/moonbase/test-precompile/test-precompile-relay-verifier.ts
+++ b/test/suites/dev/moonbase/test-precompile/test-precompile-relay-verifier.ts
@@ -129,7 +129,7 @@ describeSuite({
             functionName: "latestRelayBlockNumber",
             args: [],
           })
-        ).toBe(1);
+        ).toBe(2);
       },
     });
   },

--- a/test/suites/lazy-loading/common/test-runtime-upgrade.ts
+++ b/test/suites/lazy-loading/common/test-runtime-upgrade.ts
@@ -94,23 +94,25 @@ describeSuite({
         );
         expect(!!versionMigrationFinishedEvt, "Permanent XCM migration was executed").to.be.true;
 
-        // If there are any multi-block migrations, confirm that they are advancing
+        // If the migration queue was started, confirm it drains.
         if (upgradeStartedEvt) {
-          const migrationAdvancedEvt = (await api.query.system.events()).find(({ event }) =>
-            api.events.multiBlockMigrations.MigrationAdvanced.is(event)
-          );
-          expect(!!migrationAdvancedEvt, "Migration Advanced").to.be.true;
-
           // Ensure multi block migrations completed in less than 20 blocks.
           // We don't assume a fixed number of MigrationCompleted events:
-          // there may be one per multi-block migration. Instead, we require
-          // that at least one MigrationCompleted is observed and that
-          // UpgradeCompleted eventually fires, which indicates that all
-          // migrations have finished.
+          // there may be one per multi-block migration. Some upgrades also
+          // emit UpgradeStarted but complete without advancing any migration.
+          // In that case, UpgradeCompleted is enough to prove the queue drained.
+          let sawMigrationAdvanced = false;
           let sawMigrationCompleted = false;
           let sawUpgradeCompleted = false;
           for (let attempts = 0; attempts < 20; attempts++) {
             const events = await api.query.system.events();
+            if (
+              events.some(({ event }) =>
+                api.events.multiBlockMigrations.MigrationAdvanced.is(event)
+              )
+            ) {
+              sawMigrationAdvanced = true;
+            }
             if (
               events.some(({ event }) =>
                 api.events.multiBlockMigrations.MigrationCompleted.is(event)
@@ -127,8 +129,12 @@ describeSuite({
             await context.createBlock();
           }
 
-          expect(sawMigrationCompleted, "At least one MigrationCompleted event should be observed")
-            .to.be.true;
+          if (sawMigrationAdvanced) {
+            expect(
+              sawMigrationCompleted,
+              "At least one MigrationCompleted event should be observed"
+            ).to.be.true;
+          }
           expect(sawUpgradeCompleted, "UpgradeCompleted event should be observed").to.be.true;
         }
       },

--- a/zombienet/configs/moonbeam-polkadot.toml
+++ b/zombienet/configs/moonbeam-polkadot.toml
@@ -36,6 +36,7 @@ rpc_port = 8800
 args = [
     "--no-hardware-benchmarks",
     "--no-telemetry",
+    "--authoring=slot-based",
     "-lruntime::bridge-grandpa=trace",
     "--pool-type=fork-aware"
 ]

--- a/zombienet/configs/moonriver-kusama.toml
+++ b/zombienet/configs/moonriver-kusama.toml
@@ -36,6 +36,7 @@ rpc_port = 8801
 args = [
     "--no-hardware-benchmarks",
     "--no-telemetry",
+    "--authoring=slot-based",
     "-lruntime::bridge-grandpa=trace",
     "--pool-type=fork-aware"
 ]


### PR DESCRIPTION

## ⚠️ Breaking Changes ⚠️

- Runtime consensus validation now enforces the relay parent offset through `cumulus_pallet_parachain_system::Config::RelayParentOffset`.
- Blocks authored with a relay parent offset that does not match the runtime-configured value will be rejected by the runtime.

### What does it do?

Updates the runtimes to use the `AsyncBacking` pallet as the single source of truth for the relay parent offset.

The runtime API now returns `AsyncBacking::relay_parent_offset()`, and Moonbeam, Moonriver, and Moonbase wire `cumulus_pallet_parachain_system::Config::RelayParentOffset` to `AsyncBacking` instead of `ConstU32<0>`.

This makes the slot-based collation offset both dynamic and enforced by runtime consensus checks.

### What important points should reviewers know?

- `Cargo.lock` pins Moonkit to `8fae4417637f8e55ea04b3548809d7f1c22daf64`, which adds the `AsyncBacking` storage value and Root setter for the relay parent offset.
- The previous runtime API returned an offset of `1`, while parachain-system consensus checks used `0`; this PR removes that mismatch.
- The effective default remains `1`, but governance can update it through Moonkit’s `pallet_async_backing::set_relay_parent_offset`.

### Is there something left for follow-up PRs?

No immediate follow-up required.

### What alternative implementations were considered?

Keeping a runtime constant would enforce the offset, but would not allow governance to adjust it without a runtime upgrade. Using `AsyncBacking` directly keeps runtime API behavior and consensus validation aligned around the same storage value.

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

- Moonkit commit: `8fae4417637f8e55ea04b3548809d7f1c22daf64`

### What value does it bring to the blockchain users?

It enforces the slot-based collation relay parent offset at runtime level, reducing the risk of accepting blocks that do not follow the intended async-backing consensus configuration.
