### PR TITLE
Right-size CI runner usage after migrating to Blacksmith, and remove stale documentation

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,5 @@
 self-hosted-runner:
   labels:
     - blacksmith-4vcpu-ubuntu-2404
-    - blacksmith-32vcpu-ubuntu-2404
+    - blacksmith-16vcpu-ubuntu-2404
     - moonbeam-release-medium

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
       needs.check-cargo-toml-format.result == 'success' &&
       needs.check-forbid-evm-reentrancy.result == 'success' &&
       needs.check-rust-fmt.result == 'success'
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
       needs.check-cargo-toml-format.result == 'success' &&
       needs.check-forbid-evm-reentrancy.result == 'success' &&
       needs.check-rust-fmt.result == 'success'
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read
@@ -324,7 +324,7 @@ jobs:
           needs.set-tags.outputs.rust_changed == 'false'
         )
       )
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read
@@ -376,7 +376,7 @@ jobs:
       needs.check-forbid-evm-reentrancy.result == 'success' &&
       needs.check-rust-fmt.result == 'success' &&
       needs.dev-test.result == 'success'
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/update-typescript-api.yml
+++ b/.github/workflows/update-typescript-api.yml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:

--- a/.github/workflows/weekly-master-checks.yml
+++ b/.github/workflows/weekly-master-checks.yml
@@ -18,7 +18,7 @@ defaults:
 jobs:
   check-benchmarks:
     if: github.ref == 'refs/heads/master'
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     permissions:
       contents: read
     strategy:
@@ -103,7 +103,7 @@ jobs:
 
   build-runtimes-for-size-check:
     if: github.ref == 'refs/heads/master'
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -6,9 +6,11 @@ This section of the documentation is dedicated to the automation processes for t
 
 Automation is using Github Action, where all the actions are described in [.github/workflows](.github/workflows)
 
-### bare-metal
+### Blacksmith runners
 
-label bare-metal refers to our CI servers managed by opslayer. Those are dedicated machines, optimized to reduce the compilation and testing time of the actions.
+CI jobs run on Blacksmith ephemeral cloud runners. Runner labels such as
+`blacksmith-4vcpu-ubuntu-2404` and `blacksmith-16vcpu-ubuntu-2404` select the
+machine size used by each action.
 
 ## Cancellation
 

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -9,12 +9,6 @@ proposal.
 You may also consider joining our [Discord server](https://discord.gg/PfpUATX) or
 [Element room](https://app.element.io/#/room/#moonbeam:matrix.org) to discuss your changes.
 
-### Generated Documentation
-
-You can explore our [crate-level documentation](https://moonbeam-foundation.github.io/moonbeam).
-This documentation is
-automatically built and reflects the latest `master` commit.
-
 ### Code style
 
 Moonbeam is following the

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 **An Ethereum compatible [Parachain](https://docs.polkadot.com/polkadot-protocol/architecture/parachains) built with the [Polkadot-SDK](https://github.com/paritytech/polkadot-sdk).**
 
 👉 _Discover the Moonbeam project at [moonbeam.network](https://moonbeam.network)._<br>
-👉 _Learn to [use the Moonbeam network](https://docs.moonbeam.network/) with our technical docs._<br>
-👉 _Reference our [crate-level docs (rustdocs)](https://moonbeam-foundation.github.io/moonbeam) to contribute._
+👉 _Learn to [use the Moonbeam network](https://docs.moonbeam.network/) with our technical docs._
 
 ## Run Moonbeam with zombienet
 ```bash
@@ -238,11 +237,6 @@ The following pallets are stored in `pallets/`. They are designed for Moonbeam's
 - _Parachain Staking_: Minimal staking pallet that selects collators by total amount at stake
 
 When modifying the git repository for these dependencies, a tool called [diener](https://github.com/bkchr/diener) can be used to replace the git URL and branch for each reference in all `Cargo.toml` files with a single command. This alleviates a lot of the repetitive modifications necessary when changing dependency versions.
-
-## Rustdocs
-
-Rustdocs for the Moonbeam codebase are automatically generated and published
-[here](https://moonbeam-foundation.github.io/moonbeam/moonbeam_runtime/index.html).
 
 ## Contribute
 

--- a/pallets/parachain-staking/README.md
+++ b/pallets/parachain-staking/README.md
@@ -15,7 +15,6 @@ Implements Delegated Proof of Stake to
 
 Links:
 
-- [Rust Documentation](https://moonbeam-foundation.github.io/moonbeam/pallet_parachain_staking/index.html)
 - [Unofficial Documentation](https://meta5.world/posts/parachain-staking)
 - [(Outdated) Blog Post with Justification](https://meta5.world/posts/parachain-staking)
 


### PR DESCRIPTION
## Goal of the changes

Right-size CI runner usage after migrating to Blacksmith ephemeral cloud runners, and remove stale documentation that pointed to retired infrastructure/publication targets.

## What reviewers need to know

- Replaces remaining `blacksmith-32vcpu-ubuntu-2404` runner usage with `blacksmith-16vcpu-ubuntu-2404` in heavier workflows:
  - `.github/workflows/build.yml`
  - `.github/workflows/update-typescript-api.yml`
  - `.github/workflows/weekly-master-checks.yml`
  - `.github/actionlint.yaml`
- Moves the `cargo-clippy` job to `blacksmith-4vcpu-ubuntu-2404` because it completes quickly and does not benefit the critical path while longer required jobs still take around 10 minutes.
- Updates `AUTOMATION.md` to describe Blacksmith ephemeral cloud runners instead of the old bare-metal/opslayer-managed runner setup.
- Removes references to the retired generated Rust docs publication at `moonbeam-foundation.github.io/moonbeam` from:
  - `README.md`
  - `CONTRIBUTIONS.md`
  - `pallets/parachain-staking/README.md`

## Compatibility and operations impact

No runtime, node, RPC, storage, or public API behavior changes.

The only operational impact is CI capacity selection: affected jobs now request smaller Blacksmith runners. This should reduce runner over-provisioning without slowing the required CI path meaningfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782327537&installation_id=130617128&pr_number=3763&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3763&signature=9a345a99877a9577603daee41cf1193037b0509d2eccb993a2b6508fdcf28772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->