### PR TITLE
Fix underestimated proof-size accounting for precompile storage reads

### DIFF
--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -22,7 +22,7 @@ use crate::{
 	Total,
 };
 use frame_support::pallet_prelude::*;
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use sp_runtime::{
 	traits::{Saturating, Zero},
 	Perbill, Percent, RuntimeDebug,
@@ -34,7 +34,8 @@ pub struct CountedDelegations<T: Config> {
 	pub rewardable_delegations: Vec<Bond<T::AccountId, BalanceOf<T>>>,
 }
 
-#[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo)]
+#[derive(Clone, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
+#[codec(mel_bound(AccountId: MaxEncodedLen, Balance: MaxEncodedLen))]
 pub struct Bond<AccountId, Balance> {
 	pub owner: AccountId,
 	pub amount: Balance,
@@ -1101,7 +1102,7 @@ pub enum DelegatorAdded<B> {
 }
 
 #[allow(deprecated)]
-#[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo)]
+#[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum DelegatorStatus {
 	/// Active with no scheduled exit
 	Active,

--- a/precompiles/conviction-voting/src/lib.rs
+++ b/precompiles/conviction-voting/src/lib.rs
@@ -20,6 +20,7 @@ use account::SYSTEM_ACCOUNT_SIZE;
 use fp_evm::PrecompileHandle;
 use frame_support::dispatch::{GetDispatchInfo, PostDispatchInfo};
 use frame_support::traits::{Currency, Polling};
+use frame_support::BoundedVec;
 use pallet_conviction_voting::Call as ConvictionVotingCall;
 use pallet_conviction_voting::{
 	AccountVote, Casting, ClassLocksFor, Conviction, Delegating, Tally, TallyOf, Vote, Voting,
@@ -27,7 +28,7 @@ use pallet_conviction_voting::{
 };
 use pallet_evm::{AddressMapping, Log};
 use precompile_utils::prelude::*;
-use sp_core::{Get, MaxEncodedLen, H160, H256, U256};
+use sp_core::{MaxEncodedLen, H160, H256, U256};
 use sp_runtime::traits::{Dispatchable, StaticLookup};
 use sp_std::marker::PhantomData;
 use sp_std::vec::Vec;
@@ -56,6 +57,13 @@ type ClassOf<Runtime> = <<Runtime as pallet_conviction_voting::Config>::Polls as
 		<Runtime as pallet_conviction_voting::Config>::MaxTurnout,
 	>,
 >>::Class;
+type ClassLocksForOf<Runtime> = BoundedVec<
+	(ClassOf<Runtime>, BalanceOf<Runtime>),
+	frame_support::traits::ClassCountOf<
+		<Runtime as pallet_conviction_voting::Config>::Polls,
+		TallyOf<Runtime>,
+	>,
+>;
 type VotingOf<Runtime, Instance = ()> = Voting<
 	BalanceOf<Runtime>,
 	<Runtime as frame_system::Config>::AccountId,
@@ -104,7 +112,7 @@ pub struct ConvictionVotingPrecompile<Runtime>(PhantomData<Runtime>);
 impl<Runtime> ConvictionVotingPrecompile<Runtime>
 where
 	Runtime: pallet_conviction_voting::Config + pallet_evm::Config + frame_system::Config,
-	BalanceOf<Runtime>: TryFrom<U256> + Into<U256>,
+	BalanceOf<Runtime>: TryFrom<U256> + Into<U256> + MaxEncodedLen,
 	<Runtime as frame_system::Config>::RuntimeCall:
 		Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
 	<<Runtime as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
@@ -112,7 +120,7 @@ where
 	Runtime::AccountId: Into<H160>,
 	<Runtime as frame_system::Config>::RuntimeCall: From<ConvictionVotingCall<Runtime>>,
 	IndexOf<Runtime>: TryFrom<u32> + TryInto<u32>,
-	ClassOf<Runtime>: TryFrom<u16> + TryInto<u16>,
+	ClassOf<Runtime>: TryFrom<u16> + TryInto<u16> + MaxEncodedLen,
 	<Runtime as pallet_conviction_voting::Config>::Polls: Polling<
 		Tally<
 			<<Runtime as pallet_conviction_voting::Config>::Currency as Currency<
@@ -469,18 +477,8 @@ where
 		handle: &mut impl PrecompileHandle,
 		who: Address,
 	) -> EvmResult<Vec<OutputClassLock>> {
-		// ClassLocksFor: Twox64Concat(8) + 20 + BoundedVec(TransInfo::Id(2) * ClassCountOf)
-		handle.record_db_read::<Runtime>(
-			28 + ((2 * frame_support::traits::ClassCountOf::<
-				<Runtime as pallet_conviction_voting::Config>::Polls,
-				Tally<
-					<<Runtime as pallet_conviction_voting::Config>::Currency as Currency<
-						<Runtime as frame_system::Config>::AccountId,
-					>>::Balance,
-					<Runtime as pallet_conviction_voting::Config>::MaxTurnout,
-				>,
-			>::get()) as usize),
-		)?;
+		// ClassLocksFor: Twox64Concat(8) + AccountId(20) + BoundedVec((ClassOf, BalanceOf)).
+		handle.record_db_read::<Runtime>(28 + ClassLocksForOf::<Runtime>::max_encoded_len())?;
 
 		let who = Runtime::AddressMapping::into_account_id(who.into());
 

--- a/precompiles/conviction-voting/src/tests.rs
+++ b/precompiles/conviction-voting/src/tests.rs
@@ -23,7 +23,7 @@ use precompile_utils::{prelude::*, testing::*};
 use fp_evm::MAX_TRANSACTION_GAS_LIMIT;
 use frame_support::assert_ok;
 use pallet_evm::{Call as EvmCall, Event as EvmEvent};
-use sp_core::{H160, H256, U256};
+use sp_core::{MaxEncodedLen, H160, H256, U256};
 use sp_runtime::{
 	traits::{Dispatchable, PostDispatchInfoOf},
 	DispatchResultWithInfo,
@@ -577,4 +577,15 @@ fn test_class_locks_for_returns_correct_value() {
 					amount: U256::from(100_000),
 				}]);
 		})
+}
+
+#[test]
+fn test_class_locks_for_proof_size_accounts_for_balances() {
+	// 28 bytes for the Twox64Concat account key, plus the max encoded
+	// ClassLocksFor value, including each lock's balance.
+	assert_eq!(crate::ClassLocksForOf::<Runtime>::max_encoded_len(), 52);
+	assert_eq!(
+		28 + crate::ClassLocksForOf::<Runtime>::max_encoded_len(),
+		80
+	);
 }

--- a/precompiles/parachain-staking/src/lib.rs
+++ b/precompiles/parachain-staking/src/lib.rs
@@ -30,6 +30,7 @@ use frame_support::sp_runtime::Percent;
 use frame_support::traits::{fungible::Inspect, Get};
 use pallet_evm::AddressMapping;
 use pallet_parachain_staking::ScheduledRequest;
+use parity_scale_codec::{Compact, Encode};
 use precompile_utils::prelude::*;
 use sp_core::{H160, U256};
 use sp_runtime::traits::Dispatchable;
@@ -52,10 +53,10 @@ pub struct ParachainStakingPrecompile<Runtime>(PhantomData<Runtime>);
 impl<Runtime> ParachainStakingPrecompile<Runtime>
 where
 	Runtime: pallet_parachain_staking::Config + pallet_evm::Config,
-	Runtime::AccountId: Into<H160>,
+	Runtime::AccountId: Into<H160> + MaxEncodedLen,
 	Runtime::RuntimeCall: Dispatchable<PostInfo = PostDispatchInfo> + GetDispatchInfo,
 	Runtime::RuntimeCall: From<pallet_parachain_staking::Call<Runtime>>,
-	BalanceOf<Runtime>: TryFrom<U256> + Into<U256> + solidity::Codec,
+	BalanceOf<Runtime>: TryFrom<U256> + Into<U256> + solidity::Codec + MaxEncodedLen,
 	<Runtime as pallet_evm::Config>::AddressMapping: AddressMapping<Runtime::AccountId>,
 {
 	// Constants
@@ -197,12 +198,7 @@ where
 		delegator: Address,
 	) -> EvmResult<u32> {
 		let delegator = Runtime::AddressMapping::into_account_id(delegator.0);
-		// CandidateInfo:
-		// Twox64Concat(8) + AccountId(20) + Delegator(56 + MaxDelegationsPerDelegator)
-		handle.record_db_read::<Runtime>(
-			84 + (<Runtime as pallet_parachain_staking::Config>::MaxDelegationsPerDelegator::get()
-				as usize),
-		)?;
+		handle.record_db_read::<Runtime>(Self::delegator_state_storage_read_proof_size())?;
 		let result = if let Some(state) =
 			<pallet_parachain_staking::Pallet<Runtime>>::delegator_state(&delegator)
 		{
@@ -252,12 +248,7 @@ where
 		delegator: Address,
 		candidate: Address,
 	) -> EvmResult<U256> {
-		// DelegatorState:
-		// Twox64Concat(8) + AccountId(20) + Delegator(56 + MaxDelegationsPerDelegator)
-		handle.record_db_read::<Runtime>(
-			84 + (<Runtime as pallet_parachain_staking::Config>::MaxDelegationsPerDelegator::get()
-				as usize),
-		)?;
+		handle.record_db_read::<Runtime>(Self::delegator_state_storage_read_proof_size())?;
 		let (candidate, delegator) = (
 			Runtime::AddressMapping::into_account_id(candidate.0),
 			Runtime::AddressMapping::into_account_id(delegator.0),
@@ -316,12 +307,7 @@ where
 	#[precompile::view]
 	fn is_delegator(handle: &mut impl PrecompileHandle, delegator: Address) -> EvmResult<bool> {
 		let delegator = Runtime::AddressMapping::into_account_id(delegator.0);
-		// DelegatorState:
-		// Twox64Concat(8) + AccountId(20) + Delegator(56 + MaxDelegationsPerDelegator)
-		handle.record_db_read::<Runtime>(
-			84 + (<Runtime as pallet_parachain_staking::Config>::MaxDelegationsPerDelegator::get()
-				as usize),
-		)?;
+		handle.record_db_read::<Runtime>(Self::delegator_state_storage_read_proof_size())?;
 		let is_delegator = pallet_parachain_staking::Pallet::<Runtime>::is_delegator(&delegator);
 
 		Ok(is_delegator)
@@ -940,12 +926,7 @@ where
 		handle: &mut impl PrecompileHandle,
 		delegator: Address,
 	) -> EvmResult<U256> {
-		// DelegatorState:
-		// Twox64Concat(8) + AccountId(20) + Delegator(56 + MaxDelegationsPerDelegator)
-		handle.record_db_read::<Runtime>(
-			84 + (<Runtime as pallet_parachain_staking::Config>::MaxDelegationsPerDelegator::get()
-				as usize),
-		)?;
+		handle.record_db_read::<Runtime>(Self::delegator_state_storage_read_proof_size())?;
 
 		let delegator = Runtime::AddressMapping::into_account_id(delegator.0);
 
@@ -978,5 +959,30 @@ where
 		value
 			.try_into()
 			.map_err(|_| RevertReason::value_is_too_large("balance type").into())
+	}
+
+	/// Proof-size upper bound for one read of [`pallet_parachain_staking::Pallet::delegator_state`]
+	/// storage (`Twox64Concat` + `AccountId` key, max-sized SCALE `Delegator` value).
+	pub(crate) fn delegator_state_storage_read_proof_size() -> usize {
+		/// [`frame_support::Twox64Concat`] output length (bytes); Substrate storage key prefix.
+		const TWOX64_CONCAT_PREFIX_LEN: usize = 8;
+		let max_d =
+			<Runtime as pallet_parachain_staking::Config>::MaxDelegationsPerDelegator::get();
+		let delegation_compact_prefix = Compact(max_d).encode().len();
+		let max_bonds_bytes = (max_d as usize).saturating_mul(pallet_parachain_staking::Bond::<
+			Runtime::AccountId,
+			BalanceOf<Runtime>,
+		>::max_encoded_len());
+		// Delegator Max Size = AccountId + MaxDelegationsCompact + (max_d * BondSize) + Balance + Balance + DelegatorStatus
+		let value_max = Runtime::AccountId::max_encoded_len()
+			.saturating_add(delegation_compact_prefix)
+			.saturating_add(max_bonds_bytes)
+			.saturating_add(BalanceOf::<Runtime>::max_encoded_len())
+			.saturating_add(BalanceOf::<Runtime>::max_encoded_len())
+			.saturating_add(pallet_parachain_staking::DelegatorStatus::max_encoded_len());
+		// Total = TWOX64_CONCAT_PREFIX_LEN + AccountId + value_max
+		TWOX64_CONCAT_PREFIX_LEN
+			.saturating_add(Runtime::AccountId::max_encoded_len())
+			.saturating_add(value_max)
 	}
 }

--- a/precompiles/parachain-staking/src/tests.rs
+++ b/precompiles/parachain-staking/src/tests.rs
@@ -15,15 +15,20 @@
 // along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::mock::{
-	events, roll_to, roll_to_round_begin, set_points, ExtBuilder, PCall, ParachainStaking,
-	Precompiles, PrecompilesValue, Runtime, RuntimeCall, RuntimeOrigin,
+	events, roll_to, roll_to_round_begin, set_points, AccountId, ExtBuilder, PCall,
+	ParachainStaking, Precompiles, PrecompilesValue, Runtime, RuntimeCall, RuntimeOrigin,
 };
+use crate::ParachainStakingPrecompile;
 use core::str::from_utf8;
 use fp_evm::MAX_TRANSACTION_GAS_LIMIT;
 use frame_support::assert_ok;
+use frame_support::pallet_prelude::MaxEncodedLen;
 use frame_support::sp_runtime::Percent;
+use frame_support::traits::fungible::Inspect;
 use pallet_evm::Call as EvmCall;
 use pallet_parachain_staking::Event as StakingEvent;
+use pallet_parachain_staking::{Bond, Config as StakingConfig, DelegatorStatus};
+use parity_scale_codec::{Compact, Encode};
 use precompile_utils::{prelude::*, testing::*};
 use sp_core::{H160, U256};
 use sp_runtime::traits::Dispatchable;
@@ -1745,4 +1750,27 @@ fn test_deprecated_solidity_selectors_are_supported() {
 			)
 		}
 	}
+}
+
+/// Mirrors the proof-size composition in [`ParachainStakingPrecompile::delegator_state_storage_read_proof_size`]
+/// so this test fails if the helper drifts from the SCALE upper-bound model.
+#[test]
+fn delegator_state_storage_read_proof_size_matches_scale_upper_bound() {
+	type Bal =
+		<<Runtime as pallet_parachain_staking::Config>::Currency as Inspect<AccountId>>::Balance;
+
+	const TWOX64_CONCAT_PREFIX_LEN: usize = 8;
+	let max_d = <Runtime as StakingConfig>::MaxDelegationsPerDelegator::get();
+	let expected = TWOX64_CONCAT_PREFIX_LEN
+		.saturating_add(AccountId::max_encoded_len())
+		.saturating_add(AccountId::max_encoded_len())
+		.saturating_add(Compact(max_d).encode().len())
+		.saturating_add((max_d as usize).saturating_mul(Bond::<AccountId, Bal>::max_encoded_len()))
+		.saturating_add(Bal::max_encoded_len())
+		.saturating_add(Bal::max_encoded_len())
+		.saturating_add(DelegatorStatus::max_encoded_len());
+
+	let charged = ParachainStakingPrecompile::<Runtime>::delegator_state_storage_read_proof_size();
+
+	assert_eq!(charged, expected);
 }


### PR DESCRIPTION
## Goal

Fix underestimated proof-size accounting for precompile storage reads that return conviction-voting class locks and parachain-staking delegator state.

## What reviewers need to know

- `precompiles/conviction-voting` now charges `classLocksFor` using the max encoded length of the full `ClassLocksFor` bounded vector, including each lock balance, instead of only accounting for class IDs.
- `precompiles/parachain-staking` now computes the delegator-state read proof size from SCALE upper bounds for the key and max-sized `Delegator` value, replacing the previous fixed formula.
- `pallets/parachain-staking` derives `MaxEncodedLen` for `Bond` and `DelegatorStatus` so the staking precompile can derive the upper bound from the actual encoded types.
- This changes proof-size/gas accounting for affected view calls, but does not change storage formats, dispatch behavior, selectors, or returned values.

note: Silent label because the change was already deployed to production in release runtimes 4204 and 4303, so we should not mention it in the next regular changelog.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->