### PR TITLE
[CI] Improve sticky disk job + fix links

### DIFF
--- a/.github/workflow-templates/moonbeam-sticky-disk/action.yml
+++ b/.github/workflow-templates/moonbeam-sticky-disk/action.yml
@@ -1,7 +1,7 @@
 name: Moonbeam sticky disk
 description: |
   Publish or restore the stripped CI moonbeam binary on a Blacksmith sticky disk.
-  Use the same sticky-disk-key in the build job (publish) and downstream jobs (restore).
+  Use the same sticky-disk-key in the publish job and downstream restore jobs.
 
 inputs:
   mode:
@@ -32,37 +32,83 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        if [ ! -f build/moonbeam ]; then
-          echo "build/moonbeam not found" >&2
+        src="build/moonbeam"
+        if [ ! -f "$src" ]; then
+          echo "$src not found" >&2
           exit 1
         fi
-        cp -f build/moonbeam .ci-moonbeam-disk/moonbeam
+        cp -f "$src" .ci-moonbeam-disk/moonbeam
+        sync .ci-moonbeam-disk/moonbeam
         git rev-parse HEAD > .ci-moonbeam-disk/git-sha
+        sync .ci-moonbeam-disk/git-sha
         ls -lh .ci-moonbeam-disk/moonbeam
 
     - name: Restore moonbeam from sticky disk
+      id: restore-moonbeam-sticky
+      if: ${{ inputs.mode == 'restore' }}
+      continue-on-error: true
+      shell: bash
+      run: |
+        set -euo pipefail
+        moonbeam_path=".ci-moonbeam-disk/moonbeam"
+        # The publish job commits the disk before this job starts, so the file is
+        # normally present on the first attempt. Allow a short window for snapshot
+        # propagation, then fail fast into the artifact fallback below.
+        max_attempts=6
+        for attempt in $(seq 1 "$max_attempts"); do
+          if [ -f "$moonbeam_path" ]; then
+            echo "Found moonbeam on sticky disk (attempt ${attempt}/${max_attempts})"
+            break
+          fi
+          echo "Waiting for moonbeam on sticky disk (attempt ${attempt}/${max_attempts})..."
+          sleep 10
+        done
+        if [ ! -f "$moonbeam_path" ]; then
+          echo "Timed out waiting for ${moonbeam_path}" >&2
+          exit 1
+        fi
+        if [ -f .ci-moonbeam-disk/git-sha ]; then
+          expected="$(git rev-parse HEAD)"
+          actual="$(tr -d '[:space:]' < .ci-moonbeam-disk/git-sha)"
+          if [ "$expected" != "$actual" ]; then
+            echo "::warning::Sticky disk moonbeam was built for ${actual}, but checkout is ${expected}"
+          fi
+        fi
+        mkdir -p target/debug
+        cp -f "$moonbeam_path" target/debug/moonbeam
+        chmod uog+x target/debug/moonbeam
+        ls -lh target/debug/moonbeam
+
+    - name: Download moonbeam artifact fallback
+      if: ${{ inputs.mode == 'restore' && steps.restore-moonbeam-sticky.outcome == 'failure' }}
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      with:
+        name: moonbeam
+        path: target/debug
+
+    - name: Normalize moonbeam path after artifact fallback
+      if: ${{ inputs.mode == 'restore' && steps.restore-moonbeam-sticky.outcome == 'failure' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -f target/debug/moonbeam ]; then
+          :
+        elif [ -f target/debug/build/moonbeam ]; then
+          mv target/debug/build/moonbeam target/debug/moonbeam
+          rmdir target/debug/build 2>/dev/null || true
+        else
+          echo "Artifact fallback did not provide target/debug/moonbeam" >&2
+          exit 1
+        fi
+        chmod uog+x target/debug/moonbeam
+        ls -lh target/debug/moonbeam
+
+    - name: Verify moonbeam binary is present
       if: ${{ inputs.mode == 'restore' }}
       shell: bash
       run: |
         set -euo pipefail
-        if [ ! -f .ci-moonbeam-disk/moonbeam ]; then
-          echo "Sticky disk is missing .ci-moonbeam-disk/moonbeam; did the build job publish it?" >&2
+        if [ ! -x target/debug/moonbeam ]; then
+          echo "target/debug/moonbeam is missing after sticky restore and artifact fallback" >&2
           exit 1
         fi
-        if [ ! -f .ci-moonbeam-disk/git-sha ]; then
-          echo "Sticky disk is missing git-sha metadata" >&2
-          exit 1
-        fi
-        # The key is scoped to github.run_id, so the disk is already isolated to
-        # this workflow run. The SHA comparison is only a diagnostic: on push runs
-        # the branch ref can legitimately resolve to a slightly different commit
-        # between the build and test jobs, so a mismatch is a warning, not a failure.
-        expected="$(git rev-parse HEAD)"
-        actual="$(tr -d '[:space:]' < .ci-moonbeam-disk/git-sha)"
-        if [ "$expected" != "$actual" ]; then
-          echo "::warning::Sticky disk moonbeam was built for ${actual}, but checkout is ${expected}"
-        fi
-        mkdir -p target/debug
-        cp -f .ci-moonbeam-disk/moonbeam target/debug/moonbeam
-        chmod uog+x target/debug/moonbeam
-        ls -lh target/debug/moonbeam

--- a/.github/workflow-templates/moonbeam-sticky-disk/action.yml
+++ b/.github/workflow-templates/moonbeam-sticky-disk/action.yml
@@ -51,17 +51,21 @@ runs:
       run: |
         set -euo pipefail
         moonbeam_path=".ci-moonbeam-disk/moonbeam"
-        # The publish job commits the disk before this job starts, so the file is
-        # normally present on the first attempt. Allow a short window for snapshot
-        # propagation, then fail fast into the artifact fallback below.
+        # The publish (in build) commits the disk before this job starts, so the file
+        # is normally present on the first attempt. Allow a short window (~110s) for
+        # snapshot propagation, then fall through to the artifact fallback below.
         max_attempts=12
         for attempt in $(seq 1 "$max_attempts"); do
           if [ -f "$moonbeam_path" ]; then
             echo "Found moonbeam on sticky disk (attempt ${attempt}/${max_attempts})"
             break
           fi
-          echo "Waiting for moonbeam on sticky disk (attempt ${attempt}/${max_attempts})..."
-          sleep 10
+          # Don't sleep after the final attempt: that wait would be wasted before
+          # we drop into the fallback.
+          if [ "$attempt" -lt "$max_attempts" ]; then
+            echo "Waiting for moonbeam on sticky disk (attempt ${attempt}/${max_attempts})..."
+            sleep 10
+          fi
         done
         if [ ! -f "$moonbeam_path" ]; then
           echo "Timed out waiting for ${moonbeam_path}" >&2

--- a/.github/workflow-templates/moonbeam-sticky-disk/action.yml
+++ b/.github/workflow-templates/moonbeam-sticky-disk/action.yml
@@ -54,7 +54,7 @@ runs:
         # The publish job commits the disk before this job starts, so the file is
         # normally present on the first attempt. Allow a short window for snapshot
         # propagation, then fail fast into the artifact fallback below.
-        max_attempts=6
+        max_attempts=12
         for attempt in $(seq 1 "$max_attempts"); do
           if [ -f "$moonbeam_path" ]; then
             echo "Found moonbeam on sticky disk (attempt ${attempt}/${max_attempts})"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,9 @@ concurrency:
 env:
   NODE_OPTIONS: "--max-old-space-size=12288 --no-deprecation"
   CARGO_TERM_COLOR: always
-  # One sticky disk per workflow run; build publishes, Blacksmith test jobs restore.
-  MOONBEAM_STICKY_DISK_KEY: ${{ github.repository }}-ci-moonbeam-${{ github.run_id }}
+  # One sticky disk per workflow run (no slashes in the key). A dedicated publish job
+  # writes once; Blacksmith test jobs restore without each downloading the artifact.
+  MOONBEAM_STICKY_DISK_KEY: ${{ github.repository_owner }}-${{ github.event.repository.name }}-ci-moonbeam-${{ github.run_id }}
 
 permissions:
   contents: read
@@ -420,11 +421,6 @@ jobs:
           features: metadata-hash
           blacksmith-sticky-sccache: "true"
           blacksmith-sticky-sccache-key: ${{ github.repository }}-sccache-release-${{ runner.os }}-${{ steps.rust-toolchain-cache-key.outputs.cache-key }}
-      - name: Publish moonbeam to sticky disk
-        uses: ./.github/workflow-templates/moonbeam-sticky-disk
-        with:
-          mode: publish
-          sticky-disk-key: ${{ env.MOONBEAM_STICKY_DISK_KEY }}
       - name: Upload runtimes
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -440,6 +436,39 @@ jobs:
         with:
           name: moonbeam
           path: build
+
+  moonbeam-sticky-publish:
+    # Single writer for the per-run sticky disk. Downstream jobs mount a clone of
+    # this snapshot instead of each downloading the moonbeam artifact from blob storage.
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      needs.set-tags.outputs.blacksmith_allowed == 'true' &&
+      (
+        needs.set-tags.outputs.rust_changed == 'true' ||
+        needs.set-tags.outputs.ts_tests_changed == 'true'
+      )
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    needs: ["set-tags", "build"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.set-tags.outputs.git_ref }}
+          persist-credentials: false
+      - name: Download moonbeam artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: moonbeam
+          path: build
+      - name: Publish moonbeam to sticky disk
+        uses: ./.github/workflow-templates/moonbeam-sticky-disk
+        with:
+          mode: publish
+          sticky-disk-key: ${{ env.MOONBEAM_STICKY_DISK_KEY }}
 
   rust-test:
     # Rust tests are one of the most expensive PR jobs, so only run them after the
@@ -563,12 +592,13 @@ jobs:
     if: |
       always() &&
       needs.build.result == 'success' &&
+      needs.moonbeam-sticky-publish.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
-    needs: ["set-tags", "build"]
+    needs: ["set-tags", "build", "moonbeam-sticky-publish"]
     continue-on-error: ${{ matrix.chain == 'moonriver' || matrix.chain == 'moonbeam' }}
     timeout-minutes: 30
     strategy:
@@ -633,6 +663,7 @@ jobs:
     if: |
       always() &&
       needs.build.result == 'success' &&
+      needs.moonbeam-sticky-publish.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success' &&
@@ -644,7 +675,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-    needs: ["set-tags", "build", "dev-test"]
+    needs: ["set-tags", "build", "moonbeam-sticky-publish", "dev-test"]
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -685,6 +716,7 @@ jobs:
     if: |
       always() &&
       needs.build.result == 'success' &&
+      needs.moonbeam-sticky-publish.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success'
@@ -692,7 +724,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-    needs: ["set-tags", "build", "dev-test"]
+    needs: ["set-tags", "build", "moonbeam-sticky-publish", "dev-test"]
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -766,7 +798,7 @@ jobs:
       needs.dev-test.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
-    needs: ["set-tags", "build", "dev-test"]
+    needs: ["set-tags", "build", "moonbeam-sticky-publish", "dev-test"]
     strategy:
       fail-fast: false
       matrix:
@@ -830,12 +862,13 @@ jobs:
     if: |
       always() &&
       needs.build.result == 'success' &&
+      needs.moonbeam-sticky-publish.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
-    needs: ["set-tags", "build", "dev-test"]
+    needs: ["set-tags", "build", "moonbeam-sticky-publish", "dev-test"]
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,10 @@ env:
   CARGO_TERM_COLOR: always
   # One sticky disk per workflow run (no slashes in the key). A dedicated publish job
   # writes once; Blacksmith test jobs restore without each downloading the artifact.
-  MOONBEAM_STICKY_DISK_KEY: ${{ github.repository_owner }}-${{ github.event.repository.name }}-ci-moonbeam-${{ github.run_id }}
+  # Owner/name/id are sourced from the event's repository object so the cleanup
+  # workflow (cleanup-sticky-disk.yml) can reconstruct the exact same key from its
+  # github.event.workflow_run.repository payload. Keep these two in sync.
+  MOONBEAM_STICKY_DISK_KEY: ${{ github.event.repository.owner.login }}-${{ github.event.repository.name }}-ci-moonbeam-${{ github.run_id }}
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -798,7 +798,9 @@ jobs:
       needs.dev-test.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
-    needs: ["set-tags", "build", "moonbeam-sticky-publish", "dev-test"]
+    # Does not restore the moonbeam binary (only downloads runtimes), so it does not
+    # depend on moonbeam-sticky-publish.
+    needs: ["set-tags", "build", "dev-test"]
     strategy:
       fail-fast: false
       matrix:
@@ -998,3 +1000,29 @@ jobs:
         with:
           name: bridge-integration-tests-logs
           path: ${{ env.LOGS_ZIP }}
+
+  moonbeam-sticky-cleanup:
+    # Best-effort deletion of the per-run moonbeam sticky disk once every job that
+    # mounts it has finished. Runs even when consumers fail or are skipped. If the
+    # workflow is cancelled this may not run, but Blacksmith's 7-day inactivity
+    # eviction is the backstop.
+    if: always() && needs.set-tags.outputs.blacksmith_allowed == 'true'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    needs:
+      [
+        "set-tags",
+        "moonbeam-sticky-publish",
+        "dev-test",
+        "typescript-tracing-tests",
+        "lazy-loading-tests",
+        "zombie_upgrade_test",
+      ]
+    steps:
+      - name: Delete per-run moonbeam sticky disk
+        continue-on-error: true
+        uses: useblacksmith/stickydisk-delete@b41313d28b8647d72114c9ba3c96bb04061562b6
+        with:
+          delete-key: ${{ env.MOONBEAM_STICKY_DISK_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -453,7 +453,7 @@ jobs:
     # Rust tests are one of the most expensive PR jobs, so only run them after the
     # quick Rust checks and the moonbase dev-test gate have passed.
     if: |
-      always() &&
+      !cancelled() &&
       needs.set-tags.outputs.rust_changed == 'true' &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.check-cargo-toml-format.result == 'success' &&
@@ -566,10 +566,11 @@ jobs:
   dev-test:
     # Moonbase dev tests are the required fast gate. Moonriver and moonbeam still
     # run for signal, but their failures are tolerated because they are flakier.
-    # always() is required because TS-only changes intentionally skip the Rust
-    # check jobs that the build job depends on.
+    # !cancelled() (rather than always()) lets this run even though TS-only changes
+    # skip the Rust check jobs build depends on, while still cancelling on
+    # supersede/manual cancel so we don't burn Blacksmith minutes on stale runs.
     if: |
-      always() &&
+      !cancelled() &&
       needs.build.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true'
@@ -639,7 +640,7 @@ jobs:
     # Tracing tests are expensive, so run them on master or when explicitly
     # requested on PRs.
     if: |
-      always() &&
+      !cancelled() &&
       needs.build.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
@@ -691,7 +692,7 @@ jobs:
     # Lazy-loading tests are expensive, so skip them when the required moonbase
     # dev-test gate has already failed.
     if: |
-      always() &&
+      !cancelled() &&
       needs.build.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
@@ -767,7 +768,7 @@ jobs:
     # Upgrade tests consume larger runners, so only start them after moonbase
     # dev tests prove the PR is worth the heavier checks.
     if: |
-      always() &&
+      !cancelled() &&
       needs.build.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
@@ -837,7 +838,7 @@ jobs:
     # Zombie upgrade tests are expensive and run serially; run all runtimes on
     # master, but keep PRs to moonbeam only.
     if: |
-      always() &&
+      !cancelled() &&
       needs.build.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -424,6 +424,15 @@ jobs:
           features: metadata-hash
           blacksmith-sticky-sccache: "true"
           blacksmith-sticky-sccache-key: ${{ github.repository }}-sccache-release-${{ runner.os }}-${{ steps.rust-toolchain-cache-key.outputs.cache-key }}
+      # Publish the freshly built binary to the sticky disk from local disk (no
+      # artifact round-trip through GitHub blob storage). Consumers `needs: build`,
+      # so the commit (in the action's post-step) lands before they mount.
+      - name: Publish moonbeam to sticky disk
+        if: needs.set-tags.outputs.blacksmith_allowed == 'true'
+        uses: ./.github/workflow-templates/moonbeam-sticky-disk
+        with:
+          mode: publish
+          sticky-disk-key: ${{ env.MOONBEAM_STICKY_DISK_KEY }}
       - name: Upload runtimes
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
@@ -439,39 +448,6 @@ jobs:
         with:
           name: moonbeam
           path: build
-
-  moonbeam-sticky-publish:
-    # Single writer for the per-run sticky disk. Downstream jobs mount a clone of
-    # this snapshot instead of each downloading the moonbeam artifact from blob storage.
-    if: |
-      always() &&
-      needs.build.result == 'success' &&
-      needs.set-tags.outputs.blacksmith_allowed == 'true' &&
-      (
-        needs.set-tags.outputs.rust_changed == 'true' ||
-        needs.set-tags.outputs.ts_tests_changed == 'true'
-      )
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    needs: ["set-tags", "build"]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: ${{ needs.set-tags.outputs.git_ref }}
-          persist-credentials: false
-      - name: Download moonbeam artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: moonbeam
-          path: build
-      - name: Publish moonbeam to sticky disk
-        uses: ./.github/workflow-templates/moonbeam-sticky-disk
-        with:
-          mode: publish
-          sticky-disk-key: ${{ env.MOONBEAM_STICKY_DISK_KEY }}
 
   rust-test:
     # Rust tests are one of the most expensive PR jobs, so only run them after the
@@ -595,13 +571,12 @@ jobs:
     if: |
       always() &&
       needs.build.result == 'success' &&
-      needs.moonbeam-sticky-publish.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
-    needs: ["set-tags", "build", "moonbeam-sticky-publish"]
+    needs: ["set-tags", "build"]
     continue-on-error: ${{ matrix.chain == 'moonriver' || matrix.chain == 'moonbeam' }}
     timeout-minutes: 30
     strategy:
@@ -666,7 +641,6 @@ jobs:
     if: |
       always() &&
       needs.build.result == 'success' &&
-      needs.moonbeam-sticky-publish.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success' &&
@@ -678,7 +652,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-    needs: ["set-tags", "build", "moonbeam-sticky-publish", "dev-test"]
+    needs: ["set-tags", "build", "dev-test"]
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -719,7 +693,6 @@ jobs:
     if: |
       always() &&
       needs.build.result == 'success' &&
-      needs.moonbeam-sticky-publish.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success'
@@ -727,7 +700,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-    needs: ["set-tags", "build", "moonbeam-sticky-publish", "dev-test"]
+    needs: ["set-tags", "build", "dev-test"]
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -801,8 +774,7 @@ jobs:
       needs.dev-test.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
-    # Does not restore the moonbeam binary (only downloads runtimes), so it does not
-    # depend on moonbeam-sticky-publish.
+    # Does not restore the moonbeam binary (only downloads runtimes).
     needs: ["set-tags", "build", "dev-test"]
     strategy:
       fail-fast: false
@@ -867,13 +839,12 @@ jobs:
     if: |
       always() &&
       needs.build.result == 'success' &&
-      needs.moonbeam-sticky-publish.result == 'success' &&
       (needs.set-tags.outputs.rust_changed == 'true' || needs.set-tags.outputs.ts_tests_changed == 'true') &&
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
-    needs: ["set-tags", "build", "moonbeam-sticky-publish", "dev-test"]
+    needs: ["set-tags", "build", "dev-test"]
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -1017,7 +988,7 @@ jobs:
     needs:
       [
         "set-tags",
-        "moonbeam-sticky-publish",
+        "build",
         "dev-test",
         "typescript-tracing-tests",
         "lazy-loading-tests",

--- a/.github/workflows/cleanup-sticky-disk.yml
+++ b/.github/workflows/cleanup-sticky-disk.yml
@@ -28,6 +28,8 @@ jobs:
         continue-on-error: true
         uses: useblacksmith/stickydisk-delete@b41313d28b8647d72114c9ba3c96bb04061562b6
         with:
-          # Must match MOONBEAM_STICKY_DISK_KEY in build.yml, but resolved from the
-          # triggering Build run rather than this cleanup run.
+          # Must match MOONBEAM_STICKY_DISK_KEY in build.yml, resolved from the
+          # triggering Build run. build.yml uses github.event.repository.{owner.login,name}
+          # and github.run_id; the equivalents here are the workflow_run payload's
+          # repository.{owner.login,name} and the workflow_run id.
           delete-key: ${{ github.event.workflow_run.repository.owner.login }}-${{ github.event.workflow_run.repository.name }}-ci-moonbeam-${{ github.event.workflow_run.id }}

--- a/.github/workflows/cleanup-sticky-disk.yml
+++ b/.github/workflows/cleanup-sticky-disk.yml
@@ -1,0 +1,33 @@
+name: Cleanup moonbeam sticky disk
+
+# Catch-all deletion of the per-run moonbeam sticky disk created by the Build
+# workflow. The in-run `moonbeam-sticky-cleanup` job already deletes it on success
+# and failure; this workflow covers the case the in-run job cannot handle:
+# a cancelled Build run (e.g. superseded by `cancel-in-progress`).
+#
+# `workflow_run` fires for every conclusion (success, failure, cancelled) once the
+# Build workflow concludes. Note: workflow_run workflows only run from the version
+# on the default branch, so this takes effect after it is merged to master.
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    # Sticky disks are only created on non-fork runs (blacksmith_allowed). Skip fork
+    # PRs where no disk exists.
+    if: ${{ github.event.workflow_run.head_repository.fork == false }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - name: Delete per-run moonbeam sticky disk
+        continue-on-error: true
+        uses: useblacksmith/stickydisk-delete@b41313d28b8647d72114c9ba3c96bb04061562b6
+        with:
+          # Must match MOONBEAM_STICKY_DISK_KEY in build.yml, but resolved from the
+          # triggering Build run rather than this cleanup run.
+          delete-key: ${{ github.event.workflow_run.repository.owner.login }}-${{ github.event.workflow_run.repository.name }}-ci-moonbeam-${{ github.event.workflow_run.id }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Tests](https://github.com/moonbeam-foundation/moonbeam/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/moonbeam-foundation/moonbeam/actions/workflows/build.yml?query=branch:master)
 
-**An Ethereum compatible [Parachain](https://docs.polkadot.com/polkadot-protocol/architecture/parachains) built with the [Polkadot-SDK](https://github.com/paritytech/polkadot-sdk).**
+**An Ethereum compatible [Parachain](https://docs.polkadot.com/reference/parachains) built with the [Polkadot-SDK](https://github.com/paritytech/polkadot-sdk).**
 
 👉 _Discover the Moonbeam project at [moonbeam.network](https://moonbeam.network)._<br>
 👉 _Learn to [use the Moonbeam network](https://docs.moonbeam.network/) with our technical docs._
@@ -154,7 +154,7 @@ The `.lazy-loading/state-overrides.json` file allows you to override specific st
 
 To build Moonbeam, a proper Substrate development environment is required. If you're new to working with Substrate-based blockchains, consider starting with the [Getting Started with a Moonbeam Development Node](https://docs.moonbeam.network/builders/get-started/networks/moonbeam-dev/) documentation.
 
-If you need a refresher setting up your Substrate environment, see [Substrate's Getting Started Guide](https://substrate.dev/docs/en/knowledgebase/getting-started/).
+If you need a refresher setting up your Substrate environment, see [Polkadot's Getting Started Guide](https://wiki.polkadot.com/general/getting-started/).
 
 Please note that cloning the master branch might result in an unstable build. If you want a stable version, check out the [latest releases](https://github.com/moonbeam-foundation/moonbeam/releases).
 

--- a/runtime-diffs/README.md
+++ b/runtime-diffs/README.md
@@ -41,4 +41,4 @@ Meanwhile, `LocalAssets` pallet has been removed, so you would expect references
 - [subxt cli readme](https://github.com/paritytech/subxt/tree/master/cli) - Some basic instructions in readme
 - [subxt release docs](https://github.com/paritytech/subxt/releases) - Latest releases have usage guide for new CLI features
 - [polkadot metadata explorer](https://wiki.polkadot.network/docs/metadata) - An interactive explorer of polkadot metadata
-- [substrate docs](https://docs.polkadot.com/polkadot-protocol/basics/chain-data/#expose-runtime-information-as-metadata) - Some background on how metadata blobs get generated with which to serve when requested.
+- [substrate docs](https://docs.polkadot.com/reference/parachains/chain-data/#expose-runtime-information-as-metadata) - Some background on how metadata blobs get generated with which to serve when requested.

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -424,7 +424,7 @@
               "--max-pov-percentage=100"
             ],
             "defaultForkConfig": {
-              "url": "https://trace.api.moonbeam.network",
+              "url": "https://rpc.api.moonbeam.network",
               "stateOverridePath": "tmp/lazyLoadingStateOverrides.json",
               "verbose": true
             }


### PR DESCRIPTION
## Summary

Follow-up to #3793 (`[CI] Use sticky disk to store/restore artifacts`).

After #3793 shipped, the `dev-test (<chain>, <shard>)` jobs failed during restore with:

```
Sticky disk is missing .ci-moonbeam-disk/moonbeam; did the build job publish it?
Error: Process completed with exit code 1.
```

The `build` job published the binary, but the 12 concurrent `dev-test` jobs mounted an **empty** snapshot. Root cause: the disk key contained a `/` (`github.repository` → `moonbeam-foundation/moonbeam`), which is fragile for the storage backend, and there was no retry/fallback when a restore came up empty.

This PR makes the sticky-disk handoff reliable, keeps publish on local disk (no flaky artifact download), and adds a safety net so a sticky miss can never break the required gate.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/build.yml` | Slash-free `MOONBEAM_STICKY_DISK_KEY`; `build` publishes the binary to the sticky disk directly from local disk (no artifact round-trip); consumers `needs: build` and restore; new `moonbeam-sticky-cleanup` job deletes the per-run disk; `always()` → `!cancelled()` on test jobs so they cancel properly |
| `.github/workflow-templates/moonbeam-sticky-disk/action.yml` | Restore retry window, `continue-on-error` + `download-artifact` fallback, path normalization, final presence check; `sync` after publish writes |
| `.github/workflows/cleanup-sticky-disk.yml` | New `workflow_run` workflow that deletes the per-run disk after Build concludes, covering cancelled runs |
| `README.md`, `runtime-diffs/README.md` | Fix stale Polkadot/Substrate doc links |

## How it works now

```
build → publish moonbeam to sticky disk (from local build/moonbeam, no download)
      → upload-artifact (moonbeam)            # for ubuntu jobs + restore fallback
dev-test ×12 / tracing / lazy-loading / zombie
  restore from sticky disk → target/debug/moonbeam
    └─ on sticky miss: download-artifact fallback → verify present
```

Key changes vs #3793:

- **`MOONBEAM_STICKY_DISK_KEY`**: `${{ github.event.repository.owner.login }}-${{ github.event.repository.name }}-ci-moonbeam-${{ github.run_id }}` (no `/`, one disk per run; field-aligned with the cleanup workflow).
- **`build` is the single writer**, publishing from its local `build/moonbeam` — no `actions/download-artifact` on the publish path, so the flaky GitHub blob download is off the critical path entirely. Consumers `needs: build`, so the commit (in the action's post-step) lands before they mount.
- **Restore is non-fatal**: `continue-on-error` with a short retry (`max_attempts=12`, ~110s) for snapshot propagation, then a `download-artifact` fallback and a final check that `target/debug/moonbeam` exists.
- **Cleanup**: a best-effort `moonbeam-sticky-cleanup` job (`if: always()`, `needs` every consumer) deletes the per-run disk via `useblacksmith/stickydisk-delete` on success and failure. A separate `cleanup-sticky-disk.yml` (`workflow_run` on Build completion) covers cancelled runs by reconstructing the same key from `github.event.workflow_run`. Blacksmith has no configurable TTL; the 7-day idle eviction remains the final backstop. Note: the `workflow_run` cleanup only takes effect once merged to `master`.
- **Cancellation fix (`always()` → `!cancelled()`)**: `dev-test`, `typescript-tracing-tests`, `lazy-loading-tests`, `zombie_upgrade_test`, **`rust-test`** (16vcpu — biggest cost driver), and **`chopsticks-upgrade-test`** (60-min timeout) used `always()`, which makes a job ignore cancellation. They now use `!cancelled()`, which keeps the original "run even when upstream Rust checks are skipped" behavior but lets manual cancel and `cancel-in-progress` supersede actually stop them — so superseded runs no longer keep burning Blacksmith minutes. `build` (16vcpu producer), `cargo-clippy`, and the cleanup jobs intentionally keep `always()`; converting `build`/`cargo-clippy` is left as a follow-up.

## Tradeoffs

- **No extra job / no extra blob download:** publishing happens inside `build` as a local copy, so there is no dedicated publish job and no artifact round-trip — cheaper and removes the intermittent blob-download stall.
- **Best-effort sticky sharing:** if the sticky disk misbehaves, jobs fall back to one ~69 MB artifact download per job — slower, but never the 30-min timeout from before.
- **Storage churn:** `run_id`-scoped disks aren't reused across runs. The cleanup job removes them shortly after each run; the 7-day idle eviction covers cancelled runs. Worth watching on the Blacksmith Sticky Disks dashboard.
