### PR TITLE
Use `U256` at `from_asset_balance()`

### DIFF
--- a/runtime/common/src/impl_asset_conversion.rs
+++ b/runtime/common/src/impl_asset_conversion.rs
@@ -22,6 +22,7 @@ use frame_support::traits::{
 };
 use moonbeam_core_primitives::{AssetId, Balance};
 use pallet_xcm_weight_trader::RELATIVE_PRICE_DECIMALS;
+use sp_core::U256;
 use sp_runtime::traits::MaybeEquivalence;
 
 pub struct AssetRateConverter<T, NativeAsset>(PhantomData<(T, NativeAsset)>);
@@ -47,11 +48,15 @@ impl<
 				let relative_price =
 					pallet_xcm_weight_trader::Pallet::<T>::get_asset_relative_price(&location)
 						.ok_or(pallet_xcm_weight_trader::Error::<T>::AssetNotFound)?;
-				Ok(balance
-					.checked_mul(relative_price)
+				let result = U256::from(balance)
+					.checked_mul(U256::from(relative_price))
 					.ok_or(pallet_xcm_weight_trader::Error::<T>::PriceOverflow)?
-					.checked_div(10u128.pow(RELATIVE_PRICE_DECIMALS))
-					.ok_or(pallet_xcm_weight_trader::Error::<T>::PriceOverflow)?)
+					.checked_div(U256::from(10u128.pow(RELATIVE_PRICE_DECIMALS)))
+					.ok_or(pallet_xcm_weight_trader::Error::<T>::PriceOverflow)?;
+				let result: Balance = result
+					.try_into()
+					.map_err(|_| pallet_xcm_weight_trader::Error::<T>::PriceOverflow)?;
+				Ok(result)
 			}
 		}
 	}

--- a/test/suites/dev/moonbase/test-treasury/test-treasury-spend-asset-rate-converter.ts
+++ b/test/suites/dev/moonbase/test-treasury/test-treasury-spend-asset-rate-converter.ts
@@ -1,0 +1,80 @@
+import "@moonbeam-network/api-augment/moonbase";
+import { TREASURY_ACCOUNT, alith, beforeAll, describeSuite, ethan, expect } from "moonwall";
+import type { ApiPromise } from "@polkadot/api";
+import { foreignAssetBalance, registerAndFundAsset, type TestAsset } from "../../../../helpers";
+
+const RELATIVE_PRICE_USDC_LIKE = 5_000_000_000_000_000_000_000_000_000_000n;
+const BALANCE_RAW_SIX_DECIMAL_USDC = 1_380_000_000n;
+const TEST_ASSET_ID = 777_888n;
+const TEST_PARA = 424_242;
+
+describeSuite({
+  id: "D023704",
+  title: "AssetRateConverter — treasury.spend uses runtime BalanceConverter (wide mul)",
+  foundationMethods: "dev",
+  testCases: ({ context, it }) => {
+    let api: ApiPromise;
+    let assetKind;
+
+    const xcAsset: TestAsset = {
+      id: TEST_ASSET_ID,
+      location: {
+        Xcm: { parents: 1, interior: { X1: { Parachain: TEST_PARA } } },
+      },
+      metadata: {
+        name: "Test USD",
+        symbol: "TUSD",
+        decimals: 6n,
+        isFrozen: false,
+      },
+      relativePrice: RELATIVE_PRICE_USDC_LIKE,
+    };
+
+    const treasuryForeignHold = BALANCE_RAW_SIX_DECIMAL_USDC * 10n;
+
+    beforeAll(async function () {
+      api = context.polkadotJs();
+      assetKind = api.createType("FrameSupportTokensFungibleUnionOfNativeOrWithId", {
+        WithId: xcAsset.id,
+      });
+    });
+
+    it({
+      id: "T01",
+      title: "treasury.spend + payout succeeds when u128 product overflows (AssetRateConverter)",
+      test: async function () {
+        await registerAndFundAsset(context, xcAsset, treasuryForeignHold, TREASURY_ACCOUNT);
+
+        expect(await foreignAssetBalance(context, TEST_ASSET_ID, TREASURY_ACCOUNT)).to.eq(
+          treasuryForeignHold
+        );
+
+        const spendTx = api.tx.treasury.spend(
+          assetKind,
+          BALANCE_RAW_SIX_DECIMAL_USDC,
+          ethan.address,
+          null
+        );
+        await context.createBlock(await api.tx.sudo.sudo(spendTx).signAsync(alith), {
+          allowFailures: false,
+          expectEvents: [api.events.treasury.AssetSpendApproved],
+        });
+
+        expect((await api.query.treasury.spendCount()).toNumber()).to.eq(1);
+
+        await context.createBlock(await api.tx.treasury.payout(0).signAsync(ethan), {
+          allowFailures: false,
+          expectEvents: [api.events.treasury.Paid],
+        });
+
+        expect(
+          await foreignAssetBalance(context, TEST_ASSET_ID, ethan.address as `0x${string}`)
+        ).to.eq(BALANCE_RAW_SIX_DECIMAL_USDC);
+
+        expect(await foreignAssetBalance(context, TEST_ASSET_ID, TREASURY_ACCOUNT)).to.eq(
+          treasuryForeignHold - BALANCE_RAW_SIX_DECIMAL_USDC
+        );
+      },
+    });
+  },
+});


### PR DESCRIPTION
### What does it do?

Fixes `AssetRateConverter::from_asset_balance` so foreign-asset balances are converted to native units using **wide arithmetic** (`U256`) for the intermediate `balance × relative_price` step, then division by `10^RELATIVE_PRICE_DECIMALS` (18), with a final `try_into` to `Balance`.

Previously, a `u128` multiply could overflow even when the **final** native amount still fit in `u128`, causing `PriceOverflow` / failed conversions for realistic XCM weight-trader prices and treasury-scale notionals (e.g. 6-decimal stablecoins).

Adds a **Moonwall dev test** that drives the real runtime path: `treasury.spend` (which uses `Config::BalanceConverter` → `AssetRateConverter`) with a fixture where the product exceeds `u128::MAX`, then `treasury.payout`, and asserts ERC20 foreign-asset balances on treasury and beneficiary.

### What important points should reviewers know?

- **Call site:** `AssetRateConverter` is the runtime `BalanceConverter` for `pallet_treasury` (Moonbase / Moonriver / Moonbeam). `pallet_treasury::spend` converts the spend amount to native for `SpendOrigin` checks via `ConversionFromAssetBalance::from_asset_balance` (see upstream `frame/treasury`).
- **Semantics unchanged:** Same formula `(balance * relative_price) / 10^18`; only the intermediate width changes. `checked_mul` / `checked_div` on `U256` still map failures to `PriceOverflow`; the last `try_into` still errors if the **result** does not fit in `Balance`.
- **Data sources:** `relative_price` and location resolution still come from `pallet_xcm_weight_trader` and `pallet_moonbeam_foreign_assets` as before.
- **Tests:** The new TS suite (`test/suites/dev/moonbase/test-treasury/test-treasury-spend-asset-rate-converter.ts`, id `D023704`) intentionally mirrors production-scale `relative_price` and a raw balance so the old `u128` multiply would overflow.

### Is there something left for follow-up PRs?

No.

### What alternative implementations were considered?

None.

### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

No required upstream dependency changes for this fix.

### What value does it bring to the blockchain users?

Treasury and other flows that convert **foreign-asset amounts to native** using the same relative pricing as XCM fees keep working for **large, realistic** spends and prices, instead of failing with conversion errors when the intermediate product exceeds `u128::MAX`. That restores expected behavior for governance-funded payouts and similar operations denominated in popular low-decimal assets.