### PR TITLE
Refactor CI pnpm setup to use `pnpm/action-setup@v6` as the owner of pnpm store caching, instead of relying on `actions/setup-node`

### DIFF
--- a/.github/workflow-templates/dev-tests/action.yml
+++ b/.github/workflow-templates/dev-tests/action.yml
@@ -27,6 +27,7 @@ runs:
     - uses: actions/setup-node@v6
       with:
         node-version-file: "test/.nvmrc"
+        package-manager-cache: false
 
     - name: "Install and run dev test"
       shell: bash

--- a/.github/workflow-templates/dev-tests/action.yml
+++ b/.github/workflow-templates/dev-tests/action.yml
@@ -19,14 +19,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v6
       with:
         version: 9
-    - uses: actions/setup-node@v4
+        cache: true
+        cache_dependency_path: pnpm-lock.yaml
+    - uses: actions/setup-node@v6
       with:
         node-version-file: "test/.nvmrc"
-        cache: "pnpm"
-        cache-dependency-path: pnpm-lock.yaml
 
     - name: "Install and run dev test"
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,6 +206,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
+          package-manager-cache: false
       - run: pnpm install
       - run: pnpm check
 
@@ -623,6 +624,7 @@ jobs:
   #     - uses: actions/setup-node@v6
   #       with:
   #         node-version-file: "test/.nvmrc"
+  #         package-manager-cache: false
   #     - name: "Download branch built node"
   #       uses: actions/download-artifact@v8
   #       with:
@@ -748,6 +750,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
+          package-manager-cache: false
       - run: |
           mkdir -p target/release
       - name: "Download branch built node"
@@ -805,6 +808,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
+          package-manager-cache: false
       - name: Create local folders
         run: |
           mkdir -p target/release/wbuild/${{ matrix.chain }}-runtime/
@@ -859,12 +863,13 @@ jobs:
           ref: ${{ needs.set-tags.outputs.git_ref }}
       - uses: pnpm/action-setup@v6
         with:
-          version: 9.1.4
+          version: 9
           cache: true
           cache_dependency_path: pnpm-lock.yaml
       - uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
+          package-manager-cache: false
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -919,6 +924,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
+          package-manager-cache: false
       - name: Create local folders
         run: |
           mkdir -p target/release/wbuild/${{ matrix.chain }}-runtime/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,12 +200,12 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 9
+          cache: true
+          cache_dependency_path: pnpm-lock.yaml
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
       - run: pnpm install
       - run: pnpm check
 
@@ -618,11 +618,11 @@ jobs:
   #     - uses: pnpm/action-setup@v6
   #       with:
   #         version: 9
+  #         cache: true
+  #         cache_dependency_path: pnpm-lock.yaml
   #     - uses: actions/setup-node@v6
   #       with:
   #         node-version-file: "test/.nvmrc"
-  #         cache: "pnpm"
-  #         cache-dependency-path: pnpm-lock.yaml
   #     - name: "Download branch built node"
   #       uses: actions/download-artifact@v8
   #       with:
@@ -742,12 +742,12 @@ jobs:
         uses: pnpm/action-setup@v6
         with:
           version: 9
+          cache: true
+          cache_dependency_path: pnpm-lock.yaml
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
       - run: |
           mkdir -p target/release
       - name: "Download branch built node"
@@ -800,6 +800,8 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 9
+          cache: true
+          cache_dependency_path: pnpm-lock.yaml
       - uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
@@ -858,11 +860,11 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 9.1.4
+          cache: true
+          cache_dependency_path: pnpm-lock.yaml
       - uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -912,6 +914,8 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 9
+          cache: true
+          cache_dependency_path: pnpm-lock.yaml
       - uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"

--- a/.github/workflows/publish-types-bundle.yml
+++ b/.github/workflows/publish-types-bundle.yml
@@ -32,11 +32,12 @@ jobs:
         with:
           version: 9
           run_install: false
+          cache: true
+          cache_dependency_path: pnpm-lock.yaml
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
-          cache: pnpm
           registry-url: https://registry.npmjs.org/
       - name: Build types-bundle package
         run: |

--- a/.github/workflows/publish-types-bundle.yml
+++ b/.github/workflows/publish-types-bundle.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
       - name: Build types-bundle package
         run: |

--- a/.github/workflows/publish-typescript-api.yml
+++ b/.github/workflows/publish-typescript-api.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
       - name: Build Typescript Augment API package
         run: |

--- a/.github/workflows/publish-typescript-api.yml
+++ b/.github/workflows/publish-typescript-api.yml
@@ -32,11 +32,12 @@ jobs:
         with:
           version: 9
           run_install: false
+          cache: true
+          cache_dependency_path: pnpm-lock.yaml
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
-          cache: pnpm
           registry-url: https://registry.npmjs.org/
       - name: Build Typescript Augment API package
         run: |

--- a/.github/workflows/update-typescript-api.yml
+++ b/.github/workflows/update-typescript-api.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
       - name: Run Typegen
         run: |

--- a/.github/workflows/update-typescript-api.yml
+++ b/.github/workflows/update-typescript-api.yml
@@ -48,11 +48,12 @@ jobs:
         with:
           version: 9
           run_install: false
+          cache: true
+          cache_dependency_path: pnpm-lock.yaml
       - name: Install Node.js
         uses: actions/setup-node@v6
         with:
           node-version-file: "test/.nvmrc"
-          cache: pnpm
           registry-url: https://registry.npmjs.org/
       - name: Run Typegen
         run: |


### PR DESCRIPTION
## Goal of the changes

Fix pnpm setup in CI after the `pnpm/action-setup@v6` upgrade, with special attention to the chopsticks upgrade jobs that were still failing during `pnpm install`.

The previous v6 migration left pnpm cache ownership split between `pnpm/action-setup` and `actions/setup-node`, and the chopsticks job kept a unique `pnpm` `9.1.4` pin. In GitHub Actions run `26164399986`, that combination caused the chopsticks jobs to miss the pnpm store cache, download the full workspace dependency set, and fail with npm registry socket timeouts.

## What reviewers need to know

- `pnpm/action-setup@v6` now owns pnpm store caching in the affected workflows via:
  - `cache: true`
  - `cache_dependency_path: pnpm-lock.yaml`
- Matching `actions/setup-node@v6` steps now set `package-manager-cache: false`, so setup-node does not also try to manage package-manager caching.
- The shared Moonwall dev-test composite action was updated from `pnpm/action-setup@v4` / `actions/setup-node@v4` to v6 with the same cache ownership model.
- `chopsticks-upgrade-test` now uses `version: 9`, matching the rest of CI, instead of the previous `9.1.4` pin that produced a pnpm cache miss under v6.
- Publish/typegen workflows keep `registry-url: https://registry.npmjs.org/` on `actions/setup-node` for npm auth/publish behavior, while pnpm caching moves to `pnpm/action-setup@v6`.

## Breaking changes

None expected. This only changes GitHub Actions dependency setup and caching behavior.