### PR TITLE
CI: replace bare-metal by blacksmith runners & adapt rust cache

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,5 @@
 self-hosted-runner:
   labels:
-    - bare-metal
+    - blacksmith-8vcpu-ubuntu-2404
+    - blacksmith-32vcpu-ubuntu-2404
     - moonbeam-release-medium

--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -46,6 +46,8 @@ runs:
       run: |
         mkdir -p mold
         curl -L --retry 10 --silent --show-error https://github.com/rui314/mold/releases/download/v2.39.0/mold-2.39.0-$(uname -m)-linux.tar.gz | tar -C "$(realpath mold)" --strip-components=1 -xzf -
+    - name: Install native build dependencies
+      uses: ./.github/workflow-templates/native-build-deps
     # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
     # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
     - name: Setup Rust toolchain

--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -54,17 +54,8 @@ runs:
         curl -L --retry 10 --silent --show-error https://github.com/rui314/mold/releases/download/v2.39.0/mold-2.39.0-$(uname -m)-linux.tar.gz | tar -C "$(realpath mold)" --strip-components=1 -xzf -
     - name: Install native build dependencies
       uses: ./.github/workflow-templates/native-build-deps
-    # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-    # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
     - name: Setup Rust toolchain
-      shell: bash
-      run: |
-        if ! which "rustup" > /dev/null; then
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        fi
-        rustup override unset
-        rustup show
-        rustup target add wasm32-unknown-unknown
+      uses: ./.github/workflow-templates/rust-toolchain
     - name: Build Node
       shell: bash
       run: |

--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -7,22 +7,40 @@ inputs:
   features:
     description: features to include in the build (comma separated)
     required: false
+  blacksmith-sticky-sccache:
+    description: use a Blacksmith sticky disk for the local sccache directory
+    required: false
+    default: "false"
+  blacksmith-sticky-sccache-key:
+    description: Blacksmith sticky disk key for the local sccache directory
+    required: false
+    default: ""
 
 runs:
   using: "composite"
   steps:
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.10
+    - name: Mount Blacksmith sccache disk
+      if: ${{ inputs.blacksmith-sticky-sccache == 'true' }}
+      uses: useblacksmith/stickydisk@v1
+      with:
+        key: ${{ inputs.blacksmith-sticky-sccache-key }}
+        path: .sccache
     - name: Setup Variables
       shell: bash
       run: |
         echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
-        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
         echo "SCCACHE_CACHE_SIZE=100GB" >> $GITHUB_ENV
+        if [ "${{ inputs.blacksmith-sticky-sccache }}" = "true" ]; then
+          echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> $GITHUB_ENV
+        else
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+        fi
         if [ -z "$RUSTFLAGS" ]; then
           echo "RUSTFLAGS=-C opt-level=3 -D warnings -C linker=clang -C link-arg=-fuse-ld=$(pwd)/mold/bin/mold" >> $GITHUB_ENV
         fi
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.10
     - name: Setup Mold Linker
       shell: bash
       run: |

--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -19,6 +19,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate Blacksmith sccache key
+      if: ${{ inputs.blacksmith-sticky-sccache == 'true' && inputs.blacksmith-sticky-sccache-key == '' }}
+      shell: bash
+      run: |
+        echo "blacksmith-sticky-sccache-key is required when blacksmith-sticky-sccache is true" >&2
+        exit 1
     - name: Mount Blacksmith sccache disk
       if: ${{ inputs.blacksmith-sticky-sccache == 'true' }}
       uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab

--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -21,7 +21,7 @@ runs:
   steps:
     - name: Mount Blacksmith sccache disk
       if: ${{ inputs.blacksmith-sticky-sccache == 'true' }}
-      uses: useblacksmith/stickydisk@v1
+      uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab
       with:
         key: ${{ inputs.blacksmith-sticky-sccache-key }}
         path: .sccache
@@ -40,7 +40,7 @@ runs:
           echo "RUSTFLAGS=-C opt-level=3 -D warnings -C linker=clang -C link-arg=-fuse-ld=$(pwd)/mold/bin/mold" >> $GITHUB_ENV
         fi
     - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.10
+      uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e
     - name: Setup Mold Linker
       shell: bash
       run: |

--- a/.github/workflow-templates/native-build-deps/action.yml
+++ b/.github/workflow-templates/native-build-deps/action.yml
@@ -1,0 +1,11 @@
+name: Native build dependencies
+description: Installs system packages required by Rust builds on ephemeral runners.
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install native build dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libclang-dev llvm-dev libprotobuf-dev protobuf-compiler

--- a/.github/workflow-templates/rust-toolchain-cache-key/action.yml
+++ b/.github/workflow-templates/rust-toolchain-cache-key/action.yml
@@ -1,0 +1,25 @@
+name: Rust toolchain cache key
+description: Reads rust-toolchain and exposes the pinned Rust channel for cache keys.
+
+outputs:
+  cache-key:
+    description: Rust cache key suffix, for example rust-1.88.0.
+    value: ${{ steps.rust-toolchain.outputs.cache-key }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Read Rust toolchain
+      id: rust-toolchain
+      shell: bash
+      run: |
+        channel="$(awk -F '"' '/^channel =/ { print $2; exit }' rust-toolchain)"
+        if [ -z "$channel" ]; then
+          echo "Unable to read Rust channel from rust-toolchain" >&2
+          exit 1
+        fi
+        # Keep the Rust version visible in Blacksmith sticky disk keys. This makes
+        # it easy to identify which cache belongs to which Rust version in the
+        # Blacksmith dashboard, and to clean up obsolete caches after toolchain
+        # upgrades.
+        echo "cache-key=rust-${channel}" >> "$GITHUB_OUTPUT"

--- a/.github/workflow-templates/rust-toolchain/action.yml
+++ b/.github/workflow-templates/rust-toolchain/action.yml
@@ -43,6 +43,7 @@ runs:
             IFS=',' read -ra targets <<< "$configured_targets"
             rustup target add --toolchain "${{ inputs.toolchain }}" "${targets[@]}"
           fi
+          rustup override set "${{ inputs.toolchain }}"
         else
           rustup show
         fi

--- a/.github/workflow-templates/rust-toolchain/action.yml
+++ b/.github/workflow-templates/rust-toolchain/action.yml
@@ -1,0 +1,48 @@
+name: Rust toolchain
+description: Installs rustup when needed and configures a Rust toolchain.
+
+inputs:
+  toolchain:
+    description: Optional explicit toolchain. When empty, use the repository rust-toolchain file.
+    required: false
+    default: ""
+  components:
+    description: Comma-separated components to add to the explicit toolchain.
+    required: false
+    default: ""
+  targets:
+    description: Comma-separated targets to add to the explicit toolchain.
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Rust toolchain
+      shell: bash
+      run: |
+        if ! which "rustup" > /dev/null; then
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          export PATH="$HOME/.cargo/bin:$PATH"
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        fi
+
+        rustup override unset
+
+        if [ -n "${{ inputs.toolchain }}" ]; then
+          rustup toolchain install "${{ inputs.toolchain }}" --profile minimal --no-self-update
+          if [ -n "${{ inputs.components }}" ]; then
+            IFS=',' read -ra components <<< "${{ inputs.components }}"
+            rustup component add --toolchain "${{ inputs.toolchain }}" "${components[@]}"
+          fi
+          configured_targets="${{ inputs.targets }}"
+          if [ -z "$configured_targets" ]; then
+            configured_targets="$(awk -F '[' '/^targets =/ { print $2; exit }' rust-toolchain | tr -d '[] "')"
+          fi
+          if [ -n "$configured_targets" ]; then
+            IFS=',' read -ra targets <<< "$configured_targets"
+            rustup target add --toolchain "${{ inputs.toolchain }}" "${targets[@]}"
+          fi
+        else
+          rustup show
+        fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,12 +202,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
-      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
       - name: Setup Rust toolchain
-        run: |
-          rustup override unset
-          rustup show
+        uses: ./.github/workflow-templates/rust-toolchain
       - name: Check Cargo.toml files format with toml_sort
         run: ./scripts/check-cargo-toml-files-format.sh
 
@@ -225,9 +221,7 @@ jobs:
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
       - name: Setup Rust toolchain
-        run: |
-          rustup override unset
-          rustup show
+        uses: ./.github/workflow-templates/rust-toolchain
       - name: Verifies all 'pallet-evm/ethereum' use 'forbid-evm-reentrancy' feature
         run: ./scripts/check-forbid-evm-reentrancy.sh
 
@@ -244,12 +238,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
-      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
       - name: Setup Rust toolchain
-        run: |
-          rustup override unset
-          rustup show
+        uses: ./.github/workflow-templates/rust-toolchain
       - name: Format code with rustfmt
         run: cargo fmt -- --check
 
@@ -301,12 +291,7 @@ jobs:
       - name: Install native build dependencies
         uses: ./.github/workflow-templates/native-build-deps
       - name: Setup Rust toolchain
-        run: |
-          if ! which "rustup" > /dev/null; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          fi
-          rustup override unset
-          rustup show
+        uses: ./.github/workflow-templates/rust-toolchain
       # Development branch clippy check
       - name: Clippy (dev)
         if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'perm-')
@@ -433,16 +418,8 @@ jobs:
           curl -L --retry 10 --silent --show-error https://github.com/rui314/mold/releases/download/v2.39.0/mold-2.39.0-$(uname -m)-linux.tar.gz | tar -C $(realpath mold) --strip-components=1 -xzf -
       - name: Install native build dependencies
         uses: ./.github/workflow-templates/native-build-deps
-      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
       - name: Setup Rust toolchain
-        run: |
-          if ! which "rustup" > /dev/null; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          fi
-          rustup override unset
-          rustup show
-          rustup target add wasm32-unknown-unknown
+        uses: ./.github/workflow-templates/rust-toolchain
       # Verify that the runtime-benchmarks feature compiles on its own
       - name: Check runtime-benchmarks compilation
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,8 +295,8 @@ jobs:
           path: .sccache
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.10
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+      - name: Install native build dependencies
+        uses: ./.github/workflow-templates/native-build-deps
       - name: Setup Rust toolchain
         run: |
           rustup override unset
@@ -419,6 +419,8 @@ jobs:
         run: |
           mkdir -p mold
           curl -L --retry 10 --silent --show-error https://github.com/rui314/mold/releases/download/v2.39.0/mold-2.39.0-$(uname -m)-linux.tar.gz | tar -C $(realpath mold) --strip-components=1 -xzf -
+      - name: Install native build dependencies
+        uses: ./.github/workflow-templates/native-build-deps
       # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
       # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
       - name: Setup Rust toolchain

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -302,6 +302,9 @@ jobs:
         uses: ./.github/workflow-templates/native-build-deps
       - name: Setup Rust toolchain
         run: |
+          if ! which "rustup" > /dev/null; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          fi
           rustup override unset
           rustup show
       # Development branch clippy check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,12 +292,12 @@ jobs:
         id: rust-toolchain-cache-key
         uses: ./.github/workflow-templates/rust-toolchain-cache-key
       - name: Mount Blacksmith sccache disk
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab
         with:
           key: ${{ github.repository }}-sccache-clippy-${{ runner.os }}-${{ steps.rust-toolchain-cache-key.outputs.cache-key }}
           path: .sccache
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e
       - name: Install native build dependencies
         uses: ./.github/workflow-templates/native-build-deps
       - name: Setup Rust toolchain
@@ -413,12 +413,12 @@ jobs:
         id: rust-toolchain-cache-key
         uses: ./.github/workflow-templates/rust-toolchain-cache-key
       - name: Mount Blacksmith sccache disk
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab
         with:
           key: ${{ github.repository }}-sccache-release-${{ runner.os }}-${{ steps.rust-toolchain-cache-key.outputs.cache-key }}
           path: .sccache
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e
       - name: Setup Variables
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       any_changed: ${{ steps.changed-files.outputs.any_changed == 'true' || steps.changed-files.outputs.any_deleted == 'true' }}
       rust_changed: ${{ steps.rust-changed.outputs.any_changed == 'true' || steps.rust-changed.outputs.any_deleted == 'true' }}
       ts_tests_changed: ${{ steps.test-typescript-changed.outputs.any_changed == 'true' || steps.test-typescript-changed.outputs.any_deleted == 'true' }}
-      self_hosted_allowed: ${{ steps.check-git-ref.outputs.self_hosted_allowed }}
+      blacksmith_allowed: ${{ steps.check-git-ref.outputs.blacksmith_allowed }}
     steps:
       - name: Check git ref
         id: check-git-ref
@@ -59,18 +59,18 @@ jobs:
             echo "git_branch=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
             echo "git_ref=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
             if [[ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]]; then
-              echo "self_hosted_allowed=false" >> $GITHUB_OUTPUT
+              echo "blacksmith_allowed=false" >> $GITHUB_OUTPUT
             else
-              echo "self_hosted_allowed=true" >> $GITHUB_OUTPUT
+              echo "blacksmith_allowed=true" >> $GITHUB_OUTPUT
             fi
           elif [[ -n "${{ github.event.inputs.pull_request }}" ]]; then
             echo "git_branch=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_OUTPUT
             echo "git_ref=refs/pull/${{ github.event.inputs.pull_request }}/head" >> $GITHUB_OUTPUT
-            echo "self_hosted_allowed=false" >> $GITHUB_OUTPUT
+            echo "blacksmith_allowed=false" >> $GITHUB_OUTPUT
           else
             echo "git_branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
             echo "git_ref=$GITHUB_REF" >> $GITHUB_OUTPUT
-            echo "self_hosted_allowed=true" >> $GITHUB_OUTPUT
+            echo "blacksmith_allowed=true" >> $GITHUB_OUTPUT
           fi
           echo "repo.full_name: ${{ github.event.pull_request.head.repo.full_name }}"
           echo "github.repository: ${{ github.repository }}"
@@ -81,7 +81,7 @@ jobs:
       - name: Display variables
         run: |
           echo git_ref: ${{ steps.check-git-ref.outputs.git_ref }}
-          echo self_hosted_allowed: ${{ steps.check-git-ref.outputs.self_hosted_allowed }}
+          echo blacksmith_allowed: ${{ steps.check-git-ref.outputs.blacksmith_allowed }}
       - name: Get all changed file(s), excluding the docs
         id: changed-files
         uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62
@@ -256,22 +256,26 @@ jobs:
   ####### Building and Testing binaries #######
 
   cargo-clippy:
-    # Keep expensive bare-metal clippy behind the cheap Rust checks so formatting or
+    # Keep expensive clippy behind the cheap Rust checks so formatting or
     # repository-rule failures stop the PR before it consumes larger runners.
     # always() is required on jobs with needs: otherwise GitHub skips the job before
     # evaluating this condition when any dependency was skipped.
     if: |
       always() &&
       needs.set-tags.outputs.rust_changed == 'true' &&
-      needs.set-tags.outputs.self_hosted_allowed == 'true' &&
+      needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.check-cargo-toml-format.result == 'success' &&
       needs.check-forbid-evm-reentrancy.result == 'success' &&
       needs.check-rust-fmt.result == 'success'
-    runs-on:
-      labels: bare-metal
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read
+    env:
+      RUSTC_WRAPPER: "sccache"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_CACHE_SIZE: "100GB"
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
     needs:
       [
         "set-tags",
@@ -284,6 +288,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
+      - name: Mount Blacksmith sccache disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-sccache-clippy-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
+          path: .sccache
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
       - name: Setup Rust toolchain
@@ -299,6 +310,8 @@ jobs:
       - name: Clippy (main)
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'perm-')
         run: SKIP_WASM_BUILD=1 env -u RUSTFLAGS cargo clippy --features try-runtime,runtime-benchmarks -- -Dclippy::todo
+      - name: Display sccache stats
+        run: ${SCCACHE_PATH} --show-stats
 
   build:
     # The build is needed for Rust changes or TS/Moonwall test changes. Rust and
@@ -306,7 +319,7 @@ jobs:
     # changes can build directly.
     if: |
       always() &&
-      needs.set-tags.outputs.self_hosted_allowed == 'true' &&
+      needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       (
         (
           needs.set-tags.outputs.rust_changed == 'true' &&
@@ -319,8 +332,7 @@ jobs:
           needs.set-tags.outputs.rust_changed == 'false'
         )
       )
-    runs-on:
-      labels: bare-metal
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read
@@ -340,6 +352,8 @@ jobs:
         uses: ./.github/workflow-templates/cargo-build
         with:
           features: metadata-hash
+          blacksmith-sticky-sccache: "true"
+          blacksmith-sticky-sccache-key: ${{ github.repository }}-sccache-release-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
       - name: Upload runtimes
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -362,13 +376,12 @@ jobs:
     if: |
       always() &&
       needs.set-tags.outputs.rust_changed == 'true' &&
-      needs.set-tags.outputs.self_hosted_allowed == 'true' &&
+      needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.check-cargo-toml-format.result == 'success' &&
       needs.check-forbid-evm-reentrancy.result == 'success' &&
       needs.check-rust-fmt.result == 'success' &&
       needs.dev-test.result == 'success'
-    runs-on:
-      labels: bare-metal
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read
@@ -384,12 +397,17 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       CARGO_INCREMENTAL: "0"
       SCCACHE_CACHE_SIZE: "100GB"
-      SCCACHE_GHA_ENABLED: true
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
+      - name: Mount Blacksmith sccache disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-sccache-release-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
+          path: .sccache
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.10
       - name: Setup Variables
@@ -468,9 +486,8 @@ jobs:
     # run for signal, but their failures are tolerated because they are flakier.
     if: |
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
-      needs.set-tags.outputs.self_hosted_allowed == 'true'
-    runs-on:
-      labels: bare-metal
+      needs.set-tags.outputs.blacksmith_allowed == 'true'
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     permissions:
       contents: read
     needs: ["set-tags", "build"]
@@ -527,10 +544,9 @@ jobs:
     # gate has already failed.
     if: |
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
-      needs.set-tags.outputs.self_hosted_allowed == 'true' &&
+      needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success'
-    runs-on:
-      labels: bare-metal
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read
@@ -586,10 +602,9 @@ jobs:
     # dev-test gate has already failed.
     if: |
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
-      needs.set-tags.outputs.self_hosted_allowed == 'true' &&
+      needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success'
-    runs-on:
-      labels: bare-metal
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read
@@ -651,14 +666,13 @@ jobs:
           path: ${{ env.NODE_LOGS_ZIP }}
 
   chopsticks-upgrade-test:
-    # Upgrade tests consume bare-metal runners, so only start them after moonbase
+    # Upgrade tests consume larger runners, so only start them after moonbase
     # dev tests prove the PR is worth the heavier checks.
     if: |
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
-      needs.set-tags.outputs.self_hosted_allowed == 'true' &&
+      needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success'
-    runs-on:
-      labels: bare-metal
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 60
     needs: ["set-tags", "build", "dev-test"]
     strategy:
@@ -712,10 +726,9 @@ jobs:
     # the fast gate before reserving those runners.
     if: |
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
-      needs.set-tags.outputs.self_hosted_allowed == 'true' &&
+      needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success'
-    runs-on:
-      labels: bare-metal
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 30
     needs: ["set-tags", "build", "dev-test"]
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,10 +288,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
+      - name: Read Rust toolchain cache key
+        id: rust-toolchain-cache-key
+        uses: ./.github/workflow-templates/rust-toolchain-cache-key
       - name: Mount Blacksmith sccache disk
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-sccache-clippy-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
+          key: ${{ github.repository }}-sccache-clippy-${{ runner.os }}-${{ steps.rust-toolchain-cache-key.outputs.cache-key }}
           path: .sccache
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -348,12 +351,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
+      - name: Read Rust toolchain cache key
+        id: rust-toolchain-cache-key
+        uses: ./.github/workflow-templates/rust-toolchain-cache-key
       - name: Cargo build
         uses: ./.github/workflow-templates/cargo-build
         with:
           features: metadata-hash
           blacksmith-sticky-sccache: "true"
-          blacksmith-sticky-sccache-key: ${{ github.repository }}-sccache-release-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
+          blacksmith-sticky-sccache-key: ${{ github.repository }}-sccache-release-${{ runner.os }}-${{ steps.rust-toolchain-cache-key.outputs.cache-key }}
       - name: Upload runtimes
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -403,10 +409,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
+      - name: Read Rust toolchain cache key
+        id: rust-toolchain-cache-key
+        uses: ./.github/workflow-templates/rust-toolchain-cache-key
       - name: Mount Blacksmith sccache disk
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-sccache-release-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
+          key: ${{ github.repository }}-sccache-release-${{ runner.os }}-${{ steps.rust-toolchain-cache-key.outputs.cache-key }}
           path: .sccache
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.10

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -17,7 +17,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Setup Rust toolchain
         uses: ./.github/workflow-templates/rust-toolchain
         with:

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -18,8 +18,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rust toolchain
+        uses: ./.github/workflow-templates/rust-toolchain
         with:
           toolchain: 1.88.0
       - name: Verify Licenses

--- a/.github/workflows/scout.yml
+++ b/.github/workflows/scout.yml
@@ -17,9 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install native build dependencies
         uses: ./.github/workflow-templates/native-build-deps

--- a/.github/workflows/scout.yml
+++ b/.github/workflows/scout.yml
@@ -24,9 +24,13 @@ jobs:
 
       - name: Install native build dependencies
         uses: ./.github/workflow-templates/native-build-deps
+      - name: Setup Rust toolchain
+        uses: ./.github/workflow-templates/rust-toolchain
+        with:
+          toolchain: nightly-2025-08-07
+          components: rust-src,rustc-dev,llvm-tools-preview
       - name: Install Scout dependencies
         run: |
-          rustup component add rust-src rustc-dev llvm-tools-preview --toolchain nightly-2025-08-07
           cargo +nightly-2025-08-07 install cargo-scout-audit
 
       - name: Run scout audit

--- a/.github/workflows/scout.yml
+++ b/.github/workflows/scout.yml
@@ -16,9 +16,10 @@ jobs:
   scout-audit:
     runs-on: ubuntu-latest
     steps:
-      - name: Install required dependencies
+      - name: Install native build dependencies
+        uses: ./.github/workflow-templates/native-build-deps
+      - name: Install Scout dependencies
         run: |
-          sudo apt-get install -y libprotobuf-dev protobuf-compiler
           rustup component add rust-src rustc-dev llvm-tools-preview --toolchain nightly-2025-08-07
           cargo +nightly-2025-08-07 install cargo-scout-audit
 

--- a/.github/workflows/scout.yml
+++ b/.github/workflows/scout.yml
@@ -16,17 +16,17 @@ jobs:
   scout-audit:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Install native build dependencies
         uses: ./.github/workflow-templates/native-build-deps
       - name: Install Scout dependencies
         run: |
           rustup component add rust-src rustc-dev llvm-tools-preview --toolchain nightly-2025-08-07
           cargo +nightly-2025-08-07 install cargo-scout-audit
-
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Run scout audit
         id: run-scout

--- a/.github/workflows/subxt-diff.yml
+++ b/.github/workflows/subxt-diff.yml
@@ -32,10 +32,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Setup Rust toolchain
+        uses: ./.github/workflow-templates/rust-toolchain
       - name: Install Subxt-cli
         run: |
-          rustup override unset
-          rustup show
           cargo install subxt-cli --locked
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Lookup previous runtime release build

--- a/.github/workflows/update-typescript-api.yml
+++ b/.github/workflows/update-typescript-api.yml
@@ -20,11 +20,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Read Rust toolchain cache key
+        id: rust-toolchain-cache-key
+        uses: ./.github/workflow-templates/rust-toolchain-cache-key
       - name: Local build new Node
         uses: ./.github/workflow-templates/cargo-build
         with:
           blacksmith-sticky-sccache: "true"
-          blacksmith-sticky-sccache-key: ${{ github.repository }}-sccache-typegen-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
+          blacksmith-sticky-sccache-key: ${{ github.repository }}-sccache-typegen-${{ runner.os }}-${{ steps.rust-toolchain-cache-key.outputs.cache-key }}
       - name: Upload Node
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/update-typescript-api.yml
+++ b/.github/workflows/update-typescript-api.yml
@@ -14,8 +14,7 @@ defaults:
 
 jobs:
   build:
-    runs-on:
-      labels: bare-metal
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:
@@ -23,6 +22,9 @@ jobs:
         uses: actions/checkout@v6
       - name: Local build new Node
         uses: ./.github/workflow-templates/cargo-build
+        with:
+          blacksmith-sticky-sccache: "true"
+          blacksmith-sticky-sccache-key: ${{ github.repository }}-sccache-typegen-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
       - name: Upload Node
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/weekly-master-checks.yml
+++ b/.github/workflows/weekly-master-checks.yml
@@ -18,14 +18,18 @@ defaults:
 jobs:
   check-benchmarks:
     if: github.ref == 'refs/heads/master'
-    runs-on:
-      labels: bare-metal
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
         runtime: [moonbeam, moonbase, moonriver]
+    env:
+      RUSTC_WRAPPER: "sccache"
+      CARGO_INCREMENTAL: "0"
+      SCCACHE_CACHE_SIZE: "100GB"
+      SCCACHE_DIR: ${{ github.workspace }}/.sccache
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -33,6 +37,13 @@ jobs:
           ref: master
           persist-credentials: false
           fetch-depth: 0
+      - name: Mount Blacksmith sccache disk
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-sccache-bench-${{ matrix.runtime }}-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
+          path: .sccache
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.10
       - name: Setup Variables
         run: |
           echo "RUSTFLAGS=-C opt-level=3 -D warnings -C linker=clang -C link-arg=-fuse-ld=$(pwd)/mold/bin/mold" >> "$GITHUB_ENV"
@@ -98,8 +109,7 @@ jobs:
 
   build-runtimes-for-size-check:
     if: github.ref == 'refs/heads/master'
-    runs-on:
-      labels: bare-metal
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:
@@ -112,6 +122,8 @@ jobs:
         uses: ./.github/workflow-templates/cargo-build
         with:
           features: metadata-hash
+          blacksmith-sticky-sccache: "true"
+          blacksmith-sticky-sccache-key: ${{ github.repository }}-sccache-weekly-size-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
       - name: Upload runtimes
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/.github/workflows/weekly-master-checks.yml
+++ b/.github/workflows/weekly-master-checks.yml
@@ -52,6 +52,8 @@ jobs:
           mkdir -p mold
           ARCH="$(uname -m)"
           curl -L --retry 10 --silent --show-error "https://github.com/rui314/mold/releases/download/v2.39.0/mold-2.39.0-${ARCH}-linux.tar.gz" | tar -C "$(realpath mold)" --strip-components=1 -xzf -
+      - name: Install native build dependencies
+        uses: ./.github/workflow-templates/native-build-deps
       # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
       # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
       - name: Setup Rust toolchain
@@ -97,9 +99,10 @@ jobs:
           toolchain: nightly-2026-04-01
           components: rust-src
           targets: wasm32v1-none, wasm32-unknown-unknown
+      - name: Install native build dependencies
+        uses: ./.github/workflow-templates/native-build-deps
       - name: Install required dependencies
         run: |
-          sudo apt-get install -y libprotobuf-dev protobuf-compiler libclang-dev
           cargo +nightly-2026-04-01 install cargo-udeps
       - name: Check for unused dependencies
         run: |

--- a/.github/workflows/weekly-master-checks.yml
+++ b/.github/workflows/weekly-master-checks.yml
@@ -57,19 +57,8 @@ jobs:
           curl -L --retry 10 --silent --show-error "https://github.com/rui314/mold/releases/download/v2.39.0/mold-2.39.0-${ARCH}-linux.tar.gz" | tar -C "$(realpath mold)" --strip-components=1 -xzf -
       - name: Install native build dependencies
         uses: ./.github/workflow-templates/native-build-deps
-      # With rustup's nice new toml format, we just need to run rustup show to install the toolchain
-      # https://github.com/actions-rs/toolchain/issues/126#issuecomment-782989659
       - name: Setup Rust toolchain
-        shell: bash
-        run: |
-          if ! which "rustup" > /dev/null; then
-              curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-              export PATH="$HOME/.cargo/bin:$PATH"
-              echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          fi
-          rustup override unset
-          rustup show
-          rustup target add wasm32-unknown-unknown
+        uses: ./.github/workflow-templates/rust-toolchain
       - name: Install frame-omni-bencher
         shell: bash
         run: |
@@ -96,12 +85,11 @@ jobs:
         with:
           ref: master
           persist-credentials: false
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      - name: Setup Rust toolchain
+        uses: ./.github/workflow-templates/rust-toolchain
         with:
           toolchain: nightly-2026-04-01
           components: rust-src
-          targets: wasm32v1-none, wasm32-unknown-unknown
       - name: Install native build dependencies
         uses: ./.github/workflow-templates/native-build-deps
       - name: Install required dependencies

--- a/.github/workflows/weekly-master-checks.yml
+++ b/.github/workflows/weekly-master-checks.yml
@@ -37,10 +37,13 @@ jobs:
           ref: master
           persist-credentials: false
           fetch-depth: 0
+      - name: Read Rust toolchain cache key
+        id: rust-toolchain-cache-key
+        uses: ./.github/workflow-templates/rust-toolchain-cache-key
       - name: Mount Blacksmith sccache disk
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-sccache-bench-${{ matrix.runtime }}-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
+          key: ${{ github.repository }}-sccache-bench-${{ matrix.runtime }}-${{ runner.os }}-${{ steps.rust-toolchain-cache-key.outputs.cache-key }}
           path: .sccache
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.10
@@ -121,12 +124,15 @@ jobs:
         with:
           ref: master
           persist-credentials: false
+      - name: Read Rust toolchain cache key
+        id: rust-toolchain-cache-key
+        uses: ./.github/workflow-templates/rust-toolchain-cache-key
       - name: Cargo build
         uses: ./.github/workflow-templates/cargo-build
         with:
           features: metadata-hash
           blacksmith-sticky-sccache: "true"
-          blacksmith-sticky-sccache-key: ${{ github.repository }}-sccache-weekly-size-${{ runner.os }}-${{ hashFiles('rust-toolchain') }}
+          blacksmith-sticky-sccache-key: ${{ github.repository }}-sccache-weekly-size-${{ runner.os }}-${{ steps.rust-toolchain-cache-key.outputs.cache-key }}
       - name: Upload runtimes
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/.github/workflows/weekly-master-checks.yml
+++ b/.github/workflows/weekly-master-checks.yml
@@ -41,12 +41,12 @@ jobs:
         id: rust-toolchain-cache-key
         uses: ./.github/workflow-templates/rust-toolchain-cache-key
       - name: Mount Blacksmith sccache disk
-        uses: useblacksmith/stickydisk@v1
+        uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab
         with:
           key: ${{ github.repository }}-sccache-bench-${{ matrix.runtime }}-${{ runner.os }}-${{ steps.rust-toolchain-cache-key.outputs.cache-key }}
           path: .sccache
       - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e
       - name: Setup Variables
         run: |
           echo "RUSTFLAGS=-C opt-level=3 -D warnings -C linker=clang -C link-arg=-fuse-ld=$(pwd)/mold/bin/mold" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Goal of the changes

Move CI jobs that previously depended on persistent `bare-metal` runners to Blacksmith runners, while making Rust builds work reliably and quickly on ephemeral runners.

## What reviewers need to know

- Replaces all `bare-metal` runner usage with Blacksmith runners.
  - Rust-heavy jobs use `blacksmith-32vcpu-ubuntu-2404`.
  - Moonwall/test-heavy build workflow jobs use `blacksmith-8vcpu-ubuntu-2404`.
- Renames the build workflow gate from `self_hosted_allowed` to `blacksmith_allowed`, preserving the existing behavior that avoids running paid/external runners for forks or manually-triggered external PR refs.
- Adds opt-in Blacksmith sticky-disk support to `.github/workflow-templates/cargo-build/action.yml`.
  - Blacksmith jobs use local `sccache` storage via `SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache`.
  - Non-Blacksmith callers keep the existing `SCCACHE_GHA_ENABLED=true` behavior.
- Adds `.github/workflow-templates/rust-toolchain-cache-key/action.yml` to read the pinned Rust channel from `rust-toolchain` and include it in sticky disk cache keys.
  - This keeps cache names human-readable in the Blacksmith dashboard, making obsolete Rust-version caches easier to identify and clean up.
- Adds `.github/workflow-templates/native-build-deps/action.yml` to install native packages required by Rust builds on ephemeral runners.
  - Installs `libclang-dev`, `llvm-dev`, `libprotobuf-dev`, and `protobuf-compiler`.
  - This replaces assumptions from the old persistent runner, including availability of `llvm-config` for `clang-sys`.
- Enables optimized Rust sticky-disk caches for:
  - build
  - clippy
  - rust-test
  - weekly benchmark builds
  - weekly runtime size build
  - TypeScript API update build
- Updates `scout.yml` to use the shared native dependency setup instead of maintaining its own package list.
- Updates `actionlint` runner labels for the new Blacksmith runner names.

## Operational impact

The CI no longer relies on packages manually installed on persistent `bare-metal` runners. First runs on Blacksmith may be cold, but Rust build jobs should warm Blacksmith sticky disks over time through `sccache`.

Sticky disk cache keys include the Rust toolchain version, so a future Rust upgrade will naturally move builds to a new cache namespace.

## Testing

- `rg -n "bare-metal" .github` returned no workflow runner usage.
- `actionlint -shellcheck= .github/workflows/*.yml` passes.