### PR TITLE
CI: optimise builds and pnpm cache

### DIFF
--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -59,7 +59,7 @@ runs:
     - name: Build Node
       shell: bash
       run: |
-        params=" --locked --release -p moonbeam"
+        params=" --locked -p moonbeam"
         if [ -n "${{ inputs.features }}" ]; then
           params="$params --features ${{ inputs.features }}"
         fi
@@ -68,8 +68,8 @@ runs:
     - name: Display binary comments
       shell: bash
       run: |
-        readelf -p .comment ./target/release/moonbeam
-        GLIBC_VERSION="$(objdump -T ./target/release/moonbeam | grep "GLIBC_" | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -1)"
+        readelf -p .comment ./target/debug/moonbeam
+        GLIBC_VERSION="$(objdump -T ./target/debug/moonbeam | grep "GLIBC_" | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu | tail -1)"
         echo "GLIBC Version: $GLIBC_VERSION"
     - name: Display sccache stats
       shell: bash
@@ -78,18 +78,18 @@ runs:
       shell: bash
       run: |
         GIT_COMMIT="$(git log -1 --format="%H" | cut -c1-7)"
-        MB_VERSION="$(./target/release/moonbeam --version)"
+        MB_VERSION="$(./target/debug/moonbeam --version)"
         echo "Checking $MB_VERSION contains $GIT_COMMIT"
         echo "$MB_VERSION" | grep "$GIT_COMMIT"
     - name: Save runtimes wasm
       shell: bash
       run: |
         mkdir -p runtimes
-        cp target/release/wbuild/moon*/moon*_runtime.compact.compressed.wasm runtimes/
+        cp target/debug/wbuild/moon*/moon*_runtime.compact.compressed.wasm runtimes/
         mkdir -p uncompressed-runtimes
-        cp target/release/wbuild/moon*/moon*_runtime.wasm uncompressed-runtimes/
+        cp target/debug/wbuild/moon*/moon*_runtime.wasm uncompressed-runtimes/
     - name: Save moonbeam binary
       shell: bash
       run: |
         mkdir -p build
-        cp target/release/moonbeam build/moonbeam
+        cp target/debug/moonbeam build/moonbeam

--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -58,6 +58,10 @@ runs:
       uses: ./.github/workflow-templates/rust-toolchain
     - name: Build Node
       shell: bash
+      env:
+        # Keep the native node in target/debug while still asking substrate-wasm-builder
+        # to compact and compress runtime artifacts for CI consumers.
+        WASM_BUILD_TYPE: release
       run: |
         params=" --locked -p moonbeam"
         if [ -n "${{ inputs.features }}" ]; then

--- a/.github/workflow-templates/pnpm-blacksmith/action.yml
+++ b/.github/workflow-templates/pnpm-blacksmith/action.yml
@@ -1,0 +1,28 @@
+name: Blacksmith pnpm setup
+description: Install pnpm and Node.js with one shared Blacksmith pnpm store per pnpm version.
+
+inputs:
+  pnpm-version:
+    description: pnpm version to install and use in the shared store key.
+    required: false
+    default: "9"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+      with:
+        version: ${{ inputs.pnpm-version }}
+        cache: false
+    - name: Mount Blacksmith pnpm store
+      uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab
+      with:
+        key: ${{ github.repository }}-pnpm-store-${{ runner.os }}-pnpm-${{ inputs.pnpm-version }}
+        path: .pnpm-store
+    - name: Configure pnpm store
+      shell: bash
+      run: pnpm config set store-dir "$GITHUB_WORKSPACE/.pnpm-store"
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+      with:
+        node-version-file: "test/.nvmrc"
+        package-manager-cache: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,11 @@ jobs:
           node-version-file: "test/.nvmrc"
           package-manager-cache: false
       - run: pnpm install
-      - run: pnpm check
+      - name: Run Biome
+        run: |
+          pnpm --dir types-bundle exec biome check . --diagnostic-level=error
+          pnpm --dir typescript-api exec biome check . --diagnostic-level=error
+          pnpm --dir test exec biome check . --diagnostic-level=error
 
   check-cargo-toml-format:
     if: ${{ needs.set-tags.outputs.rust_changed == 'true' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,8 @@ jobs:
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
           persist-credentials: false
+      - name: Install Chrome for linkspector
+        run: npx --yes puppeteer browsers install chrome
       - uses: umbrelladocs/action-linkspector@ec40914b4aaecb3c7648033eac41abbb0a6a33b8
         with:
           reporter: github-pr-review

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -523,8 +523,8 @@ jobs:
   #       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
   #       with:
   #         name: moonbeam
-  #         path: target/release
-  #     - run: chmod uog+x target/release/moonbeam
+  #         path: target/debug
+  #     - run: chmod uog+x target/debug/moonbeam
   #     - name: Run Typegen
   #       run: |
   #         pnpm i
@@ -574,17 +574,17 @@ jobs:
           persist-credentials: false
       - name: Create local folders
         run: |
-          mkdir -p target/release/wbuild/${{ matrix.chain }}-runtime/
+          mkdir -p target/debug/wbuild/${{ matrix.chain }}-runtime/
       - name: "Download branch built runtime"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: runtimes
-          path: target/release/wbuild/${{ matrix.chain }}-runtime/
+          path: target/debug/wbuild/${{ matrix.chain }}-runtime/
       - name: "Download branch built node"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: moonbeam
-          path: target/release
+          path: target/debug
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
         with:
           version: 9
@@ -599,7 +599,7 @@ jobs:
           DEBUG_COLOURS: "1"
           NODE_OPTIONS: "--max-old-space-size=12288"
         run: |
-          chmod uog+x target/release/moonbeam
+          chmod uog+x target/debug/moonbeam
           cd test
           pnpm install
           pnpm compile-solidity
@@ -645,12 +645,12 @@ jobs:
           node-version-file: "test/.nvmrc"
           package-manager-cache: false
       - run: |
-          mkdir -p target/release
+          mkdir -p target/debug
       - name: "Download branch built node"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: moonbeam
-          path: target/release
+          path: target/debug
       - name: Get tracing runtimes
         run: |
           ./scripts/build-last-tracing-runtime.sh ${{ needs.set-tags.outputs.git_branch }}
@@ -659,7 +659,7 @@ jobs:
       - name: Preparing the repository
         run: |
           chmod uog+x build/moonbeam
-          chmod uog+x target/release/moonbeam
+          chmod uog+x target/debug/moonbeam
       - name: Running Tracing Tests
         env:
           DEBUG_COLOURS: "1"
@@ -710,21 +710,21 @@ jobs:
           package-manager-cache: false
       - name: Create local folders
         run: |
-          mkdir -p target/release/wbuild/${{ matrix.chain }}-runtime/
+          mkdir -p target/debug/wbuild/${{ matrix.chain }}-runtime/
           mkdir -p test/tmp
       - name: "Download branch built runtime"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: runtimes
-          path: target/release/wbuild/${{ matrix.chain }}-runtime/
+          path: target/debug/wbuild/${{ matrix.chain }}-runtime/
       - name: "Download branch built node"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: moonbeam
-          path: target/release
+          path: target/debug
       - name: "Run lazy loading tests"
         run: |
-          chmod uog+x target/release/moonbeam
+          chmod uog+x target/debug/moonbeam
           cd test
           pnpm install
           pnpm moonwall test lazy_loading_${{ matrix.chain }}
@@ -780,13 +780,13 @@ jobs:
           bun-version: latest
       - name: Create local folders
         run: |
-          mkdir -p target/release/wbuild/${{ matrix.chain }}-runtime/
+          mkdir -p target/debug/wbuild/${{ matrix.chain }}-runtime/
           mkdir -p test/tmp/node_logs
       - name: "Download runtime"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: runtimes
-          path: target/release/wbuild/${{ matrix.chain }}-runtime/
+          path: target/debug/wbuild/${{ matrix.chain }}-runtime/
       - name: "Install and run upgrade test"
         run: |
           pnpm install
@@ -842,18 +842,18 @@ jobs:
           package-manager-cache: false
       - name: Create local folders
         run: |
-          mkdir -p target/release/wbuild/${{ matrix.chain }}-runtime/
+          mkdir -p target/debug/wbuild/${{ matrix.chain }}-runtime/
           mkdir -p test/tmp
       - name: "Download branch built runtime"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: runtimes
-          path: target/release/wbuild/${{ matrix.chain }}-runtime/
+          path: target/debug/wbuild/${{ matrix.chain }}-runtime/
       - name: "Download branch built node"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: moonbeam
-          path: target/release
+          path: target/debug
       - name: Retrieve moonbeam binary from docker (for plainSpec generation)
         run: |
           LATEST_CLIENT=$(curl -s https://api.github.com/repos/moonbeam-foundation/moonbeam/releases | jq -r '.[] | select(.name | test("v";"i")) | .tag_name' | sort -rs | head -n 1 | tr -d '[:blank:]')
@@ -866,11 +866,11 @@ jobs:
 
           ## Generate old spec using latest published node, modify it, and generate raw spec
           chmod uog+x tmp/moonbeam_rt
-          chmod uog+x ../target/release/moonbeam
+          chmod uog+x ../target/debug/moonbeam
           tmp/moonbeam_rt build-spec --chain ${{ matrix.chain }}-local > tmp/${{ matrix.chain }}-plain-spec.json
           pnpm tsx scripts/modify-plain-specs.ts process tmp/${{ matrix.chain }}-plain-spec.json tmp/${{ matrix.chain }}-modified-spec.json
           tmp/moonbeam_rt build-spec --chain tmp/${{ matrix.chain }}-modified-spec.json --raw > tmp/${{ matrix.chain }}-raw-spec.json
-          pnpm tsx scripts/preapprove-rt-rawspec.ts process tmp/${{ matrix.chain }}-raw-spec.json tmp/${{ matrix.chain }}-modified-raw-spec.json ../target/release/wbuild/${{ matrix.chain }}-runtime/${{ matrix.chain }}_runtime.compact.compressed.wasm
+          pnpm tsx scripts/preapprove-rt-rawspec.ts process tmp/${{ matrix.chain }}-raw-spec.json tmp/${{ matrix.chain }}-modified-raw-spec.json ../target/debug/wbuild/${{ matrix.chain }}-runtime/${{ matrix.chain }}_runtime.compact.compressed.wasm
       - name: "Run zombie upgrade test"
         run: |
           cd test
@@ -913,18 +913,18 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: runtimes
-          path: target/release
+          path: target/debug
       - name: "Download branch built node"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: moonbeam
-          path: target/release
+          path: target/debug
       - name: Setup
         run: |
           # Install polkadot-js-api
           # https://github.com/paritytech/polkadot-sdk/blob/56f683fabfc5a4554d4b9208e91103624264407c/bridges/testing/framework/utils/bridges.sh#L21
           npm install -g @polkadot/api-cli
-          chmod uog+x ./target/release/moonbeam
+          chmod uog+x ./target/debug/moonbeam
           # This command prepares all required binaries and runs the bridge integration tests
           make run-bridge-integration-tests
       - name: Zip and Upload Logs on Failure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -587,15 +587,7 @@ jobs:
         with:
           name: moonbeam
           path: target/debug
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
-        with:
-          version: 9
-          cache: true
-          cache_dependency_path: pnpm-lock.yaml
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: "test/.nvmrc"
-          package-manager-cache: false
+      - uses: ./.github/workflow-templates/pnpm-blacksmith
       - name: "Run Moonwall Dev Tests"
         env:
           DEBUG_COLOURS: "1"
@@ -635,17 +627,7 @@ jobs:
         with:
           name: moonbeam
           path: build
-      - name: Use pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
-        with:
-          version: 9
-          cache: true
-          cache_dependency_path: pnpm-lock.yaml
-      - name: Use Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: "test/.nvmrc"
-          package-manager-cache: false
+      - uses: ./.github/workflow-templates/pnpm-blacksmith
       - run: |
           mkdir -p target/debug
       - name: "Download branch built node"
@@ -701,15 +683,7 @@ jobs:
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
           persist-credentials: false
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
-        with:
-          version: 9
-          cache: true
-          cache_dependency_path: pnpm-lock.yaml
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: "test/.nvmrc"
-          package-manager-cache: false
+      - uses: ./.github/workflow-templates/pnpm-blacksmith
       - name: Create local folders
         run: |
           mkdir -p target/debug/wbuild/${{ matrix.chain }}-runtime/
@@ -768,15 +742,7 @@ jobs:
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
           persist-credentials: false
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
-        with:
-          version: 9
-          cache: true
-          cache_dependency_path: pnpm-lock.yaml
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: "test/.nvmrc"
-          package-manager-cache: false
+      - uses: ./.github/workflow-templates/pnpm-blacksmith
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: latest
@@ -833,15 +799,7 @@ jobs:
         with:
           ref: ${{ needs.set-tags.outputs.git_ref }}
           persist-credentials: false
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
-        with:
-          version: 9
-          cache: true
-          cache_dependency_path: pnpm-lock.yaml
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: "test/.nvmrc"
-          package-manager-cache: false
+      - uses: ./.github/workflow-templates/pnpm-blacksmith
       - name: Create local folders
         run: |
           mkdir -p target/debug/wbuild/${{ matrix.chain }}-runtime/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -493,11 +493,11 @@ jobs:
       - name: Check runtime-benchmarks compilation
         if: github.ref == 'refs/heads/master' || needs.set-tags.outputs.benchmarks_changed == 'true'
         run: |
-          cargo check --profile testnet --workspace --features=runtime-benchmarks
+          cargo check --profile rust-tests --workspace --features=runtime-benchmarks
       # Checks are run after uploading artifacts since they are modified by the tests
       - name: Unit tests
         run: |
-          cargo test --profile testnet --workspace --features=evm-tracing
+          cargo test --profile rust-tests --workspace --features=evm-tracing
 
   # Renable typegen_check when we have a bot in place to update PR for us in case of missing it
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,7 @@ jobs:
           ref: ${{ needs.set-tags.outputs.git_ref }}
           persist-credentials: false
       - name: Install Chrome for linkspector
-        run: npx --yes puppeteer browsers install chrome
+        run: npx --yes puppeteer@24.31.0 browsers install chrome@148.0.7778.97
       - uses: umbrelladocs/action-linkspector@ec40914b4aaecb3c7648033eac41abbb0a6a33b8
         with:
           reporter: github-pr-review

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,7 +487,7 @@ opt-level = 3
 # Moonbeam runtime requires unwinding.
 panic = "unwind"
 
-[profile.testnet]
+[profile.rust-tests]
 inherits = "dev"
 codegen-units = 256
 debug = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,9 +481,9 @@ codegen-units = 1
 incremental = false
 lto = true
 
-[profile.release]
+[profile.dev]
 debug-assertions = true # Enable debug-assert! for non-production profiles
-opt-level = 3
+opt-level = 1
 # Moonbeam runtime requires unwinding.
 panic = "unwind"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -494,7 +494,7 @@ debug = 0
 debug-assertions = true # Enable debug-assert! for non-production profiles
 incremental = false
 lto = false
-opt-level = 1
+opt-level = 0
 overflow-checks = true
 # Moonbeam runtime requires unwinding.
 panic = "unwind"

--- a/test/README.md
+++ b/test/README.md
@@ -20,7 +20,7 @@ There are [various](https://pnpm.io/installation) ways to install it, but perhap
 Build the node before running tests (`metadata-hash` feature is required to run `/test-transaction/test-transaction-with-metadata-hash.ts`):
 
 ```
-cargo build --features metadata-hash
+WASM_BUILD_TYPE=release cargo build --features metadata-hash
 ```
 
 Always install and update the package dependencies:

--- a/test/README.md
+++ b/test/README.md
@@ -20,7 +20,7 @@ There are [various](https://pnpm.io/installation) ways to install it, but perhap
 Build the node before running tests (`metadata-hash` feature is required to run `/test-transaction/test-transaction-with-metadata-hash.ts`):
 
 ```
-cargo build --release --features metadata-hash 
+cargo build --features metadata-hash
 ```
 
 Always install and update the package dependencies:

--- a/test/configs/localZombie.json
+++ b/test/configs/localZombie.json
@@ -48,7 +48,7 @@
       "collator": {
         "name": "alith",
         "rpc_port": 33345,
-        "command": "../target/release/moonbeam",
+        "command": "../target/debug/moonbeam",
         "args": [
           "--no-hardware-benchmarks",
           "--force-authoring",

--- a/test/configs/zombieAlphanet.json
+++ b/test/configs/zombieAlphanet.json
@@ -49,7 +49,7 @@
         {
           "name": "alith",
           "rpc_port": 33345,
-          "command": "../target/release/moonbeam",
+          "command": "../target/debug/moonbeam",
           "args": [
             "--no-hardware-benchmarks",
             "--force-authoring",
@@ -64,7 +64,7 @@
           "validator": false,
           "rpc_port": 33048,
           "p2p_port": 33049,
-          "command": "../target/release/moonbeam",
+          "command": "../target/debug/moonbeam",
           "args": [
             "--no-hardware-benchmarks",
             "-lparachain=trace",

--- a/test/configs/zombieMoonbeam.json
+++ b/test/configs/zombieMoonbeam.json
@@ -48,7 +48,7 @@
       "collators": [
         {
           "name": "alith",
-          "command": "../target/release/moonbeam",
+          "command": "../target/debug/moonbeam",
           "rpc_port": 33345,
           "args": [
             "--no-hardware-benchmarks",
@@ -64,7 +64,7 @@
           "validator": false,
           "rpc_port": 33048,
           "p2p_port": 33049,
-          "command": "../target/release/moonbeam",
+          "command": "../target/debug/moonbeam",
           "args": [
             "--no-hardware-benchmarks",
             "-lparachain=debug",

--- a/test/configs/zombieMoonriver.json
+++ b/test/configs/zombieMoonriver.json
@@ -48,7 +48,7 @@
       "collators": [
         {
           "name": "alith",
-          "command": "../target/release/moonbeam",
+          "command": "../target/debug/moonbeam",
           "rpc_port": 33345,
           "args": [
             "--no-hardware-benchmarks",
@@ -64,7 +64,7 @@
           "validator": false,
           "rpc_port": 33048,
           "p2p_port": 33049,
-          "command": "../target/release/moonbeam",
+          "command": "../target/debug/moonbeam",
           "args": [
             "--no-hardware-benchmarks",
             "-lparachain=debug",

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -31,7 +31,7 @@
       "multiThreads": false,
       "runScripts": ["download-polkadot.sh"],
       "foundation": {
-        "rtUpgradePath": "../target/release/wbuild/moonbeam-runtime/moonbeam_runtime.compact.compressed.wasm",
+        "rtUpgradePath": "../target/debug/wbuild/moonbeam-runtime/moonbeam_runtime.compact.compressed.wasm",
         "type": "zombie",
         "zombieSpec": {
           "configPath": "./configs/zombieMoonbeam.json"
@@ -66,7 +66,7 @@
       "multiThreads": false,
       "runScripts": ["download-polkadot.sh"],
       "foundation": {
-        "rtUpgradePath": "../target/release/wbuild/moonriver-runtime/moonriver_runtime.compact.compressed.wasm",
+        "rtUpgradePath": "../target/debug/wbuild/moonriver-runtime/moonriver_runtime.compact.compressed.wasm",
         "type": "zombie",
         "zombieSpec": {
           "configPath": "./configs/zombieMoonriver.json"
@@ -101,7 +101,7 @@
       "multiThreads": false,
       "runScripts": ["download-polkadot.sh"],
       "foundation": {
-        "rtUpgradePath": "../target/release/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm",
+        "rtUpgradePath": "../target/debug/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm",
         "type": "zombie",
         "zombieSpec": {
           "configPath": "./configs/zombieAlphanet.json"
@@ -388,8 +388,8 @@
       "contracts": "contracts/",
       "runScripts": [
         "compile-contracts.ts compile",
-        "compile-wasm.ts compile -b ../target/release/moonbeam -o wasm -c moonbeam-dev",
-        "prepare-lazy-loading-overrides.ts process configs/lazyLoadingStateOverrides.json tmp/lazyLoadingStateOverrides.json ../target/release/wbuild/moonbeam-runtime/moonbeam_runtime.compact.compressed.wasm"
+        "compile-wasm.ts compile -b ../target/debug/moonbeam -o wasm -c moonbeam-dev",
+        "prepare-lazy-loading-overrides.ts process configs/lazyLoadingStateOverrides.json tmp/lazyLoadingStateOverrides.json ../target/debug/wbuild/moonbeam-runtime/moonbeam_runtime.compact.compressed.wasm"
       ],
       "multiThreads": 4,
       "envVars": ["DEBUG_COLORS=1"],
@@ -402,7 +402,7 @@
         "launchSpec": [
           {
             "name": "moonbeam",
-            "binPath": "../target/release/moonbeam",
+            "binPath": "../target/debug/moonbeam",
             "newRpcBehaviour": true,
             "legacy": false,
             "options": [
@@ -440,7 +440,7 @@
       "contracts": "contracts/",
       "runScripts": [
         "compile-contracts.ts compile",
-        "compile-wasm.ts compile -b ../target/release/moonbeam -o wasm -c moonbeam-dev"
+        "compile-wasm.ts compile -b ../target/debug/moonbeam -o wasm -c moonbeam-dev"
       ],
       "multiThreads": 4,
       "envVars": ["DEBUG_COLORS=1"],
@@ -453,7 +453,7 @@
         "launchSpec": [
           {
             "name": "moonbeam",
-            "binPath": "../target/release/moonbeam",
+            "binPath": "../target/debug/moonbeam",
             "newRpcBehaviour": true,
             "legacy": false,
             "options": [
@@ -485,7 +485,7 @@
       "contracts": "contracts/",
       "runScripts": [
         "compile-contracts.ts compile",
-        "compile-wasm.ts compile -b ../target/release/moonbeam -o wasm -c moonriver-dev"
+        "compile-wasm.ts compile -b ../target/debug/moonbeam -o wasm -c moonriver-dev"
       ],
       "multiThreads": 8,
       "envVars": ["DEBUG_COLORS=1"],
@@ -498,7 +498,7 @@
         "launchSpec": [
           {
             "name": "moonbeam",
-            "binPath": "../target/release/moonbeam",
+            "binPath": "../target/debug/moonbeam",
             "newRpcBehaviour": true,
             "legacy": false,
             "options": [
@@ -530,7 +530,7 @@
       "contracts": "contracts/",
       "runScripts": [
         "compile-contracts.ts compile",
-        "compile-wasm.ts compile -b ../target/release/moonbeam -o wasm -c moonbase-dev"
+        "compile-wasm.ts compile -b ../target/debug/moonbeam -o wasm -c moonbase-dev"
       ],
       "multiThreads": 4,
       "envVars": ["DEBUG_COLORS=1"],
@@ -543,7 +543,7 @@
         "launchSpec": [
           {
             "name": "moonbeam",
-            "binPath": "../target/release/moonbeam",
+            "binPath": "../target/debug/moonbeam",
             "newRpcBehaviour": true,
             "legacy": false,
             "options": [
@@ -574,7 +574,7 @@
       "contracts": "contracts/",
       "runScripts": [
         "compile-contracts.ts compile",
-        "compile-wasm.ts compile -b ../target/release/moonbeam -o wasm -c moonbase-dev"
+        "compile-wasm.ts compile -b ../target/debug/moonbeam -o wasm -c moonbase-dev"
       ],
       "multiThreads": 4,
       "envVars": ["DEBUG_COLORS=1"],
@@ -584,7 +584,7 @@
         "launchSpec": [
           {
             "name": "moonbeam",
-            "binPath": "../target/release/moonbeam",
+            "binPath": "../target/debug/moonbeam",
             "newRpcBehaviour": true,
             "options": [
               "--ethapi=txpool,debug,trace",
@@ -665,7 +665,7 @@
       "testFileDir": ["suites/chopsticks/"],
       "foundation": {
         "type": "chopsticks",
-        "rtUpgradePath": "../target/release/wbuild/moonbeam-runtime/moonbeam_runtime.compact.compressed.wasm",
+        "rtUpgradePath": "../target/debug/wbuild/moonbeam-runtime/moonbeam_runtime.compact.compressed.wasm",
         "launchSpec": [
           {
             "name": "mb",
@@ -688,7 +688,7 @@
       "testFileDir": ["suites/chopsticks/"],
       "foundation": {
         "type": "chopsticks",
-        "rtUpgradePath": "../target/release/wbuild/moonriver-runtime/moonriver_runtime.compact.compressed.wasm",
+        "rtUpgradePath": "../target/debug/wbuild/moonriver-runtime/moonriver_runtime.compact.compressed.wasm",
         "launchSpec": [
           {
             "name": "mb",
@@ -711,7 +711,7 @@
       "testFileDir": ["suites/chopsticks/"],
       "foundation": {
         "type": "chopsticks",
-        "rtUpgradePath": "../target/release/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm",
+        "rtUpgradePath": "../target/debug/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm",
         "launchSpec": [
           {
             "name": "mb",

--- a/test/scripts/prepare-chainspecs-for-zombie.sh
+++ b/test/scripts/prepare-chainspecs-for-zombie.sh
@@ -27,11 +27,11 @@ docker cp moonbeam_container:moonbeam/moonbeam tmp/moonbeam_rt
 docker rm -f moonbeam_container
 
 chmod uog+x tmp/moonbeam_rt
-chmod uog+x ../target/release/moonbeam
+chmod uog+x ../target/debug/moonbeam
 echo "Building plain Moonbase specs..."
 tmp/moonbeam_rt build-spec --chain $CHAIN-local > tmp/$CHAIN\-plain-spec.json
 pnpm tsx scripts/modify-plain-specs.ts process tmp/$CHAIN\-plain-spec.json tmp/$CHAIN\-modified-spec.json
 tmp/moonbeam_rt build-spec --chain tmp/$CHAIN\-modified-spec.json --raw > tmp/$CHAIN\-raw-spec.json
-pnpm tsx scripts/preapprove-rt-rawspec.ts process tmp/$CHAIN\-raw-spec.json tmp/$CHAIN\-modified-raw-spec.json ../target/release/wbuild/$CHAIN\-runtime/$CHAIN\_runtime.compact.compressed.wasm
+pnpm tsx scripts/preapprove-rt-rawspec.ts process tmp/$CHAIN\-raw-spec.json tmp/$CHAIN\-modified-raw-spec.json ../target/debug/wbuild/$CHAIN\-runtime/$CHAIN\_runtime.compact.compressed.wasm
 
 echo "Done preparing chainspecs for Zombienet tests! ✅"

--- a/test/scripts/update-local-types.ts
+++ b/test/scripts/update-local-types.ts
@@ -40,17 +40,19 @@ const writeFile = async (relativeDir: string, fileName: string, data: string) =>
 
 const checkBinary = async () => {
   try {
-    const { stderr } = await execAsync("ls ../target/release/moonbeam");
+    const { stderr } = await execAsync("ls ../target/debug/moonbeam");
     if (stderr) console.error(`stderr: ${stderr}`);
   } catch {
-    console.error("Moonbeam binary missing, please build it first using `cargo build --release`");
+    console.error(
+      "Moonbeam binary missing, please build it first using `cargo build`"
+    );
   }
 };
 
 const startNode = (network: string, rpcPort: string, port: string) => {
   console.log(`Starting ${network.toUpperCase()} node at port `, port);
   const node = spawn(
-    "../target/release/moonbeam",
+    "../target/debug/moonbeam",
     [
       "--alice",
       `--chain=${network}`,

--- a/test/scripts/update-local-types.ts
+++ b/test/scripts/update-local-types.ts
@@ -43,9 +43,7 @@ const checkBinary = async () => {
     const { stderr } = await execAsync("ls ../target/debug/moonbeam");
     if (stderr) console.error(`stderr: ${stderr}`);
   } catch {
-    console.error(
-      "Moonbeam binary missing, please build it first using `cargo build`"
-    );
+    console.error("Moonbeam binary missing, please build it first using `cargo build`");
   }
 };
 

--- a/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
+++ b/test/suites/dev/moonbase/test-staking/test-delegate-with-auto-compound7.ts
@@ -28,7 +28,7 @@ describeSuite({
 
         // Submit a huge preimage (to have a deposit greater than the staked amount)
         const wasm = fs.readFileSync(
-          "../target/release/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm"
+          "../target/debug/wbuild/moonbase-runtime/moonbase_runtime.compact.compressed.wasm"
         );
         const encodedPreimage = `0x${wasm.toString("hex")}`;
         await context.createBlock(

--- a/test/suites/lazy-loading/common/test-runtime-upgrade.ts
+++ b/test/suites/lazy-loading/common/test-runtime-upgrade.ts
@@ -23,7 +23,7 @@ describeSuite({
         .filter((v) => Object.keys(RUNTIME_CONSTANTS).includes(v))
         .join()
         .toLowerCase();
-      const wasmPath = `../target/release/wbuild/${runtime}-runtime/${runtime}_runtime.compact.compressed.wasm`;
+      const wasmPath = `../target/debug/wbuild/${runtime}-runtime/${runtime}_runtime.compact.compressed.wasm`;
       const runtimeWasmHex = u8aToHex(await fs.readFile(wasmPath));
 
       const rtBefore = api.consts.system.version.specVersion.toNumber();


### PR DESCRIPTION
## Goal of the changes

Make Rust and end-to-end test builds faster and clearer by separating the Rust test profile from the dev/debug binary used by TypeScript end-to-end tests, and fix CI issues around pnpm caching and linkspector Chrome setup.

## What reviewers need to know

- Renames the Rust compilation profile from `testnet` to `rust-tests`.
- Lowers the `rust-tests` profile `opt-level` from `1` to `0` to optimize Rust test compilation time.
- Moves the non-production end-to-end node build settings from the overridden `release` profile onto `dev`, so `cargo build` produces the test node at `target/debug/moonbeam`.
- Lowers the dev/end-to-end build `opt-level` from `3` to `1` to reduce build cost while keeping a usable test binary.
- Keeps `production` as the profile used for real release builds.
- Updates CI artifact paths, Moonwall config, ZombieNet config, chopsticks/lazy-loading runtime paths, typegen helpers, and test docs from `target/release` to `target/debug`.
- Adds a shared Blacksmith pnpm setup action that disables per-job pnpm action caching and uses one sticky `.pnpm-store` cache keyed by repo, OS, and pnpm version.
- Installs Puppeteer Chrome before `action-linkspector` so the link checker does not fail because `/home/runner/.cache/puppeteer` is missing the expected browser.

## Testing

- `cargo metadata --no-deps --format-version 1`
- `jq empty test/moonwall.config.json test/configs/localZombie.json test/configs/zombieMoonriver.json test/configs/zombieMoonbeam.json test/configs/zombieAlphanet.json`
- `ruby -e 'require "yaml"; ...'` for `.github/workflows/build.yml` and `.github/workflow-templates/pnpm-blacksmith/action.yml`
- `actionlint -shellcheck= .github/workflows/build.yml`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782554586&installation_id=130617128&pr_number=3773&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3773&signature=9dc84598b27ffd0d9f811a66c48e7f0863105d5e02ac1c2b84cb0d95eacd04b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->