### PR TITLE
feat: include the new DNS multiaddr filtering policy for node operators.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "hash-db",
  "log",
@@ -1167,7 +1167,7 @@ dependencies = [
 [[package]]
 name = "bp-bridge-hub-cumulus"
 version = "0.27.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -1183,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1200,7 +1200,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1265,7 +1265,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1282,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1300,7 +1300,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1323,7 +1323,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.11.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1360,7 +1360,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.22.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1372,7 +1372,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.18.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1391,7 +1391,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.26.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.7.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.28.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2336,7 +2336,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.28.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2359,7 +2359,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.28.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.28.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2439,7 +2439,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.24.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.28.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.28.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2510,7 +2510,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.22.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2532,7 +2532,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.28.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2560,7 +2560,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.31.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -2603,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.25.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "bytes",
@@ -2641,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.7.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -2652,7 +2652,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.7.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -2671,7 +2671,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.24.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2686,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "approx",
  "bounded-collections",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.21.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -2721,7 +2721,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.23.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2738,7 +2738,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.23.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2752,7 +2752,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.16.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2762,7 +2762,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "16.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -2779,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.31.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -2824,7 +2824,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.28.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2844,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.31.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -2880,7 +2880,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.28.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2913,7 +2913,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.6.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures 0.3.32",
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.24.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4238,7 +4238,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4365,7 +4365,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "45.0.3"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "53.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -4468,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -4479,7 +4479,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4496,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "45.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4526,7 +4526,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.13.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -4542,7 +4542,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.6.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -4556,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "45.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -4597,7 +4597,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "36.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4617,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.5.0",
@@ -4629,7 +4629,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4672,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4682,7 +4682,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.51.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -7214,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "50.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "log",
@@ -7233,7 +7233,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8895,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "27.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8913,7 +8913,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8927,7 +8927,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8943,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "48.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9036,7 +9036,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9051,7 +9051,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9087,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "44.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9108,7 +9108,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "46.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9124,7 +9124,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "46.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9143,7 +9143,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "46.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -9168,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9185,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -9204,7 +9204,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -9243,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -9266,7 +9266,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.24.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9284,7 +9284,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9302,7 +9302,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "26.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9338,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9375,7 +9375,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "12.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9390,7 +9390,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9407,7 +9407,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9428,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "46.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10167,7 +10167,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "44.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10185,7 +10185,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10207,7 +10207,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -10223,7 +10223,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10273,7 +10273,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "48.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10292,7 +10292,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.7.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10310,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "15.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10329,7 +10329,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10406,7 +10406,7 @@ dependencies = [
 [[package]]
 name = "pallet-multi-asset-bounties"
 version = "0.2.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10423,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10434,7 +10434,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10444,7 +10444,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "43.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10462,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "43.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10482,7 +10482,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "41.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -10492,7 +10492,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10507,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10552,7 +10552,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.16.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "docify",
@@ -10590,7 +10590,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10606,7 +10606,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10659,7 +10659,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10677,7 +10677,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10687,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10728,7 +10728,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "43.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "21.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10757,7 +10757,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "46.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10774,7 +10774,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "45.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10796,7 +10796,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10812,7 +10812,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "45.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10829,7 +10829,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "45.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10851,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.7.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10871,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.7.3"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10891,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -10900,7 +10900,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "30.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10910,7 +10910,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "50.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10926,7 +10926,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10941,7 +10941,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10959,7 +10959,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10993,7 +10993,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "48.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -11009,7 +11009,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -11021,7 +11021,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -11040,7 +11040,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.8.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11070,7 +11070,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11084,7 +11084,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -11094,7 +11094,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "25.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -11119,7 +11119,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "25.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -11136,7 +11136,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.21.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -11205,7 +11205,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "27.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -11571,7 +11571,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "futures-timer",
@@ -11589,7 +11589,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "futures-timer",
@@ -11604,7 +11604,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "fatality",
  "futures 0.3.32",
@@ -11627,7 +11627,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "fatality",
@@ -11660,7 +11660,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "31.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -11685,7 +11685,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11708,7 +11708,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "21.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11719,7 +11719,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "fatality",
  "futures 0.3.32",
@@ -11741,7 +11741,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -11755,7 +11755,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "futures-timer",
@@ -11776,7 +11776,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -11799,7 +11799,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "parity-scale-codec",
@@ -11817,7 +11817,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -11849,7 +11849,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.11.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -11873,7 +11873,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bitvec",
  "futures 0.3.32",
@@ -11892,7 +11892,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11913,7 +11913,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "polkadot-node-subsystem",
@@ -11928,7 +11928,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -11950,7 +11950,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "polkadot-node-metrics",
@@ -11964,7 +11964,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "futures-timer",
@@ -11980,7 +11980,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "fatality",
  "futures 0.3.32",
@@ -11998,7 +11998,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -12015,7 +12015,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "27.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "fatality",
  "futures 0.3.32",
@@ -12029,7 +12029,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12048,7 +12048,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -12076,7 +12076,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "polkadot-node-subsystem",
@@ -12089,7 +12089,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cpu-time",
  "futures 0.3.32",
@@ -12116,7 +12116,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "polkadot-node-metrics",
@@ -12131,7 +12131,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bs58",
  "futures 0.3.32",
@@ -12148,7 +12148,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -12173,7 +12173,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -12197,7 +12197,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -12206,7 +12206,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -12234,7 +12234,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "fatality",
  "futures 0.3.32",
@@ -12264,7 +12264,7 @@ dependencies = [
 [[package]]
 name = "polkadot-omni-node-lib"
 version = "0.13.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "clap",
@@ -12349,7 +12349,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -12369,7 +12369,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "20.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -12386,7 +12386,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "22.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -12415,7 +12415,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives-test-helpers"
 version = "0.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -12430,7 +12430,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "29.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -12463,7 +12463,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12513,7 +12513,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "25.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -12525,7 +12525,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -12573,7 +12573,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.14.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12608,7 +12608,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "31.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -12717,7 +12717,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12737,7 +12737,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13841,7 +13841,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "29.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -13939,7 +13939,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "25.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -14223,7 +14223,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "35.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "log",
  "sp-core",
@@ -14234,7 +14234,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.55.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -14266,7 +14266,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.53.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "log",
@@ -14288,7 +14288,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.48.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -14303,7 +14303,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "48.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "clap",
@@ -14330,7 +14330,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -14341,7 +14341,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.57.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "bip39",
@@ -14386,7 +14386,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "fnv",
  "futures 0.3.32",
@@ -14412,7 +14412,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.51.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -14440,7 +14440,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.54.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -14463,7 +14463,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.55.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -14494,7 +14494,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.55.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -14531,7 +14531,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.55.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "jsonrpsee",
@@ -14553,7 +14553,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14587,7 +14587,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "34.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "jsonrpsee",
@@ -14607,7 +14607,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.54.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -14620,7 +14620,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.40.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "ahash 0.8.12",
  "array-bytes 6.2.3",
@@ -14664,7 +14664,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.40.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.32",
@@ -14684,7 +14684,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.56.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -14719,7 +14719,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.54.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -14742,7 +14742,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.47.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14766,7 +14766,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "polkavm",
@@ -14780,7 +14780,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.40.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "log",
  "polkavm",
@@ -14791,7 +14791,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.43.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "anyhow",
  "log",
@@ -14808,7 +14808,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.54.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "console",
  "futures 0.3.32",
@@ -14824,7 +14824,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.5",
@@ -14838,7 +14838,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -14866,7 +14866,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.55.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14915,7 +14915,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.52.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -14925,7 +14925,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.55.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "ahash 0.8.12",
  "futures 0.3.32",
@@ -14944,7 +14944,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.54.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14965,7 +14965,7 @@ dependencies = [
 [[package]]
 name = "sc-network-statement"
 version = "0.37.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14986,7 +14986,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.54.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -15021,7 +15021,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.54.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.32",
@@ -15040,7 +15040,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.20.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bs58",
  "bytes",
@@ -15061,7 +15061,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "50.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bytes",
  "fnv",
@@ -15095,7 +15095,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -15104,7 +15104,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "50.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "jsonrpsee",
@@ -15136,7 +15136,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.54.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15156,7 +15156,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "27.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -15180,7 +15180,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.55.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.32",
@@ -15213,7 +15213,7 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.7.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
@@ -15228,7 +15228,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.56.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "directories",
@@ -15292,7 +15292,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.41.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15303,7 +15303,7 @@ dependencies = [
 [[package]]
 name = "sc-statement-store"
 version = "26.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "log",
  "parity-db 0.4.13",
@@ -15323,7 +15323,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.27.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "clap",
  "fs4",
@@ -15336,7 +15336,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.55.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15355,7 +15355,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "46.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "derive_more 0.99.20",
  "futures 0.3.32",
@@ -15375,7 +15375,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "30.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "chrono",
  "futures 0.3.32",
@@ -15394,7 +15394,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "chrono",
  "console",
@@ -15422,7 +15422,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -15433,7 +15433,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "44.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -15465,7 +15465,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "43.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -15483,7 +15483,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "20.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.32",
@@ -16124,7 +16124,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "21.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -16283,7 +16283,7 @@ dependencies = [
 [[package]]
 name = "snowbridge-core"
 version = "0.18.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -16353,7 +16353,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "hash-db",
@@ -16375,7 +16375,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "26.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -16389,7 +16389,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16401,7 +16401,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -16415,7 +16415,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16427,7 +16427,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -16437,7 +16437,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "43.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "parity-scale-codec",
@@ -16456,7 +16456,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.46.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -16470,7 +16470,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.46.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16486,7 +16486,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.46.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16504,7 +16504,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "28.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16524,7 +16524,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "27.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -16541,7 +16541,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.46.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16552,7 +16552,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "39.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -16613,7 +16613,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -16626,7 +16626,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512)",
@@ -16636,7 +16636,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "kvdb",
  "kvdb-rocksdb",
@@ -16646,7 +16646,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16656,7 +16656,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.31.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -16666,7 +16666,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.21.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16678,7 +16678,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -16691,7 +16691,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "44.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bytes",
  "docify",
@@ -16717,7 +16717,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -16727,7 +16727,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.45.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -16738,7 +16738,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -16747,7 +16747,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.12.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -16757,7 +16757,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.18.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16768,7 +16768,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16785,7 +16785,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16798,7 +16798,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -16808,7 +16808,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "backtrace",
  "regex",
@@ -16817,7 +16817,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "37.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -16827,7 +16827,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "45.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "binary-merkle-tree",
  "bytes",
@@ -16858,7 +16858,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "33.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -16876,7 +16876,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "Inflector",
  "expander",
@@ -16889,7 +16889,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "42.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16903,7 +16903,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "42.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -16916,7 +16916,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.49.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "hash-db",
  "log",
@@ -16936,7 +16936,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -16960,12 +16960,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -16977,7 +16977,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16989,7 +16989,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "19.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -17001,7 +17001,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "40.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -17010,7 +17010,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "40.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17025,7 +17025,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "42.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -17050,7 +17050,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "43.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -17067,7 +17067,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -17079,7 +17079,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "24.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -17091,7 +17091,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "33.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -17265,7 +17265,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staging-chain-spec-builder"
 version = "16.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "clap",
  "docify",
@@ -17278,7 +17278,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.25.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -17291,7 +17291,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "21.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -17312,7 +17312,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "25.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "environmental",
  "frame-support",
@@ -17336,7 +17336,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "24.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -17452,7 +17452,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.12.2",
@@ -17477,7 +17477,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 
 [[package]]
 name = "substrate-fixed"
@@ -17493,7 +17493,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "49.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -17513,7 +17513,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.7"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "http-body-util",
  "hyper 1.8.1",
@@ -17527,7 +17527,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.54.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -17540,7 +17540,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "48.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -17557,7 +17557,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "async-trait",
@@ -17582,7 +17582,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "frame-executive",
@@ -17628,7 +17628,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "futures 0.3.32",
  "sc-block-builder",
@@ -17656,7 +17656,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "31.1.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -18468,7 +18468,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "23.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -18479,7 +18479,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "expander",
  "proc-macro-crate 3.5.0",
@@ -19427,7 +19427,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "30.2.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -19535,7 +19535,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "25.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -20249,7 +20249,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -20260,7 +20260,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.12.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -20274,7 +20274,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "25.0.0"
-source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#e4d0430705cf7e0c31ef3ad6a8de8e671212a679"
+source = "git+https://github.com/moonbeam-foundation/polkadot-sdk?branch=moonbeam-polkadot-stable2512#09e2fee3c53b217db27ea1197ef045048a95ca7b"
 dependencies = [
  "frame-support",
  "frame-system",


### PR DESCRIPTION
## Goal

Update the `polkadot-sdk` pin from `e4d0430705cf7e0c31ef3ad6a8de8e671212a679` to `09e2fee3c53b217db27ea1197ef045048a95ca7b` to include the new DNS multiaddr filtering policy for node operators.

## What reviewers need to know

This is a `Cargo.lock`-only dependency pin update. The important upstream change is `09e2fee3c53b217db27ea1197ef045048a95ca7b`, which adds opt-in DNS multiaddr filtering to `sc-cli`/`sc-network`:

- `--deny-untrusted-dns-multiaddrs` denies DNS multiaddresses learned from untrusted discovery sources.
- `--deny-dns-suffixes <suffixes>` denies DNS multiaddresses matching configured suffixes.
- Default behavior is unchanged: DNS multiaddresses remain allowed unless operators enable the new policy.
- The policy is wired through both libp2p and litep2p discovery paths, including known addresses, self-reported addresses, DHT/provider results, and external address handling.

The pin bump also includes two smaller upstream commits:

- improved weight reclaim logging, adding call metadata and lowering the relevant log level to `warn`;
- an `xcm-emulator` extension that allows non-Aura parachains to override block/digest production, which supports Moonbeam/Nimbus-based integration testing.

No runtime storage, extrinsic, RPC, or default node behavior changes are expected from this PR. The operator-facing DNS filtering behavior is opt-in through the new CLI flags.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782984836&installation_id=130617128&pr_number=3790&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3790&signature=3a3d5ae6789ba2009ec5553e07dcb67d3c99ab5aa3412280552dba82eabfb5d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->