### PR TITLE
CI: properly skip tests for docs only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -603,6 +603,24 @@ jobs:
           pnpm compile-solidity
           pnpm moonwall test dev_${{ matrix.chain }} --ts ${{ matrix.shard }}/4
 
+  dev-test-docs-only:
+    # Branch protection requires the matrix-expanded dev-test check names. When
+    # only docs changed, the real job-level condition skips before matrix
+    # expansion, so emit cheap successful placeholders with the same names.
+    if: ${{ needs.set-tags.outputs.any_changed == 'false' }}
+    name: "dev-test (${{ matrix.chain }}, ${{ matrix.shard }})"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: ["set-tags"]
+    strategy:
+      fail-fast: false
+      matrix:
+        chain: ["moonbase", "moonriver", "moonbeam"]
+        shard: [1, 2, 3, 4]
+    steps:
+      - run: echo "Skipping dev tests for docs-only changes."
+
   typescript-tracing-tests:
     # Tracing tests are expensive, so run them on master or when explicitly
     # requested on PRs.
@@ -721,6 +739,20 @@ jobs:
           name: failed-node-logs-lazy-loading-${{ matrix.chain }}
           path: ${{ env.NODE_LOGS_ZIP }}
 
+  lazy-loading-tests-docs-only:
+    if: ${{ needs.set-tags.outputs.any_changed == 'false' }}
+    name: "lazy-loading-tests (${{ matrix.chain }})"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: ["set-tags"]
+    strategy:
+      fail-fast: false
+      matrix:
+        chain: ["moonbeam"]
+    steps:
+      - run: echo "Skipping lazy loading tests for docs-only changes."
+
   chopsticks-upgrade-test:
     # Upgrade tests consume larger runners, so only start them after moonbase
     # dev tests prove the PR is worth the heavier checks.
@@ -775,6 +807,20 @@ jobs:
           command: |
             cd test
             bun moonwall test upgrade_${{matrix.chain}}
+
+  chopsticks-upgrade-test-docs-only:
+    if: ${{ needs.set-tags.outputs.any_changed == 'false' }}
+    name: "chopsticks-upgrade-test (${{ matrix.chain }})"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: ["set-tags"]
+    strategy:
+      fail-fast: false
+      matrix:
+        chain: ["moonbase", "moonriver", "moonbeam"]
+    steps:
+      - run: echo "Skipping chopsticks upgrade tests for docs-only changes."
 
   zombie_upgrade_test:
     # Zombie upgrade tests are expensive and run serially; run all runtimes on
@@ -852,6 +898,20 @@ jobs:
         with:
           name: failed-node-logs-zombie-${{ matrix.chain }}
           path: ${{ env.NODE_LOGS_ZIP }}
+
+  zombie_upgrade_test-docs-only:
+    if: ${{ needs.set-tags.outputs.any_changed == 'false' }}
+    name: "zombie_upgrade_test (${{ matrix.chain }})"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: ["set-tags"]
+    strategy:
+      fail-fast: false
+      matrix:
+        chain: ${{ github.ref == 'refs/heads/master' && fromJSON('["moonbase", "moonriver", "moonbeam"]') || fromJSON('["moonbeam"]') }}
+    steps:
+      - run: echo "Skipping zombie upgrade tests for docs-only changes."
 
   bridge-integration-tests:
     # Bridge integration tests are expensive and only relevant to Rust changes, so


### PR DESCRIPTION
### What does it do?

Adds docs-only placeholder jobs for required matrix CI checks that otherwise never get emitted when a PR changes only documentation files.

For docs-only PRs, the workflow now creates successful lightweight checks for:

- `dev-test (...)`
- `lazy-loading-tests (...)`
- `chopsticks-upgrade-test (...)`
- `zombie_upgrade_test (...)`

This prevents GitHub branch protection from waiting forever on matrix-expanded required checks that are skipped before matrix expansion.

### What important points should reviewers know?

The real CI jobs are unchanged. Code or mixed code+docs PRs still follow the existing build/test paths.

The placeholder jobs only run when `set-tags.outputs.any_changed == 'false'`, which is the existing workflow signal for “only ignored docs/text files changed”.

`zombie_upgrade_test-docs-only` mirrors the real job’s branch-dependent matrix: all three chains on `master`, only `moonbeam` on PRs.

Validation performed locally:

- YAML parse check
- `actionlint` (only existing shellcheck warnings in unrelated workflow scripts)

### What alternative implementations were considered?

I considered folding the docs-only fast path into the existing matrix jobs, but that made the workflow harder to read because every real test step needed extra conditional guards. The explicit placeholder jobs are more verbose, but keep the production CI path simple and easier to reason about.

### What value does it bring to the blockchain users?

No direct runtime or node behavior changes. This improves repository CI reliability by allowing documentation-only PRs to satisfy branch protection without running expensive build/test jobs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782567352&installation_id=130617128&pr_number=3777&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3777&signature=e6061e3a06c8fe8dc3f4716a5904565c3f7b1c9861423da2daf8f9c997e7d6d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->