### PR TITLE
Fix Cargo.toml version replacement in bump-node-version script

### DIFF
--- a/scripts/bump-node-version.sh
+++ b/scripts/bump-node-version.sh
@@ -9,13 +9,13 @@ fi
 FROM=$1
 TO=$2
 sed -i "s/moonbeam-foundation\/moonbeam:v$FROM/moonbeam-foundation\/moonbeam:v$TO/" README.md
-sed -i "s/^version = '$FROM'$/version = '$TO'/" node/Cargo.toml
-sed -i "s/^version = '$FROM'$/version = '$TO'/" node/cli/Cargo.toml
-sed -i "s/^version = '$FROM'$/version = '$TO'/" node/cli-opt/Cargo.toml
-sed -i "s/^version = '$FROM'$/version = '$TO'/" node/service/Cargo.toml
+sed -i "s/^version = \"$FROM\"$/version = \"$TO\"/" node/Cargo.toml
+sed -i "s/^version = \"$FROM\"$/version = \"$TO\"/" node/cli/Cargo.toml
+sed -i "s/^version = \"$FROM\"$/version = \"$TO\"/" node/cli-opt/Cargo.toml
+sed -i "s/^version = \"$FROM\"$/version = \"$TO\"/" node/service/Cargo.toml
 
-sed -i "s/^version = '$FROM'$/version = '$TO'/" runtime/moonbase/Cargo.toml
-sed -i "s/^version = '$FROM'$/version = '$TO'/" runtime/moonriver/Cargo.toml
-sed -i "s/^version = '$FROM'$/version = '$TO'/" runtime/moonbeam/Cargo.toml
+sed -i "s/^version = \"$FROM\"$/version = \"$TO\"/" runtime/moonbase/Cargo.toml
+sed -i "s/^version = \"$FROM\"$/version = \"$TO\"/" runtime/moonriver/Cargo.toml
+sed -i "s/^version = \"$FROM\"$/version = \"$TO\"/" runtime/moonbeam/Cargo.toml
 
 cargo build --release


### PR DESCRIPTION
### What does it do?

Updates `scripts/bump-node-version.sh` so it matches the current Cargo.toml version format.

The script was looking for version lines using single quotes, for example:

`version = '0.53.0'`

but the repository currently uses double quotes:

`version = "0.53.0"`

As a result, the script would not update the Cargo.toml package versions. This change updates the replacement patterns to match the existing format.



### What important points should reviewers know?

This is a maintenance-only script fix. It does not change any runtime, client, or release version.



### Is there something left for follow-up PRs?

No.

### What alternative implementations were considered?

Keeping the current script unchanged was considered, but it does not match the current Cargo.toml format and would silently skip the version updates.


### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

No.

### What value does it bring to the blockchain users?

No direct user-facing blockchain behavior changes. It improves release maintenance tooling reliability.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784653651&installation_id=130617128&pr_number=3801&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3801&signature=62ffd3dee688e9186de7bfb5e734abb1fc0a71d7f846fb79d108a0bf391821c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->