### PR TITLE
[CI] Reuse waitFor in the block creation test

### DIFF
--- a/test/suites/dev/common/test-block/test-block-2.ts
+++ b/test/suites/dev/common/test-block/test-block-2.ts
@@ -12,7 +12,12 @@ describeSuite({
       await context.createBlock();
       // The eth RPC layer can lag behind freshly sealed blocks. Force fresh
       // reads while waiting for it to catch up before running assertions.
-      await waitFor(async () => (await context.viem().getBlockNumber({ cacheTime: 0 })) >= 2n);
+      const isReady = await waitFor(
+        async () => (await context.viem().getBlockNumber({ cacheTime: 0 })) >= 2n
+      );
+      if (!isReady) {
+        throw new Error("Timed out waiting for RPC layer to catch up to block 2");
+      }
     });
 
     it({

--- a/test/suites/dev/common/test-block/test-block-2.ts
+++ b/test/suites/dev/common/test-block/test-block-2.ts
@@ -1,5 +1,6 @@
 import "@moonbeam-network/api-augment";
 import { beforeAll, describeSuite, expect } from "moonwall";
+import { waitFor } from "../../../../helpers";
 
 describeSuite({
   id: "D010102",
@@ -9,25 +10,16 @@ describeSuite({
     beforeAll(async () => {
       await context.createBlock();
       await context.createBlock();
+      // The eth RPC layer can lag behind freshly sealed blocks. Force fresh
+      // reads while waiting for it to catch up before running assertions.
+      await waitFor(async () => (await context.viem().getBlockNumber({ cacheTime: 0 })) >= 2n);
     });
 
     it({
       id: "T01",
       title: "should be at block 2",
       test: async function () {
-        // viem caches the block number for `cacheTime` (defaults to the 4s
-        // polling interval), so a plain `getBlockNumber()` can return a stale
-        // height right after the blocks were sealed. Force a fresh read and
-        // poll briefly to absorb any eth-layer import lag.
-        let blockNumber = 0n;
-        for (let i = 0; i < 20; i++) {
-          blockNumber = await context.viem().getBlockNumber({ cacheTime: 0 });
-          if (blockNumber === 2n) {
-            break;
-          }
-          await new Promise((resolve) => setTimeout(resolve, 50));
-        }
-        expect(blockNumber).toBe(2n);
+        expect(await context.viem().getBlockNumber({ cacheTime: 0 })).toBe(2n);
       },
     });
 


### PR DESCRIPTION
### What does it do?

Replaces the hand-rolled polling loop in the `D010102` block creation test with the shared `waitFor` helper introduced in #3811.

The synchronization now happens in `beforeAll`, immediately after sealing the two blocks, so every test case starts after the Ethereum RPC view has caught up.



### What important points should reviewers know?

- This is a test-only change. It does not affect runtime, node, or consensus behavior.
- Fresh RPC reads are preserved with `cacheTime: 0`, avoiding viem's block-number cache while polling.
- `waitFor` is bounded by its default timeout. If the RPC layer does not catch up, the setup fails immediately with an explicit timeout error.
- The change removes a duplicated retry implementation and follows the pattern already used by `D010101`.


### Is there something left for follow-up PRs?

Other dev suites still contain specialized polling loops. They can be migrated separately where the shared helper preserves their existing behavior.


### What alternative implementations were considered?

Keeping the local retry loop was considered, but it duplicates the timeout and polling behavior now provided by the shared helper.


### Are there relevant PRs or issues in other repositories (Substrate, Polkadot, Frontier, Cumulus)?

This is a small follow-up to #3811. No changes are required in other repositories.


### What value does it bring to the blockchain users?

There is no direct on-chain impact. It keeps CI test synchronization consistent and reduces duplicated test code, making flaky-test handling easier to maintain.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786780263&installation_id=130617128&pr_number=3812&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3812&signature=7516064bcf3be874dec0fe578e05ca27a4c89863868e30b3b64cb860277a26c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->