### PR TITLE
Align XCM weight accounting with ERC20 transfer gas limits when ERC20 assets include a custom `gas_limit:` override

### DIFF
--- a/runtime/moonbase/src/weights/xcm/mod.rs
+++ b/runtime/moonbase/src/weights/xcm/mod.rs
@@ -55,6 +55,34 @@ impl WeighMultiAssets for Assets {
 	}
 }
 
+fn erc20_asset_weight<Runtime>(asset: &Asset, benchmark_weight: Weight) -> Weight
+where
+	Runtime: pallet_erc20_xcm_bridge::Config,
+{
+	if pallet_erc20_xcm_bridge::Pallet::<Runtime>::is_erc20_asset(asset) {
+		let gas_weight =
+			pallet_erc20_xcm_bridge::Pallet::<Runtime>::weight_of_erc20_transfer(&asset.id);
+		Weight::from_parts(
+			benchmark_weight.ref_time().max(gas_weight.ref_time()),
+			benchmark_weight.proof_size().max(gas_weight.proof_size()),
+		)
+	} else {
+		benchmark_weight
+	}
+}
+
+fn weigh_erc20_assets<Runtime>(assets: &Assets, benchmark_weight: Weight) -> XCMWeight
+where
+	Runtime: pallet_erc20_xcm_bridge::Config,
+{
+	assets
+		.inner()
+		.into_iter()
+		.fold(Weight::zero(), |weight, asset| {
+			weight.saturating_add(erc20_asset_weight::<Runtime>(asset, benchmark_weight))
+		})
+}
+
 pub struct XcmWeight<Runtime, Call>(core::marker::PhantomData<(Runtime, Call)>);
 impl<Runtime, Call> XcmWeightInfo<Call> for XcmWeight<Runtime, Call>
 where
@@ -63,7 +91,7 @@ where
 		+ pallet_moonbeam_foreign_assets::Config,
 {
 	fn withdraw_asset(assets: &Assets) -> XCMWeight {
-		assets.weigh_assets(XcmFungibleWeight::<Runtime>::withdraw_asset())
+		weigh_erc20_assets::<Runtime>(assets, XcmFungibleWeight::<Runtime>::withdraw_asset())
 	}
 	// Currently there is no trusted reserve
 	fn reserve_asset_deposited(assets: &Assets) -> XCMWeight {
@@ -82,10 +110,13 @@ where
 		XcmGeneric::<Runtime>::query_response()
 	}
 	fn transfer_asset(assets: &Assets, _dest: &Location) -> XCMWeight {
-		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_asset())
+		weigh_erc20_assets::<Runtime>(assets, XcmFungibleWeight::<Runtime>::transfer_asset())
 	}
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> XCMWeight {
-		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_reserve_asset())
+		weigh_erc20_assets::<Runtime>(
+			assets,
+			XcmFungibleWeight::<Runtime>::transfer_reserve_asset(),
+		)
 	}
 	fn transact(
 		_origin_type: &OriginKind,

--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -676,8 +676,8 @@ parameter_types! {
 		].into()
 	};
 
-	// To be able to support almost all erc20 implementations,
-	// we provide a sufficiently hight gas limit.
+	// Default gas limit for ERC20 transfers executed through XCM when no
+	// gas_limit override is provided.
 	pub Erc20XcmBridgeTransferGasLimit: u64 = 400_000;
 }
 

--- a/runtime/moonbeam/src/weights/xcm/mod.rs
+++ b/runtime/moonbeam/src/weights/xcm/mod.rs
@@ -55,6 +55,34 @@ impl WeighMultiAssets for Assets {
 	}
 }
 
+fn erc20_asset_weight<Runtime>(asset: &Asset, benchmark_weight: Weight) -> Weight
+where
+	Runtime: pallet_erc20_xcm_bridge::Config,
+{
+	if pallet_erc20_xcm_bridge::Pallet::<Runtime>::is_erc20_asset(asset) {
+		let gas_weight =
+			pallet_erc20_xcm_bridge::Pallet::<Runtime>::weight_of_erc20_transfer(&asset.id);
+		Weight::from_parts(
+			benchmark_weight.ref_time().max(gas_weight.ref_time()),
+			benchmark_weight.proof_size().max(gas_weight.proof_size()),
+		)
+	} else {
+		benchmark_weight
+	}
+}
+
+fn weigh_erc20_assets<Runtime>(assets: &Assets, benchmark_weight: Weight) -> XCMWeight
+where
+	Runtime: pallet_erc20_xcm_bridge::Config,
+{
+	assets
+		.inner()
+		.into_iter()
+		.fold(Weight::zero(), |weight, asset| {
+			weight.saturating_add(erc20_asset_weight::<Runtime>(asset, benchmark_weight))
+		})
+}
+
 pub struct XcmWeight<Runtime, Call>(core::marker::PhantomData<(Runtime, Call)>);
 impl<Runtime, Call> XcmWeightInfo<Call> for XcmWeight<Runtime, Call>
 where
@@ -63,7 +91,7 @@ where
 		+ pallet_moonbeam_foreign_assets::Config,
 {
 	fn withdraw_asset(assets: &Assets) -> XCMWeight {
-		assets.weigh_assets(XcmFungibleWeight::<Runtime>::withdraw_asset())
+		weigh_erc20_assets::<Runtime>(assets, XcmFungibleWeight::<Runtime>::withdraw_asset())
 	}
 	// Currently there is no trusted reserve
 	fn reserve_asset_deposited(assets: &Assets) -> XCMWeight {
@@ -82,10 +110,13 @@ where
 		XcmGeneric::<Runtime>::query_response()
 	}
 	fn transfer_asset(assets: &Assets, _dest: &Location) -> XCMWeight {
-		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_asset())
+		weigh_erc20_assets::<Runtime>(assets, XcmFungibleWeight::<Runtime>::transfer_asset())
 	}
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> XCMWeight {
-		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_reserve_asset())
+		weigh_erc20_assets::<Runtime>(
+			assets,
+			XcmFungibleWeight::<Runtime>::transfer_reserve_asset(),
+		)
 	}
 	fn transact(
 		_origin_type: &OriginKind,

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -669,8 +669,8 @@ parameter_types! {
 		].into()
 	};
 
-	// To be able to support almost all erc20 implementations,
-	// we provide a sufficiently hight gas limit.
+	// Default gas limit for ERC20 transfers executed through XCM when no
+	// gas_limit override is provided.
 	pub Erc20XcmBridgeTransferGasLimit: u64 = 400_000;
 }
 

--- a/runtime/moonriver/src/weights/xcm/mod.rs
+++ b/runtime/moonriver/src/weights/xcm/mod.rs
@@ -55,6 +55,34 @@ impl WeighMultiAssets for Assets {
 	}
 }
 
+fn erc20_asset_weight<Runtime>(asset: &Asset, benchmark_weight: Weight) -> Weight
+where
+	Runtime: pallet_erc20_xcm_bridge::Config,
+{
+	if pallet_erc20_xcm_bridge::Pallet::<Runtime>::is_erc20_asset(asset) {
+		let gas_weight =
+			pallet_erc20_xcm_bridge::Pallet::<Runtime>::weight_of_erc20_transfer(&asset.id);
+		Weight::from_parts(
+			benchmark_weight.ref_time().max(gas_weight.ref_time()),
+			benchmark_weight.proof_size().max(gas_weight.proof_size()),
+		)
+	} else {
+		benchmark_weight
+	}
+}
+
+fn weigh_erc20_assets<Runtime>(assets: &Assets, benchmark_weight: Weight) -> XCMWeight
+where
+	Runtime: pallet_erc20_xcm_bridge::Config,
+{
+	assets
+		.inner()
+		.into_iter()
+		.fold(Weight::zero(), |weight, asset| {
+			weight.saturating_add(erc20_asset_weight::<Runtime>(asset, benchmark_weight))
+		})
+}
+
 pub struct XcmWeight<Runtime, Call>(core::marker::PhantomData<(Runtime, Call)>);
 impl<Runtime, Call> XcmWeightInfo<Call> for XcmWeight<Runtime, Call>
 where
@@ -63,7 +91,7 @@ where
 		+ pallet_moonbeam_foreign_assets::Config,
 {
 	fn withdraw_asset(assets: &Assets) -> XCMWeight {
-		assets.weigh_assets(XcmFungibleWeight::<Runtime>::withdraw_asset())
+		weigh_erc20_assets::<Runtime>(assets, XcmFungibleWeight::<Runtime>::withdraw_asset())
 	}
 	// Currently there is no trusted reserve
 	fn reserve_asset_deposited(assets: &Assets) -> XCMWeight {
@@ -82,10 +110,13 @@ where
 		XcmGeneric::<Runtime>::query_response()
 	}
 	fn transfer_asset(assets: &Assets, _dest: &Location) -> XCMWeight {
-		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_asset())
+		weigh_erc20_assets::<Runtime>(assets, XcmFungibleWeight::<Runtime>::transfer_asset())
 	}
 	fn transfer_reserve_asset(assets: &Assets, _dest: &Location, _xcm: &Xcm<()>) -> XCMWeight {
-		assets.weigh_assets(XcmFungibleWeight::<Runtime>::transfer_reserve_asset())
+		weigh_erc20_assets::<Runtime>(
+			assets,
+			XcmFungibleWeight::<Runtime>::transfer_reserve_asset(),
+		)
 	}
 	fn transact(
 		_origin_type: &OriginKind,

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -682,8 +682,8 @@ parameter_types! {
 		].into()
 	};
 
-	// To be able to support almost all erc20 implementations,
-	// we provide a sufficiently hight gas limit.
+	// Default gas limit for ERC20 transfers executed through XCM when no
+	// gas_limit override is provided.
 	pub Erc20XcmBridgeTransferGasLimit: u64 = 400_000;
 }
 


### PR DESCRIPTION
## Goal of the changes

Align XCM weight accounting with ERC20 transfer gas limits when ERC20 assets include a custom `gas_limit:` override.

## What reviewers need to know

- ERC20 `gas_limit:` overrides remain supported for assets that need more than the default `400_000` gas to transfer.
- `WithdrawAsset`, `TransferAsset`, and `TransferReserveAsset` now use ERC20-aware weighing for concrete asset lists.
- For ERC20 assets, the XCM weigher compares the benchmarked fungible instruction weight with the gas-derived ERC20 transfer weight and charges the larger value.
- The change is applied consistently across Moonbase, Moonbeam, and Moonriver.
- Runtime comments now clarify that `Erc20XcmBridgeTransferGasLimit` is the default value used when no `gas_limit:` override is provided.

## Testing

- `cargo test -p pallet-erc20-xcm-bridge gas_limit`
- `cargo check -p moonbeam-runtime`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782311111&installation_id=130617128&pr_number=3761&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3761&signature=92077e13006abcb349ff610b9ac11cc01239793011651a1c137b88b06ba18d72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->