### PR TITLE
ci: bind composite action inputs via env before shell

### DIFF
--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -33,11 +33,13 @@ runs:
         path: .sccache
     - name: Setup Variables
       shell: bash
+      env:
+        BLACKSMITH_STICKY_SCCACHE: ${{ inputs.blacksmith-sticky-sccache }}
       run: |
         echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
         echo "SCCACHE_CACHE_SIZE=100GB" >> $GITHUB_ENV
-        if [ "${{ inputs.blacksmith-sticky-sccache }}" = "true" ]; then
+        if [ "$BLACKSMITH_STICKY_SCCACHE" = "true" ]; then
           echo "SCCACHE_DIR=$GITHUB_WORKSPACE/.sccache" >> $GITHUB_ENV
         else
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
@@ -62,10 +64,11 @@ runs:
         # Keep the native node in target/debug while still asking substrate-wasm-builder
         # to compact and compress runtime artifacts for CI consumers.
         WASM_BUILD_TYPE: release
+        FEATURES: ${{ inputs.features }}
       run: |
         params=" --locked -p moonbeam"
-        if [ -n "${{ inputs.features }}" ]; then
-          params="$params --features ${{ inputs.features }}"
+        if [ -n "$FEATURES" ]; then
+          params="$params --features $FEATURES"
         fi
         echo "cargo build $params"
         cargo build $params

--- a/.github/workflow-templates/cargo-build/action.yml
+++ b/.github/workflow-templates/cargo-build/action.yml
@@ -66,12 +66,12 @@ runs:
         WASM_BUILD_TYPE: release
         FEATURES: ${{ inputs.features }}
       run: |
-        params=" --locked -p moonbeam"
+        params=(--locked -p moonbeam)
         if [ -n "$FEATURES" ]; then
-          params="$params --features $FEATURES"
+          params+=(--features "$FEATURES")
         fi
-        echo "cargo build $params"
-        cargo build $params
+        echo "cargo build ${params[*]}"
+        cargo build "${params[@]}"
     - name: Display binary comments
       shell: bash
       run: |

--- a/.github/workflow-templates/moonbeam-sticky-disk/action.yml
+++ b/.github/workflow-templates/moonbeam-sticky-disk/action.yml
@@ -16,9 +16,11 @@ runs:
   steps:
     - name: Validate mode input
       shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
       run: |
-        if [[ "${{ inputs.mode }}" != "publish" && "${{ inputs.mode }}" != "restore" ]]; then
-          echo "Invalid mode '${{ inputs.mode }}'. Must be 'publish' or 'restore'." >&2
+        if [[ "$MODE" != "publish" && "$MODE" != "restore" ]]; then
+          echo "Invalid mode '$MODE'. Must be 'publish' or 'restore'." >&2
           exit 1
         fi
     - name: Mount Blacksmith CI moonbeam disk

--- a/.github/workflow-templates/rust-toolchain/action.yml
+++ b/.github/workflow-templates/rust-toolchain/action.yml
@@ -20,6 +20,10 @@ runs:
   steps:
     - name: Setup Rust toolchain
       shell: bash
+      env:
+        TOOLCHAIN: ${{ inputs.toolchain }}
+        COMPONENTS: ${{ inputs.components }}
+        TARGETS: ${{ inputs.targets }}
       run: |
         if ! which "rustup" > /dev/null; then
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -29,21 +33,21 @@ runs:
 
         rustup override unset
 
-        if [ -n "${{ inputs.toolchain }}" ]; then
-          rustup toolchain install "${{ inputs.toolchain }}" --profile minimal --no-self-update
-          if [ -n "${{ inputs.components }}" ]; then
-            IFS=',' read -ra components <<< "${{ inputs.components }}"
-            rustup component add --toolchain "${{ inputs.toolchain }}" "${components[@]}"
+        if [ -n "$TOOLCHAIN" ]; then
+          rustup toolchain install "$TOOLCHAIN" --profile minimal --no-self-update
+          if [ -n "$COMPONENTS" ]; then
+            IFS=',' read -ra components <<< "$COMPONENTS"
+            rustup component add --toolchain "$TOOLCHAIN" "${components[@]}"
           fi
-          configured_targets="${{ inputs.targets }}"
+          configured_targets="$TARGETS"
           if [ -z "$configured_targets" ]; then
             configured_targets="$(awk -F '[' '/^targets =/ { print $2; exit }' rust-toolchain | tr -d '[] "')"
           fi
           if [ -n "$configured_targets" ]; then
             IFS=',' read -ra targets <<< "$configured_targets"
-            rustup target add --toolchain "${{ inputs.toolchain }}" "${targets[@]}"
+            rustup target add --toolchain "$TOOLCHAIN" "${targets[@]}"
           fi
-          rustup override set "${{ inputs.toolchain }}"
+          rustup override set "$TOOLCHAIN"
         else
           rustup show
         fi


### PR DESCRIPTION
## Summary
Bind composite-action `inputs.*` into step `env:` before shell use in:
- `.github/workflow-templates/rust-toolchain`
- `.github/workflow-templates/cargo-build`
- `.github/workflow-templates/moonbeam-sticky-disk`

`if:` / `with:` expressions are unchanged. This keeps `${{ }}` expansions out of `run:` scripts.

## Test plan
- [ ] Confirm action YAML still validates
- [ ] Optional: re-run a workflow that uses these templates (build/toolchain path)

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/moonbeam-foundation/codesmith/moonbeam/pr/3819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788529184&installation_model_id=20986&pr_number=3819&repository=moonbeam-foundation%2Fmoonbeam&return_to=https%3A%2F%2Fgithub.com%2Fmoonbeam-foundation%2Fmoonbeam%2Fpull%2F3819&signature=1e6c8408c7283297261e7bae9d7d715aa6252078d1c6f1d1c1c5f34563524f26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->