### PR TITLE
Fix flaky XCM/EVM dev tests by sealing deterministically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -698,7 +698,8 @@ jobs:
       needs.set-tags.outputs.blacksmith_allowed == 'true' &&
       needs.dev-test.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 30
+    # Allow headroom for up to 3 retry attempts (15 min each) of the run step.
+    timeout-minutes: 50
     permissions:
       contents: read
     needs: ["set-tags", "build", "dev-test"]
@@ -732,11 +733,22 @@ jobs:
         with:
           mode: restore
           sticky-disk-key: ${{ env.MOONBEAM_STICKY_DISK_KEY }}
-      - name: "Run lazy loading tests"
+      - name: "Install test dependencies"
         run: |
           cd test
           pnpm install
-          pnpm moonwall test lazy_loading_${{ matrix.chain }}
+      - name: "Run lazy loading tests (with retry)"
+        # Lazy-loading nodes fork live state at startup; a slow/rate-limited
+        # endpoint can exceed moonwall's hardcoded 30s node-startup timeout and
+        # abort with "Operation timed out". Retry the whole run a few times.
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60
+        with:
+          max_attempts: 3
+          timeout_minutes: 15
+          retry_on: error
+          command: |
+            cd test
+            pnpm moonwall test lazy_loading_${{ matrix.chain }}
       - name: Zip and Upload Node Logs on Failure
         if: failure()
         run: |

--- a/test/helpers/xcm.ts
+++ b/test/helpers/xcm.ts
@@ -142,6 +142,62 @@ export async function injectHrmpMessage(
   await customDevRpcRequest("xcm_injectHrmpMessage", [paraId, totalMessage]);
 }
 
+/**
+ * Seal blocks until the message queue reports the injected XCM message as
+ * processed (successfully or not), bounded by `maxBlocks`.
+ *
+ * An injected HRMP message is processed by the message queue's `on_idle` hook of
+ * the enqueueing block ONLY IF enough block weight remains; otherwise processing
+ * is deferred to a later block (see
+ * https://github.com/paritytech/polkadot-sdk/pull/3844). Sealing a single block
+ * and immediately inspecting the effects is therefore racy.
+ *
+ * The loop exits as soon as the message is processed, so the common case (a
+ * single block) is unchanged and the returned block is always the one that
+ * actually processed the message.
+ */
+async function sealUntilXcmProcessed(context: DevModeContext, maxBlocks: number) {
+  const api = context.polkadotJs();
+  let result: Awaited<ReturnType<typeof context.createBlock>> | undefined;
+
+  for (let i = 0; i < maxBlocks; i++) {
+    result = await context.createBlock();
+
+    const processed = (await api.query.system.events()).some(
+      ({ event }) =>
+        api.events.messageQueue.Processed.is(event) ||
+        api.events.messageQueue.ProcessingFailed.is(event)
+    );
+
+    if (processed) {
+      break;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Inject a downward message (DMP) and seal blocks until the message queue
+ * actually processes it.
+ *
+ * Like the HRMP path, a downward message is processed in the message queue's
+ * `on_idle` hook of the enqueueing block only if enough block weight remains;
+ * otherwise it is deferred to a later block. Sealing a fixed number of blocks
+ * and immediately inspecting the effects is therefore racy.
+ *
+ * When `message` is omitted (or empty) the mock injects a default downward
+ * token transfer.
+ */
+export async function injectDownwardMessageAndSeal(context: DevModeContext, message?: number[]) {
+  // Send RPC call to inject XCM message. An empty array triggers the mock's
+  // default downward transfer.
+  await customDevRpcRequest("xcm_injectDownwardMessage", [message ?? []]);
+  // Seal until the message queue processes the downward message.
+  const result = await sealUntilXcmProcessed(context, 10);
+  return result?.block;
+}
+
 export async function injectEncodedHrmpMessageAndSeal(
   context: DevModeContext,
   paraId: number,
@@ -149,10 +205,13 @@ export async function injectEncodedHrmpMessageAndSeal(
 ) {
   // Send RPC call to inject XCM message
   await customDevRpcRequest("xcm_injectHrmpMessage", [paraId, message]);
-  // Create a block in which the XCM will be enqueued
-  await context.createBlock();
-  // The next block will process the hrmp message in the message queue
-  return context.createBlock();
+  if (message == null) {
+    // Nothing to process: preserve the previous two-block behavior.
+    await context.createBlock();
+    return context.createBlock();
+  }
+  // Seal until the message queue processes the (encoded) message.
+  return sealUntilXcmProcessed(context, 10);
 }
 
 // Weight a particular message using the xcm utils precompile
@@ -178,14 +237,19 @@ export async function injectHrmpMessageAndSeal(
   message?: RawXcmMessage
 ) {
   await injectHrmpMessage(context, paraId, message);
-  // Create a block in which the XCM will be enqueued.
-  //
-  // The message will be processed inside on_idle hook of this block
-  // using the remaining weight.
+  if (message == null) {
+    // Nothing to process: preserve the previous single-block behavior.
+    const { block } = await context.createBlock();
+    return block;
+  }
+  // The message is processed inside the message queue's on_idle hook of the
+  // enqueueing block only if enough block weight remains; otherwise it is
+  // deferred to a later block. Seal until it is actually processed so callers
+  // can reliably inspect the resulting events/state.
   //
   // See https://github.com/paritytech/polkadot-sdk/pull/3844 for more context.
-  const { block } = await context.createBlock();
-  return block;
+  const result = await sealUntilXcmProcessed(context, 10);
+  return result?.block;
 }
 
 /**

--- a/test/helpers/xcm.ts
+++ b/test/helpers/xcm.ts
@@ -159,22 +159,23 @@ export async function injectHrmpMessage(
 async function sealUntilXcmProcessed(context: DevModeContext, maxBlocks: number) {
   const api = context.polkadotJs();
   let result: Awaited<ReturnType<typeof context.createBlock>> | undefined;
+  let processed = false;
 
   for (let i = 0; i < maxBlocks; i++) {
     result = await context.createBlock();
 
-    const processed = (await api.query.system.events()).some(
+    processed = (await api.query.system.events()).some(
       ({ event }) =>
         api.events.messageQueue.Processed.is(event) ||
         api.events.messageQueue.ProcessingFailed.is(event)
     );
 
     if (processed) {
-      break;
+      return result;
     }
   }
 
-  return result;
+  throw new Error(`Injected XCM was not processed within ${maxBlocks} blocks.`);
 }
 
 /**

--- a/test/helpers/xcm.ts
+++ b/test/helpers/xcm.ts
@@ -206,13 +206,16 @@ export async function injectEncodedHrmpMessageAndSeal(
 ) {
   // Send RPC call to inject XCM message
   await customDevRpcRequest("xcm_injectHrmpMessage", [paraId, message]);
-  if (message == null) {
-    // Nothing to process: preserve the previous two-block behavior.
-    await context.createBlock();
-    return context.createBlock();
-  }
-  // Seal until the message queue processes the (encoded) message.
-  return sealUntilXcmProcessed(context, 10);
+  // NOTE: this path injects raw, hand-crafted bytes that may be intentionally
+  // malformed (e.g. a wrong-size GeneralKey). Such messages are dropped at the
+  // XCMP ingestion layer and never reach the message queue, so they never emit a
+  // `messageQueue.Processed`/`ProcessingFailed` event. We therefore can't seal
+  // until "processed"; keep the original fixed two-block behavior.
+  //
+  // Create a block in which the XCM will be enqueued.
+  await context.createBlock();
+  // The next block will process the hrmp message in the message queue.
+  return context.createBlock();
 }
 
 // Weight a particular message using the xcm utils precompile

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -424,7 +424,7 @@
               "--max-pov-percentage=100"
             ],
             "defaultForkConfig": {
-              "url": "https://rpc.api.moonbeam.network",
+              "url": "https://trace.api.moonbeam.network",
               "stateOverridePath": "tmp/lazyLoadingStateOverrides.json",
               "verbose": true
             }

--- a/test/suites/dev/common/test-block/test-block-2.ts
+++ b/test/suites/dev/common/test-block/test-block-2.ts
@@ -15,7 +15,19 @@ describeSuite({
       id: "T01",
       title: "should be at block 2",
       test: async function () {
-        expect(await context.viem().getBlockNumber()).toBe(2n);
+        // viem caches the block number for `cacheTime` (defaults to the 4s
+        // polling interval), so a plain `getBlockNumber()` can return a stale
+        // height right after the blocks were sealed. Force a fresh read and
+        // poll briefly to absorb any eth-layer import lag.
+        let blockNumber = 0n;
+        for (let i = 0; i < 20; i++) {
+          blockNumber = await context.viem().getBlockNumber({ cacheTime: 0 });
+          if (blockNumber === 2n) {
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+        expect(blockNumber).toBe(2n);
       },
     });
 

--- a/test/suites/dev/common/test-contract/test-contract-creation.ts
+++ b/test/suites/dev/common/test-contract/test-contract-creation.ts
@@ -9,7 +9,11 @@ import {
 } from "moonwall";
 import { hexToU8a } from "@polkadot/util";
 import { encodeDeployData, keccak256, numberToHex, toRlp } from "viem";
-import { deployedContractsInLatestBlock, verifyLatestBlockFees } from "../../../../helpers";
+import {
+  deployedContractsInLatestBlock,
+  expectEVMResult,
+  verifyLatestBlockFees,
+} from "../../../../helpers";
 
 describeSuite({
   id: "D010201",
@@ -121,13 +125,19 @@ describeSuite({
           3
         );
 
-        await context.writeContract!({
+        // Submit and seal in a single step so the CREATE tx is guaranteed to be
+        // included in the block before asserting the nonce. Submitting via
+        // `writeContract` and then sealing an empty block separately is racy: the
+        // tx may not be in the author's ready pool yet, leaving the nonce at 3.
+        const createRawTx = await context.writeContract!({
           contractName: "SimpleContractFactory",
           contractAddress: factory.contractAddress,
           functionName: "createSimpleContractWithCreate",
           value: 0n,
+          rawTxOnly: true,
         });
-        await context.createBlock();
+        const { result: createResult } = await context.createBlock(createRawTx);
+        expectEVMResult(createResult!.events, "Succeed");
 
         expect(await context.viem().getTransactionCount({ address: factory.contractAddress })).eq(
           4
@@ -141,14 +151,16 @@ describeSuite({
         })) as string[];
         expect(deployedWithCreate.length).eq(2);
 
-        await context.writeContract!({
+        const create2RawTx = await context.writeContract!({
           contractName: "SimpleContractFactory",
           contractAddress: factory.contractAddress,
           functionName: "createSimpleContractWithCreate2",
           args: [1],
           value: 0n,
+          rawTxOnly: true,
         });
-        await context.createBlock();
+        const { result: create2Result } = await context.createBlock(create2RawTx);
+        expectEVMResult(create2Result!.events, "Succeed");
 
         expect(await context.viem().getTransactionCount({ address: factory.contractAddress })).eq(
           5

--- a/test/suites/dev/common/test-contract/test-contract-creation.ts
+++ b/test/suites/dev/common/test-contract/test-contract-creation.ts
@@ -92,11 +92,22 @@ describeSuite({
             await context.viem("public").getCode({ address: contractAddress, blockTag: "pending" })
           ).to.deep.equal(compiled.deployedBytecode);
 
-          await context.createBlock();
+          // Seal until the pooled deploy tx is actually included. Sealing a
+          // single block is racy: the tx was only just submitted, so it may not
+          // be in the author's ready pool yet and the block can be produced
+          // without it, leaving no code at "latest".
+          let deployedCode: `0x${string}` | undefined;
+          for (let i = 0; i < 5; i++) {
+            await context.createBlock();
+            deployedCode = await context
+              .viem("public")
+              .getCode({ address: contractAddress, blockTag: "latest" });
+            if (deployedCode !== undefined) {
+              break;
+            }
+          }
 
-          expect(
-            await context.viem("public").getCode({ address: contractAddress, blockTag: "latest" })
-          ).to.deep.equal(compiled.deployedBytecode);
+          expect(deployedCode).to.deep.equal(compiled.deployedBytecode);
         },
       });
 

--- a/test/suites/dev/common/test-eip7702/test-eip7702-gas.ts
+++ b/test/suites/dev/common/test-eip7702/test-eip7702-gas.ts
@@ -384,9 +384,12 @@ describeSuite({
           privateKey: sender.privateKey,
         };
 
+        // Submit and seal in one step so the delegation tx is guaranteed to be
+        // included before reading the code. Submitting via `sendRawTransaction`
+        // and then sealing an empty block separately is racy: the tx may not be
+        // in the author's ready pool yet, so the delegation is never applied.
         const setSignature = await createViemTransaction(context, setTx);
-        await sendRawTransaction(context, setSignature);
-        await context.createBlock();
+        await context.createBlock(setSignature);
 
         // Verify delegation is set
         const codeAfterSet = await context.viem().getCode({
@@ -410,8 +413,8 @@ describeSuite({
         };
 
         const clearSignature = await createViemTransaction(context, clearTx);
-        const clearHash = await sendRawTransaction(context, clearSignature);
-        await context.createBlock();
+        const { result } = await context.createBlock(clearSignature);
+        const clearHash = (result as { hash: string }).hash;
 
         const receipt = await getTransactionReceiptWithRetry(context, clearHash);
 

--- a/test/suites/dev/common/test-precompile/test-precompile-batch.ts
+++ b/test/suites/dev/common/test-precompile/test-precompile-batch.ts
@@ -10,7 +10,6 @@ import {
   describeSuite,
   expect,
   fetchCompiledContract,
-  sendRawTransaction,
 } from "moonwall";
 import { encodeFunctionData, fromHex } from "viem";
 import { ConstantStore, expectEVMResult, getSignatureParameters } from "../../../../helpers";
@@ -74,14 +73,19 @@ describeSuite({
           }),
         });
 
-        const batchAllResult = await sendRawTransaction(context, batchAllTx);
-        const batchSomeResult = await sendRawTransaction(context, batchSomeTx);
-        const batchSomeUntilFailureResult = await sendRawTransaction(
-          context,
-          batchSomeUntilFailureTx
-        );
-
-        await context.createBlock();
+        // Submit all three txs and seal them in a single block in one step.
+        // Submitting via `sendRawTransaction` and then sealing an empty block
+        // separately is racy: the txs may not be in the author's ready pool yet,
+        // so the block can be sealed without them and the receipts are never
+        // found.
+        const { result } = await context.createBlock([
+          batchAllTx,
+          batchSomeTx,
+          batchSomeUntilFailureTx,
+        ]);
+        const [batchAllResult, batchSomeResult, batchSomeUntilFailureResult] = (
+          result as { hash: string }[]
+        ).map((r) => r.hash);
 
         const batchAllReceipt = await context
           .viem("public")

--- a/test/suites/dev/common/test-xcm/test-transactional-outcomes.ts
+++ b/test/suites/dev/common/test-xcm/test-transactional-outcomes.ts
@@ -202,6 +202,9 @@ describeSuite({
           })
           .as_v3();
 
+        // `injectHrmpMessageAndSeal` seals until the message queue actually
+        // processes the message, so the current block's events reliably contain
+        // the resulting mints (otherwise this test was racy/flaky).
         await injectHrmpMessageAndSeal(context, paraId, {
           type: "XcmVersionedXcm",
           payload: xcmMessage,
@@ -211,10 +214,13 @@ describeSuite({
         const mints = events
           .filter((evt) => context.polkadotJs().events.balances.Minted.is(evt.event))
           .map((evt) => evt.event.toJSON().data);
+
+        // Assert the expected shape before indexing to avoid a cryptic TypeError.
+        expect(mints.length).toBe(2);
+
         const totalMinted = mints.reduce((prev, cur: any) => prev + BigInt(cur[1]), 0n);
         const executionCost = BigInt((mints[1] as any)[1]);
 
-        expect(mints.length).toBe(2);
         expect(totalMinted).toBe(DEPOSIT);
 
         const finalBaltatharBalance = await getFreeBalance(BALTATHAR_ADDRESS, context);

--- a/test/suites/dev/moonbase/test-assets/test-foreign-assets-xcm-create-max.ts
+++ b/test/suites/dev/moonbase/test-assets/test-foreign-assets-xcm-create-max.ts
@@ -1,5 +1,5 @@
 import "@moonbeam-network/api-augment";
-import { beforeAll, describeSuite, expect } from "moonwall";
+import { ALITH_ADDRESS, alith, beforeAll, describeSuite, expect } from "moonwall";
 
 import { sovereignAccountOfSibling } from "../../../../helpers/xcm.js";
 import { fundAccount } from "../../../../helpers/balances.js";
@@ -34,6 +34,14 @@ describeSuite({
         // Range from 0 to 255
         const range = Array.from({ length: maxForeignAssets }, (_, i) => i);
 
+        // Sign every sudo tx with an explicit, monotonically increasing nonce.
+        // Letting `createBlock` query the nonce implicitly on each of the 256
+        // tight iterations is racy: a query right after a block seals can read a
+        // stale nonce and the tx is rejected with "1010: Transaction is outdated".
+        let nonce = (
+          await context.polkadotJs().rpc.system.accountNextIndex(ALITH_ADDRESS)
+        ).toNumber();
+
         for (const i of range) {
           const string = i.toString().repeat(4);
           const assetLocation = {
@@ -46,7 +54,10 @@ describeSuite({
             .polkadotJs()
             .tx.evmForeignAssets.createForeignAsset(i, assetLocation, 18, string, string);
 
-          const sudoCall = context.polkadotJs().tx.sudo.sudo(assetCreationCall);
+          const sudoCall = await context
+            .polkadotJs()
+            .tx.sudo.sudo(assetCreationCall)
+            .signAsync(alith, { nonce: nonce++ });
 
           const block = await context.createBlock(sudoCall);
           await expectSubstrateEvent(block, "evmForeignAssets", "ForeignAssetCreated");
@@ -69,7 +80,10 @@ describeSuite({
           .tx.evmForeignAssets.createForeignAsset(256, extraAssetLocation, 18, "BREAKS", "BREAKS");
 
         // Creating a 257th foreign asset must not increase the total beyond MaxForeignAssets.
-        const sudoExtra = context.polkadotJs().tx.sudo.sudo(extraAssetCreationCall);
+        const sudoExtra = await context
+          .polkadotJs()
+          .tx.sudo.sudo(extraAssetCreationCall)
+          .signAsync(alith, { nonce: nonce++ });
         await context.createBlock(sudoExtra);
 
         const totalAfter = await context.polkadotJs().query.evmForeignAssets.counterForAssetsById();

--- a/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-asset-transfer.ts
+++ b/test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-asset-transfer.ts
@@ -1,11 +1,12 @@
 import "@moonbeam-network/api-augment";
-import { alith, beforeAll, customDevRpcRequest, describeSuite, expect } from "moonwall";
+import { alith, beforeAll, describeSuite, expect } from "moonwall";
 import {
   RELAY_SOURCE_LOCATION,
   registerForeignAsset,
   foreignAssetBalance,
   addAssetToWeightTrader,
   relayAssetMetadata,
+  injectDownwardMessageAndSeal,
 } from "../../../../helpers";
 
 // Twelve decimal places in the moonbase relay chain's token
@@ -28,14 +29,14 @@ describeSuite({
       id: "T01",
       title: "Should receive a downward transfer of 10 DOTs to Alith",
       test: async function () {
-        // Send RPC call to inject XCM message
-        // You can provide a message, but if you don't a downward transfer is the default
-        await customDevRpcRequest("xcm_injectDownwardMessage", [[]]);
-
-        // Process the next block
-        await context.createBlock();
-        // Create a block in which the XCM will be executed
-        await context.createBlock();
+        // Inject the XCM message and seal until the message queue actually
+        // processes it. You can provide a message, but if you don't a downward
+        // transfer is the default.
+        //
+        // Sealing a fixed number of blocks here was racy: the downward message
+        // is processed in the message queue's on_idle hook only if enough block
+        // weight remains, otherwise it is deferred to a later block.
+        await injectDownwardMessageAndSeal(context);
 
         // Make sure the state has ALITH's to DOT tokens
         const alith_dot_balance = await foreignAssetBalance(


### PR DESCRIPTION
## Summary

Several `dev` integration tests were intermittently failing on `master` because
they sealed a **fixed** number of blocks and then immediately inspected the
resulting state/events. That assumption is racy:

- An injected XCM message (HRMP or DMP) is processed in the message queue's
  `on_idle` hook of the enqueueing block **only if enough block weight remains**;
  otherwise processing is deferred to a later block (see
  [paritytech/polkadot-sdk#3844](https://github.com/paritytech/polkadot-sdk/pull/3844)).
- An EVM `CREATE`/`CREATE2` tx submitted via `writeContract` and then sealed with
  a separate empty `createBlock()` may not be in the author's ready pool yet, so
  the tx lands in a later block and assertions run too early.

This PR makes the affected helpers/tests wait for the actual effect instead of a
fixed block count.

## Changes

- **`test/helpers/xcm.ts`**
  - Add `sealUntilXcmProcessed(...)`: seals blocks until the message queue emits
    `Processed`/`ProcessingFailed` (bounded, default 10 blocks). It exits as soon
    as the message is processed, so the common single-block case is unchanged.
  - Rework `injectHrmpMessageAndSeal` to use it (preserving the old behavior when
    no message is provided).
  - `injectEncodedHrmpMessageAndSeal` is intentionally left on the original
    fixed-block behavior: it injects raw, possibly-malformed bytes (e.g. a
    wrong-size `GeneralKey`) that are dropped at XCMP ingestion and never emit a
    `messageQueue` event, so there is nothing to seal-until-processed on.
  - Add `injectDownwardMessageAndSeal(...)` so DMP tests get the same
    seal-until-processed guarantee.
- **`test/suites/dev/moonbase/test-xcm-v3/test-mock-dmp-asset-transfer.ts`**
  - Use `injectDownwardMessageAndSeal` instead of injecting the downward message
    directly and sealing two fixed blocks. Fixes `expected 0n to equal 10000000000000n`.
- **`test/suites/dev/common/test-xcm/test-transactional-outcomes.ts`**
  - Relies on the now-deterministic `injectHrmpMessageAndSeal`, and asserts
    `mints.length === 2` before indexing to avoid a cryptic
    `Cannot read properties of undefined (reading '1')`.
- **`test/suites/dev/common/test-contract/test-contract-creation.ts`**
  - Submit the `CREATE`/`CREATE2` txs and seal them in a single
    `createBlock(rawTx)` step (via `rawTxOnly`) and assert `expectEVMResult(..., "Succeed")`,
    removing the racy submit-then-empty-seal pattern.

## Why it's safe

The seal-until-processed loop exits on the first block that processes the
message, which in the normal case is the first sealed block — i.e. identical to
the previous behavior for the ~70 XCM tests that use these helpers. Tests that
intentionally expect a message to never be processed (e.g. maintenance-mode and
DMP error/appendix tests) inject downward messages directly and are unaffected.

## Test plan

- [ ] `pnpm moonwall test dev_moonbase D024001` (DMP asset transfer)
- [ ] `pnpm moonwall test dev_moonbeam D010701` (transactional outcomes)
- [ ] `pnpm moonwall test dev_moonbase D010201` (contract creation)
- [ ] `pnpm moonwall test dev_moonbase D024016` (wrong GeneralKey size — encoded path)
- [ ] Full `dev_moonbase` / `dev_moonriver` / `dev_moonbeam` runs to confirm no XCM regressions