### PR TITLE
Consume CallPermit nonce on subcall failure

### DIFF
--- a/precompiles/call-permit/CallPermit.sol
+++ b/precompiles/call-permit/CallPermit.sol
@@ -14,9 +14,9 @@ CallPermit constant CALL_PERMIT_CONTRACT = CallPermit(CALL_PERMIT_ADDRESS);
 /// @custom:address 0x000000000000000000000000000000000000080a
 interface CallPermit {
     /// @dev Dispatch a call on the behalf of an other user with a EIP712 permit.
-    /// Will revert if the permit is not valid or if the dispatched call reverts or errors (such as
-    /// out of gas).
-    /// If successful the EIP712 nonce is increased to prevent this permit to be replayed.
+    /// Will revert if the permit is not valid.
+    /// If the permit is valid, the EIP712 nonce is increased to prevent this permit from being
+    /// replayed even when the dispatched call reverts or errors (such as out of gas).
     /// @param from Who made the permit and want its call to be dispatched on their behalf.
     /// @param to Which address the call is made to.
     /// @param value Value being transfered from the "from" account.

--- a/precompiles/call-permit/src/lib.rs
+++ b/precompiles/call-permit/src/lib.rs
@@ -18,7 +18,7 @@
 
 use core::marker::PhantomData;
 use evm::ExitReason;
-use fp_evm::{Context, ExitRevert, PrecompileFailure, PrecompileHandle, Transfer};
+use fp_evm::{Context, PrecompileFailure, PrecompileHandle, Transfer};
 use frame_support::{
 	ensure,
 	storage::types::{StorageMap, ValueQuery},
@@ -232,12 +232,11 @@ where
 		let (reason, output) =
 			handle.call(to, transfer, data, Some(gas_limit), false, &sub_context);
 		match reason {
-			ExitReason::Error(exit_status) => Err(PrecompileFailure::Error { exit_status }),
+			// A valid permit must be consumed even when the dispatched call fails.
+			// Returning a precompile failure here would revert the nonce increment too.
+			ExitReason::Error(_) => Ok(output.into()),
 			ExitReason::Fatal(exit_status) => Err(PrecompileFailure::Fatal { exit_status }),
-			ExitReason::Revert(_) => Err(PrecompileFailure::Revert {
-				exit_status: ExitRevert::Reverted,
-				output,
-			}),
+			ExitReason::Revert(_) => Ok(output.into()),
 			ExitReason::Succeed(_) => Ok(output.into()),
 		}
 	}

--- a/precompiles/call-permit/src/tests.rs
+++ b/precompiles/call-permit/src/tests.rs
@@ -209,7 +209,7 @@ fn valid_permit_returns() {
 }
 
 #[test]
-fn valid_permit_reverts() {
+fn valid_permit_consumes_nonce_when_subcall_reverts() {
 	ExtBuilder::default()
 		.with_balances(vec![(CryptoAlith.into(), 1000)])
 		.build()
@@ -259,7 +259,7 @@ fn valid_permit_reverts() {
 						from: Address(from),
 						to: Address(to),
 						value,
-						data: data.into(),
+						data: data.clone().into(),
 						gas_limit,
 						deadline,
 						v: v.serialize(),
@@ -302,7 +302,40 @@ fn valid_permit_reverts() {
 				.with_target_gas(Some(call_cost + 100_000 + dispatch_cost()))
 				.expect_cost(call_cost + 13 + dispatch_cost())
 				.expect_no_logs()
-				.execute_reverts(|x| x == b"TEST".to_vec());
+				.execute_returns(UnboundedBytes::from(revert_as_bytes("TEST")));
+
+			precompiles()
+				.prepare_test(
+					CryptoAlith,
+					CallPermit,
+					PCall::nonces {
+						owner: Address(CryptoAlith.into()),
+					},
+				)
+				.expect_cost(0) // TODO: Test db read/write costs
+				.expect_no_logs()
+				.execute_returns(U256::from(1u8));
+
+			precompiles()
+				.prepare_test(
+					Charlie, // can be anyone
+					CallPermit,
+					PCall::dispatch {
+						from: Address(from),
+						to: Address(to),
+						value,
+						data: data.into(),
+						gas_limit,
+						deadline,
+						v: v.serialize(),
+						r: H256::from(rs.r.b32()),
+						s: H256::from(rs.s.b32()),
+					},
+				)
+				.with_subcall_handle(move |_| panic!("should not replay permit"))
+				.with_target_gas(Some(call_cost + 100_000 + dispatch_cost()))
+				.expect_cost(dispatch_cost())
+				.execute_reverts(|x| x == b"Invalid permit");
 		})
 }
 


### PR DESCRIPTION
Ensure CallPermit authorizations are single-use once the permit has been validated, even when the dispatched subcall reverts or returns a non-fatal error.

Previously, CallPermit incremented the nonce before executing the subcall but returned a precompile revert/error when the subcall failed. Frontier then rolled back the EVM substate, including the nonce increment, allowing the same signed permit to be replayed.

Return the subcall failure payload as successful precompile output after nonce consumption so the nonce write is committed. Fatal subcall failures still propagate as fatal errors.

Also update the Solidity interface docs and add a regression test covering nonce consumption and replay rejection after a reverting subcall.
