### PR TITLE
Opti ci 3

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,5 @@
 self-hosted-runner:
   labels:
-    - blacksmith-8vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404
     - blacksmith-32vcpu-ubuntu-2404
     - moonbeam-release-medium

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ name: Build
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   push:
     branches:
       - master
@@ -531,13 +532,17 @@ jobs:
           pnpm moonwall test dev_${{ matrix.chain }} --ts ${{ matrix.shard }}/4
 
   typescript-tracing-tests:
-    # Tracing tests are expensive, so skip them when the required moonbase dev-test
-    # gate has already failed.
+    # Tracing tests are expensive, so run them on master or when explicitly
+    # requested on PRs.
     if: |
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
-      needs.dev-test.result == 'success'
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+      needs.dev-test.result == 'success' &&
+      (
+        github.ref == 'refs/heads/master' ||
+        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'A10-evmtracing'))
+      )
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read
@@ -713,20 +718,20 @@ jobs:
             bun moonwall test upgrade_${{matrix.chain}}
 
   zombie_upgrade_test:
-    # Zombie upgrade tests are expensive and run serially; use moonbase dev-test as
-    # the fast gate before reserving those runners.
+    # Zombie upgrade tests are expensive and run serially; run all runtimes on
+    # master, but keep PRs to moonbeam only.
     if: |
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success'
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     needs: ["set-tags", "build", "dev-test"]
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        chain: ["moonbase", "moonriver", "moonbeam"]
+        chain: ${{ github.ref == 'refs/heads/master' && fromJSON('["moonbase", "moonriver", "moonbeam"]') || fromJSON('["moonbeam"]') }}
     env:
       GH_WORKFLOW_MATRIX_CHAIN: ${{ matrix.chain }}
       DEBUG_COLORS: 1
@@ -796,10 +801,14 @@ jobs:
 
   bridge-integration-tests:
     # Bridge integration tests are expensive and only relevant to Rust changes, so
-    # require the moonbase dev-test gate before running them.
+    # run them on master or when explicitly requested on PRs.
     if: |
       needs.set-tags.outputs.rust_changed == 'true' &&
-      needs.dev-test.result == 'success'
+      needs.dev-test.result == 'success' &&
+      (
+        github.ref == 'refs/heads/master' ||
+        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'B10-Bridge'))
+      )
     needs: ["set-tags", "build", "dev-test"]
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -479,7 +479,7 @@ jobs:
     if: |
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true'
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
     needs: ["set-tags", "build"]
@@ -600,7 +600,7 @@ jobs:
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success'
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read
@@ -668,7 +668,7 @@ jobs:
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success'
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
     needs: ["set-tags", "build", "dev-test"]
     strategy:


### PR DESCRIPTION
Goal of the changes
-------------------

Reduce Blacksmith CI cost for the Build workflow by using smaller runners for non-Rust-compilation jobs and avoiding expensive optional test jobs on every PR.

What reviewers need to know
---------------------------

- Replaces Build workflow jobs that used `blacksmith-8vcpu-ubuntu-2404` with `blacksmith-4vcpu-ubuntu-2404`:
  - `dev-test`
  - `typescript-tracing-tests`
  - `lazy-loading-tests`
  - `chopsticks-upgrade-test`
  - `zombie_upgrade_test`

- Updates `.github/actionlint.yaml` so `blacksmith-4vcpu-ubuntu-2404` is recognized as an allowed self-hosted runner label.

- Runs TypeScript tracing tests only on:
  - `master`
  - PRs labeled `A10-evmtracing`

- Runs bridge integration tests only on:
  - `master`
  - PRs labeled `B10-Bridge`

- Adds `labeled` and `unlabeled` pull request events to the Build workflow so adding or removing those labels can re-evaluate the gated jobs.

- Reduces zombie upgrade test coverage on PRs to `moonbeam` only, while preserving `moonbase`, `moonriver`, and `moonbeam` on `master`.

Risk / compatibility
--------------------

This changes CI coverage behavior, not runtime or node behavior. The main review point is whether the reduced PR coverage is acceptable for tracing, bridge, and zombie upgrade tests, and whether the selected labels match the team’s triage conventions.

Testing
-------

- Ran `actionlint .github/workflows/build.yml`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782313765&installation_id=130617128&pr_number=3762&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3762&signature=870da3360c50cfd355efaa15adda339fcb8e1976ab855979b5c2c572c0f82430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->