### PR TITLE
`P256Verify` precompile should charges EVM gas for signature verification

### DIFF
--- a/pallets/precompile-benchmarks/src/benchmarks.rs
+++ b/pallets/precompile-benchmarks/src/benchmarks.rs
@@ -65,8 +65,16 @@ fn p256verify<T: Config>(input: Vec<u8>) -> PrecompileResult {
 			<T as Config>::WeightInfo::p256_verify()
 		}
 	}
+	struct P256VerifyGas<T>(PhantomData<T>);
+	impl<T: Config> Get<u64> for P256VerifyGas<T> {
+		fn get() -> u64 {
+			4000
+		}
+	}
 
-	pallet_evm_precompile_p256verify::P256Verify::<P256VerifyWeight<T>>::execute(&mut handle)
+	pallet_evm_precompile_p256verify::P256Verify::<P256VerifyWeight<T>, P256VerifyGas<T>>::execute(
+		&mut handle,
+	)
 }
 
 #[benchmarks]

--- a/precompiles/p256verify/src/lib.rs
+++ b/precompiles/p256verify/src/lib.rs
@@ -29,9 +29,9 @@ use fp_evm::{
 use frame_support::{traits::Get, weights::Weight};
 use p256::ecdsa::{signature::hazmat::PrehashVerifier, Signature, VerifyingKey};
 
-pub struct P256Verify<W: Get<Weight>>(PhantomData<W>);
+pub struct P256Verify<W: Get<Weight>, G: Get<u64>>(PhantomData<(W, G)>);
 
-impl<W: Get<Weight>> P256Verify<W> {
+impl<W: Get<Weight>, G: Get<u64>> P256Verify<W, G> {
 	/// Expected input length (160 bytes)
 	const INPUT_LENGTH: usize = 160;
 
@@ -39,6 +39,7 @@ impl<W: Get<Weight>> P256Verify<W> {
 	#[inline]
 	fn handle_cost(handle: &mut impl PrecompileHandle) -> Result<(), ExitError> {
 		let weight = W::get();
+		handle.record_cost(G::get())?;
 		handle.record_external_cost(Some(weight.ref_time()), None, None)
 	}
 
@@ -93,7 +94,7 @@ impl<W: Get<Weight>> P256Verify<W> {
 
 /// Implements RIP-7212 P256VERIFY precompile.
 /// https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md
-impl<W: Get<Weight>> Precompile for P256Verify<W> {
+impl<W: Get<Weight>, G: Get<u64>> Precompile for P256Verify<W, G> {
 	fn execute(handle: &mut impl PrecompileHandle) -> PrecompileResult {
 		Self::handle_cost(handle)?;
 
@@ -125,9 +126,10 @@ mod tests {
 
 	parameter_types! {
 		pub const DummyWeight: Weight = Weight::from_parts(3450, 0);
+		pub const DummyGas: u64 = 3450;
 	}
 
-	fn prepare_handle(input: Vec<u8>, cost: u64) -> impl PrecompileHandle {
+	fn prepare_handle(input: Vec<u8>, cost: u64) -> MockHandle {
 		let context: Context = Context {
 			address: Default::default(),
 			caller: Default::default(),
@@ -199,11 +201,16 @@ mod tests {
 
 			let unsuccessful_result = Vec::<u8>::new();
 
-			match (input.0, P256Verify::<DummyWeight>::execute(&mut handle)) {
+			match (
+				input.0,
+				P256Verify::<DummyWeight, DummyGas>::execute(&mut handle),
+			) {
 				(true, Ok(result)) => assert_eq!(result.output, success_result.to_vec()),
 				(false, Ok(result)) => assert_eq!(result.output, unsuccessful_result),
 				(_, Err(_)) => panic!("Test not expected to fail for input: {:?}", input),
 			}
+
+			assert_eq!(handle.gas_used, DummyGas::get());
 		}
 	}
 }

--- a/runtime/moonbase/src/precompiles.rs
+++ b/runtime/moonbase/src/precompiles.rs
@@ -21,6 +21,7 @@ use frame_support::parameter_types;
 use moonkit_xcm_primitives::location_matcher::{
 	Erc20PalletMatcher, ForeignAssetMatcher, SingleAddressMatcher,
 };
+use pallet_evm::GasWeightMapping;
 use pallet_evm_precompile_author_mapping::AuthorMappingPrecompile;
 use pallet_evm_precompile_balances_erc20::{Erc20BalancesPrecompile, Erc20Metadata};
 use pallet_evm_precompile_batch::BatchPrecompile;
@@ -60,6 +61,8 @@ use precompile_utils::precompile_set::*;
 parameter_types! {
 	pub P256VerifyWeight: frame_support::weights::Weight =
 		moonbase_weights::pallet_precompile_benchmarks::WeightInfo::<Runtime>::p256_verify();
+	pub P256VerifyGas: u64 =
+		<Runtime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(P256VerifyWeight::get());
 	pub AssetHubTransactor: crate::xcm_config::Transactors = crate::xcm_config::Transactors::AssetHub;
 }
 
@@ -141,7 +144,11 @@ type MoonbasePrecompilesAt<R> = (
 	PrecompileAt<AddressU64<16>, Bls12381MapG1, EthereumPrecompilesChecks>,
 	PrecompileAt<AddressU64<17>, Bls12381MapG2, EthereumPrecompilesChecks>,
 	// (0x100 => 256) https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md
-	PrecompileAt<AddressU64<256>, P256Verify<P256VerifyWeight>, EthereumPrecompilesChecks>,
+	PrecompileAt<
+		AddressU64<256>,
+		P256Verify<P256VerifyWeight, P256VerifyGas>,
+		EthereumPrecompilesChecks,
+	>,
 	// Non-Moonbeam specific nor Ethereum precompiles :
 	PrecompileAt<
 		AddressU64<1024>,

--- a/runtime/moonbeam/src/precompiles.rs
+++ b/runtime/moonbeam/src/precompiles.rs
@@ -23,6 +23,7 @@ use frame_support::parameter_types;
 use moonkit_xcm_primitives::location_matcher::{
 	Erc20PalletMatcher, ForeignAssetMatcher, SingleAddressMatcher,
 };
+use pallet_evm::GasWeightMapping;
 use pallet_evm_precompile_author_mapping::AuthorMappingPrecompile;
 use pallet_evm_precompile_balances_erc20::{Erc20BalancesPrecompile, Erc20Metadata};
 use pallet_evm_precompile_batch::BatchPrecompile;
@@ -62,6 +63,8 @@ use precompile_utils::precompile_set::*;
 parameter_types! {
 	pub P256VerifyWeight: frame_support::weights::Weight =
 		moonbeam_weights::pallet_precompile_benchmarks::WeightInfo::<Runtime>::p256_verify();
+	pub P256VerifyGas: u64 =
+		<Runtime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(P256VerifyWeight::get());
 	pub AssetHubTransactor: crate::xcm_config::Transactors = crate::xcm_config::Transactors::AssetHub;
 }
 
@@ -143,7 +146,11 @@ type MoonbeamPrecompilesAt<R> = (
 	PrecompileAt<AddressU64<16>, Bls12381MapG1, EthereumPrecompilesChecks>,
 	PrecompileAt<AddressU64<17>, Bls12381MapG2, EthereumPrecompilesChecks>,
 	// (0x100 => 256) https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md
-	PrecompileAt<AddressU64<256>, P256Verify<P256VerifyWeight>, EthereumPrecompilesChecks>,
+	PrecompileAt<
+		AddressU64<256>,
+		P256Verify<P256VerifyWeight, P256VerifyGas>,
+		EthereumPrecompilesChecks,
+	>,
 	// Non-Moonbeam specific nor Ethereum precompiles :
 	PrecompileAt<
 		AddressU64<1024>,

--- a/runtime/moonriver/src/precompiles.rs
+++ b/runtime/moonriver/src/precompiles.rs
@@ -23,6 +23,7 @@ use frame_support::parameter_types;
 use moonkit_xcm_primitives::location_matcher::{
 	Erc20PalletMatcher, ForeignAssetMatcher, SingleAddressMatcher,
 };
+use pallet_evm::GasWeightMapping;
 use pallet_evm_precompile_author_mapping::AuthorMappingPrecompile;
 use pallet_evm_precompile_balances_erc20::{Erc20BalancesPrecompile, Erc20Metadata};
 use pallet_evm_precompile_batch::BatchPrecompile;
@@ -62,6 +63,8 @@ use precompile_utils::precompile_set::*;
 parameter_types! {
 	pub P256VerifyWeight: frame_support::weights::Weight =
 		moonriver_weights::pallet_precompile_benchmarks::WeightInfo::<Runtime>::p256_verify();
+	pub P256VerifyGas: u64 =
+		<Runtime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(P256VerifyWeight::get());
 	pub AssetHubTransactor: crate::xcm_config::Transactors = crate::xcm_config::Transactors::AssetHub;
 }
 
@@ -139,7 +142,11 @@ type MoonriverPrecompilesAt<R> = (
 	PrecompileAt<AddressU64<16>, Bls12381MapG1, EthereumPrecompilesChecks>,
 	PrecompileAt<AddressU64<17>, Bls12381MapG2, EthereumPrecompilesChecks>,
 	// (0x100 => 256) https://github.com/ethereum/RIPs/blob/master/RIPS/rip-7212.md
-	PrecompileAt<AddressU64<256>, P256Verify<P256VerifyWeight>, EthereumPrecompilesChecks>,
+	PrecompileAt<
+		AddressU64<256>,
+		P256Verify<P256VerifyWeight, P256VerifyGas>,
+		EthereumPrecompilesChecks,
+	>,
 	// Non-Moonbeam specific nor Ethereum precompiles :
 	PrecompileAt<
 		AddressU64<1024>,


### PR DESCRIPTION
## :warning: Breaking changes :warning:

- `P256Verify` at `0x0000000000000000000000000000000000000100` now charges EVM gas for signature verification. Transactions or contracts that call this precompile with tight gas limits may need to raise their gas limit.

## Goal of the changes

Fix P256Verify fee undercharging by making the precompile charge the EVM gasometer for its native signature verification work, while keeping the existing external ref-time accounting.

## What reviewers need to know

- `precompiles/p256verify/src/lib.rs` now takes a separate gas provider and calls `handle.record_cost(...)` before `record_external_cost(...)`.
- `runtime/{moonbeam,moonriver,moonbase}/src/precompiles.rs` derives the P256 gas charge from the runtime benchmarked weight via `GasWeightMapping::weight_to_gas(P256VerifyWeight::get())`.
- The existing ref-time accounting remains in place, so the transaction ref-time limiter still accounts for the native verification work.
- The P256 precompile unit test now asserts that the mock EVM gasometer is charged.
- The precompile benchmark helper was updated to pass a mock gas provider.

## Testing

- `cargo test -p pallet-evm-precompile-p256verify`
- `cargo check -p moonbeam-runtime`
- `cargo check -p moonriver-runtime -p moonbase-runtime`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782465738&installation_id=130617128&pr_number=3768&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3768&signature=5001086d8920527565b49f41aa52806de8775b84017c1d333919e5b39d95d210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->