### PR TITLE
smoke tests: drop unused ethersTransactionsFees from dynamic fee test

### DIFF
--- a/test/suites/smoke/test-dynamic-fees.ts
+++ b/test/suites/smoke/test-dynamic-fees.ts
@@ -31,7 +31,6 @@ type BlockFilteredRecord = {
   nextFeeMultiplier: u128;
   ethBlock: EthereumBlock;
   extrinsics: GenericExtrinsic<AnyTuple>[];
-  ethersTransactionsFees: bigint[];
   baseFeePerGasInGwei: string;
   transactionStatuses: FpRpcTransactionStatus[];
   weights: FrameSupportDispatchPerDispatchClassWeight;
@@ -160,11 +159,6 @@ describeSuite({
         const transactionStatuses = (
           await apiAt.query.ethereum.currentTransactionStatuses()
         ).unwrapOrDefault();
-        const ethersTransactionsFees = await Promise.all(
-          ethersBlock!.transactions.map(
-            async (hash) => (await context.ethers().provider!.getTransactionReceipt(hash))!.gasUsed
-          )
-        );
         const weights = await apiAt.query.system.blockWeight();
         const receipts = (await apiAt.query.ethereum.currentReceipts()).unwrapOr([]);
         const events = await apiAt.query.system.events();
@@ -224,7 +218,6 @@ describeSuite({
           blockNum,
           nextFeeMultiplier,
           ethBlock,
-          ethersTransactionsFees,
           transactionStatuses,
           extrinsics: signedBlock.block.extrinsics,
           baseFeePerGasInGwei: ethers.formatUnits(ethersBlock!.baseFeePerGas!, "gwei"),


### PR DESCRIPTION
Drop the unused ethersTransactionsFees collection from the dynamic fee smoke test setup.

The receipt lookup could intermittently return null on quieter networks such as Moonbase Alpha and Moonriver, causing setup to fail before the assertions ran. Since the collected gasUsed values were never consumed by the test, removing the lookup avoids the flaky null dereference without changing test coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782401995&installation_id=130617128&pr_number=3766&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3766&signature=32c7340daec1a13d5b877aed58b64493c13dcc73a0aa4f63eee22d3b2b03187f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->