### PR TITLE
Deflake dev & chopsticks integration tests

### DIFF
--- a/test/helpers/block.ts
+++ b/test/helpers/block.ts
@@ -1,6 +1,12 @@
 import "@moonbeam-network/api-augment/moonbase";
 import type { DevModeContext, BlockRangeOption } from "moonwall";
-import { EXTRINSIC_BASE_WEIGHT, WEIGHT_PER_GAS, expect, mapExtrinsics } from "moonwall";
+import {
+  ALITH_ADDRESS,
+  EXTRINSIC_BASE_WEIGHT,
+  WEIGHT_PER_GAS,
+  expect,
+  mapExtrinsics,
+} from "moonwall";
 import type { ApiPromise } from "@polkadot/api";
 import type { TxWithEvent } from "@polkadot/api-derive/types";
 import type { Option, u128, u32 } from "@polkadot/types";
@@ -344,6 +350,40 @@ export async function jumpBlocks(context: DevModeContext, blockCount: number) {
     (await context.createBlock()).block.hash.toString();
     blocksToCreate--;
   }
+}
+
+/**
+ * Seal blocks until `address`'s on-chain (latest) nonce has caught up with its
+ * pending nonce — i.e. the transaction pool holds no more *ready* transactions
+ * for that account. Returns the number of blocks sealed; throws if the pool is
+ * not drained within `maxBlocks`.
+ *
+ * Useful to stop transactions submitted by one test case from leaking into a
+ * later block and corrupting nonce or gas-usage expectations.
+ */
+export async function sealUntilTxPoolEmpty(
+  context: DevModeContext,
+  address: `0x${string}` = ALITH_ADDRESS,
+  maxBlocks = 20
+): Promise<number> {
+  const pub = context.viem("public");
+  const nonces = () =>
+    Promise.all([
+      pub.getTransactionCount({ address, blockTag: "latest" }),
+      pub.getTransactionCount({ address, blockTag: "pending" }),
+    ]);
+
+  let sealed = 0;
+  let [latest, pending] = await nonces();
+  while (latest !== pending) {
+    expect(sealed, `tx pool for ${address} not drained after ${maxBlocks} blocks`).toBeLessThan(
+      maxBlocks
+    );
+    await context.createBlock();
+    sealed++;
+    [latest, pending] = await nonces();
+  }
+  return sealed;
 }
 
 export async function jumpRounds(context: DevModeContext, count: number): Promise<string | null> {

--- a/test/helpers/xcm.ts
+++ b/test/helpers/xcm.ts
@@ -1,5 +1,6 @@
 import type { DevModeContext } from "moonwall";
 import { ALITH_ADDRESS, GLMR, alith, customDevRpcRequest, expect } from "moonwall";
+import type { ApiPromise } from "@polkadot/api";
 import type { DispatchError, XcmpMessageFormat } from "@polkadot/types/interfaces";
 import type {
   CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot,
@@ -143,34 +144,47 @@ export async function injectHrmpMessage(
 }
 
 /**
- * Seal blocks until the message queue reports the injected XCM message as
- * processed (successfully or not), bounded by `maxBlocks`.
+ * Returns true once the message queue has no remaining work to service.
  *
- * An injected HRMP message is processed by the message queue's `on_idle` hook of
- * the enqueueing block ONLY IF enough block weight remains; otherwise processing
- * is deferred to a later block (see
- * https://github.com/paritytech/polkadot-sdk/pull/3844). Sealing a single block
- * and immediately inspecting the effects is therefore racy.
+ * `messageQueue.serviceHead` is `None` exactly when every enqueued page has been
+ * fully processed, so it is the authoritative "queue drained" signal.
+ */
+async function isMessageQueueDrained(api: ApiPromise): Promise<boolean> {
+  return (await api.query.messageQueue.serviceHead()).isNone;
+}
+
+/**
+ * Seal blocks until the injected XCM message has been processed (successfully or
+ * not) AND the message queue is fully drained, bounded by `maxBlocks`.
  *
- * The loop exits as soon as the message is processed, so the common case (a
- * single block) is unchanged and the returned block is always the one that
- * actually processed the message.
+ * An injected HRMP/DMP message is processed by the message queue's `on_idle` hook
+ * of the enqueueing block ONLY IF enough block weight remains; otherwise it is
+ * deferred to a later block (see
+ * https://github.com/paritytech/polkadot-sdk/pull/3844). Inspecting the effects
+ * after a single block is therefore racy.
+ *
+ * Waiting for the queue to drain (rather than for the first `Processed` event) is
+ * what makes this deterministic under load: a deferred message is given as many
+ * blocks as needed, and an unrelated/residual message emitting `Processed` first
+ * cannot make us return while ours is still queued.
  */
 export async function sealUntilXcmProcessed(context: DevModeContext, maxBlocks = 10) {
   const api = context.polkadotJs();
   let result: Awaited<ReturnType<typeof context.createBlock>> | undefined;
-  let processed = false;
+  let processedSeen = false;
 
   for (let i = 0; i < maxBlocks; i++) {
     result = await context.createBlock();
 
-    processed = (await api.query.system.events()).some(
-      ({ event }) =>
-        api.events.messageQueue.Processed.is(event) ||
-        api.events.messageQueue.ProcessingFailed.is(event)
-    );
+    if (!processedSeen) {
+      processedSeen = (await api.query.system.events()).some(
+        ({ event }) =>
+          api.events.messageQueue.Processed.is(event) ||
+          api.events.messageQueue.ProcessingFailed.is(event)
+      );
+    }
 
-    if (processed) {
+    if (processedSeen && (await isMessageQueueDrained(api))) {
       return result;
     }
   }

--- a/test/moonwall.config.json
+++ b/test/moonwall.config.json
@@ -671,7 +671,8 @@
             "name": "mb",
             "type": "parachain",
             "allowUnresolvedImports": true,
-            "configPath": "./configs/moonbeam.yml"
+            "configPath": "./configs/moonbeam.yml",
+            "newBlockTimeout": 300000
           }
         ]
       },
@@ -694,7 +695,8 @@
             "name": "mb",
             "type": "parachain",
             "allowUnresolvedImports": true,
-            "configPath": "./configs/moonriver.yml"
+            "configPath": "./configs/moonriver.yml",
+            "newBlockTimeout": 300000
           }
         ]
       },
@@ -717,7 +719,8 @@
             "name": "mb",
             "type": "parachain",
             "allowUnresolvedImports": true,
-            "configPath": "./configs/alphanet.yml"
+            "configPath": "./configs/alphanet.yml",
+            "newBlockTimeout": 300000
           }
         ]
       },

--- a/test/suites/dev/common/test-eip7702/helpers.ts
+++ b/test/suites/dev/common/test-eip7702/helpers.ts
@@ -72,7 +72,14 @@ export async function createViemTransaction(
   const value = options?.value ? options.value : 0n;
   const to = options?.to ? options.to : "0x0000000000000000000000000000000000000000";
   const chainId = await context.viem().getChainId();
-  const txnCount = await context.viem().getTransactionCount({ address: account.address });
+  // Use the pending nonce so multiple transactions submitted from the same
+  // account before they are sealed get distinct, incrementing nonces. Reading
+  // the latest nonce would reuse the same nonce and, with identical priority,
+  // fail with "Priority is too low ... replace another transaction already in
+  // the pool".
+  const txnCount = await context
+    .viem()
+    .getTransactionCount({ address: account.address, blockTag: "pending" });
   const gasPrice = await context.viem().getGasPrice();
   const data = options?.data ? options.data : "0x";
 

--- a/test/suites/dev/moonbase/test-eth-fee/test-eth-fee-history.ts
+++ b/test/suites/dev/moonbase/test-eth-fee/test-eth-fee-history.ts
@@ -28,6 +28,24 @@ describeSuite({
       priority_fees: number[],
       max_fee_per_gas: string
     ) {
+      // Flush any transactions left in the pool by previous test cases into
+      // their own block(s) first. Otherwise they leak into the first block we
+      // are about to produce and inflate its gasUsedRatio non-deterministically.
+      for (let i = 0; i < 20; i++) {
+        const [latest, pending] = await Promise.all([
+          context
+            .viem("public")
+            .getTransactionCount({ address: ALITH_ADDRESS, blockTag: "latest" }),
+          context
+            .viem("public")
+            .getTransactionCount({ address: ALITH_ADDRESS, blockTag: "pending" }),
+        ]);
+        if (latest === pending) {
+          break;
+        }
+        await context.createBlock();
+      }
+
       let nonce = await context
         .viem("public")
         .getTransactionCount({ address: ALITH_ADDRESS, blockTag: "pending" });

--- a/test/suites/dev/moonbase/test-eth-fee/test-eth-fee-history.ts
+++ b/test/suites/dev/moonbase/test-eth-fee/test-eth-fee-history.ts
@@ -8,6 +8,7 @@ import {
 } from "moonwall";
 import { hexToNumber, numberToHex } from "@polkadot/util";
 import { parseGwei } from "viem";
+import { sealUntilTxPoolEmpty } from "../../../../helpers";
 
 // We use ethers library in this test as apparently web3js's types are not fully EIP-1559
 // compliant yet.
@@ -31,29 +32,7 @@ describeSuite({
       // Flush any transactions left in the pool by previous test cases into
       // their own block(s) first. Otherwise they leak into the first block we
       // are about to produce and inflate its gasUsedRatio non-deterministically.
-      for (let i = 0; i < 20; i++) {
-        const [latest, pending] = await Promise.all([
-          context
-            .viem("public")
-            .getTransactionCount({ address: ALITH_ADDRESS, blockTag: "latest" }),
-          context
-            .viem("public")
-            .getTransactionCount({ address: ALITH_ADDRESS, blockTag: "pending" }),
-        ]);
-        if (latest === pending) {
-          break;
-        }
-        await context.createBlock();
-      }
-
-      const [latest, pending] = await Promise.all([
-        context.viem("public").getTransactionCount({ address: ALITH_ADDRESS, blockTag: "latest" }),
-        context.viem("public").getTransactionCount({ address: ALITH_ADDRESS, blockTag: "pending" }),
-      ]);
-      expect(
-        latest,
-        "previous tests must not leave pending transactions before fee-history blocks are produced"
-      ).toBe(pending);
+      await sealUntilTxPoolEmpty(context);
 
       let nonce = await context
         .viem("public")

--- a/test/suites/dev/moonbase/test-eth-fee/test-eth-fee-history.ts
+++ b/test/suites/dev/moonbase/test-eth-fee/test-eth-fee-history.ts
@@ -46,6 +46,19 @@ describeSuite({
         await context.createBlock();
       }
 
+      const [latest, pending] = await Promise.all([
+        context
+          .viem("public")
+          .getTransactionCount({ address: ALITH_ADDRESS, blockTag: "latest" }),
+        context
+          .viem("public")
+          .getTransactionCount({ address: ALITH_ADDRESS, blockTag: "pending" }),
+      ]);
+      expect(
+        latest,
+        "previous tests must not leave pending transactions before fee-history blocks are produced"
+      ).toBe(pending);
+
       let nonce = await context
         .viem("public")
         .getTransactionCount({ address: ALITH_ADDRESS, blockTag: "pending" });

--- a/test/suites/dev/moonbase/test-eth-fee/test-eth-fee-history.ts
+++ b/test/suites/dev/moonbase/test-eth-fee/test-eth-fee-history.ts
@@ -47,12 +47,8 @@ describeSuite({
       }
 
       const [latest, pending] = await Promise.all([
-        context
-          .viem("public")
-          .getTransactionCount({ address: ALITH_ADDRESS, blockTag: "latest" }),
-        context
-          .viem("public")
-          .getTransactionCount({ address: ALITH_ADDRESS, blockTag: "pending" }),
+        context.viem("public").getTransactionCount({ address: ALITH_ADDRESS, blockTag: "latest" }),
+        context.viem("public").getTransactionCount({ address: ALITH_ADDRESS, blockTag: "pending" }),
       ]);
       expect(
         latest,

--- a/test/suites/dev/moonbase/test-eth-tx/test-test-tx-nonce.ts
+++ b/test/suites/dev/moonbase/test-eth-tx/test-test-tx-nonce.ts
@@ -87,7 +87,23 @@ describeSuite({
             .getTransactionCount({ address: ALITH_ADDRESS, blockTag: "pending" }),
           "should increase transaction count in pending block"
         ).toBe(nonce + 1);
-        await context.createBlock();
+
+        // The transaction submitted via `eth_sendRawTransaction` can still be in
+        // the pool (not yet "ready") when a single block is sealed, which would
+        // leak it into the next test's block and corrupt its nonce expectations.
+        // Seal until the sender nonce actually advances so the pending
+        // transaction is guaranteed to be included before the next test runs.
+        for (
+          let i = 0;
+          i < 5 && (await context.viem().getTransactionCount({ address: ALITH_ADDRESS })) === nonce;
+          i++
+        ) {
+          await context.createBlock();
+        }
+        expect(
+          await context.viem().getTransactionCount({ address: ALITH_ADDRESS }),
+          "pending transaction should be included before continuing"
+        ).toBe(nonce + 1);
       },
     });
 

--- a/test/suites/dev/moonbase/test-eth-tx/test-test-tx-nonce.ts
+++ b/test/suites/dev/moonbase/test-eth-tx/test-test-tx-nonce.ts
@@ -12,6 +12,7 @@ import {
   fetchCompiledContract,
 } from "moonwall";
 import { encodeFunctionData } from "viem";
+import { sealUntilTxPoolEmpty } from "../../../../helpers";
 
 describeSuite({
   id: "D021205",
@@ -91,15 +92,9 @@ describeSuite({
         // The transaction submitted via `eth_sendRawTransaction` can still be in
         // the pool (not yet "ready") when a single block is sealed, which would
         // leak it into the next test's block and corrupt its nonce expectations.
-        // Seal until the sender nonce actually advances so the pending
-        // transaction is guaranteed to be included before the next test runs.
-        for (
-          let i = 0;
-          i < 5 && (await context.viem().getTransactionCount({ address: ALITH_ADDRESS })) === nonce;
-          i++
-        ) {
-          await context.createBlock();
-        }
+        // Seal until the pool is drained so the pending transaction is
+        // guaranteed to be included before the next test runs.
+        await sealUntilTxPoolEmpty(context);
         expect(
           await context.viem().getTransactionCount({ address: ALITH_ADDRESS }),
           "pending transaction should be included before continuing"


### PR DESCRIPTION
## Summary

Fixes intermittent CI failures in the integration test suite. None of these
change runtime behaviour — they only make the affected tests deterministic.
Two are caused by transactions leaking between dev test cases through the
shared transaction pool, one is a Chopsticks RPC timeout during the
post-upgrade migration, and one hardens the shared XCM sealing helper.

## Changes

### 1. `test-eth-tx/test-test-tx-nonce.ts` (D021205) — pending tx leak

`T05` submits a transaction via `eth_sendRawTransaction` and then seals a
single block. When that transaction is not yet "ready" at seal time it stays
in the pool and gets included in the **next** test's block, so `T06` saw the
sender nonce jump by two (`expected 4 to be 3`).

Fix: after submitting, seal until the sender nonce actually advances so the
pending transaction is guaranteed to be included before the next test runs.

### 2. `test-eth-fee/test-eth-fee-history.ts` (D020901) — stale pool leak

`createBlocks()` produced the blocks it then measures without first flushing
transactions left in the pool by earlier test cases. A leftover batch from a
previous case leaked into the first measured block and inflated its
`gasUsedRatio` (`[0.035075, 0.0105225]` instead of `[0.0105225, 0.0105225]`).

Fix: drain any pending transactions into their own block(s) before producing
the blocks whose gas usage is asserted, so each measured block only contains
its intended transactions.

### 3. `moonwall.config.json` — Chopsticks upgrade block timeout (C01)

Post-upgrade multi-migration blocks can take longer than the default 60s
`WsProvider` request timeout to produce, causing
`No response received from RPC endpoint in 60s` even though the test-level
timeout is much higher.

Fix: set `newBlockTimeout: 300000` (5 min) on the `upgrade_moonbeam`,
`upgrade_moonriver` and `upgrade_moonbase` Chopsticks launch specs, raising the
per-block RPC ceiling above the 60s default while staying within the test
budget.

### 4. `test/helpers/xcm.ts` — `sealUntilXcmProcessed` queue drain

The helper previously returned as soon as it saw the first `Processed` /
`ProcessingFailed` event. Under load an unrelated/residual message could emit
that event first, or a deferred message could still be queued, letting a test
proceed before its own message was actually handled.

Fix: seal until both a processing event is observed **and** the message queue
is fully drained (`messageQueue.serviceHead().isNone`). This builds on the
already-merged deterministic-sealing work and makes the shared helper robust
against deferred and residual messages.

## Test plan

- [ ] `D021205` (nonce) — passes deterministically across repeated runs
- [ ] `D020901` (fee history) — passes deterministically across repeated runs
- [ ] `C01` Chopsticks upgrade (`upgrade_moonriver` / `upgrade_moonbase`) — verify on CI
- [ ] Full `dev_moonbase` / `dev_moonbeam` suites green on CI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785330557&installation_id=130617128&pr_number=3804&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3804&signature=2cfa756d0080d5c86da61c5394c52f64ca267bb8022f69ff102830013ec6932d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->