### PR TITLE
Handle partial pure proxy reserves in balance smoke test

### DIFF
--- a/test/suites/smoke/test-balances-consistency.ts
+++ b/test/suites/smoke/test-balances-consistency.ts
@@ -198,32 +198,31 @@ describeSuite({
       const reserveTypes = Object.keys(expectedReserve);
 
       return (
-        failure.reservedBalance === 0n &&
-        failure.expected > 0n &&
+        failure.expected > failure.reservedBalance &&
         reserveTypes.length === 1 &&
         expectedReserve[ReserveType.Proxy] === failure.expected
       );
     };
 
     const isPureProxyDepositSurplus = (failure: ReservedFailure) => {
-      return failure.expected === 0n && failure.reservedBalance > 0n;
+      return failure.reservedBalance > failure.expected;
     };
 
     const sumPureProxyReserveDelta = (failures: ReservedFailure[]) => {
       return failures.reduce(
         (acc, failure) => {
           if (isPureProxyDepositDeficit(failure)) {
-            acc.expectedOnPureProxy += failure.expected;
+            acc.missingFromPureProxy += failure.expected - failure.reservedBalance;
           } else if (isPureProxyDepositSurplus(failure)) {
-            acc.reservedOnSpawners += failure.reservedBalance;
+            acc.extraReservedOnSpawners += failure.reservedBalance - failure.expected;
           } else {
             acc.unaccountedFailures.push(failure);
           }
           return acc;
         },
         {
-          expectedOnPureProxy: 0n,
-          reservedOnSpawners: 0n,
+          missingFromPureProxy: 0n,
+          extraReservedOnSpawners: 0n,
           unaccountedFailures: [] as ReservedFailure[],
         }
       );
@@ -725,30 +724,30 @@ describeSuite({
       id: "C100",
       title: "should have matching deposit/reserved",
       test: async function () {
-        const { expectedOnPureProxy, reservedOnSpawners, unaccountedFailures } =
+        const { missingFromPureProxy, extraReservedOnSpawners, unaccountedFailures } =
           sumPureProxyReserveDelta(failedReserved);
 
-        if (expectedOnPureProxy > 0n || reservedOnSpawners > 0n) {
+        if (missingFromPureProxy > 0n || extraReservedOnSpawners > 0n) {
           log(
-            `Reconciling pure proxy deposits: expected ${printTokens(
+            `Reconciling pure proxy deposits: missing ${printTokens(
               paraApi,
-              expectedOnPureProxy,
+              missingFromPureProxy,
               1,
               5
-            )} ${symbol} on pure proxy accounts and found ${printTokens(
+            )} ${symbol} from pure proxy accounts and found ${printTokens(
               paraApi,
-              reservedOnSpawners,
+              extraReservedOnSpawners,
               1,
               5
-            )} ${symbol} reserved on spawner accounts`
+            )} ${symbol} extra reserved on spawner accounts`
           );
         }
 
         expect(
-          reservedOnSpawners,
-          `❌ Pure proxy deposit reserves do not balance: expected ${expectedOnPureProxy} ` +
-            `but found ${reservedOnSpawners} reserved on spawner accounts`
-        ).to.equal(expectedOnPureProxy);
+          extraReservedOnSpawners,
+          `❌ Pure proxy deposit reserves do not balance: expected ${missingFromPureProxy} ` +
+            `but found ${extraReservedOnSpawners} reserved on spawner accounts`
+        ).to.equal(missingFromPureProxy);
 
         if (unaccountedFailures.length > 0) {
           log("Failed accounts reserves");


### PR DESCRIPTION
### What does it do?

Follow up PR #3750 by fixing the pure-proxy reserve reconciliation for Moonriver, where the pure proxy account can already hold part of the expected proxy deposit reserve.

### What important points should reviewers know?

PR #3750 reconciled pure proxy deposits by comparing expected pure-proxy deposits with extra reserves found on spawner accounts. Moonriver exposed a variant where the pure proxy account itself has a partial reserved balance, so comparing full expected deposits was too strict.

This change reconciles the delta instead:

- pure proxy deficit: `expected proxy deposit - actual reserved`
- spawner surplus: `actual reserved - expected reserve`
- assert both totals match exactly

This keeps the smoke test strict while supporting both observed live-network shapes:
- Moonbeam: pure proxy has `0` reserved, full deposit is reserved on the spawner
- Moonriver: pure proxy has a partial reserve, remaining deposit is reserved on the spawner

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->