### PR TITLE
remove completed ResetStorage<DestinationAssetFeePerSecond> multi-block migration

### DIFF
--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -287,4 +287,4 @@ pub type SingleBlockMigrations<Runtime> = (
 
 /// List of common multiblock migrations to be executed by the pallet-migrations pallet.
 /// The migrations listed here are common to every moonbeam runtime.
-pub type MultiBlockMigrations<Runtime> = ();
+pub type MultiBlockMigrations = ();

--- a/runtime/common/src/migrations.rs
+++ b/runtime/common/src/migrations.rs
@@ -23,7 +23,7 @@ use frame_support::traits::PalletInfoAccess;
 use frame_support::weights::WeightMeter;
 use pallet_migrations::WeightInfo;
 use parity_scale_codec::Encode;
-use sp_core::{parameter_types, twox_128, Get};
+use sp_core::{twox_128, Get};
 use sp_io::{storage::clear_prefix, KillStorageResult};
 use sp_runtime::SaturatedConversion;
 
@@ -285,16 +285,6 @@ pub type SingleBlockMigrations<Runtime> = (
 	PermanentSingleBlockMigrations<Runtime>,
 );
 
-parameter_types! {
-	pub const DestinationAssetFeePerSecondStorageName: &'static str = "DestinationAssetFeePerSecond";
-}
-
 /// List of common multiblock migrations to be executed by the pallet-migrations pallet.
 /// The migrations listed here are common to every moonbeam runtime.
-pub type MultiBlockMigrations<Runtime> = (
-	ResetStorage<
-		Runtime,
-		pallet_xcm_transactor::Pallet<Runtime>,
-		DestinationAssetFeePerSecondStorageName,
-	>,
-);
+pub type MultiBlockMigrations<Runtime> = ();

--- a/runtime/moonbase/src/lib.rs
+++ b/runtime/moonbase/src/lib.rs
@@ -1406,7 +1406,7 @@ impl cumulus_pallet_weight_reclaim::Config for Runtime {
 impl pallet_migrations::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	#[cfg(not(feature = "runtime-benchmarks"))]
-	type Migrations = migrations::MultiBlockMigrationList<Runtime>;
+	type Migrations = migrations::MultiBlockMigrationList;
 	#[cfg(feature = "runtime-benchmarks")]
 	type Migrations = pallet_migrations::mock_helpers::MockedMigrations;
 	type CursorMaxLen = ConstU32<65_536>;

--- a/runtime/moonbase/src/migrations.rs
+++ b/runtime/moonbase/src/migrations.rs
@@ -36,8 +36,8 @@ pub type SingleBlockMigrations<Runtime> = (
 
 /// List of multi block migrations to be executed by the pallet_migrations.
 #[cfg(not(feature = "runtime-benchmarks"))]
-pub type MultiBlockMigrationList<Runtime> = (
+pub type MultiBlockMigrationList = (
 	// Common multiblock migrations applied on all Moonbeam runtimes
-	moonbeam_runtime_common::migrations::MultiBlockMigrations<Runtime>,
+	moonbeam_runtime_common::migrations::MultiBlockMigrations,
 	// ... Moonbase specific multiblock migrations
 );

--- a/runtime/moonbeam/src/lib.rs
+++ b/runtime/moonbeam/src/lib.rs
@@ -1406,7 +1406,7 @@ impl cumulus_pallet_weight_reclaim::Config for Runtime {
 impl pallet_migrations::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	#[cfg(not(feature = "runtime-benchmarks"))]
-	type Migrations = migrations::MultiBlockMigrationList<Runtime>;
+	type Migrations = migrations::MultiBlockMigrationList;
 	#[cfg(feature = "runtime-benchmarks")]
 	type Migrations = pallet_migrations::mock_helpers::MockedMigrations;
 	type CursorMaxLen = ConstU32<65_536>;

--- a/runtime/moonbeam/src/migrations.rs
+++ b/runtime/moonbeam/src/migrations.rs
@@ -36,8 +36,8 @@ pub type SingleBlockMigrations<Runtime> = (
 
 /// List of multi block migrations to be executed by the pallet_migrations.
 #[cfg(not(feature = "runtime-benchmarks"))]
-pub type MultiBlockMigrationList<Runtime> = (
+pub type MultiBlockMigrationList = (
 	// Common multiblock migrations applied on all Moonbeam runtimes
-	moonbeam_runtime_common::migrations::MultiBlockMigrations<Runtime>,
+	moonbeam_runtime_common::migrations::MultiBlockMigrations,
 	// ... Moonbeam specific multiblock migrations
 );

--- a/runtime/moonriver/src/lib.rs
+++ b/runtime/moonriver/src/lib.rs
@@ -1406,7 +1406,7 @@ impl cumulus_pallet_weight_reclaim::Config for Runtime {
 impl pallet_migrations::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	#[cfg(not(feature = "runtime-benchmarks"))]
-	type Migrations = migrations::MultiBlockMigrationList<Runtime>;
+	type Migrations = migrations::MultiBlockMigrationList;
 	#[cfg(feature = "runtime-benchmarks")]
 	type Migrations = pallet_migrations::mock_helpers::MockedMigrations;
 	type CursorMaxLen = ConstU32<65_536>;

--- a/runtime/moonriver/src/migrations.rs
+++ b/runtime/moonriver/src/migrations.rs
@@ -36,8 +36,8 @@ pub type SingleBlockMigrations<Runtime> = (
 
 /// List of multi block migrations to be executed by the pallet_migrations.
 #[cfg(not(feature = "runtime-benchmarks"))]
-pub type MultiBlockMigrationList<Runtime> = (
+pub type MultiBlockMigrationList = (
 	// Common multiblock migrations applied on all Moonbeam runtimes
-	moonbeam_runtime_common::migrations::MultiBlockMigrations<Runtime>,
+	moonbeam_runtime_common::migrations::MultiBlockMigrations,
 	// ... Moonriver specific multiblock migrations
 );


### PR DESCRIPTION
## Summary
- Removes `ResetStorage<XcmTransactor, DestinationAssetFeePerSecond>` from `MultiBlockMigrations` in `runtime/common/src/migrations.rs`.
- Drops the now-orphaned `DestinationAssetFeePerSecondStorageName` constant and `parameter_types` import.

## Rationale
The migration was introduced in #3569 to wipe the legacy `XcmTransactor::DestinationAssetFeePerSecond` storage after the XCM Transactor fee-pricing refactor. Same cleanup pattern as #3552 and #3588.

## Verification (2026-05-28)
Queried each network's `pallet-migrations` state directly via RPC:

| Network    | spec_version | `DestinationAssetFeePerSecond` keys | Migration in `Historic` | `Cursor` |
|------------|-------------:|-------------------------------------:|-------------------------:|---------:|
| Moonbeam   | 4303         | 0                                    | present                  | None     |
| Moonriver  | 4303         | 0                                    | present                  | None     |
| Moonbase   | 4302         | 0                                    | present                  | None     |

Migration ID: `0xe31f4cde56337c95903898a716b1a161` (twox_128 of `("ResetStorage", "XcmTransactor", "DestinationAssetFeePerSecond")`).

## Test plan
- [ ] CI green (build + try-runtime)
- [ ] try-runtime upgrade on Moonbeam / Moonriver / Moonbase shows no pending multi-block migrations

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782571872&installation_id=130617128&pr_number=3779&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3779&signature=5a1c2adcbc9c1c58c9bc0c72d9f20d79d5cfe7ac517123d216d71e029628addc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->