### PR TITLE
fix: SafeCallFilter XCM Transact vulnerability (Immunefi #81386)

### DIFF
--- a/runtime/moonbase/src/xcm_config.rs
+++ b/runtime/moonbase/src/xcm_config.rs
@@ -220,10 +220,14 @@ moonbeam_runtime_common::impl_evm_runner_precompile_or_eth_xcm!();
 
 pub struct SafeCallFilter;
 impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
-	fn contains(_call: &RuntimeCall) -> bool {
-		// TODO review
-		// This needs to be addressed at EVM level
-		true
+	fn contains(call: &RuntimeCall) -> bool {
+		match call {
+			RuntimeCall::Balances(_) => true,
+			RuntimeCall::Ethereum(_) => true,
+			RuntimeCall::EVM(_) => true,
+			RuntimeCall::Utility(_) => true,
+			_ => false,
+		}
 	}
 }
 

--- a/runtime/moonbeam/src/xcm_config.rs
+++ b/runtime/moonbeam/src/xcm_config.rs
@@ -201,10 +201,14 @@ parameter_types! {
 
 pub struct SafeCallFilter;
 impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
-	fn contains(_call: &RuntimeCall) -> bool {
-		// TODO review
-		// This needs to be addressed at EVM level
-		true
+	fn contains(call: &RuntimeCall) -> bool {
+		match call {
+			RuntimeCall::Balances(_) => true,
+			RuntimeCall::Ethereum(_) => true,
+			RuntimeCall::EVM(_) => true,
+			RuntimeCall::Utility(_) => true,
+			_ => false,
+		}
 	}
 }
 

--- a/runtime/moonriver/src/xcm_config.rs
+++ b/runtime/moonriver/src/xcm_config.rs
@@ -209,10 +209,14 @@ parameter_types! {
 
 pub struct SafeCallFilter;
 impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
-	fn contains(_call: &RuntimeCall) -> bool {
-		// TODO review
-		// This needs to be addressed at EVM level
-		true
+	fn contains(call: &RuntimeCall) -> bool {
+		match call {
+			RuntimeCall::Balances(_) => true,
+			RuntimeCall::Ethereum(_) => true,
+			RuntimeCall::EVM(_) => true,
+			RuntimeCall::Utility(_) => true,
+			_ => false,
+		}
 	}
 }
 


### PR DESCRIPTION
## Security Fix: SafeCallFilter XCM Transact Vulnerability

**Immunefi Submission:** https://bugs.immunefi.com/dashboard/submission/81386

### Problem
The `SafeCallFilter` in all three runtimes (Moonbeam, Moonriver, Moonbase) unconditionally returns `true` for ALL runtime calls, completely bypassing XCM Transact security controls.

```rust
// Current vulnerable code (runtime/moonbeam/src/xcm_config.rs:202)
pub struct SafeCallFilter;
impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
    fn contains(_call: &RuntimeCall) -> bool {
        // TODO review
        true  // ← Accepts ALL calls
    }
}
```

### Impact
An attacker with XCM access can execute ANY runtime call including:
- `balances.transfer` - Direct fund theft
- `governance.*` - Governance manipulation  
- `system.setCode` - Chain state modification
- `ethereum.transact` - Arbitrary EVM execution

**Severity:** Critical (Immunefi classification)

### Fix
Implement proper call filtering that whitelists only safe operations:

```rust
pub struct SafeCallFilter;
impl frame_support::traits::Contains<RuntimeCall> for SafeCallFilter {
    fn contains(call: &RuntimeCall) -> bool {
        match call {
            // Allow balance transfers
            RuntimeCall::Balances(_) => true,
            // Allow EVM calls (needed for cross-chain DeFi)
            RuntimeCall::Ethereum(_) => true,
            RuntimeCall::EVM(_) => true,
            // Allow utility batch calls (inner calls filtered separately)
            RuntimeCall::Utility(_) => true,
            // Block governance and privileged calls
            _ => false,
        }
    }
}
```

### Affected Files
- `runtime/moonbeam/src/xcm_config.rs` (line 202)
- `runtime/moonriver/src/xcm_config.rs` (line 210)  
- `runtime/moonbase/src/xcm_config.rs` (line 221)

### Testing
- [ ] Verify XCM Transact with allowed calls works
- [ ] Verify governance calls are blocked via XCM
- [ ] Verify system.setCode is blocked via XCM
- [ ] Run existing XCM test suite

---
*This PR addresses a security vulnerability reported via [Immunefi](https://immunefi.com/bug-bounty/moonbeamnetwork/information/).*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783610131&installation_id=130617128&pr_number=3798&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3798&signature=2517cc5c99e2141bacdb98730f40185c52f5a449263175e6eef3a71984efc4a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->